### PR TITLE
feat: add learn command for CLI error pattern detection (#64)

### DIFF
--- a/crates/rskim/src/cmd/completions.rs
+++ b/crates/rskim/src/cmd/completions.rs
@@ -76,8 +76,12 @@ fn build_full_command() -> Command {
     // Add the discover subcommand (definition lives in discover.rs to avoid duplication)
     cmd = cmd.subcommand(super::discover::command());
 
+    // Add the learn subcommand (definition lives in learn.rs to avoid duplication)
+    cmd = cmd.subcommand(super::learn::command());
+
     // Subcommands with full arg definitions added above — skip in the stub loop.
-    const IMPLEMENTED_SUBCOMMANDS: &[&str] = &["completions", "discover", "init", "rewrite"];
+    const IMPLEMENTED_SUBCOMMANDS: &[&str] =
+        &["completions", "discover", "init", "learn", "rewrite"];
 
     // Add stub subcommands for all OTHER known subcommands
     for name in super::KNOWN_SUBCOMMANDS {

--- a/crates/rskim/src/cmd/discover.rs
+++ b/crates/rskim/src/cmd/discover.rs
@@ -6,7 +6,7 @@
 use std::io::{self, Write};
 use std::process::ExitCode;
 
-use super::session::{self, AgentKind, ToolInput, ToolInvocation};
+use super::session::{self, parse_duration_ago, AgentKind, ToolInput, ToolInvocation};
 
 /// Run the discover subcommand.
 pub(crate) fn run(args: &[String]) -> anyhow::Result<ExitCode> {
@@ -125,34 +125,6 @@ fn parse_args(args: &[String]) -> anyhow::Result<DiscoverConfig> {
     }
 
     Ok(config)
-}
-
-/// Parse a human-readable duration string into a SystemTime in the past.
-/// Supports: Nd (days), Nh (hours), Nw (weeks).
-fn parse_duration_ago(s: &str) -> anyhow::Result<std::time::SystemTime> {
-    let s = s.trim();
-    let (num_str, unit) = if let Some(stripped) = s.strip_suffix('d') {
-        (stripped, "d")
-    } else if let Some(stripped) = s.strip_suffix('h') {
-        (stripped, "h")
-    } else if let Some(stripped) = s.strip_suffix('w') {
-        (stripped, "w")
-    } else {
-        anyhow::bail!("invalid duration format: '{s}' (expected Nd, Nh, or Nw)");
-    };
-
-    let num: u64 = num_str
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid number in duration: '{s}'"))?;
-
-    let secs = match unit {
-        "h" => num * 3600,
-        "d" => num * 86400,
-        "w" => num * 7 * 86400,
-        _ => unreachable!(),
-    };
-
-    Ok(std::time::SystemTime::now() - std::time::Duration::from_secs(secs))
 }
 
 // ---- Analysis ----

--- a/crates/rskim/src/cmd/learn.rs
+++ b/crates/rskim/src/cmd/learn.rs
@@ -1,0 +1,1135 @@
+//! `skim learn` -- detect CLI error patterns and generate correction rules (#64)
+//!
+//! Scans AI agent session files for error-retry patterns: a failed Bash command
+//! followed by a similar successful command within the next few invocations.
+//! Optionally generates a `.claude/rules/cli-corrections.md` rules file.
+
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+use super::session::{self, parse_duration_ago, AgentKind, ToolInput, ToolInvocation};
+
+/// Run the learn subcommand.
+pub(crate) fn run(args: &[String]) -> anyhow::Result<ExitCode> {
+    if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
+        print_help();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let config = parse_args(args)?;
+
+    let providers = session::get_providers(config.agent_filter);
+    if providers.is_empty() {
+        println!("No AI agent sessions found.");
+        println!("hint: skim learn scans for Claude Code sessions in ~/.claude/projects/");
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let filter = session::TimeFilter {
+        since: config.since,
+        latest_only: false,
+    };
+
+    // Collect all invocations from all providers
+    let mut all_invocations: Vec<ToolInvocation> = Vec::new();
+    for provider in &providers {
+        let sessions = provider.find_sessions(&filter)?;
+        for session_file in &sessions {
+            match provider.parse_session(session_file) {
+                Ok(invocations) => all_invocations.extend(invocations),
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to parse {}: {}",
+                        session_file.path.display(),
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    if all_invocations.is_empty() {
+        println!("No tool invocations found in the specified time window.");
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    // Extract only Bash invocations (in order)
+    let bash_invocations: Vec<&ToolInvocation> = all_invocations
+        .iter()
+        .filter(|inv| matches!(&inv.input, ToolInput::Bash { .. }))
+        .collect();
+
+    if bash_invocations.is_empty() {
+        println!("No Bash commands found in sessions.");
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    // Detect error-retry correction patterns
+    let corrections = detect_corrections(&bash_invocations);
+    let corrections = deduplicate_and_filter(corrections);
+
+    if corrections.is_empty() {
+        println!("No CLI error patterns detected.");
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    if config.json_output {
+        print_json_report(&corrections)?;
+    } else if config.generate {
+        let content = generate_rules_content(&corrections);
+        write_rules_file(&content, config.dry_run)?;
+    } else {
+        print_text_report(&corrections);
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// ============================================================================
+// Config
+// ============================================================================
+
+#[derive(Debug)]
+struct LearnConfig {
+    since: Option<std::time::SystemTime>,
+    generate: bool,
+    dry_run: bool,
+    json_output: bool,
+    agent_filter: Option<AgentKind>,
+}
+
+fn parse_args(args: &[String]) -> anyhow::Result<LearnConfig> {
+    let mut config = LearnConfig {
+        since: Some(std::time::SystemTime::now() - std::time::Duration::from_secs(7 * 86400)),
+        generate: false,
+        dry_run: false,
+        json_output: false,
+        agent_filter: None,
+    };
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--since" => {
+                i += 1;
+                if i >= args.len() {
+                    anyhow::bail!("--since requires a value (e.g., 7d, 24h, 1w)");
+                }
+                config.since = Some(parse_duration_ago(&args[i])?);
+            }
+            "--generate" => config.generate = true,
+            "--dry-run" => config.dry_run = true,
+            "--json" => config.json_output = true,
+            "--agent" => {
+                i += 1;
+                if i >= args.len() {
+                    anyhow::bail!("--agent requires a value (e.g., claude-code)");
+                }
+                config.agent_filter = Some(AgentKind::from_str(&args[i]).ok_or_else(|| {
+                    anyhow::anyhow!("unknown agent: '{}'\nSupported: claude-code", &args[i])
+                })?);
+            }
+            other => {
+                anyhow::bail!(
+                    "unknown flag: '{other}'\n\nUsage: skim learn [--since <duration>] [--generate] [--dry-run] [--json]"
+                );
+            }
+        }
+        i += 1;
+    }
+
+    Ok(config)
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// A detected correction pair: failed command followed by successful fix.
+#[derive(Debug, Clone)]
+struct CorrectionPair {
+    failed_command: String,
+    successful_command: String,
+    error_output: String,
+    pattern_type: PatternType,
+    occurrences: usize,
+    sessions: Vec<String>,
+}
+
+/// Classification of how the correction differs from the original.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)] // Other variant reserved for future pattern types
+enum PatternType {
+    /// Edit distance 1-2 (e.g., `carg test` -> `cargo test`)
+    FlagTypo,
+    /// Missing separator (e.g., `cargo test --nocapture` -> `cargo test -- --nocapture`)
+    MissingSeparator,
+    /// Wrong flag (e.g., `cargo test --release` -> `cargo test --profile=release`)
+    WrongFlag,
+    /// Missing argument (e.g., `cargo test --package` -> `cargo test --package rskim`)
+    MissingArg,
+    /// Other pattern
+    Other,
+}
+
+impl PatternType {
+    fn label(&self) -> &'static str {
+        match self {
+            PatternType::FlagTypo => "Typo",
+            PatternType::MissingSeparator => "Missing separator",
+            PatternType::WrongFlag => "Wrong flag",
+            PatternType::MissingArg => "Missing argument",
+            PatternType::Other => "Correction",
+        }
+    }
+}
+
+// ============================================================================
+// Pattern detection
+// ============================================================================
+
+/// Detect error-retry patterns in a sequence of Bash invocations.
+///
+/// For each failed Bash command, look at the next N (default 5) Bash commands.
+/// If a similar successful command is found, create a `CorrectionPair`.
+fn detect_corrections(bash_invocations: &[&ToolInvocation]) -> Vec<CorrectionPair> {
+    let mut corrections = Vec::new();
+    const LOOKAHEAD: usize = 5;
+
+    for (i, inv) in bash_invocations.iter().enumerate() {
+        // Only look at failed commands
+        let result = match &inv.result {
+            Some(r) if r.is_error || looks_like_error(&r.content) => r,
+            _ => continue,
+        };
+
+        // Skip TDD cycles
+        if is_tdd_cycle(bash_invocations, i) {
+            continue;
+        }
+
+        let failed_cmd = match &inv.input {
+            ToolInput::Bash { command } => command.as_str(),
+            _ => continue,
+        };
+
+        // Look ahead for a similar successful command
+        let end = (i + 1 + LOOKAHEAD).min(bash_invocations.len());
+        for candidate in bash_invocations.iter().take(end).skip(i + 1) {
+            let is_success = match &candidate.result {
+                Some(r) => !r.is_error && !looks_like_error(&r.content),
+                None => false,
+            };
+            if !is_success {
+                continue;
+            }
+
+            let candidate_cmd = match &candidate.input {
+                ToolInput::Bash { command } => command.as_str(),
+                _ => continue,
+            };
+
+            // Check similarity
+            if let Some(pattern) = classify_correction(failed_cmd, candidate_cmd) {
+                corrections.push(CorrectionPair {
+                    failed_command: failed_cmd.to_string(),
+                    successful_command: candidate_cmd.to_string(),
+                    error_output: result.content.chars().take(200).collect(),
+                    pattern_type: pattern,
+                    occurrences: 1,
+                    sessions: vec![inv.session_id.clone()],
+                });
+                break; // Only match the first correction per failure
+            }
+        }
+    }
+
+    corrections
+}
+
+// ============================================================================
+// Similarity matching
+// ============================================================================
+
+/// Classify how a correction differs from the failed command.
+fn classify_correction(failed: &str, success: &str) -> Option<PatternType> {
+    // Skip if commands are identical
+    if failed == success {
+        return None;
+    }
+
+    let failed_tokens: Vec<&str> = failed.split_whitespace().collect();
+    let success_tokens: Vec<&str> = success.split_whitespace().collect();
+
+    // Must have tokens
+    if failed_tokens.is_empty() || success_tokens.is_empty() {
+        return None;
+    }
+
+    // At minimum, first token must match (same tool) -- or be a typo
+    if failed_tokens[0] != success_tokens[0] {
+        // Check edit distance 1-2 on first token (typo in command name)
+        if levenshtein(failed_tokens[0], success_tokens[0]) <= 2 {
+            return Some(PatternType::FlagTypo);
+        }
+        return None;
+    }
+
+    // Check for missing separator: failed has no --, success has --
+    if !failed.contains(" -- ") && success.contains(" -- ") {
+        return Some(PatternType::MissingSeparator);
+    }
+
+    // Compare full strings via edit distance
+    let edit_dist = levenshtein(failed, success);
+    if edit_dist <= 3 {
+        // Close enough to be a typo or minor fix
+        if failed_tokens.len() < success_tokens.len() {
+            return Some(PatternType::MissingArg);
+        }
+        if failed_tokens.len() == success_tokens.len() {
+            // Check if exactly one token differs and it looks like a flag
+            let diffs: Vec<usize> = failed_tokens
+                .iter()
+                .zip(success_tokens.iter())
+                .enumerate()
+                .filter(|(_, (a, b))| a != b)
+                .map(|(i, _)| i)
+                .collect();
+            if diffs.len() == 1 {
+                let diff_idx = diffs[0];
+                if failed_tokens[diff_idx].starts_with('-')
+                    || success_tokens[diff_idx].starts_with('-')
+                {
+                    return Some(PatternType::WrongFlag);
+                }
+                return Some(PatternType::FlagTypo);
+            }
+        }
+        return Some(PatternType::FlagTypo);
+    }
+
+    // Looser match: same base command (first 2 tokens), different flags
+    if failed_tokens.len() >= 2
+        && success_tokens.len() >= 2
+        && failed_tokens[..2] == success_tokens[..2]
+    {
+        if failed_tokens.len() < success_tokens.len() {
+            return Some(PatternType::MissingArg);
+        }
+        return Some(PatternType::WrongFlag);
+    }
+
+    None
+}
+
+/// Simple Levenshtein distance implementation.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    let m = a_chars.len();
+    let n = b_chars.len();
+
+    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+
+    for (i, row) in dp.iter_mut().enumerate().take(m + 1) {
+        row[0] = i;
+    }
+    for (j, val) in dp[0].iter_mut().enumerate().take(n + 1) {
+        *val = j;
+    }
+
+    for i in 1..=m {
+        for j in 1..=n {
+            let cost = if a_chars[i - 1] == b_chars[j - 1] {
+                0
+            } else {
+                1
+            };
+            dp[i][j] = (dp[i - 1][j] + 1)
+                .min(dp[i][j - 1] + 1)
+                .min(dp[i - 1][j - 1] + cost);
+        }
+    }
+
+    dp[m][n]
+}
+
+// ============================================================================
+// Error detection
+// ============================================================================
+
+/// Heuristic: does the output content look like a command error?
+///
+/// Checks for common error indicators in command output. Deliberately
+/// excludes "0 failed" which appears in successful test output like
+/// "test result: ok. 5 passed; 0 failed".
+fn looks_like_error(content: &str) -> bool {
+    let lower = content.to_lowercase();
+
+    // Quick exclusion: "0 failed" is a success indicator in test output
+    let has_failed = if lower.contains("failed") {
+        // Only count as error if there's a non-zero count before "failed"
+        !lower.contains("0 failed")
+    } else {
+        false
+    };
+
+    lower.contains("error")
+        || lower.contains("not found")
+        || lower.contains("no such file")
+        || lower.contains("permission denied")
+        || lower.contains("command not found")
+        || has_failed
+        || lower.starts_with("fatal:")
+        || (content.contains("FAILED") && !lower.contains("0 failed"))
+        || content.contains("Exit code")
+}
+
+// ============================================================================
+// TDD cycle detection
+// ============================================================================
+
+/// Check if a sequence of commands represents a TDD cycle.
+///
+/// TDD cycles: same command alternates fail/pass/fail 3+ times.
+/// These should be excluded from correction detection.
+fn is_tdd_cycle(invocations: &[&ToolInvocation], start_idx: usize) -> bool {
+    let cmd = match &invocations[start_idx].input {
+        ToolInput::Bash { command } => command.as_str(),
+        _ => return false,
+    };
+
+    let mut alternations = 0;
+    let mut last_was_error = true; // We start from a failed command
+
+    for inv in invocations.iter().skip(start_idx + 1).take(10) {
+        let inv_cmd = match &inv.input {
+            ToolInput::Bash { command } => command.as_str(),
+            _ => continue,
+        };
+
+        // Must be the same (or very similar) command
+        if normalize_command(inv_cmd) != normalize_command(cmd) {
+            continue;
+        }
+
+        let is_error = inv
+            .result
+            .as_ref()
+            .map(|r| r.is_error || looks_like_error(&r.content))
+            .unwrap_or(false);
+
+        if is_error != last_was_error {
+            alternations += 1;
+            last_was_error = is_error;
+        }
+    }
+
+    alternations >= 2 // fail -> pass -> fail = 2 alternations = TDD cycle
+}
+
+// ============================================================================
+// Deduplication and filtering
+// ============================================================================
+
+/// Merge duplicate correction pairs and apply exclusion filters.
+fn deduplicate_and_filter(corrections: Vec<CorrectionPair>) -> Vec<CorrectionPair> {
+    // Group by (normalized_failed, normalized_success)
+    let mut groups: HashMap<(String, String), CorrectionPair> = HashMap::new();
+
+    for pair in corrections {
+        let key = (
+            normalize_command(&pair.failed_command),
+            normalize_command(&pair.successful_command),
+        );
+        groups
+            .entry(key)
+            .and_modify(|existing| {
+                existing.occurrences += 1;
+                if !existing.sessions.contains(&pair.sessions[0]) {
+                    existing.sessions.extend(pair.sessions.clone());
+                }
+            })
+            .or_insert(pair);
+    }
+
+    groups
+        .into_values()
+        .filter(|pair| {
+            // Minimum 2 occurrences, except for edit distance 1 typos
+            if pair.occurrences < 2 && pair.pattern_type != PatternType::FlagTypo {
+                return false;
+            }
+            // Exclude path-only differences
+            if is_path_only_difference(&pair.failed_command, &pair.successful_command) {
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
+/// Normalize a command for grouping: keep first 3 tokens, replace paths.
+fn normalize_command(cmd: &str) -> String {
+    cmd.split_whitespace().take(3).collect::<Vec<_>>().join(" ")
+}
+
+/// Check if two commands differ only in path arguments.
+fn is_path_only_difference(a: &str, b: &str) -> bool {
+    let a_tokens: Vec<&str> = a.split_whitespace().collect();
+    let b_tokens: Vec<&str> = b.split_whitespace().collect();
+
+    if a_tokens.len() != b_tokens.len() {
+        return false;
+    }
+
+    let diffs: Vec<(&&str, &&str)> = a_tokens
+        .iter()
+        .zip(b_tokens.iter())
+        .filter(|(x, y)| x != y)
+        .collect();
+
+    if diffs.is_empty() {
+        return false; // identical commands -- not a "path-only difference"
+    }
+
+    // All differences are in path-like tokens
+    diffs
+        .iter()
+        .all(|(a_tok, b_tok)| looks_like_path(a_tok) && looks_like_path(b_tok))
+}
+
+fn looks_like_path(s: &str) -> bool {
+    s.contains('/') || s.starts_with("./") || s.starts_with("../")
+}
+
+// ============================================================================
+// Rules file generation
+// ============================================================================
+
+/// Generate the rules file content from correction pairs.
+fn generate_rules_content(corrections: &[CorrectionPair]) -> String {
+    let mut output = String::new();
+    output.push_str("# CLI Corrections\n\n");
+    output
+        .push_str("Generated by `skim learn`. Common CLI mistakes detected in your sessions.\n\n");
+
+    for pair in corrections {
+        output.push_str(&format!(
+            "## {} (seen {} time{})\n\n",
+            pair.pattern_type.label(),
+            pair.occurrences,
+            if pair.occurrences == 1 { "" } else { "s" },
+        ));
+        output.push_str(&format!("Instead of: `{}`\n", pair.failed_command));
+        output.push_str(&format!("Use: `{}`\n\n", pair.successful_command));
+    }
+
+    output
+}
+
+/// Write the rules file to `.claude/rules/cli-corrections.md`.
+fn write_rules_file(content: &str, dry_run: bool) -> anyhow::Result<()> {
+    let rules_dir = std::path::Path::new(".claude").join("rules");
+    let rules_path = rules_dir.join("cli-corrections.md");
+
+    if dry_run {
+        println!("Would write to: {}", rules_path.display());
+        println!("---");
+        print!("{content}");
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&rules_dir)?;
+    std::fs::write(&rules_path, content)?;
+    println!("Wrote corrections to: {}", rules_path.display());
+    Ok(())
+}
+
+// ============================================================================
+// Output
+// ============================================================================
+
+fn print_text_report(corrections: &[CorrectionPair]) {
+    println!(
+        "skim learn -- {} correction{} detected\n",
+        corrections.len(),
+        if corrections.len() == 1 { "" } else { "s" }
+    );
+
+    for (i, pair) in corrections.iter().enumerate() {
+        println!(
+            "{}. {} (seen {} time{})",
+            i + 1,
+            pair.pattern_type.label(),
+            pair.occurrences,
+            if pair.occurrences == 1 { "" } else { "s" },
+        );
+        println!("   Failed:  {}", pair.failed_command);
+        println!("   Correct: {}", pair.successful_command);
+        if !pair.error_output.is_empty() {
+            // Show first line of error output
+            let first_line = pair.error_output.lines().next().unwrap_or("");
+            if !first_line.is_empty() {
+                println!("   Error:   {first_line}");
+            }
+        }
+        println!();
+    }
+
+    println!(
+        "hint: run `skim learn --generate` to write corrections to .claude/rules/cli-corrections.md"
+    );
+}
+
+fn print_json_report(corrections: &[CorrectionPair]) -> anyhow::Result<()> {
+    let report = serde_json::json!({
+        "version": 1,
+        "corrections": corrections.iter().map(|pair| {
+            serde_json::json!({
+                "failed_command": pair.failed_command,
+                "successful_command": pair.successful_command,
+                "error_output": pair.error_output,
+                "pattern_type": format!("{:?}", pair.pattern_type),
+                "occurrences": pair.occurrences,
+                "sessions": pair.sessions,
+            })
+        }).collect::<Vec<_>>(),
+    });
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer_pretty(&mut handle, &report)?;
+    writeln!(handle)?;
+    Ok(())
+}
+
+// ============================================================================
+// Help
+// ============================================================================
+
+fn print_help() {
+    println!("skim learn");
+    println!();
+    println!("  Detect CLI error patterns and generate correction rules");
+    println!();
+    println!("Usage: skim learn [OPTIONS]");
+    println!();
+    println!("Options:");
+    println!("  --since <duration>   Time window (e.g., 24h, 7d, 1w) [default: 7d]");
+    println!("  --generate           Write rules to .claude/rules/cli-corrections.md");
+    println!("  --dry-run            Preview rules without writing (requires --generate)");
+    println!("  --agent <name>       Only scan sessions from a specific agent");
+    println!("  --json               Output machine-readable JSON");
+    println!("  --help, -h           Print help information");
+    println!();
+    println!("Examples:");
+    println!("  skim learn                       Analyze last 7 days, print findings");
+    println!("  skim learn --generate            Write correction rules file");
+    println!("  skim learn --generate --dry-run  Preview without writing");
+    println!("  skim learn --since 30d           Analyze last 30 days");
+}
+
+// ============================================================================
+// Clap command (for completions)
+// ============================================================================
+
+pub(super) fn command() -> clap::Command {
+    clap::Command::new("learn")
+        .about("Detect CLI error patterns and generate correction rules")
+        .arg(
+            clap::Arg::new("since")
+                .long("since")
+                .value_name("DURATION")
+                .help("Time window (e.g., 24h, 7d, 1w)"),
+        )
+        .arg(
+            clap::Arg::new("generate")
+                .long("generate")
+                .action(clap::ArgAction::SetTrue)
+                .help("Write rules file"),
+        )
+        .arg(
+            clap::Arg::new("dry-run")
+                .long("dry-run")
+                .action(clap::ArgAction::SetTrue)
+                .help("Preview without writing"),
+        )
+        .arg(
+            clap::Arg::new("agent")
+                .long("agent")
+                .value_name("NAME")
+                .help("Filter by agent"),
+        )
+        .arg(
+            clap::Arg::new("json")
+                .long("json")
+                .action(clap::ArgAction::SetTrue)
+                .help("JSON output"),
+        )
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::session::types::ToolResult;
+
+    // ---- levenshtein ----
+
+    #[test]
+    fn test_levenshtein_identical() {
+        assert_eq!(levenshtein("cargo", "cargo"), 0);
+    }
+
+    #[test]
+    fn test_levenshtein_one_char() {
+        assert_eq!(levenshtein("carg", "cargo"), 1);
+    }
+
+    #[test]
+    fn test_levenshtein_two_chars() {
+        // "crgo" -> "cargo" is 1 edit (insert 'a'), so test a true distance-2 case
+        assert_eq!(levenshtein("crgo", "cargo"), 1);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("ab", "cd"), 2);
+    }
+
+    #[test]
+    fn test_levenshtein_empty() {
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("", ""), 0);
+    }
+
+    #[test]
+    fn test_levenshtein_completely_different() {
+        assert_eq!(levenshtein("abc", "xyz"), 3);
+    }
+
+    // ---- looks_like_error ----
+
+    #[test]
+    fn test_looks_like_error_positive() {
+        assert!(looks_like_error("error: command not found: carg"));
+        assert!(looks_like_error("bash: carg: command not found"));
+        assert!(looks_like_error("No such file or directory"));
+        assert!(looks_like_error("permission denied"));
+        assert!(looks_like_error("Build FAILED"));
+        assert!(looks_like_error("fatal: not a git repository"));
+        assert!(looks_like_error("Exit code 1"));
+    }
+
+    #[test]
+    fn test_looks_like_error_negative() {
+        // "0 failed" is excluded -- it appears in successful test output
+        assert!(!looks_like_error("test result: ok. 5 passed; 0 failed"));
+        assert!(!looks_like_error("test result: ok. 5 passed; 0 warnings"));
+        assert!(!looks_like_error("Compiling rskim v1.0.0"));
+        assert!(!looks_like_error("Finished dev profile"));
+        assert!(!looks_like_error(""));
+    }
+
+    #[test]
+    fn test_looks_like_error_empty() {
+        assert!(!looks_like_error(""));
+    }
+
+    // ---- classify_correction ----
+
+    #[test]
+    fn test_classify_identical_commands() {
+        assert_eq!(classify_correction("cargo test", "cargo test"), None);
+    }
+
+    #[test]
+    fn test_classify_typo_in_command_name() {
+        let result = classify_correction("carg test", "cargo test");
+        assert_eq!(result, Some(PatternType::FlagTypo));
+    }
+
+    #[test]
+    fn test_classify_missing_separator() {
+        let result = classify_correction("cargo test --nocapture", "cargo test -- --nocapture");
+        assert_eq!(result, Some(PatternType::MissingSeparator));
+    }
+
+    #[test]
+    fn test_classify_wrong_flag() {
+        // "--relase" -> "--release" is a flag correction (both start with -)
+        let result = classify_correction("cargo test --relase", "cargo test --release");
+        assert_eq!(result, Some(PatternType::WrongFlag));
+    }
+
+    #[test]
+    fn test_classify_missing_arg() {
+        // Same first 2 tokens, different length
+        let result = classify_correction("cargo test", "cargo test --package rskim");
+        assert_eq!(result, Some(PatternType::MissingArg));
+    }
+
+    #[test]
+    fn test_classify_completely_different() {
+        assert_eq!(classify_correction("ls", "cargo build"), None);
+    }
+
+    #[test]
+    fn test_classify_empty_commands() {
+        assert_eq!(classify_correction("", "cargo test"), None);
+        assert_eq!(classify_correction("cargo test", ""), None);
+    }
+
+    // ---- normalize_command ----
+
+    #[test]
+    fn test_normalize_command_short() {
+        assert_eq!(normalize_command("ls"), "ls");
+    }
+
+    #[test]
+    fn test_normalize_command_truncates() {
+        assert_eq!(
+            normalize_command("cargo test --package rskim --verbose"),
+            "cargo test --package"
+        );
+    }
+
+    #[test]
+    fn test_normalize_command_preserves_three() {
+        assert_eq!(normalize_command("go test ./..."), "go test ./...");
+    }
+
+    // ---- is_path_only_difference ----
+
+    #[test]
+    fn test_path_only_difference_true() {
+        assert!(is_path_only_difference("cat /tmp/a.rs", "cat /tmp/b.rs"));
+    }
+
+    #[test]
+    fn test_path_only_difference_false_flag() {
+        assert!(!is_path_only_difference(
+            "cargo test --release",
+            "cargo test --debug"
+        ));
+    }
+
+    #[test]
+    fn test_path_only_difference_different_length() {
+        assert!(!is_path_only_difference(
+            "cargo test",
+            "cargo test --verbose"
+        ));
+    }
+
+    #[test]
+    fn test_path_only_difference_identical() {
+        assert!(!is_path_only_difference("cargo test", "cargo test"));
+    }
+
+    // ---- looks_like_path ----
+
+    #[test]
+    fn test_looks_like_path_positive() {
+        assert!(looks_like_path("/tmp/test.rs"));
+        assert!(looks_like_path("./src/main.rs"));
+        assert!(looks_like_path("../test"));
+    }
+
+    #[test]
+    fn test_looks_like_path_negative() {
+        assert!(!looks_like_path("--release"));
+        assert!(!looks_like_path("cargo"));
+    }
+
+    // ---- detect_corrections ----
+
+    fn make_bash_invocation(
+        command: &str,
+        result_content: &str,
+        is_error: bool,
+        session_id: &str,
+    ) -> ToolInvocation {
+        ToolInvocation {
+            tool_name: "Bash".to_string(),
+            input: ToolInput::Bash {
+                command: command.to_string(),
+            },
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            session_id: session_id.to_string(),
+            agent: AgentKind::ClaudeCode,
+            result: Some(ToolResult {
+                content: result_content.to_string(),
+                is_error,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_detect_corrections_basic() {
+        let inv1 =
+            make_bash_invocation("carg test", "error: command not found: carg", true, "sess1");
+        let inv2 = make_bash_invocation("cargo test", "test result: ok. 5 passed", false, "sess1");
+        let invocations = vec![&inv1, &inv2];
+        let corrections = detect_corrections(&invocations);
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].pattern_type, PatternType::FlagTypo);
+        assert_eq!(corrections[0].failed_command, "carg test");
+        assert_eq!(corrections[0].successful_command, "cargo test");
+    }
+
+    #[test]
+    fn test_detect_corrections_no_fix() {
+        let inv1 =
+            make_bash_invocation("carg test", "error: command not found: carg", true, "sess1");
+        let inv2 = make_bash_invocation("ls", "file.rs\nmain.rs", false, "sess1");
+        let invocations = vec![&inv1, &inv2];
+        let corrections = detect_corrections(&invocations);
+        assert!(corrections.is_empty());
+    }
+
+    #[test]
+    fn test_detect_corrections_missing_separator() {
+        let inv1 = make_bash_invocation(
+            "cargo test --nocapture",
+            "error: unexpected argument '--nocapture'",
+            true,
+            "sess1",
+        );
+        let inv2 = make_bash_invocation(
+            "cargo test -- --nocapture",
+            "test result: ok. 5 passed",
+            false,
+            "sess1",
+        );
+        let invocations = vec![&inv1, &inv2];
+        let corrections = detect_corrections(&invocations);
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].pattern_type, PatternType::MissingSeparator);
+    }
+
+    #[test]
+    fn test_detect_corrections_respects_lookahead() {
+        // Create a failed command, then 6 unrelated commands, then the fix.
+        // The fix should NOT be found (lookahead is 5).
+        let failed = make_bash_invocation("carg test", "error: command not found", true, "sess1");
+        let filler = make_bash_invocation("ls", "ok", false, "sess1");
+        let fix = make_bash_invocation("cargo test", "ok. 5 passed", false, "sess1");
+
+        let invocations: Vec<&ToolInvocation> =
+            vec![&failed, &filler, &filler, &filler, &filler, &filler, &fix];
+        let corrections = detect_corrections(&invocations);
+        assert!(corrections.is_empty());
+    }
+
+    // ---- is_tdd_cycle ----
+
+    #[test]
+    fn test_tdd_cycle_detected() {
+        let inv1 = make_bash_invocation(
+            "cargo test --test my_test",
+            "test result: FAILED. 0 passed; 1 failed",
+            true,
+            "sess1",
+        );
+        let inv2 = make_bash_invocation(
+            "cargo test --test my_test",
+            "test result: ok. 1 passed; 0 failed",
+            false,
+            "sess1",
+        );
+        let inv3 = make_bash_invocation(
+            "cargo test --test my_test",
+            "test result: FAILED. 0 passed; 1 failed",
+            true,
+            "sess1",
+        );
+        let inv4 = make_bash_invocation(
+            "cargo test --test my_test",
+            "test result: ok. 1 passed; 0 failed",
+            false,
+            "sess1",
+        );
+
+        let invocations = vec![&inv1, &inv2, &inv3, &inv4];
+        assert!(is_tdd_cycle(&invocations, 0));
+    }
+
+    #[test]
+    fn test_tdd_cycle_not_detected() {
+        // Only one fail -> pass, not enough for TDD
+        let inv1 = make_bash_invocation("cargo test", "FAILED", true, "sess1");
+        let inv2 = make_bash_invocation("cargo test", "ok. 5 passed", false, "sess1");
+
+        let invocations = vec![&inv1, &inv2];
+        assert!(!is_tdd_cycle(&invocations, 0));
+    }
+
+    // ---- deduplicate_and_filter ----
+
+    #[test]
+    fn test_deduplicate_merges_same_pair() {
+        let pair1 = CorrectionPair {
+            failed_command: "carg test".to_string(),
+            successful_command: "cargo test".to_string(),
+            error_output: "error: command not found".to_string(),
+            pattern_type: PatternType::FlagTypo,
+            occurrences: 1,
+            sessions: vec!["sess1".to_string()],
+        };
+        let pair2 = CorrectionPair {
+            failed_command: "carg test".to_string(),
+            successful_command: "cargo test".to_string(),
+            error_output: "error: command not found".to_string(),
+            pattern_type: PatternType::FlagTypo,
+            occurrences: 1,
+            sessions: vec!["sess2".to_string()],
+        };
+
+        let result = deduplicate_and_filter(vec![pair1, pair2]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].occurrences, 2);
+        assert_eq!(result[0].sessions.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_single_occurrence_non_typo() {
+        let pair = CorrectionPair {
+            failed_command: "cargo test --package".to_string(),
+            successful_command: "cargo test --package rskim".to_string(),
+            error_output: "error: requires value".to_string(),
+            pattern_type: PatternType::MissingArg,
+            occurrences: 1,
+            sessions: vec!["sess1".to_string()],
+        };
+
+        let result = deduplicate_and_filter(vec![pair]);
+        assert!(
+            result.is_empty(),
+            "Single-occurrence MissingArg should be filtered"
+        );
+    }
+
+    #[test]
+    fn test_filter_keeps_single_occurrence_typo() {
+        let pair = CorrectionPair {
+            failed_command: "carg test".to_string(),
+            successful_command: "cargo test".to_string(),
+            error_output: "error: not found".to_string(),
+            pattern_type: PatternType::FlagTypo,
+            occurrences: 1,
+            sessions: vec!["sess1".to_string()],
+        };
+
+        let result = deduplicate_and_filter(vec![pair]);
+        assert_eq!(result.len(), 1, "Single-occurrence FlagTypo should be kept");
+    }
+
+    #[test]
+    fn test_filter_excludes_path_only() {
+        let pair = CorrectionPair {
+            failed_command: "cat /tmp/a.rs".to_string(),
+            successful_command: "cat /tmp/b.rs".to_string(),
+            error_output: "no such file".to_string(),
+            pattern_type: PatternType::FlagTypo,
+            occurrences: 1,
+            sessions: vec!["sess1".to_string()],
+        };
+
+        let result = deduplicate_and_filter(vec![pair]);
+        assert!(result.is_empty(), "Path-only difference should be filtered");
+    }
+
+    // ---- generate_rules_content ----
+
+    #[test]
+    fn test_generate_rules_content() {
+        let corrections = vec![CorrectionPair {
+            failed_command: "carg test".to_string(),
+            successful_command: "cargo test".to_string(),
+            error_output: "error".to_string(),
+            pattern_type: PatternType::FlagTypo,
+            occurrences: 3,
+            sessions: vec!["sess1".to_string()],
+        }];
+
+        let content = generate_rules_content(&corrections);
+        assert!(content.contains("# CLI Corrections"));
+        assert!(content.contains("Typo (seen 3 times)"));
+        assert!(content.contains("Instead of: `carg test`"));
+        assert!(content.contains("Use: `cargo test`"));
+    }
+
+    // ---- parse_args ----
+
+    #[test]
+    fn test_parse_args_defaults() {
+        let config = parse_args(&[]).unwrap();
+        assert!(config.since.is_some());
+        assert!(!config.generate);
+        assert!(!config.dry_run);
+        assert!(!config.json_output);
+        assert!(config.agent_filter.is_none());
+    }
+
+    #[test]
+    fn test_parse_args_generate() {
+        let config = parse_args(&["--generate".to_string()]).unwrap();
+        assert!(config.generate);
+    }
+
+    #[test]
+    fn test_parse_args_dry_run() {
+        let config = parse_args(&["--dry-run".to_string()]).unwrap();
+        assert!(config.dry_run);
+    }
+
+    #[test]
+    fn test_parse_args_json() {
+        let config = parse_args(&["--json".to_string()]).unwrap();
+        assert!(config.json_output);
+    }
+
+    #[test]
+    fn test_parse_args_agent() {
+        let config = parse_args(&["--agent".to_string(), "claude-code".to_string()]).unwrap();
+        assert_eq!(config.agent_filter, Some(AgentKind::ClaudeCode));
+    }
+
+    #[test]
+    fn test_parse_args_since() {
+        let config = parse_args(&["--since".to_string(), "30d".to_string()]).unwrap();
+        assert!(config.since.is_some());
+    }
+
+    #[test]
+    fn test_parse_args_unknown_flag() {
+        let result = parse_args(&["--nonexistent".to_string()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("unknown flag"));
+    }
+
+    #[test]
+    fn test_parse_args_unknown_agent() {
+        let result = parse_args(&["--agent".to_string(), "nonexistent".to_string()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("unknown agent"));
+    }
+
+    #[test]
+    fn test_parse_args_since_missing_value() {
+        let result = parse_args(&["--since".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_args_agent_missing_value() {
+        let result = parse_args(&["--agent".to_string()]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -10,6 +10,7 @@ mod completions;
 mod discover;
 mod git;
 mod init;
+mod learn;
 mod rewrite;
 mod session;
 mod test;
@@ -30,6 +31,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "discover",
     "git",
     "init",
+    "learn",
     "rewrite",
     "test",
 ];
@@ -206,6 +208,7 @@ pub(crate) fn dispatch(subcommand: &str, args: &[String]) -> anyhow::Result<Exit
         "completions" => return completions::run(args),
         "discover" => return discover::run(args),
         "git" => return git::run(args),
+        "learn" => return learn::run(args),
         "init" => return init::run(args),
         "rewrite" => return rewrite::run(args),
         "test" => return test::run(args),

--- a/crates/rskim/src/cmd/session/mod.rs
+++ b/crates/rskim/src/cmd/session/mod.rs
@@ -7,7 +7,9 @@
 mod claude;
 pub(crate) mod types;
 
-pub(crate) use types::{AgentKind, SessionFile, TimeFilter, ToolInput, ToolInvocation};
+pub(crate) use types::{
+    parse_duration_ago, AgentKind, SessionFile, TimeFilter, ToolInput, ToolInvocation,
+};
 
 // ============================================================================
 // SessionProvider trait

--- a/crates/rskim/src/cmd/session/types.rs
+++ b/crates/rskim/src/cmd/session/types.rs
@@ -116,8 +116,43 @@ impl ToolInput {
 
 /// Tool execution result.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Fields populated by providers, consumed by analysis and future learn command
+#[allow(dead_code)] // Fields populated by providers, consumed by analysis and learn command
 pub(crate) struct ToolResult {
     pub(crate) content: String,
     pub(crate) is_error: bool,
+}
+
+// ============================================================================
+// Shared duration parsing
+// ============================================================================
+
+/// Parse a human-readable duration string into a `SystemTime` in the past.
+///
+/// Supports: `Nd` (days), `Nh` (hours), `Nw` (weeks).
+///
+/// Shared by `discover` and `learn` subcommands.
+pub(crate) fn parse_duration_ago(s: &str) -> anyhow::Result<SystemTime> {
+    let s = s.trim();
+    let (num_str, unit) = if let Some(stripped) = s.strip_suffix('d') {
+        (stripped, "d")
+    } else if let Some(stripped) = s.strip_suffix('h') {
+        (stripped, "h")
+    } else if let Some(stripped) = s.strip_suffix('w') {
+        (stripped, "w")
+    } else {
+        anyhow::bail!("invalid duration format: '{s}' (expected Nd, Nh, or Nw)");
+    };
+
+    let num: u64 = num_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid number in duration: '{s}'"))?;
+
+    let secs = match unit {
+        "h" => num * 3600,
+        "d" => num * 86400,
+        "w" => num * 7 * 86400,
+        _ => unreachable!(),
+    };
+
+    Ok(SystemTime::now() - std::time::Duration::from_secs(secs))
 }

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -77,7 +77,9 @@ fn test_rewrite_npx_vitest_with_args() {
         .args(["rewrite", "npx", "vitest", "--reporter=json", "--run"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim test vitest --reporter=json --run"));
+        .stdout(predicate::str::contains(
+            "skim test vitest --reporter=json --run",
+        ));
 }
 
 #[test]
@@ -153,7 +155,9 @@ fn test_rewrite_cargo_clippy_with_args() {
         .args(["rewrite", "cargo", "clippy", "--", "-W", "clippy::pedantic"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim build clippy -- -W clippy::pedantic"));
+        .stdout(predicate::str::contains(
+            "skim build clippy -- -W clippy::pedantic",
+        ));
 }
 
 // ============================================================================
@@ -164,7 +168,15 @@ fn test_rewrite_cargo_clippy_with_args() {
 fn test_rewrite_three_segment_compound() {
     skim_cmd()
         .args([
-            "rewrite", "--suggest", "cargo", "test", "&&", "cargo", "build", "&&", "cargo",
+            "rewrite",
+            "--suggest",
+            "cargo",
+            "test",
+            "&&",
+            "cargo",
+            "build",
+            "&&",
+            "cargo",
             "clippy",
         ])
         .assert()

--- a/crates/rskim/tests/cli_learn.rs
+++ b/crates/rskim/tests/cli_learn.rs
@@ -1,0 +1,224 @@
+//! Integration tests for `skim learn` subcommand (#64).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn skim_cmd() -> Command {
+    Command::cargo_bin("skim").unwrap()
+}
+
+#[test]
+fn test_learn_help() {
+    skim_cmd()
+        .args(["learn", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skim learn"))
+        .stdout(predicate::str::contains("--generate"));
+}
+
+#[test]
+fn test_learn_with_error_patterns() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_errors.jsonl");
+    std::fs::write(project_dir.join("error-session.jsonl"), fixture).unwrap();
+
+    skim_cmd()
+        .args(["learn", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("correction"));
+}
+
+#[test]
+fn test_learn_json_output() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_errors.jsonl");
+    std::fs::write(project_dir.join("error-session.jsonl"), fixture).unwrap();
+
+    skim_cmd()
+        .args(["learn", "--since", "7d", "--json"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"version\":"));
+}
+
+#[test]
+fn test_learn_dry_run() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_errors.jsonl");
+    std::fs::write(project_dir.join("error-session.jsonl"), fixture).unwrap();
+
+    skim_cmd()
+        .args(["learn", "--generate", "--dry-run", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Would write to:"));
+}
+
+#[test]
+fn test_learn_generate_writes_file() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_errors.jsonl");
+    std::fs::write(project_dir.join("error-session.jsonl"), fixture).unwrap();
+
+    // Use a temp working dir for the rules file
+    let work_dir = TempDir::new().unwrap();
+
+    skim_cmd()
+        .args(["learn", "--generate", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .current_dir(work_dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote corrections to:"));
+
+    // Verify the file was created
+    let rules_file = work_dir.path().join(".claude/rules/cli-corrections.md");
+    assert!(rules_file.exists(), "Rules file should be created");
+    let content = std::fs::read_to_string(&rules_file).unwrap();
+    assert!(content.contains("CLI Corrections"), "Should have header");
+}
+
+#[test]
+fn test_learn_empty_session() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    std::fs::write(project_dir.join("empty.jsonl"), "").unwrap();
+
+    skim_cmd()
+        .args(["learn", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_learn_no_sessions() {
+    let dir = TempDir::new().unwrap();
+    skim_cmd()
+        .args(["learn"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_learn_unknown_flag() {
+    skim_cmd()
+        .args(["learn", "--nonexistent"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_learn_tdd_cycle_excluded() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_tdd.jsonl");
+    std::fs::write(project_dir.join("tdd-session.jsonl"), fixture).unwrap();
+
+    // TDD cycle should not produce corrections
+    skim_cmd()
+        .args(["learn", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No CLI error patterns detected"));
+}
+
+#[test]
+fn test_learn_json_has_structure() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_errors.jsonl");
+    std::fs::write(project_dir.join("error-session.jsonl"), fixture).unwrap();
+
+    let output = skim_cmd()
+        .args(["learn", "--since", "7d", "--json"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["version"], 1);
+    assert!(json["corrections"].is_array());
+    let corrections = json["corrections"].as_array().unwrap();
+    assert!(!corrections.is_empty());
+    assert!(corrections[0]["failed_command"].is_string());
+    assert!(corrections[0]["successful_command"].is_string());
+    assert!(corrections[0]["pattern_type"].is_string());
+}
+
+#[test]
+fn test_learn_invalid_since() {
+    skim_cmd()
+        .args(["learn", "--since", "abc"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_learn_unknown_agent_error() {
+    skim_cmd()
+        .args(["learn", "--agent", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown agent"));
+}
+
+#[test]
+fn test_learn_agent_filter() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let fixture = include_str!("fixtures/cmd/session/session_errors.jsonl");
+    std::fs::write(project_dir.join("error-session.jsonl"), fixture).unwrap();
+
+    skim_cmd()
+        .args(["learn", "--agent", "claude-code", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_learn_no_bash_commands() {
+    let dir = TempDir::new().unwrap();
+    let project_dir = dir.path().join("test-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    // Use a session with only Read invocations (no Bash)
+    let fixture = include_str!("fixtures/cmd/session/claude_reads.jsonl");
+    std::fs::write(project_dir.join("read-session.jsonl"), fixture).unwrap();
+
+    skim_cmd()
+        .args(["learn", "--since", "7d"])
+        .env("SKIM_PROJECTS_DIR", dir.path().to_str().unwrap())
+        .assert()
+        .success();
+}

--- a/crates/rskim/tests/fixtures/cmd/session/session_errors.jsonl
+++ b/crates/rskim/tests/fixtures/cmd/session/session_errors.jsonl
@@ -1,0 +1,8 @@
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"carg test","description":"Run tests"}}]},"timestamp":"2024-01-01T00:00:00Z","sessionId":"error-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_01","type":"tool_result","content":"error: command not found: carg","is_error":true}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_02","name":"Bash","input":{"command":"cargo test","description":"Run tests"}}]},"timestamp":"2024-01-01T00:01:00Z","sessionId":"error-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_02","type":"tool_result","content":"test result: ok. 5 passed; 0 failed"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_03","name":"Bash","input":{"command":"cargo test --nocapture","description":"Run tests with output"}}]},"timestamp":"2024-01-01T00:02:00Z","sessionId":"error-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_03","type":"tool_result","content":"error: unexpected argument '--nocapture'","is_error":true}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_04","name":"Bash","input":{"command":"cargo test -- --nocapture","description":"Run tests with output"}}]},"timestamp":"2024-01-01T00:03:00Z","sessionId":"error-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_04","type":"tool_result","content":"test result: ok. 5 passed; 0 failed"}]}}

--- a/crates/rskim/tests/fixtures/cmd/session/session_tdd.jsonl
+++ b/crates/rskim/tests/fixtures/cmd/session/session_tdd.jsonl
@@ -1,0 +1,8 @@
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"cargo test --test my_test","description":"Run test"}}]},"timestamp":"2024-01-01T00:00:00Z","sessionId":"tdd-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_01","type":"tool_result","content":"test result: FAILED. 0 passed; 1 failed","is_error":true}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_02","name":"Bash","input":{"command":"cargo test --test my_test","description":"Run test"}}]},"timestamp":"2024-01-01T00:01:00Z","sessionId":"tdd-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_02","type":"tool_result","content":"test result: ok. 1 passed; 0 failed"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_03","name":"Bash","input":{"command":"cargo test --test my_test","description":"Run test"}}]},"timestamp":"2024-01-01T00:02:00Z","sessionId":"tdd-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_03","type":"tool_result","content":"test result: FAILED. 0 passed; 1 failed","is_error":true}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_04","name":"Bash","input":{"command":"cargo test --test my_test","description":"Run test"}}]},"timestamp":"2024-01-01T00:03:00Z","sessionId":"tdd-session"}
+{"type":"user","message":{"content":[{"tool_use_id":"toolu_04","type":"tool_result","content":"test result: ok. 1 passed; 0 failed"}]}}


### PR DESCRIPTION
## Summary

- Adds `skim learn` command that scans AI agent session files for CLI error-retry patterns (failed command followed by a corrected version within next 5 Bash invocations)
- Detects and classifies correction patterns: typos, missing separators, wrong flags, missing arguments
- Optionally generates `.claude/rules/cli-corrections.md` rules file with `--generate` flag
- Refactors `parse_duration_ago` from `discover.rs` into `session/types.rs` as shared `pub(crate)` utility

## Changes

### New files
- `crates/rskim/src/cmd/learn.rs` — Full learn command implementation (pattern detection, dedup, filtering, output)
- `crates/rskim/tests/cli_learn.rs` — 14 integration tests
- `crates/rskim/tests/fixtures/cmd/session/session_errors.jsonl` — Error correction fixture
- `crates/rskim/tests/fixtures/cmd/session/session_tdd.jsonl` — TDD cycle fixture

### Modified files
- `crates/rskim/src/cmd/mod.rs` — Register learn subcommand
- `crates/rskim/src/cmd/completions.rs` — Add learn to shell completions
- `crates/rskim/src/cmd/session/types.rs` — Add shared `parse_duration_ago`
- `crates/rskim/src/cmd/session/mod.rs` — Re-export `parse_duration_ago`
- `crates/rskim/src/cmd/discover.rs` — Use shared `parse_duration_ago`

### Key algorithms
- Levenshtein distance for command similarity
- Token-based classification (FlagTypo, MissingSeparator, WrongFlag, MissingArg)
- TDD cycle detection (fail/pass alternation >= 2) to avoid false positives
- Smart error heuristic that excludes "0 failed" from test success output

## Test plan

- [x] 45 unit tests covering all internal functions (levenshtein, classify_correction, looks_like_error, is_tdd_cycle, detect_corrections, deduplicate_and_filter, parse_args, etc.)
- [x] 14 integration tests covering help, error patterns, JSON output, dry-run, generate, TDD exclusion, empty sessions, unknown flags/agents
- [x] All 1,212 tests pass (up from 1,153 baseline)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `skim learn --help` produces expected output