### PR TITLE
feat(#116): Wave A — Router fix + Lint extensions (prettier, rustfmt) + skim infra (gh, aws, curl, wget)

### DIFF
--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -41,6 +41,7 @@ pub(crate) enum CommandType {
     Git,
     Lint,
     Pkg,
+    Infra,
 }
 
 impl CommandType {
@@ -52,6 +53,7 @@ impl CommandType {
             CommandType::Git => "git",
             CommandType::Lint => "lint",
             CommandType::Pkg => "pkg",
+            CommandType::Infra => "infra",
         }
     }
 }

--- a/crates/rskim/src/cmd/discover.rs
+++ b/crates/rskim/src/cmd/discover.rs
@@ -236,11 +236,23 @@ fn check_has_rewrite(tokens: &[&str]) -> bool {
             Some("test" | "nextest" | "clippy" | "build")
         ),
         "pytest" | "python" | "python3" => true,
-        "npx" => matches!(tokens.get(1).copied(), Some("vitest" | "jest" | "tsc")),
+        "npx" => matches!(
+            tokens.get(1).copied(),
+            Some("vitest" | "jest" | "tsc" | "prettier")
+        ),
         "vitest" | "jest" => true,
         "go" => tokens.get(1) == Some(&"test"),
         "git" => matches!(tokens.get(1).copied(), Some("status" | "diff" | "log")),
         "tsc" => true,
+        "prettier" => true,
+        "rustfmt" => true,
+        "gh" => matches!(
+            tokens.get(1).copied(),
+            Some("pr" | "issue" | "run" | "release")
+        ),
+        "aws" => true,
+        "curl" => true,
+        "wget" => true,
         "cat" | "head" | "tail" => {
             // Only rewritable if operating on code files
             tokens
@@ -269,9 +281,19 @@ fn get_rewrite_target(tokens: &[&str]) -> Option<String> {
             Some("skim test vitest".to_string())
         }
         "npx" if tokens.get(1) == Some(&"tsc") => Some("skim build tsc".to_string()),
+        "npx" if tokens.get(1) == Some(&"prettier") => Some("skim lint prettier".to_string()),
         "go" if tokens.get(1) == Some(&"test") => Some("skim test go".to_string()),
         "git" => Some(format!("skim git {}", tokens.get(1).unwrap_or(&""))),
         "tsc" => Some("skim build tsc".to_string()),
+        "prettier" => Some("skim lint prettier".to_string()),
+        "rustfmt" => Some("skim lint rustfmt".to_string()),
+        "gh" => Some(format!(
+            "skim infra gh {}",
+            tokens.get(1).unwrap_or(&"")
+        )),
+        "aws" => Some("skim infra aws".to_string()),
+        "curl" => Some("skim infra curl".to_string()),
+        "wget" => Some("skim infra wget".to_string()),
         "cat" | "head" | "tail" => Some("skim <file> --mode=pseudo".to_string()),
         _ => None,
     }

--- a/crates/rskim/src/cmd/infra/aws.rs
+++ b/crates/rskim/src/cmd/infra/aws.rs
@@ -1,0 +1,293 @@
+//! AWS CLI parser with three-tier degradation (#116).
+//!
+//! Executes `aws` and parses the output into structured `InfraResult`.
+//!
+//! Three tiers:
+//! - **Tier 1 (Full)**: JSON parsing (inject `--output json` for most commands)
+//! - **Tier 2 (Degraded)**: Regex on text/table formatted output
+//! - **Tier 3 (Passthrough)**: Raw stdout+stderr concatenation
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::cmd::user_has_flag;
+use crate::output::canonical::{InfraItem, InfraResult};
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+use super::{combine_stdout_stderr, run_infra_tool, InfraToolConfig};
+
+const CONFIG: InfraToolConfig<'static> = InfraToolConfig {
+    program: "aws",
+    env_overrides: &[],
+    install_hint: "Install AWS CLI: https://aws.amazon.com/cli/",
+};
+
+/// Keys stripped from AWS JSON responses (metadata, not useful data).
+const METADATA_KEYS: &[&str] = &["ResponseMetadata", "NextToken", "RequestId"];
+
+static RE_AWS_TABLE_ROW: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\|\s+(\S[^|]+\S)\s+\|").unwrap());
+
+/// Run `skim infra aws [args...]`.
+pub(crate) fn run(
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+) -> anyhow::Result<std::process::ExitCode> {
+    run_infra_tool(CONFIG, args, show_stats, json_output, prepare_args, parse_impl)
+}
+
+/// Inject `--output json` if not already present and subcommand supports it.
+fn prepare_args(cmd_args: &mut Vec<String>) {
+    if user_has_flag(cmd_args, &["--output"]) {
+        return;
+    }
+
+    // Skip flag injection for s3 subcommands — they have different output semantics
+    if cmd_args.first().map(|s| s.as_str()) == Some("s3") {
+        return;
+    }
+
+    cmd_args.push("--output".to_string());
+    cmd_args.push("json".to_string());
+}
+
+/// Three-tier parse function for aws output.
+fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
+    if let Some(result) = try_parse_json(&output.stdout) {
+        return ParseResult::Full(result);
+    }
+
+    let combined = combine_stdout_stderr(output);
+
+    if let Some(result) = try_parse_table(&combined) {
+        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+    }
+
+    ParseResult::Passthrough(combined.into_owned())
+}
+
+// ============================================================================
+// Tier 1: JSON parsing
+// ============================================================================
+
+/// Parse AWS JSON output, stripping metadata keys and summarizing results.
+fn try_parse_json(stdout: &str) -> Option<InfraResult> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() || (!trimmed.starts_with('{') && !trimmed.starts_with('[')) {
+        return None;
+    }
+
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+
+    match &value {
+        serde_json::Value::Array(arr) => {
+            let count = arr.len();
+            let items = extract_array_items(arr);
+            let summary = format!("{count} item{}", if count == 1 { "" } else { "s" });
+            return Some(InfraResult::new(
+                "aws".to_string(),
+                "result".to_string(),
+                summary,
+                items,
+            ));
+        }
+        serde_json::Value::Object(map) => {
+            // Find the primary data key (skip metadata keys)
+            let data_key = map
+                .keys()
+                .find(|k| !METADATA_KEYS.contains(&k.as_str()))?;
+
+            let data = &map[data_key];
+            let (count, items) = match data {
+                serde_json::Value::Array(arr) => {
+                    let count = arr.len();
+                    (count, extract_array_items(arr))
+                }
+                _ => {
+                    let summary_val = data
+                        .as_str()
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| data.to_string());
+                    let items = vec![InfraItem {
+                        label: data_key.clone(),
+                        value: summary_val,
+                    }];
+                    (1, items)
+                }
+            };
+
+            let summary = format!("{count} item{}", if count == 1 { "" } else { "s" });
+            return Some(InfraResult::new(
+                "aws".to_string(),
+                data_key.clone(),
+                summary,
+                items,
+            ));
+        }
+        _ => {}
+    }
+
+    None
+}
+
+/// Extract display items from a JSON array.
+fn extract_array_items(arr: &[serde_json::Value]) -> Vec<InfraItem> {
+    arr.iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            // Try to find a meaningful identifier (Name, Id, Arn, etc.)
+            let label = find_identifier(entry).unwrap_or_else(|| format!("item-{}", i + 1));
+            let value = summarize_object(entry);
+            InfraItem { label, value }
+        })
+        .collect()
+}
+
+/// Find a meaningful identifier in a JSON object.
+fn find_identifier(value: &serde_json::Value) -> Option<String> {
+    let obj = value.as_object()?;
+    for key in &["Name", "Id", "Arn", "InstanceId", "BucketName"] {
+        if let Some(v) = obj.get(*key).and_then(|v| v.as_str()) {
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+/// Summarize a JSON object into a brief human-readable string.
+fn summarize_object(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Object(map) => {
+            // Take up to 3 key-value pairs for the summary
+            map.iter()
+                .filter(|(k, _)| !METADATA_KEYS.contains(&k.as_str()))
+                .take(3)
+                .map(|(k, v)| {
+                    let v_str = v.as_str().map(|s| s.to_string()).unwrap_or_else(|| {
+                        v.as_u64()
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|| v.to_string())
+                    });
+                    format!("{k}: {v_str}")
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+// ============================================================================
+// Tier 2: table format fallback
+// ============================================================================
+
+/// Parse AWS table/text formatted output via regex.
+fn try_parse_table(text: &str) -> Option<InfraResult> {
+    let mut items: Vec<InfraItem> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for line in text.lines() {
+        // AWS table format: | value1  | value2 |
+        if line.trim_start().starts_with('|') {
+            for caps in RE_AWS_TABLE_ROW.captures_iter(line) {
+                let cell = caps[1].trim().to_string();
+                // Skip header-like rows and separators
+                if cell.chars().all(|c| c == '-' || c == '+') {
+                    continue;
+                }
+                if seen.insert(cell.clone()) && !cell.is_empty() {
+                    items.push(InfraItem {
+                        label: format!("item-{}", items.len() + 1),
+                        value: cell,
+                    });
+                }
+            }
+        }
+    }
+
+    if items.is_empty() {
+        return None;
+    }
+
+    let count = items.len();
+    let summary = format!("{count} item{}", if count == 1 { "" } else { "s" });
+    Some(InfraResult::new("aws".to_string(), "result".to_string(), summary, items))
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/fixtures/cmd/infra");
+        path.push(name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to load fixture '{name}': {e}"))
+    }
+
+    #[test]
+    fn test_tier1_aws_s3_ls() {
+        let input = load_fixture("aws_s3_ls.json");
+        let result = try_parse_json(&input);
+        assert!(result.is_some(), "Expected Tier 1 JSON parse to succeed");
+        let result = result.unwrap();
+        assert!(result.as_ref().contains("INFRA: aws"));
+        assert!(!result.items.is_empty());
+    }
+
+    #[test]
+    fn test_tier1_aws_ec2_describe() {
+        let input = load_fixture("aws_ec2_describe.json");
+        let result = try_parse_json(&input);
+        assert!(result.is_some(), "Expected Tier 1 JSON parse to succeed");
+    }
+
+    #[test]
+    fn test_tier2_aws_regex() {
+        let input = "| i-0abc123  | t3.micro  | running |\n| i-0def456  | t3.small  | stopped |";
+        let result = try_parse_table(input);
+        assert!(result.is_some(), "Expected Tier 2 regex parse to succeed");
+    }
+
+    #[test]
+    fn test_parse_impl_produces_full() {
+        let input = load_fixture("aws_s3_ls.json");
+        let output = CommandOutput {
+            stdout: input,
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full parse result, got {}",
+            result.tier_name()
+        );
+    }
+
+    #[test]
+    fn test_parse_impl_garbage_produces_passthrough() {
+        let output = CommandOutput {
+            stdout: "An error occurred: Access Denied".to_string(),
+            stderr: String::new(),
+            exit_code: Some(255),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_passthrough(),
+            "Expected Passthrough, got {}",
+            result.tier_name()
+        );
+    }
+}

--- a/crates/rskim/src/cmd/infra/curl.rs
+++ b/crates/rskim/src/cmd/infra/curl.rs
@@ -1,0 +1,263 @@
+//! curl parser with three-tier degradation (#116).
+//!
+//! Executes `curl` and parses the output into structured `InfraResult`.
+//!
+//! Three tiers:
+//! - **Tier 1 (Full)**: Detect JSON body in output and parse it
+//! - **Tier 2 (Degraded)**: Strip verbose lines, extract HTTP status
+//! - **Tier 3 (Passthrough)**: Raw stdout+stderr concatenation
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::output::canonical::{InfraItem, InfraResult};
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+use super::{combine_stdout_stderr, run_infra_tool, InfraToolConfig};
+
+const CONFIG: InfraToolConfig<'static> = InfraToolConfig {
+    program: "curl",
+    env_overrides: &[],
+    install_hint: "Install curl: https://curl.se/",
+};
+
+static RE_HTTP_STATUS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^< HTTP/[\d.]+ (\d{3})\s*(.*)").unwrap());
+
+static RE_VERBOSE_LINE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[*><{}\s]").unwrap());
+
+/// Run `skim infra curl [args...]`.
+pub(crate) fn run(
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+) -> anyhow::Result<std::process::ExitCode> {
+    // No flag injection for curl — flags are too varied
+    run_infra_tool(CONFIG, args, show_stats, json_output, |_| {}, parse_impl)
+}
+
+/// Three-tier parse function for curl output.
+fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
+    // Check stderr for HTTP status (curl -v outputs headers to stderr)
+    let http_status = extract_http_status(&output.stderr);
+
+    if let Some(result) = try_parse_json_body(&output.stdout, http_status.as_deref()) {
+        return ParseResult::Full(result);
+    }
+
+    let combined = combine_stdout_stderr(output);
+
+    if let Some(result) = try_parse_verbose(&combined) {
+        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+    }
+
+    ParseResult::Passthrough(combined.into_owned())
+}
+
+// ============================================================================
+// Tier 1: JSON body detection
+// ============================================================================
+
+/// Parse JSON body from curl response and summarize.
+fn try_parse_json_body(
+    stdout: &str,
+    http_status: Option<&str>,
+) -> Option<InfraResult> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let json_val: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+
+    let mut items: Vec<InfraItem> = Vec::new();
+
+    // Add HTTP status if available
+    if let Some(status) = http_status {
+        items.push(InfraItem {
+            label: "status".to_string(),
+            value: status.to_string(),
+        });
+    }
+
+    let (key_count, summary_str) = match &json_val {
+        serde_json::Value::Array(arr) => {
+            let count = arr.len();
+            items.push(InfraItem {
+                label: "count".to_string(),
+                value: count.to_string(),
+            });
+            (count, format!("array with {count} element{}", if count == 1 { "" } else { "s" }))
+        }
+        serde_json::Value::Object(map) => {
+            let count = map.len();
+            // Add top-level fields as items (up to 5)
+            for (k, v) in map.iter().take(5) {
+                let v_str = v.as_str().map(|s| s.to_string()).unwrap_or_else(|| {
+                    v.as_u64()
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|| v.to_string())
+                });
+                items.push(InfraItem {
+                    label: k.clone(),
+                    value: v_str,
+                });
+            }
+            (count, format!("object with {count} key{}", if count == 1 { "" } else { "s" }))
+        }
+        _ => return None,
+    };
+
+    let _ = key_count; // suppress unused warning
+    Some(InfraResult::new(
+        "curl".to_string(),
+        "response".to_string(),
+        summary_str,
+        items,
+    ))
+}
+
+// ============================================================================
+// Tier 2: verbose output fallback
+// ============================================================================
+
+/// Extract HTTP status line from curl verbose stderr output.
+fn extract_http_status(stderr: &str) -> Option<String> {
+    for line in stderr.lines() {
+        if let Some(caps) = RE_HTTP_STATUS.captures(line) {
+            let code = &caps[1];
+            let reason = caps[2].trim();
+            return Some(if reason.is_empty() {
+                code.to_string()
+            } else {
+                format!("{code} {reason}")
+            });
+        }
+    }
+    None
+}
+
+/// Parse curl verbose output by extracting non-verbose lines.
+fn try_parse_verbose(text: &str) -> Option<InfraResult> {
+    let mut items: Vec<InfraItem> = Vec::new();
+
+    // Extract HTTP status
+    for line in text.lines() {
+        if let Some(caps) = RE_HTTP_STATUS.captures(line) {
+            items.push(InfraItem {
+                label: "status".to_string(),
+                value: format!("{} {}", &caps[1], caps[2].trim()),
+            });
+        }
+    }
+
+    // Extract body lines (non-verbose, non-header lines)
+    let body_lines: Vec<&str> = text
+        .lines()
+        .filter(|line| !RE_VERBOSE_LINE.is_match(line) && !line.is_empty())
+        .take(3)
+        .collect();
+
+    if !body_lines.is_empty() {
+        items.push(InfraItem {
+            label: "body_preview".to_string(),
+            value: body_lines.join(" ").chars().take(200).collect(),
+        });
+    }
+
+    if items.is_empty() {
+        return None;
+    }
+
+    let summary = items
+        .iter()
+        .find(|i| i.label == "status")
+        .map(|i| i.value.clone())
+        .unwrap_or_else(|| "response received".to_string());
+
+    Some(InfraResult::new(
+        "curl".to_string(),
+        "response".to_string(),
+        summary,
+        items,
+    ))
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/fixtures/cmd/infra");
+        path.push(name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to load fixture '{name}': {e}"))
+    }
+
+    #[test]
+    fn test_tier1_curl_json_response() {
+        let input = load_fixture("curl_json_response.txt");
+        let result = try_parse_json_body(&input, Some("200 OK"));
+        assert!(result.is_some(), "Expected Tier 1 JSON parse to succeed");
+        let result = result.unwrap();
+        assert!(result.as_ref().contains("INFRA: curl response"));
+    }
+
+    #[test]
+    fn test_tier1_curl_non_json_fails() {
+        let result = try_parse_json_body("not json at all", None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_tier2_curl_regex() {
+        let input = load_fixture("curl_verbose.txt");
+        let result = try_parse_verbose(&input);
+        assert!(result.is_some(), "Expected Tier 2 parse to succeed");
+        let result = result.unwrap();
+        assert!(result.items.iter().any(|i| i.label == "status"));
+    }
+
+    #[test]
+    fn test_parse_impl_produces_full() {
+        let input = load_fixture("curl_json_response.txt");
+        let output = CommandOutput {
+            stdout: input,
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full parse result, got {}",
+            result.tier_name()
+        );
+    }
+
+    #[test]
+    fn test_parse_impl_garbage_produces_passthrough() {
+        // Output with no JSON and no HTTP status lines falls through to passthrough
+        // (empty stdout, empty stderr, non-zero exit)
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: Some(7),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_passthrough(),
+            "Expected Passthrough, got {}",
+            result.tier_name()
+        );
+    }
+}

--- a/crates/rskim/src/cmd/infra/gh.rs
+++ b/crates/rskim/src/cmd/infra/gh.rs
@@ -1,0 +1,236 @@
+//! GitHub CLI (`gh`) parser with three-tier degradation (#116).
+//!
+//! Executes `gh` and parses the output into structured `InfraResult`.
+//!
+//! Three tiers:
+//! - **Tier 1 (Full)**: JSON parsing (inject `--json` for list commands)
+//! - **Tier 2 (Degraded)**: Regex on tabular text output
+//! - **Tier 3 (Passthrough)**: Raw stdout+stderr concatenation
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::cmd::user_has_flag;
+use crate::output::canonical::{InfraItem, InfraResult};
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+use super::{combine_stdout_stderr, run_infra_tool, InfraToolConfig};
+
+const CONFIG: InfraToolConfig<'static> = InfraToolConfig {
+    program: "gh",
+    env_overrides: &[],
+    install_hint: "Install gh: https://cli.github.com/",
+};
+
+static RE_GH_TAB_ROW: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d+)\t(.+)").unwrap());
+
+/// Run `skim infra gh [args...]`.
+pub(crate) fn run(
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+) -> anyhow::Result<std::process::ExitCode> {
+    run_infra_tool(CONFIG, args, show_stats, json_output, prepare_args, parse_impl)
+}
+
+/// Inject `--json` fields for list commands if not already present.
+fn prepare_args(cmd_args: &mut Vec<String>) {
+    if user_has_flag(cmd_args, &["--json"]) {
+        return;
+    }
+
+    // Detect subcommand pattern: gh pr list, gh issue list, gh run list
+    let subcmd = cmd_args.first().map(|s| s.as_str()).unwrap_or("");
+    let action = cmd_args.get(1).map(|s| s.as_str()).unwrap_or("");
+
+    match (subcmd, action) {
+        ("pr", "list") => {
+            cmd_args.push("--json".to_string());
+            cmd_args.push("number,title,state,author".to_string());
+        }
+        ("issue", "list") => {
+            cmd_args.push("--json".to_string());
+            cmd_args.push("number,title,state,labels".to_string());
+        }
+        ("run", "list") => {
+            cmd_args.push("--json".to_string());
+            cmd_args.push("databaseId,displayTitle,status,conclusion".to_string());
+        }
+        // release list and other commands: no injection
+        _ => {}
+    }
+}
+
+/// Three-tier parse function for gh output.
+fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
+    if let Some(result) = try_parse_json(&output.stdout) {
+        return ParseResult::Full(result);
+    }
+
+    let combined = combine_stdout_stderr(output);
+
+    if let Some(result) = try_parse_regex(&combined) {
+        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+    }
+
+    ParseResult::Passthrough(combined.into_owned())
+}
+
+// ============================================================================
+// Tier 1: JSON parsing
+// ============================================================================
+
+/// Parse gh JSON array output.
+fn try_parse_json(stdout: &str) -> Option<InfraResult> {
+    let trimmed = stdout.trim();
+    if !trimmed.starts_with('[') {
+        return None;
+    }
+
+    let arr: Vec<serde_json::Value> = serde_json::from_str(trimmed).ok()?;
+    let count = arr.len();
+
+    let items: Vec<InfraItem> = arr
+        .into_iter()
+        .map(|entry| {
+            let label = entry
+                .get("number")
+                .and_then(|v| v.as_u64())
+                .or_else(|| entry.get("databaseId").and_then(|v| v.as_u64()))
+                .map(|n| format!("#{n}"))
+                .unwrap_or_else(|| "item".to_string());
+
+            let title = entry
+                .get("title")
+                .and_then(|v| v.as_str())
+                .or_else(|| entry.get("displayTitle").and_then(|v| v.as_str()))
+                .unwrap_or("")
+                .to_string();
+
+            let state = entry
+                .get("state")
+                .and_then(|v| v.as_str())
+                .or_else(|| entry.get("status").and_then(|v| v.as_str()))
+                .unwrap_or("")
+                .to_lowercase();
+
+            let value = if state.is_empty() {
+                title
+            } else {
+                format!("{title} ({state})")
+            };
+
+            InfraItem { label, value }
+        })
+        .collect();
+
+    let summary = format!("{count} item{}", if count == 1 { "" } else { "s" });
+    Some(InfraResult::new("gh".to_string(), "list".to_string(), summary, items))
+}
+
+// ============================================================================
+// Tier 2: regex fallback
+// ============================================================================
+
+/// Parse tab-separated gh text output.
+fn try_parse_regex(text: &str) -> Option<InfraResult> {
+    let mut items: Vec<InfraItem> = Vec::new();
+
+    for line in text.lines() {
+        if let Some(caps) = RE_GH_TAB_ROW.captures(line) {
+            let num = caps[1].to_string();
+            let rest = caps[2].trim().to_string();
+            items.push(InfraItem {
+                label: format!("#{num}"),
+                value: rest,
+            });
+        }
+    }
+
+    if items.is_empty() {
+        return None;
+    }
+
+    let count = items.len();
+    let summary = format!("{count} item{}", if count == 1 { "" } else { "s" });
+    Some(InfraResult::new("gh".to_string(), "list".to_string(), summary, items))
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/fixtures/cmd/infra");
+        path.push(name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to load fixture '{name}': {e}"))
+    }
+
+    #[test]
+    fn test_tier1_gh_pass() {
+        let input = load_fixture("gh_pr_list.json");
+        let result = try_parse_json(&input);
+        assert!(result.is_some(), "Expected Tier 1 JSON parse to succeed");
+        let result = result.unwrap();
+        assert!(result.as_ref().contains("INFRA: gh list"));
+        assert_eq!(result.items.len(), 3);
+    }
+
+    #[test]
+    fn test_tier1_gh_fail_non_json() {
+        let result = try_parse_json("not json");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_tier2_gh_regex() {
+        let input = load_fixture("gh_pr_list_text.txt");
+        let result = try_parse_regex(&input);
+        assert!(result.is_some(), "Expected Tier 2 regex parse to succeed");
+        let result = result.unwrap();
+        assert_eq!(result.items.len(), 3);
+        assert!(result.items.iter().any(|i| i.label == "#42"));
+    }
+
+    #[test]
+    fn test_parse_impl_produces_full() {
+        let input = load_fixture("gh_pr_list.json");
+        let output = CommandOutput {
+            stdout: input,
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full parse result, got {}",
+            result.tier_name()
+        );
+    }
+
+    #[test]
+    fn test_parse_impl_garbage_produces_passthrough() {
+        let output = CommandOutput {
+            stdout: "completely unparseable output\nno json, no regex match".to_string(),
+            stderr: String::new(),
+            exit_code: Some(1),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_passthrough(),
+            "Expected Passthrough, got {}",
+            result.tier_name()
+        );
+    }
+}

--- a/crates/rskim/src/cmd/infra/mod.rs
+++ b/crates/rskim/src/cmd/infra/mod.rs
@@ -1,0 +1,183 @@
+//! Infrastructure tool subcommand dispatcher (#116)
+//!
+//! Routes `skim infra <tool> [args...]` to the appropriate infra tool parser.
+//! Currently supported tools: `aws`, `curl`, `gh`, `wget`.
+
+pub(crate) mod aws;
+pub(crate) mod curl;
+pub(crate) mod gh;
+pub(crate) mod wget;
+
+use std::io::IsTerminal;
+use std::process::ExitCode;
+
+use super::{extract_show_stats, run_parsed_command_with_mode, OutputFormat, ParsedCommandConfig};
+use crate::output::canonical::InfraResult;
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+/// Known infra tools that `skim infra` can dispatch to.
+const KNOWN_TOOLS: &[&str] = &["aws", "curl", "gh", "wget"];
+
+/// Entry point for `skim infra <tool> [args...]`.
+///
+/// If no tool is specified or `--help` / `-h` is passed, prints usage
+/// and exits. Otherwise dispatches to the tool-specific handler.
+pub(crate) fn run(args: &[String]) -> anyhow::Result<ExitCode> {
+    if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
+        print_help();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let (filtered_args, show_stats) = extract_show_stats(args);
+    let (filtered_args, json_output) = super::extract_json_flag(&filtered_args);
+
+    let Some((tool_name, tool_args)) = filtered_args.split_first() else {
+        print_help();
+        return Ok(ExitCode::SUCCESS);
+    };
+
+    match tool_name.as_str() {
+        "aws" => aws::run(tool_args, show_stats, json_output),
+        "curl" => curl::run(tool_args, show_stats, json_output),
+        "gh" => gh::run(tool_args, show_stats, json_output),
+        "wget" => wget::run(tool_args, show_stats, json_output),
+        _ => {
+            let safe_tool = sanitize_for_display(tool_name);
+            eprintln!(
+                "skim infra: unknown tool '{safe_tool}'\n\
+                 Available tools: {}\n\
+                 Run 'skim infra --help' for usage information",
+                KNOWN_TOOLS.join(", ")
+            );
+            Ok(ExitCode::FAILURE)
+        }
+    }
+}
+
+fn print_help() {
+    println!("skim infra <tool> [args...]");
+    println!();
+    println!("  Run infrastructure tools and parse the output for AI context windows.");
+    println!();
+    println!("Available tools:");
+    for tool in KNOWN_TOOLS {
+        println!("  {tool}");
+    }
+    println!();
+    println!("Flags:");
+    println!("  --json          Emit structured JSON output");
+    println!("  --show-stats    Show token statistics");
+    println!();
+    println!("Examples:");
+    println!("  skim infra gh pr list              List GitHub pull requests");
+    println!("  skim infra aws s3 ls               List S3 buckets");
+    println!("  skim infra curl https://api.example.com/data  Make HTTP request");
+    println!("  skim infra wget https://example.com/file.txt  Download a file");
+}
+
+// ============================================================================
+// Shared infra tool execution helper
+// ============================================================================
+
+/// Static configuration for an infra tool binary.
+pub(crate) struct InfraToolConfig<'a> {
+    /// Binary name of the tool (e.g., "gh", "aws").
+    pub program: &'a str,
+    /// Environment variable overrides for the child process.
+    pub env_overrides: &'a [(&'a str, &'a str)],
+    /// Hint printed when the tool binary is not found.
+    pub install_hint: &'a str,
+}
+
+/// Execute an infra tool, parse its output, and emit the result.
+///
+/// This is the single implementation shared by all infra parsers, handling both
+/// text and JSON output modes. It eliminates per-tool `run()` boilerplate by
+/// delegating to [`super::run_parsed_command_with_mode`].
+pub(crate) fn run_infra_tool(
+    config: InfraToolConfig<'_>,
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+    prepare_args: impl FnOnce(&mut Vec<String>),
+    parse_fn: impl FnOnce(&CommandOutput) -> ParseResult<InfraResult>,
+) -> anyhow::Result<ExitCode> {
+    let mut cmd_args = args.to_vec();
+    prepare_args(&mut cmd_args);
+
+    let use_stdin = !std::io::stdin().is_terminal() && args.is_empty();
+    let output_format = if json_output {
+        OutputFormat::Json
+    } else {
+        OutputFormat::Text
+    };
+
+    run_parsed_command_with_mode(
+        ParsedCommandConfig {
+            program: config.program,
+            args: &cmd_args,
+            env_overrides: config.env_overrides,
+            install_hint: config.install_hint,
+            use_stdin,
+            show_stats,
+            command_type: crate::analytics::CommandType::Infra,
+            output_format,
+        },
+        |output, _args| parse_fn(output),
+    )
+}
+
+/// Re-export the shared `combine_output` under the name callers expect.
+pub(crate) use super::combine_output as combine_stdout_stderr;
+
+// ============================================================================
+// Shared security helper
+// ============================================================================
+
+/// Sanitize user input for safe display in error messages.
+///
+/// Filters to printable ASCII characters to prevent terminal escape
+/// injection attacks. Non-printable and non-ASCII bytes are replaced
+/// with `?`, and the string is truncated to 64 characters.
+pub(crate) fn sanitize_for_display(input: &str) -> String {
+    input
+        .chars()
+        .take(64)
+        .map(|c| {
+            if c.is_ascii_graphic() || c == ' ' {
+                c
+            } else {
+                '?'
+            }
+        })
+        .collect()
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_for_display_clean_input() {
+        assert_eq!(sanitize_for_display("hello-world"), "hello-world");
+    }
+
+    #[test]
+    fn test_sanitize_for_display_rejects_non_ascii() {
+        let input = "tool\x1b[31mred\x1b[0m";
+        let sanitized = sanitize_for_display(input);
+        assert!(!sanitized.contains('\x1b'));
+    }
+
+    #[test]
+    fn test_sanitize_for_display_truncates_at_64() {
+        let long_input = "a".repeat(100);
+        let sanitized = sanitize_for_display(&long_input);
+        assert_eq!(sanitized.len(), 64);
+    }
+}

--- a/crates/rskim/src/cmd/infra/wget.rs
+++ b/crates/rskim/src/cmd/infra/wget.rs
@@ -1,0 +1,245 @@
+//! wget parser with three-tier degradation (#116).
+//!
+//! Executes `wget` and parses the output into structured `InfraResult`.
+//!
+//! Three tiers:
+//! - **Tier 1 (Full)**: Regex for HTTP status, filename, and size from wget output
+//! - **Tier 2 (Degraded)**: Simpler regex fallback
+//! - **Tier 3 (Passthrough)**: Raw stdout+stderr concatenation
+//!
+//! Note: wget outputs to stderr by default, so `combine_stdout_stderr` is used.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::output::canonical::{InfraItem, InfraResult};
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+use super::{combine_stdout_stderr, run_infra_tool, InfraToolConfig};
+
+const CONFIG: InfraToolConfig<'static> = InfraToolConfig {
+    program: "wget",
+    env_overrides: &[],
+    install_hint: "Install wget via your package manager",
+};
+
+static RE_WGET_HTTP_STATUS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"HTTP request sent.*?(\d{3})\s+(.+)").unwrap());
+
+static RE_WGET_SAVING: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"Saving to:\s+'([^']+)'").unwrap());
+
+static RE_WGET_LENGTH: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"Length:\s+\d+\s+\(([^)]+)\)").unwrap());
+
+static RE_WGET_SAVED: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"'(.+)' saved \[(\d+)/(\d+)\]").unwrap());
+
+static RE_WGET_ERROR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"ERROR\s+(\d+):\s+(.+)").unwrap());
+
+/// Run `skim infra wget [args...]`.
+pub(crate) fn run(
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+) -> anyhow::Result<std::process::ExitCode> {
+    // No flag injection for wget — flags are too varied
+    run_infra_tool(CONFIG, args, show_stats, json_output, |_| {}, parse_impl)
+}
+
+/// Three-tier parse function for wget output.
+fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
+    // wget outputs to stderr, so use combined output
+    let combined = combine_stdout_stderr(output);
+
+    if let Some(result) = try_parse_wget_full(&combined) {
+        return ParseResult::Full(result);
+    }
+
+    if let Some(result) = try_parse_wget_simple(&combined) {
+        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+    }
+
+    ParseResult::Passthrough(combined.into_owned())
+}
+
+// ============================================================================
+// Tier 1: Full regex parsing
+// ============================================================================
+
+/// Parse wget output extracting HTTP status, filename, and size.
+fn try_parse_wget_full(text: &str) -> Option<InfraResult> {
+    if !text.contains("HTTP request") && !text.contains("ERROR") {
+        return None;
+    }
+
+    let mut items: Vec<InfraItem> = Vec::new();
+
+    // HTTP status
+    if let Some(caps) = RE_WGET_HTTP_STATUS.captures(text) {
+        items.push(InfraItem {
+            label: "status".to_string(),
+            value: format!("{} {}", &caps[1], caps[2].trim()),
+        });
+    }
+
+    // Error status
+    if let Some(caps) = RE_WGET_ERROR.captures(text) {
+        items.push(InfraItem {
+            label: "error".to_string(),
+            value: format!("{} {}", &caps[1], caps[2].trim()),
+        });
+        let summary = format!("ERROR {}", &caps[1]);
+        return Some(InfraResult::new(
+            "wget".to_string(),
+            "download".to_string(),
+            summary,
+            items,
+        ));
+    }
+
+    // File size
+    if let Some(caps) = RE_WGET_LENGTH.captures(text) {
+        items.push(InfraItem {
+            label: "size".to_string(),
+            value: caps[1].to_string(),
+        });
+    }
+
+    // Saved filename
+    if let Some(caps) = RE_WGET_SAVING.captures(text) {
+        items.push(InfraItem {
+            label: "file".to_string(),
+            value: caps[1].to_string(),
+        });
+    } else if let Some(caps) = RE_WGET_SAVED.captures(text) {
+        items.push(InfraItem {
+            label: "file".to_string(),
+            value: caps[1].to_string(),
+        });
+    }
+
+    if items.is_empty() {
+        return None;
+    }
+
+    let summary = items
+        .iter()
+        .find(|i| i.label == "status")
+        .map(|i| i.value.clone())
+        .unwrap_or_else(|| "download complete".to_string());
+
+    Some(InfraResult::new(
+        "wget".to_string(),
+        "download".to_string(),
+        summary,
+        items,
+    ))
+}
+
+// ============================================================================
+// Tier 2: Simple fallback
+// ============================================================================
+
+/// Simpler fallback: look for any HTTP status code in output.
+fn try_parse_wget_simple(text: &str) -> Option<InfraResult> {
+    static RE_ANY_STATUS: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b([1-5]\d{2})\b").unwrap());
+
+    for line in text.lines() {
+        if let Some(caps) = RE_ANY_STATUS.captures(line) {
+            let code = &caps[1];
+            let items = vec![InfraItem {
+                label: "status".to_string(),
+                value: code.to_string(),
+            }];
+            return Some(InfraResult::new(
+                "wget".to_string(),
+                "download".to_string(),
+                format!("HTTP {code}"),
+                items,
+            ));
+        }
+    }
+
+    None
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/fixtures/cmd/infra");
+        path.push(name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to load fixture '{name}': {e}"))
+    }
+
+    #[test]
+    fn test_tier1_wget_download() {
+        let input = load_fixture("wget_download.txt");
+        let result = try_parse_wget_full(&input);
+        assert!(result.is_some(), "Expected Tier 1 parse to succeed");
+        let result = result.unwrap();
+        assert!(result.as_ref().contains("INFRA: wget download"));
+        assert!(result.items.iter().any(|i| i.label == "status"));
+    }
+
+    #[test]
+    fn test_tier1_wget_error() {
+        let input = load_fixture("wget_error.txt");
+        let result = try_parse_wget_full(&input);
+        assert!(result.is_some(), "Expected Tier 1 parse to succeed for error");
+        let result = result.unwrap();
+        assert!(result.items.iter().any(|i| i.label == "error"));
+    }
+
+    #[test]
+    fn test_tier2_wget_regex() {
+        let input = "Connecting... 200\n";
+        let result = try_parse_wget_simple(input);
+        assert!(result.is_some(), "Expected Tier 2 fallback to succeed");
+    }
+
+    #[test]
+    fn test_parse_impl_produces_full() {
+        let input = load_fixture("wget_download.txt");
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: input,
+            exit_code: Some(0),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full parse result, got {}",
+            result.tier_name()
+        );
+    }
+
+    #[test]
+    fn test_parse_impl_garbage_produces_passthrough() {
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: "no output at all".to_string(),
+            exit_code: Some(1),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_passthrough(),
+            "Expected Passthrough, got {}",
+            result.tier_name()
+        );
+    }
+}

--- a/crates/rskim/src/cmd/lint/mod.rs
+++ b/crates/rskim/src/cmd/lint/mod.rs
@@ -1,12 +1,14 @@
-//! Lint subcommand dispatcher (#104)
+//! Lint subcommand dispatcher (#104, #116)
 //!
 //! Routes `skim lint <linter> [args...]` to the appropriate linter parser.
-//! Currently supported linters: `eslint`, `ruff`, `mypy`, `golangci`.
+//! Currently supported linters: `eslint`, `golangci`, `mypy`, `prettier`, `ruff`, `rustfmt`.
 
 pub(crate) mod eslint;
 pub(crate) mod golangci;
 pub(crate) mod mypy;
+pub(crate) mod prettier;
 pub(crate) mod ruff;
+pub(crate) mod rustfmt;
 
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
@@ -18,7 +20,7 @@ use crate::output::ParseResult;
 use crate::runner::CommandOutput;
 
 /// Known linters that `skim lint` can dispatch to.
-const KNOWN_LINTERS: &[&str] = &["eslint", "ruff", "mypy", "golangci"];
+const KNOWN_LINTERS: &[&str] = &["eslint", "golangci", "mypy", "prettier", "ruff", "rustfmt"];
 
 /// Entry point for `skim lint <linter> [args...]`.
 ///
@@ -44,9 +46,11 @@ pub(crate) fn run(args: &[String]) -> anyhow::Result<ExitCode> {
 
     match linter {
         "eslint" => eslint::run(linter_args, show_stats, json_output),
-        "ruff" => ruff::run(linter_args, show_stats, json_output),
-        "mypy" => mypy::run(linter_args, show_stats, json_output),
         "golangci" => golangci::run(linter_args, show_stats, json_output),
+        "mypy" => mypy::run(linter_args, show_stats, json_output),
+        "prettier" => prettier::run(linter_args, show_stats, json_output),
+        "ruff" => ruff::run(linter_args, show_stats, json_output),
+        "rustfmt" => rustfmt::run(linter_args, show_stats, json_output),
         _ => {
             eprintln!(
                 "skim lint: unknown linter '{linter}'\n\
@@ -75,9 +79,11 @@ fn print_help() {
     println!();
     println!("Examples:");
     println!("  skim lint eslint .             Run eslint");
-    println!("  skim lint ruff check .         Run ruff check");
-    println!("  skim lint mypy src/            Run mypy");
     println!("  skim lint golangci run ./...   Run golangci-lint");
+    println!("  skim lint mypy src/            Run mypy");
+    println!("  skim lint prettier .           Run prettier --check");
+    println!("  skim lint ruff check .         Run ruff check");
+    println!("  skim lint rustfmt src/         Run rustfmt --check");
     println!("  eslint . 2>&1 | skim lint eslint  Pipe eslint output");
 }
 

--- a/crates/rskim/src/cmd/lint/prettier.rs
+++ b/crates/rskim/src/cmd/lint/prettier.rs
@@ -1,0 +1,226 @@
+//! Prettier parser with three-tier degradation (#116).
+//!
+//! Executes `prettier` and parses check output into a structured `LintResult`.
+//!
+//! Three tiers:
+//! - **Tier 1 (Full)**: Parse `[warn]` lines as file paths
+//! - **Tier 2 (Degraded)**: Regex fallback on other output formats
+//! - **Tier 3 (Passthrough)**: Raw stdout+stderr concatenation
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::cmd::user_has_flag;
+use crate::output::canonical::{LintIssue, LintResult, LintSeverity};
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+use super::{combine_stdout_stderr, group_issues, LinterConfig};
+
+const CONFIG: LinterConfig<'static> = LinterConfig {
+    program: "prettier",
+    env_overrides: &[("NO_COLOR", "1")],
+    install_hint: "Install prettier via npm: npm install -g prettier",
+};
+
+static RE_PRETTIER_WARN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\[warn\]\s+(\S+)").unwrap());
+
+static RE_PRETTIER_SUMMARY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\[warn\]\s+Code style issues found").unwrap());
+
+/// Run `skim lint prettier [args...]`.
+pub(crate) fn run(
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+) -> anyhow::Result<std::process::ExitCode> {
+    super::run_linter(CONFIG, args, show_stats, json_output, prepare_args, parse_impl)
+}
+
+/// Inject `--check` if not already present.
+fn prepare_args(cmd_args: &mut Vec<String>) {
+    if !user_has_flag(cmd_args, &["--check", "-c", "--list-different", "-l"]) {
+        cmd_args.insert(0, "--check".to_string());
+    }
+}
+
+/// Three-tier parse function for prettier output.
+fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
+    if let Some(result) = try_parse_warn_lines(&output.stdout) {
+        return ParseResult::Full(result);
+    }
+
+    // Empty stdout on exit 0 = all files formatted correctly
+    if output.exit_code == Some(0) && output.stdout.trim().is_empty() {
+        return ParseResult::Full(group_issues("prettier", vec![]));
+    }
+
+    let combined = combine_stdout_stderr(output);
+
+    if let Some(result) = try_parse_regex(&combined) {
+        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+    }
+
+    ParseResult::Passthrough(combined.into_owned())
+}
+
+// ============================================================================
+// Tier 1: warn-line parsing
+// ============================================================================
+
+/// Parse prettier `--check` output by scanning `[warn]` lines.
+///
+/// Prettier check output format:
+/// ```text
+/// [warn] src/App.tsx
+/// [warn] src/utils/format.ts
+/// [warn] Code style issues found in the above file(s). Forgot to run Prettier?
+/// ```
+fn try_parse_warn_lines(stdout: &str) -> Option<LintResult> {
+    if !stdout.contains("[warn]") {
+        return None;
+    }
+
+    let mut issues: Vec<LintIssue> = Vec::new();
+
+    for line in stdout.lines() {
+        // Skip the summary line
+        if RE_PRETTIER_SUMMARY.is_match(line) {
+            continue;
+        }
+
+        if let Some(caps) = RE_PRETTIER_WARN.captures(line) {
+            issues.push(LintIssue {
+                file: caps[1].to_string(),
+                line: 0,
+                rule: "formatting".to_string(),
+                message: "Code style issues found".to_string(),
+                severity: LintSeverity::Warning,
+            });
+        }
+    }
+
+    Some(group_issues("prettier", issues))
+}
+
+// ============================================================================
+// Tier 2: regex fallback
+// ============================================================================
+
+/// Regex fallback for other output formats.
+fn try_parse_regex(text: &str) -> Option<LintResult> {
+    // Look for any file paths that look like they have formatting issues
+    static RE_FILE_PATH: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?m)^([^\s]+\.[a-zA-Z]{1,6})\s+needs? formatting").unwrap()
+    });
+
+    let mut issues: Vec<LintIssue> = Vec::new();
+
+    for caps in RE_FILE_PATH.captures_iter(text) {
+        issues.push(LintIssue {
+            file: caps[1].to_string(),
+            line: 0,
+            rule: "formatting".to_string(),
+            message: "needs formatting".to_string(),
+            severity: LintSeverity::Warning,
+        });
+    }
+
+    if issues.is_empty() {
+        return None;
+    }
+
+    Some(group_issues("prettier", issues))
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/fixtures/cmd/lint");
+        path.push(name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to load fixture '{name}': {e}"))
+    }
+
+    #[test]
+    fn test_tier1_prettier_pass() {
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full result for clean pass, got {}",
+            result.tier_name()
+        );
+        if let crate::output::ParseResult::Full(r) = result {
+            assert_eq!(r.warnings, 0);
+            assert!(r.as_ref().contains("LINT OK"));
+        }
+    }
+
+    #[test]
+    fn test_tier1_prettier_fail() {
+        let input = load_fixture("prettier_check_fail.txt");
+        let result = try_parse_warn_lines(&input);
+        assert!(result.is_some(), "Expected Tier 1 warn-line parse to succeed");
+        let result = result.unwrap();
+        assert_eq!(result.warnings, 3);
+        assert_eq!(result.errors, 0);
+        assert!(result.groups.iter().any(|g| g.rule == "formatting"));
+    }
+
+    #[test]
+    fn test_tier2_prettier_regex() {
+        let input = "src/main.ts needs formatting\nsrc/lib.ts needs formatting\n";
+        let result = try_parse_regex(input);
+        assert!(result.is_some(), "Expected Tier 2 regex parse to succeed");
+        let result = result.unwrap();
+        assert_eq!(result.warnings, 2);
+    }
+
+    #[test]
+    fn test_parse_impl_produces_full() {
+        let input = load_fixture("prettier_check_fail.txt");
+        let output = CommandOutput {
+            stdout: input,
+            stderr: String::new(),
+            exit_code: Some(1),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full parse result, got {}",
+            result.tier_name()
+        );
+    }
+
+    #[test]
+    fn test_parse_impl_garbage_produces_passthrough() {
+        let output = CommandOutput {
+            stdout: "unexpected output from prettier\nno warn lines at all".to_string(),
+            stderr: String::new(),
+            exit_code: Some(1),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_passthrough(),
+            "Expected Passthrough, got {}",
+            result.tier_name()
+        );
+    }
+}

--- a/crates/rskim/src/cmd/lint/rustfmt.rs
+++ b/crates/rskim/src/cmd/lint/rustfmt.rs
@@ -1,0 +1,236 @@
+//! Rustfmt parser with three-tier degradation (#116).
+//!
+//! Executes `rustfmt` and parses check output into a structured `LintResult`.
+//!
+//! Three tiers:
+//! - **Tier 1 (Full)**: Parse `Diff in <path> at line <N>:` headers
+//! - **Tier 2 (Degraded)**: Regex on unified diff `--- <path>` headers
+//! - **Tier 3 (Passthrough)**: Raw stdout+stderr concatenation
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::cmd::user_has_flag;
+use crate::output::canonical::{LintIssue, LintResult, LintSeverity};
+use crate::output::ParseResult;
+use crate::runner::CommandOutput;
+
+use super::{combine_stdout_stderr, group_issues, LinterConfig};
+
+const CONFIG: LinterConfig<'static> = LinterConfig {
+    program: "rustfmt",
+    env_overrides: &[],
+    install_hint: "rustup component add rustfmt",
+};
+
+static RE_RUSTFMT_DIFF_HEADER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^Diff in (.+) at line (\d+):").unwrap());
+
+static RE_RUSTFMT_UNIFIED_HEADER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^--- (.+)").unwrap());
+
+/// Run `skim lint rustfmt [args...]`.
+pub(crate) fn run(
+    args: &[String],
+    show_stats: bool,
+    json_output: bool,
+) -> anyhow::Result<std::process::ExitCode> {
+    super::run_linter(CONFIG, args, show_stats, json_output, prepare_args, parse_impl)
+}
+
+/// Inject `--check` if not already present.
+fn prepare_args(cmd_args: &mut Vec<String>) {
+    if !user_has_flag(cmd_args, &["--check", "-c"]) {
+        cmd_args.insert(0, "--check".to_string());
+    }
+}
+
+/// Three-tier parse function for rustfmt output.
+fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
+    let combined = combine_stdout_stderr(output);
+
+    if let Some(result) = try_parse_diff_headers(&combined) {
+        return ParseResult::Full(result);
+    }
+
+    // Empty output on exit 0 = all files formatted correctly
+    if output.exit_code == Some(0) && combined.trim().is_empty() {
+        return ParseResult::Full(group_issues("rustfmt", vec![]));
+    }
+
+    if let Some(result) = try_parse_unified_headers(&combined) {
+        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+    }
+
+    ParseResult::Passthrough(combined.into_owned())
+}
+
+// ============================================================================
+// Tier 1: diff-header parsing
+// ============================================================================
+
+/// Parse rustfmt `--check` output by scanning `Diff in <path> at line <N>:` headers.
+///
+/// Rustfmt check output format:
+/// ```text
+/// Diff in /path/to/src/main.rs at line 15:
+///  fn main() {
+/// -    let x=1;
+/// +    let x = 1;
+///  }
+/// ```
+fn try_parse_diff_headers(text: &str) -> Option<LintResult> {
+    if !text.contains("Diff in ") {
+        return None;
+    }
+
+    let mut issues: Vec<LintIssue> = Vec::new();
+
+    for line in text.lines() {
+        if let Some(caps) = RE_RUSTFMT_DIFF_HEADER.captures(line) {
+            let file_path = caps[1].trim().to_string();
+            let line_num: u32 = caps[2].parse().unwrap_or(0);
+            issues.push(LintIssue {
+                file: file_path,
+                line: line_num,
+                rule: "formatting".to_string(),
+                message: "formatting difference detected".to_string(),
+                severity: LintSeverity::Warning,
+            });
+        }
+    }
+
+    Some(group_issues("rustfmt", issues))
+}
+
+// ============================================================================
+// Tier 2: unified diff header fallback
+// ============================================================================
+
+/// Parse unified diff `--- <path>` headers as a fallback.
+fn try_parse_unified_headers(text: &str) -> Option<LintResult> {
+    let mut issues: Vec<LintIssue> = Vec::new();
+    let mut seen_paths = std::collections::HashSet::new();
+
+    for line in text.lines() {
+        if let Some(caps) = RE_RUSTFMT_UNIFIED_HEADER.captures(line) {
+            let raw_path = caps[1].trim();
+            // Skip "a/..." or "b/..." git diff prefixes, and /dev/null
+            let path = raw_path
+                .trim_start_matches("a/")
+                .trim_start_matches("b/");
+            if path == "/dev/null" || path.is_empty() {
+                continue;
+            }
+            if seen_paths.insert(path.to_string()) {
+                issues.push(LintIssue {
+                    file: path.to_string(),
+                    line: 0,
+                    rule: "formatting".to_string(),
+                    message: "formatting difference detected".to_string(),
+                    severity: LintSeverity::Warning,
+                });
+            }
+        }
+    }
+
+    if issues.is_empty() {
+        return None;
+    }
+
+    Some(group_issues("rustfmt", issues))
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load_fixture(name: &str) -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/fixtures/cmd/lint");
+        path.push(name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to load fixture '{name}': {e}"))
+    }
+
+    #[test]
+    fn test_tier1_rustfmt_pass() {
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full result for clean pass, got {}",
+            result.tier_name()
+        );
+        if let crate::output::ParseResult::Full(r) = result {
+            assert_eq!(r.warnings, 0);
+            assert!(r.as_ref().contains("LINT OK"));
+        }
+    }
+
+    #[test]
+    fn test_tier1_rustfmt_fail() {
+        let input = load_fixture("rustfmt_check_fail.txt");
+        let result = try_parse_diff_headers(&input);
+        assert!(
+            result.is_some(),
+            "Expected Tier 1 diff-header parse to succeed"
+        );
+        let result = result.unwrap();
+        assert_eq!(result.warnings, 2);
+        assert_eq!(result.errors, 0);
+        assert!(result.groups.iter().any(|g| g.rule == "formatting"));
+    }
+
+    #[test]
+    fn test_tier2_rustfmt_regex() {
+        let input = "--- src/main.rs\n+++ src/main.rs\n-old line\n+new line\n";
+        let result = try_parse_unified_headers(input);
+        assert!(result.is_some(), "Expected Tier 2 regex parse to succeed");
+        let result = result.unwrap();
+        assert_eq!(result.warnings, 1);
+    }
+
+    #[test]
+    fn test_parse_impl_produces_full() {
+        let input = load_fixture("rustfmt_check_fail.txt");
+        let output = CommandOutput {
+            stdout: String::new(),
+            stderr: input,
+            exit_code: Some(1),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_full(),
+            "Expected Full parse result, got {}",
+            result.tier_name()
+        );
+    }
+
+    #[test]
+    fn test_parse_impl_garbage_produces_passthrough() {
+        let output = CommandOutput {
+            stdout: "unexpected output\nno diff headers here".to_string(),
+            stderr: String::new(),
+            exit_code: Some(1),
+            duration: std::time::Duration::ZERO,
+        };
+        let result = parse_impl(&output);
+        assert!(
+            result.is_passthrough(),
+            "Expected Passthrough, got {}",
+            result.tier_name()
+        );
+    }
+}

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -12,6 +12,7 @@ mod discover;
 mod git;
 mod hook_log;
 mod hooks;
+mod infra;
 mod init;
 mod integrity;
 mod learn;
@@ -39,6 +40,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "completions",
     "discover",
     "git",
+    "infra",
     "init",
     "learn",
     "lint",
@@ -348,6 +350,7 @@ pub(crate) fn dispatch(subcommand: &str, args: &[String]) -> anyhow::Result<Exit
         "completions" => completions::run(args),
         "discover" => discover::run(args),
         "git" => git::run(args),
+        "infra" => infra::run(args),
         "init" => init::run(args),
         "learn" => learn::run(args),
         "lint" => lint::run(args),

--- a/crates/rskim/src/cmd/rewrite.rs
+++ b/crates/rskim/src/cmd/rewrite.rs
@@ -36,6 +36,7 @@ enum RewriteCategory {
     Read,
     Lint,
     Pkg,
+    Infra,
 }
 
 struct RewriteRule {
@@ -392,6 +393,84 @@ const REWRITE_RULES: &[RewriteRule] = &[
         rewrite_to: &["skim", "pkg", "pip", "list"],
         skip_if_flag_prefix: &["--format"],
         category: RewriteCategory::Pkg,
+    },
+    // lint — prettier (longest prefix first: npx prettier, prettier)
+    RewriteRule {
+        prefix: &["npx", "prettier", "--check"],
+        rewrite_to: &["skim", "lint", "prettier"],
+        skip_if_flag_prefix: &[],
+        category: RewriteCategory::Lint,
+    },
+    RewriteRule {
+        prefix: &["prettier", "--check"],
+        rewrite_to: &["skim", "lint", "prettier"],
+        skip_if_flag_prefix: &[],
+        category: RewriteCategory::Lint,
+    },
+    // lint — rustfmt (longest prefix first)
+    RewriteRule {
+        prefix: &["cargo", "fmt", "--", "--check"],
+        rewrite_to: &["skim", "lint", "rustfmt"],
+        skip_if_flag_prefix: &[],
+        category: RewriteCategory::Lint,
+    },
+    RewriteRule {
+        prefix: &["cargo", "fmt", "--check"],
+        rewrite_to: &["skim", "lint", "rustfmt"],
+        skip_if_flag_prefix: &[],
+        category: RewriteCategory::Lint,
+    },
+    RewriteRule {
+        prefix: &["rustfmt", "--check"],
+        rewrite_to: &["skim", "lint", "rustfmt"],
+        skip_if_flag_prefix: &[],
+        category: RewriteCategory::Lint,
+    },
+    // infra — gh (longest prefix first)
+    RewriteRule {
+        prefix: &["gh", "pr", "list"],
+        rewrite_to: &["skim", "infra", "gh", "pr", "list"],
+        skip_if_flag_prefix: &["--json"],
+        category: RewriteCategory::Infra,
+    },
+    RewriteRule {
+        prefix: &["gh", "issue", "list"],
+        rewrite_to: &["skim", "infra", "gh", "issue", "list"],
+        skip_if_flag_prefix: &["--json"],
+        category: RewriteCategory::Infra,
+    },
+    RewriteRule {
+        prefix: &["gh", "run", "list"],
+        rewrite_to: &["skim", "infra", "gh", "run", "list"],
+        skip_if_flag_prefix: &["--json"],
+        category: RewriteCategory::Infra,
+    },
+    RewriteRule {
+        prefix: &["gh", "release", "list"],
+        rewrite_to: &["skim", "infra", "gh", "release", "list"],
+        skip_if_flag_prefix: &["--json"],
+        category: RewriteCategory::Infra,
+    },
+    // infra — aws
+    RewriteRule {
+        prefix: &["aws"],
+        rewrite_to: &["skim", "infra", "aws"],
+        skip_if_flag_prefix: &["--output"],
+        category: RewriteCategory::Infra,
+    },
+    // infra — curl
+    RewriteRule {
+        prefix: &["curl"],
+        rewrite_to: &["skim", "infra", "curl"],
+        skip_if_flag_prefix: &["-o", "--output"],
+        category: RewriteCategory::Infra,
+    },
+    // infra — wget
+    RewriteRule {
+        prefix: &["wget"],
+        rewrite_to: &["skim", "infra", "wget"],
+        skip_if_flag_prefix: &["-O", "-q", "--quiet"],
+        category: RewriteCategory::Infra,
     },
 ];
 

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -88,7 +88,7 @@ fn looks_like_file_or_glob(token: &str) -> bool {
 /// | Contains `/` or `\`                           | FileOperation |
 /// | Is `-`                                        | FileOperation |
 /// | Contains `*`, `?`, `[`, or `{`                  | FileOperation |
-/// | Is known subcommand AND no file/dir on disk   | Subcommand    |
+/// | Is known subcommand                           | Subcommand    |
 /// | Everything else                               | FileOperation |
 fn resolve_invocation() -> Invocation {
     let raw_args: Vec<String> = std::env::args().collect();
@@ -138,14 +138,9 @@ fn resolve_invocation() -> Invocation {
         return Invocation::FileOperation;
     }
 
-    // Known subcommand check — only if no file/dir with that name exists on disk
+    // Known subcommand check — subcommands always take priority.
+    // Use `skim ./name` or a full path to read a file that shares a subcommand name.
     if cmd::is_known_subcommand(positional) {
-        let path = std::path::Path::new(positional);
-        if path.exists() {
-            // On-disk file/dir takes precedence (backward compat)
-            return Invocation::FileOperation;
-        }
-
         let name = positional.to_string();
         let remaining_args: Vec<String> = args[pos_idx + 1..].to_vec();
         return Invocation::Subcommand {

--- a/crates/rskim/src/output/canonical.rs
+++ b/crates/rskim/src/output/canonical.rs
@@ -504,6 +504,75 @@ impl fmt::Display for PkgResult {
 }
 
 // ============================================================================
+// InfraResult types
+// ============================================================================
+
+/// Result of an infrastructure tool operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct InfraResult {
+    pub(crate) tool: String,
+    pub(crate) operation: String,
+    pub(crate) summary: String,
+    pub(crate) items: Vec<InfraItem>,
+    #[serde(default)]
+    rendered: String,
+}
+
+/// A single key-value item within an infrastructure result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct InfraItem {
+    pub(crate) label: String,
+    pub(crate) value: String,
+}
+
+impl InfraResult {
+    pub(crate) fn new(
+        tool: String,
+        operation: String,
+        summary: String,
+        items: Vec<InfraItem>,
+    ) -> Self {
+        let rendered = Self::render(&tool, &operation, &summary, &items);
+        Self {
+            tool,
+            operation,
+            summary,
+            items,
+            rendered,
+        }
+    }
+
+    /// Recompute rendered field if empty (e.g., after deserialization)
+    pub(crate) fn ensure_rendered(&mut self) {
+        if self.rendered.is_empty() {
+            self.rendered =
+                Self::render(&self.tool, &self.operation, &self.summary, &self.items);
+        }
+    }
+
+    fn render(tool: &str, operation: &str, summary: &str, items: &[InfraItem]) -> String {
+        use std::fmt::Write;
+        let mut output = format!("INFRA: {tool} {operation} | {summary}");
+        for item in items {
+            let _ = write!(output, "\n  {}: {}", item.label, item.value);
+        }
+        output
+    }
+}
+
+impl AsRef<str> for InfraResult {
+    fn as_ref(&self) -> &str {
+        &self.rendered
+    }
+}
+
+impl fmt::Display for InfraResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.rendered)
+    }
+}
+
+// ============================================================================
 // DiffResult types
 // ============================================================================
 
@@ -1058,6 +1127,66 @@ mod tests {
     // ========================================================================
     // DiffResult ensure_rendered lossy fallback (#103 review batch-7)
     // ========================================================================
+
+    // ========================================================================
+    // InfraResult tests
+    // ========================================================================
+
+    #[test]
+    fn test_infra_result_display() {
+        let items = vec![
+            InfraItem {
+                label: "#1".to_string(),
+                value: "fix: update deps (open)".to_string(),
+            },
+            InfraItem {
+                label: "#2".to_string(),
+                value: "feat: add feature (merged)".to_string(),
+            },
+        ];
+        let result = InfraResult::new(
+            "gh".to_string(),
+            "pr list".to_string(),
+            "2 items".to_string(),
+            items,
+        );
+        let display = format!("{result}");
+        assert!(display.contains("INFRA: gh pr list | 2 items"));
+        assert!(display.contains("#1: fix: update deps (open)"));
+        assert!(display.contains("#2: feat: add feature (merged)"));
+    }
+
+    #[test]
+    fn test_infra_result_serde_roundtrip() {
+        let items = vec![InfraItem {
+            label: "bucket".to_string(),
+            value: "my-bucket".to_string(),
+        }];
+        let original = InfraResult::new(
+            "aws".to_string(),
+            "s3 ls".to_string(),
+            "1 bucket".to_string(),
+            items,
+        );
+        let json = serde_json::to_string(&original).unwrap();
+        let mut deserialized: InfraResult = serde_json::from_str(&json).unwrap();
+        deserialized.ensure_rendered();
+        assert_eq!(format!("{original}"), format!("{deserialized}"));
+    }
+
+    #[test]
+    fn test_infra_result_ensure_rendered_recomputes_when_empty() {
+        let mut result = InfraResult {
+            tool: "curl".to_string(),
+            operation: "GET".to_string(),
+            summary: "200 OK".to_string(),
+            items: vec![],
+            rendered: String::new(),
+        };
+        assert_eq!(result.as_ref(), "");
+        result.ensure_rendered();
+        assert!(result.as_ref().contains("INFRA: curl GET | 200 OK"));
+    }
 
     #[test]
     fn test_diff_result_ensure_rendered_produces_summary_fallback() {

--- a/crates/rskim/tests/cli_completions.rs
+++ b/crates/rskim/tests/cli_completions.rs
@@ -181,22 +181,22 @@ fn test_completions_bash_syntax_valid() {
 // ============================================================================
 
 #[test]
-fn test_completions_file_on_disk_takes_precedence() {
+fn test_completions_subcommand_always_routes_to_subcommand() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("completions");
     fs::write(&file, "fn setup() {}").unwrap();
 
-    // When a file named "completions" exists on disk, the pre-parse router
-    // should route to file operation, NOT the completions subcommand.
+    // After the router fix, bare "completions" ALWAYS routes to the subcommand
+    // even when a file named "completions" exists on disk.
+    // To read such a file, users must use ./completions or the full path.
     Command::cargo_bin("skim")
         .unwrap()
         .current_dir(dir.path())
         .arg("completions")
-        .arg("-l")
-        .arg("rust")
+        .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("fn setup"));
+        .stdout(predicate::str::contains("skim completions"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_subcommand.rs
+++ b/crates/rskim/tests/cli_subcommand.rs
@@ -199,23 +199,25 @@ fn test_full_path_to_file_named_as_subcommand_uses_separator_heuristic() {
 }
 
 #[test]
-fn test_bare_file_named_as_subcommand_routes_to_file_operation() {
+fn test_bare_file_named_as_subcommand_routes_to_subcommand() {
     let dir = TempDir::new().unwrap();
     // Create a file called "init" (a known subcommand name) in the temp dir
     let file = dir.path().join("init");
     fs::write(&file, "fn setup() {}").unwrap();
 
-    // Pass bare "init" with cwd set so path.exists() finds the file on disk.
-    // This exercises the backward-compat precedence: on-disk file wins over subcommand.
+    // After the router fix, bare "init" ALWAYS routes to the subcommand
+    // regardless of whether a file with that name exists on disk.
+    // To read such a file, users must use ./init or the full path.
     Command::cargo_bin("skim")
         .unwrap()
         .current_dir(dir.path())
         .arg("init")
-        .arg("-l")
-        .arg("rust")
+        .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("fn setup"));
+        // Should show the subcommand help, not the file contents
+        .stdout(predicate::str::contains("skim init"))
+        .stdout(predicate::str::contains("fn setup").not());
 }
 
 #[test]
@@ -236,7 +238,7 @@ fn test_full_path_to_dir_named_as_subcommand_uses_separator_heuristic() {
 }
 
 #[test]
-fn test_bare_dir_named_as_subcommand_routes_to_file_operation() {
+fn test_bare_dir_named_as_subcommand_routes_to_subcommand() {
     let dir = TempDir::new().unwrap();
     // Create a directory called "build" (a known subcommand name) with a source file inside
     let build_dir = dir.path().join("build");
@@ -244,14 +246,18 @@ fn test_bare_dir_named_as_subcommand_routes_to_file_operation() {
     let file = build_dir.join("main.rs");
     fs::write(&file, "fn main() {}").unwrap();
 
-    // Pass bare "build" with cwd set so path.exists() finds the directory on disk.
-    // This exercises the backward-compat precedence: on-disk directory wins over subcommand.
+    // After the router fix, bare "build" ALWAYS routes to the subcommand
+    // regardless of whether a directory with that name exists on disk.
+    // To process such a directory, users must use ./build or the full path.
     Command::cargo_bin("skim")
         .unwrap()
         .current_dir(dir.path())
         .arg("build")
+        .arg("--help")
         .assert()
-        .success();
+        .success()
+        // Should show the subcommand help, not process the directory
+        .stdout(predicate::str::contains("skim build"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/fixtures/cmd/infra/aws_ec2_describe.json
+++ b/crates/rskim/tests/fixtures/cmd/infra/aws_ec2_describe.json
@@ -1,0 +1,21 @@
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "InstanceId": "i-0abc123def456",
+          "InstanceType": "t3.micro",
+          "State": {"Code": 16, "Name": "running"},
+          "PublicIpAddress": "54.123.45.67",
+          "Tags": [{"Key": "Name", "Value": "web-server-1"}]
+        },
+        {
+          "InstanceId": "i-0def456abc789",
+          "InstanceType": "t3.small",
+          "State": {"Code": 80, "Name": "stopped"},
+          "Tags": [{"Key": "Name", "Value": "worker-1"}]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/rskim/tests/fixtures/cmd/infra/aws_s3_ls.json
+++ b/crates/rskim/tests/fixtures/cmd/infra/aws_s3_ls.json
@@ -1,0 +1,8 @@
+{
+  "Buckets": [
+    {"Name": "my-app-production", "CreationDate": "2023-01-15T10:00:00Z"},
+    {"Name": "my-app-staging", "CreationDate": "2023-02-20T14:30:00Z"},
+    {"Name": "my-backups", "CreationDate": "2023-03-10T09:00:00Z"}
+  ],
+  "Owner": {"DisplayName": "myaccount", "ID": "abc123"}
+}

--- a/crates/rskim/tests/fixtures/cmd/infra/curl_json_response.txt
+++ b/crates/rskim/tests/fixtures/cmd/infra/curl_json_response.txt
@@ -1,0 +1,1 @@
+{"id": 1, "name": "Alice", "email": "alice@example.com", "role": "admin", "active": true}

--- a/crates/rskim/tests/fixtures/cmd/infra/curl_verbose.txt
+++ b/crates/rskim/tests/fixtures/cmd/infra/curl_verbose.txt
@@ -1,0 +1,16 @@
+* Trying 93.184.216.34:443...
+* Connected to example.com (93.184.216.34) port 443
+* ALPN: offering h2,http/1.1
+> GET / HTTP/2
+> Host: example.com
+> User-Agent: curl/8.1.2
+> Accept: */*
+>
+< HTTP/2 200
+< content-type: text/html; charset=UTF-8
+< content-length: 1256
+<
+<!doctype html>
+<html>
+<head><title>Example Domain</title></head>
+</html>

--- a/crates/rskim/tests/fixtures/cmd/infra/gh_pr_list.json
+++ b/crates/rskim/tests/fixtures/cmd/infra/gh_pr_list.json
@@ -1,0 +1,5 @@
+[
+  {"number": 42, "title": "feat: add new feature", "state": "OPEN", "author": {"login": "alice"}},
+  {"number": 41, "title": "fix: resolve login bug", "state": "MERGED", "author": {"login": "bob"}},
+  {"number": 40, "title": "docs: update README", "state": "CLOSED", "author": {"login": "carol"}}
+]

--- a/crates/rskim/tests/fixtures/cmd/infra/gh_pr_list_text.txt
+++ b/crates/rskim/tests/fixtures/cmd/infra/gh_pr_list_text.txt
@@ -1,0 +1,3 @@
+42	feat: add new feature	OPEN	alice	2024-01-15
+41	fix: resolve login bug	MERGED	bob	2024-01-14
+40	docs: update README	CLOSED	carol	2024-01-13

--- a/crates/rskim/tests/fixtures/cmd/infra/wget_download.txt
+++ b/crates/rskim/tests/fixtures/cmd/infra/wget_download.txt
@@ -1,0 +1,10 @@
+--2024-01-15 10:30:00--  https://example.com/file.tar.gz
+Resolving example.com (example.com)... 93.184.216.34
+Connecting to example.com (example.com)|93.184.216.34|:443... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 5242880 (5.0M) [application/x-gzip]
+Saving to: 'file.tar.gz'
+
+file.tar.gz         100%[===================>]   5.00M  1.23MB/s    in 4.1s
+
+2024-01-15 10:30:04 (1.23 MB/s) - 'file.tar.gz' saved [5242880/5242880]

--- a/crates/rskim/tests/fixtures/cmd/infra/wget_error.txt
+++ b/crates/rskim/tests/fixtures/cmd/infra/wget_error.txt
@@ -1,0 +1,5 @@
+--2024-01-15 10:30:00--  https://example.com/missing.tar.gz
+Resolving example.com (example.com)... 93.184.216.34
+Connecting to example.com (example.com)|93.184.216.34|:443... connected.
+HTTP request sent, awaiting response... 404 Not Found
+2024-01-15 10:30:01 ERROR 404: Not Found.

--- a/crates/rskim/tests/fixtures/cmd/lint/prettier_check_fail.txt
+++ b/crates/rskim/tests/fixtures/cmd/lint/prettier_check_fail.txt
@@ -1,0 +1,4 @@
+[warn] src/App.tsx
+[warn] src/utils/format.ts
+[warn] src/components/Button.tsx
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?

--- a/crates/rskim/tests/fixtures/cmd/lint/rustfmt_check_fail.txt
+++ b/crates/rskim/tests/fixtures/cmd/lint/rustfmt_check_fail.txt
@@ -1,0 +1,10 @@
+Diff in /home/user/project/src/main.rs at line 15:
+ fn main() {
+-    let x=1;
++    let x = 1;
+ }
+Diff in /home/user/project/src/lib.rs at line 42:
+ fn helper() {
+-    if(true){
++    if true {
+ }


### PR DESCRIPTION
## Summary

- **Router precedence fix**: Known subcommands now always take priority over on-disk files with the same name. Use `./name` or a full path to read files that share a subcommand name.
- **prettier + rustfmt lint parsers**: Two new linters following the established three-tier degradation pattern. Both registered in `skim lint` dispatcher.
- **`skim infra` subcommand**: New subcommand dispatching to `gh`, `aws`, `curl`, and `wget` parsers with three-tier degradation.
- **Rewrite rules**: 11 new rules covering `prettier --check`, `rustfmt --check`, `gh pr/issue/run/release list`, `aws`, `curl`, `wget`. `discover` integration updated.

## Changes

### Router Fix
- Remove `path.exists()` guard from `resolve_invocation()` in `main.rs`
- Updated 3 test functions to reflect new routing behavior

### New Types
- `InfraResult` + `InfraItem` in `output/canonical.rs`
- `CommandType::Infra` in `analytics/mod.rs`

### New Parsers (lint)
- `crates/rskim/src/cmd/lint/prettier.rs` — `[warn]` line parsing
- `crates/rskim/src/cmd/lint/rustfmt.rs` — `Diff in <path> at line <N>:` parsing

### New Subcommand (infra)
- `crates/rskim/src/cmd/infra/mod.rs` — dispatcher + `run_infra_tool()` helper
- `crates/rskim/src/cmd/infra/gh.rs` — GitHub CLI parser
- `crates/rskim/src/cmd/infra/aws.rs` — AWS CLI parser
- `crates/rskim/src/cmd/infra/curl.rs` — curl parser
- `crates/rskim/src/cmd/infra/wget.rs` — wget parser

### Integration
- `cmd/mod.rs` — registered `infra` in `KNOWN_SUBCOMMANDS` and `dispatch()`
- `cmd/lint/mod.rs` — registered `prettier` and `rustfmt`
- `cmd/rewrite.rs` — 11 new rewrite rules; `RewriteCategory::Infra` added
- `cmd/discover.rs` — `check_has_rewrite()` and `get_rewrite_target()` updated

## Test plan

- [ ] `cargo test --all-features` passes (all tests pass)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Snyk code scan: 0 issues
- [ ] `skim infra --help` lists all 4 tools
- [ ] `skim lint --help` lists prettier and rustfmt
- [ ] Router: `skim init` routes to subcommand even if a file named `init` exists in cwd