### PR TITLE
refactor: wave 1 tech debt from issue #28

### DIFF
--- a/crates/rskim/src/cache.rs
+++ b/crates/rskim/src/cache.rs
@@ -111,9 +111,8 @@ fn cache_key(
     let canonical_display = canonical_path.display();
     let max_lines_str = fmt_opt(max_lines);
     let token_budget_str = fmt_opt(token_budget);
-    let hash_input = format!(
-        "{canonical_display}|{mtime_secs}|{mode:?}|{max_lines_str}|{token_budget_str}",
-    );
+    let hash_input =
+        format!("{canonical_display}|{mtime_secs}|{mode:?}|{max_lines_str}|{token_budget_str}");
 
     let mut hasher = Sha256::new();
     hasher.update(hash_input.as_bytes());

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -386,8 +386,7 @@ fn try_cached_result(
         return Ok(None);
     }
 
-    let Some(hit) =
-        cache::read_cache(path, options.mode, options.max_lines, options.token_budget)
+    let Some(hit) = cache::read_cache(path, options.mode, options.max_lines, options.token_budget)
     else {
         return Ok(None);
     };
@@ -993,10 +992,7 @@ mod tests {
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("--max-lines must be at least 1"),
-            "got: {msg}"
-        );
+        assert!(msg.contains("--max-lines must be at least 1"), "got: {msg}");
         assert!(
             msg.contains("Use --max-lines 1"),
             "expected hint in message, got: {msg}"


### PR DESCRIPTION
## Summary

- **S13**: Extract `validate_bounded_arg` helper — 3 one-liner calls replace 50 lines of duplicated validation
- **S6**: Compose `ProcessOptions` inside `MultiFileOptions` — eliminates 5 duplicated fields
- **B6**: Extract `validate_args`, `read_and_validate`, `try_cached_result`, `run_transform` helpers — `process_file` drops from ~135 to ~30 lines
- **S5**: Hoist config creation out of cascade loop — create once, mutate `mode` per iteration
- **S2**: Add `effective_mode` to cache metadata — observability when cascade selects a different mode
- Simplifier pass: noise comment removal, idiomatic Rust patterns, TOCTOU fix in cache read

All internal refactors with no behavioral changes. Only `crates/rskim/src/main.rs` and `crates/rskim/src/cache.rs` modified.

Resolves S13, S6, B6, S5, S2 from #28.

## Test plan

- [x] `cargo test` — all 262 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Scrutinizer 9-pillar review — PASS on all pillars