### PR TITLE
chore: branding and public release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Skim transforms source code by removing implementation details while preserving structure, signatures, and types. Built with tree-sitter for fast, accurate multi-language parsing.
 
+[![Website](https://img.shields.io/badge/Website-skim-e87040)](https://dean0x.github.io/x/skim/)
+[![CI](https://github.com/dean0x/skim/actions/workflows/ci.yml/badge.svg)](https://github.com/dean0x/skim/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/rskim.svg)](https://crates.io/crates/rskim)
 [![npm](https://img.shields.io/npm/v/rskim.svg)](https://www.npmjs.com/package/rskim)
 [![Downloads](https://img.shields.io/crates/d/rskim.svg)](https://crates.io/crates/rskim)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
-[![Built with Rust](https://img.shields.io/badge/built%20with-Rust-orange.svg?logo=rust)](https://www.rust-lang.org/)
 
 ## Why Skim?
 
@@ -584,6 +584,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Links
 
+- **Website**: https://dean0x.github.io/x/skim/
 - **Repository**: https://github.com/dean0x/skim
 - **Issues**: https://github.com/dean0x/skim/issues
 - **Crates.io**: https://crates.io/crates/rskim

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,9 +64,7 @@ Current limits are conservative defaults:
 
 **Please DO NOT open public issues for security vulnerabilities.**
 
-Instead, please report security issues by emailing:
-
-**security@[your-domain].com** (or create a private security advisory on GitHub)
+To report a vulnerability, [create a private security advisory](https://github.com/dean0x/skim/security/advisories/new) on this repository.
 
 ### What to Include
 


### PR DESCRIPTION
## Summary
- Add website badge (links to landing page) and CI badge to README
- Remove redundant "Rust" and "Built with Rust" badges
- Add landing page URL to README Links section
- Replace placeholder email in SECURITY.md with GitHub private security advisory link
- Set repo homepage URL via `gh repo edit`

## Manual step (post-merge)
Upload `launch/social-preview.png` via GitHub web UI: **Settings > General > Social preview**