### PR TITLE
feat: debug-gated warnings + git fetch compression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ cargo fmt -- --check           # Format check
 - `completions` — Shell completion scripts
 - `discover` — Scan agent sessions for missed skim optimization opportunities (`--since`, `--agent`, `--json`)
 - `file` — File operations compression: find, ls, tree, grep, rg output parsing (`--json`, `--show-stats`)
-- `git` — Git output compression: AST-aware diff (function boundaries, `--mode`), status, log. All support `--json`.
+- `git` — Git output compression: AST-aware diff (function boundaries, `--mode`), status, log, fetch. All support `--json`.
 - `infra` — Infrastructure tool compression: gh, aws, curl, wget output parsing (`--json`, `--show-stats`)
 - `init` — Install skim as an agent hook (Claude Code, Cursor, Codex, Gemini, Copilot, OpenCode)
 - `learn` — Detect CLI error-retry patterns in agent sessions and generate correction rules (`--generate`, `--agent`, `--dry-run`)
@@ -178,6 +178,9 @@ cargo fmt -- --check           # Format check
 - `SKIM_CURSOR_DB_PATH` — Override Cursor workspace state database path
 - `SKIM_GEMINI_DIR` — Override Gemini CLI sessions directory
 - `SKIM_OPENCODE_DIR` — Override OpenCode sessions directory
+
+**Debug:**
+- `SKIM_DEBUG` — Set to `1`/`true`/`yes` to enable debug output (warnings/notices on stderr). Also available as `--debug` CLI flag.
 
 **Cache:**
 - `SKIM_CACHE_DIR` — Override skim cache directory (default: `~/.cache/skim/`)

--- a/crates/rskim/src/cmd/build/cargo.rs
+++ b/crates/rskim/src/cmd/build/cargo.rs
@@ -426,7 +426,9 @@ mod tests {
         if let ParseResult::Degraded(build_result, markers) = &result {
             assert_eq!(build_result.errors, 2, "expected 2 errors from regex");
             assert!(!build_result.success, "expected failure");
-            assert!(markers.contains(&"cargo build: structured parse failed, using regex".to_string()));
+            assert!(
+                markers.contains(&"cargo build: structured parse failed, using regex".to_string())
+            );
         }
     }
 

--- a/crates/rskim/src/cmd/build/cargo.rs
+++ b/crates/rskim/src/cmd/build/cargo.rs
@@ -250,7 +250,7 @@ fn try_tier2_regex(stderr: &str) -> Option<ParseResult<BuildResult>> {
 
     Some(ParseResult::Degraded(
         result,
-        vec!["regex fallback".to_string()],
+        vec!["cargo build: structured parse failed, using regex".to_string()],
     ))
 }
 
@@ -426,7 +426,7 @@ mod tests {
         if let ParseResult::Degraded(build_result, markers) = &result {
             assert_eq!(build_result.errors, 2, "expected 2 errors from regex");
             assert!(!build_result.success, "expected failure");
-            assert!(markers.contains(&"regex fallback".to_string()));
+            assert!(markers.contains(&"cargo build: structured parse failed, using regex".to_string()));
         }
     }
 

--- a/crates/rskim/src/cmd/build/tsc.rs
+++ b/crates/rskim/src/cmd/build/tsc.rs
@@ -146,7 +146,7 @@ fn try_tier2_combined(combined: &str) -> Option<ParseResult<BuildResult>> {
     let result = BuildResult::new(false, 0, error_count, None, error_messages);
     Some(ParseResult::Degraded(
         result,
-        vec!["combined stdout+stderr fallback".to_string()],
+        vec!["tsc: structured parse failed, using combined stdout+stderr".to_string()],
     ))
 }
 

--- a/crates/rskim/src/cmd/file/ls.rs
+++ b/crates/rskim/src/cmd/file/ls.rs
@@ -216,7 +216,7 @@ fn parse_tree(output: &CommandOutput) -> ParseResult<FileResult> {
 
     // Tier 2: text output with box-drawing lines
     if let Some(result) = try_parse_tree_text(&output.stdout) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["ls: structured parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(output.stdout.clone())

--- a/crates/rskim/src/cmd/file/ls.rs
+++ b/crates/rskim/src/cmd/file/ls.rs
@@ -216,7 +216,10 @@ fn parse_tree(output: &CommandOutput) -> ParseResult<FileResult> {
 
     // Tier 2: text output with box-drawing lines
     if let Some(result) = try_parse_tree_text(&output.stdout) {
-        return ParseResult::Degraded(result, vec!["ls: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["ls: structured parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(output.stdout.clone())

--- a/crates/rskim/src/cmd/file/ls.rs
+++ b/crates/rskim/src/cmd/file/ls.rs
@@ -104,7 +104,10 @@ fn parse_ls(output: &CommandOutput) -> ParseResult<FileResult> {
     }
 
     if let Some(result) = try_parse_ls_plain(&output.stdout) {
-        return ParseResult::Degraded(result, vec!["ls: structured parse failed, using plain text".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["ls: structured parse failed, using plain text".to_string()],
+        );
     }
 
     ParseResult::Passthrough(output.stdout.clone())

--- a/crates/rskim/src/cmd/file/ls.rs
+++ b/crates/rskim/src/cmd/file/ls.rs
@@ -104,7 +104,7 @@ fn parse_ls(output: &CommandOutput) -> ParseResult<FileResult> {
     }
 
     if let Some(result) = try_parse_ls_plain(&output.stdout) {
-        return ParseResult::Degraded(result, vec!["plain ls fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["ls: structured parse failed, using plain text".to_string()]);
     }
 
     ParseResult::Passthrough(output.stdout.clone())

--- a/crates/rskim/src/cmd/file/rg.rs
+++ b/crates/rskim/src/cmd/file/rg.rs
@@ -63,7 +63,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<FileResult> {
     }
 
     if let Some(result) = try_parse_regex(&output.stdout) {
-        return ParseResult::Degraded(result, vec!["rg: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["rg: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(output.stdout.clone())

--- a/crates/rskim/src/cmd/file/rg.rs
+++ b/crates/rskim/src/cmd/file/rg.rs
@@ -63,7 +63,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<FileResult> {
     }
 
     if let Some(result) = try_parse_regex(&output.stdout) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["rg: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(output.stdout.clone())

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -8,15 +8,17 @@
 use std::collections::HashMap;
 use std::process::ExitCode;
 
-use crate::cmd::{extract_output_format, user_has_flag, OutputFormat};
+use crate::cmd::{extract_output_format, user_has_flag};
 use crate::output::canonical::GitResult;
-use crate::runner::CommandRunner;
 
-use super::{map_exit_code, run_passthrough};
+use super::{run_parsed_command, run_passthrough};
 
 /// Run `git fetch` with output compression.
 ///
 /// Flag-aware passthrough: `--dry-run`, `-q`, `--quiet` pass through unmodified.
+///
+/// Git fetch writes its ref updates to stderr, so `run_parsed_command` is
+/// called with `combine_stderr: true` to merge stderr+stdout before parsing.
 pub(super) fn run_fetch(
     global_flags: &[String],
     args: &[String],
@@ -32,56 +34,7 @@ pub(super) fn run_fetch(
     full_args.push("fetch".to_string());
     full_args.extend_from_slice(&filtered_args);
 
-    let runner = CommandRunner::new(None);
-    let arg_refs: Vec<&str> = full_args.iter().map(|s| s.as_str()).collect();
-    let output = runner.run("git", &arg_refs)?;
-
-    if output.exit_code != Some(0) {
-        // On failure, pass through stderr
-        if !output.stderr.is_empty() {
-            eprint!("{}", output.stderr);
-        }
-        if !output.stdout.is_empty() {
-            print!("{}", output.stdout);
-        }
-        return Ok(map_exit_code(output.exit_code));
-    }
-
-    // Git fetch writes its output to stderr; combine both for parsing
-    let combined = format!("{}\n{}", output.stderr, output.stdout);
-    let result = parse_fetch(&combined);
-
-    let result_str = match output_format {
-        OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(&result)
-                .map_err(|e| anyhow::anyhow!("failed to serialize result: {e}"))?;
-            println!("{json}");
-            json
-        }
-        OutputFormat::Text => {
-            let s = result.to_string();
-            println!("{s}");
-            s
-        }
-    };
-
-    if show_stats {
-        let (orig, comp) = crate::process::count_token_pair(&combined, &result_str);
-        crate::process::report_token_stats(orig, comp, "");
-    }
-
-    if crate::analytics::is_analytics_enabled() {
-        crate::analytics::try_record_command(
-            combined,
-            result_str,
-            format!("skim git fetch {}", args.join(" ")),
-            crate::analytics::CommandType::Git,
-            output.duration,
-            None,
-        );
-    }
-
-    Ok(ExitCode::SUCCESS)
+    run_parsed_command(&full_args, show_stats, output_format, true, parse_fetch)
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -5,6 +5,7 @@
 //! and submodule fetches. Progress/noise lines (`remote: ...`, `Unpacking ...`)
 //! are stripped.
 
+use std::collections::HashMap;
 use std::process::ExitCode;
 
 use crate::cmd::{extract_output_format, user_has_flag, OutputFormat};
@@ -87,6 +88,176 @@ pub(super) fn run_fetch(
 // Parser
 // ============================================================================
 
+/// Accumulated, classified lines from a `git fetch` output pass.
+///
+/// Submodule sections use a `HashMap` for O(1) insertion (avoids O(n) linear
+/// scan per call) and a separate ordered key list to preserve encounter order.
+struct FetchCategories {
+    remote: String,
+    new_branches: Vec<String>,
+    new_tags: Vec<String>,
+    updated: Vec<String>,
+    pruned: Vec<String>,
+    forced: Vec<String>,
+    /// Ordered submodule names (insertion order).
+    submodule_order: Vec<String>,
+    /// Per-submodule entries; keyed by submodule path.
+    submodule_map: HashMap<String, Vec<String>>,
+}
+
+impl FetchCategories {
+    fn new() -> Self {
+        Self {
+            remote: String::new(),
+            new_branches: Vec::new(),
+            new_tags: Vec::new(),
+            updated: Vec::new(),
+            pruned: Vec::new(),
+            forced: Vec::new(),
+            submodule_order: Vec::new(),
+            submodule_map: HashMap::new(),
+        }
+    }
+
+    /// Add an entry to a submodule section in O(1) time.
+    fn add_submodule_entry(&mut self, sub: &str, entry: String) {
+        if !self.submodule_map.contains_key(sub) {
+            self.submodule_order.push(sub.to_string());
+            self.submodule_map.insert(sub.to_string(), Vec::new());
+        }
+        self.submodule_map.get_mut(sub).unwrap().push(entry);
+    }
+
+    /// Iterate submodule sections in the order they were first encountered.
+    fn submodule_sections(&self) -> impl Iterator<Item = (&str, &Vec<String>)> {
+        self.submodule_order
+            .iter()
+            .filter_map(|name| self.submodule_map.get(name).map(|v| (name.as_str(), v)))
+    }
+}
+
+/// Classify all lines from `git fetch` output into `FetchCategories`.
+///
+/// Uses `next_from_is_submodule` to distinguish a submodule's `From` line
+/// (which follows `Fetching submodule`) from a top-level `From` line (which
+/// resets the submodule context). This prevents top-level refs from being
+/// incorrectly attributed to the previously-active submodule.
+fn classify_lines<'a>(lines: impl Iterator<Item = &'a str>) -> FetchCategories {
+    let mut cats = FetchCategories::new();
+    let mut current_submodule: Option<String> = None;
+    // True immediately after a "Fetching submodule" line so the following
+    // "From" is recognised as that submodule's remote, not a new top-level block.
+    let mut next_from_is_submodule = false;
+
+    for trimmed in lines.map(str::trim) {
+        // Skip progress/noise lines
+        if trimmed.starts_with("remote:")
+            || trimmed.starts_with("Unpacking")
+            || trimmed.is_empty()
+        {
+            continue;
+        }
+
+        // Submodule header
+        if let Some(sub) = trimmed.strip_prefix("Fetching submodule ") {
+            current_submodule = Some(sub.to_string());
+            next_from_is_submodule = true;
+            continue;
+        }
+
+        // From line
+        if let Some(rest) = trimmed.strip_prefix("From ") {
+            if next_from_is_submodule {
+                // This "From" belongs to the submodule — preserve current_submodule.
+                next_from_is_submodule = false;
+            } else {
+                // Top-level "From" — reset submodule context.
+                current_submodule = None;
+                if cats.remote.is_empty() {
+                    cats.remote = rest.to_string();
+                }
+            }
+            continue;
+        }
+
+        // New branch
+        if trimmed.contains("[new branch]") {
+            if let Some(name) = extract_ref_name(trimmed) {
+                if let Some(ref sub) = current_submodule {
+                    cats.add_submodule_entry(sub, format!("new branch: {name}"));
+                } else {
+                    cats.new_branches.push(name);
+                }
+            }
+            continue;
+        }
+
+        // New tag
+        if trimmed.contains("[new tag]") {
+            if let Some(name) = extract_ref_name(trimmed) {
+                cats.new_tags.push(name);
+            }
+            continue;
+        }
+
+        // Deleted/pruned
+        if trimmed.contains("[deleted]") {
+            if let Some(name) = extract_pruned_ref(trimmed) {
+                cats.pruned.push(name);
+            }
+            continue;
+        }
+
+        // Forced update
+        if trimmed.contains("(forced update)") {
+            if let Some(name) = extract_updated_ref(trimmed) {
+                cats.forced.push(name);
+            }
+            continue;
+        }
+
+        // Regular update (abc..def ref -> origin/ref)
+        if trimmed.contains("->") && (trimmed.contains("..") || trimmed.contains("...")) {
+            if let Some(name) = extract_updated_ref(trimmed) {
+                if let Some(ref sub) = current_submodule {
+                    cats.add_submodule_entry(sub, format!("updated: {name}"));
+                } else {
+                    cats.updated.push(name);
+                }
+            }
+        }
+    }
+
+    cats
+}
+
+/// Build the detail lines from classified categories.
+fn build_details(cats: &FetchCategories) -> Vec<String> {
+    let mut details: Vec<String> = Vec::new();
+    for b in &cats.new_branches {
+        details.push(format!("+ {b} (new branch)"));
+    }
+    for t in &cats.new_tags {
+        details.push(format!("+ {t} (new tag)"));
+    }
+    for u in &cats.updated {
+        details.push(format!("~ {u}"));
+    }
+    for f in &cats.forced {
+        details.push(format!("! {f} (forced)"));
+    }
+    for p in &cats.pruned {
+        details.push(format!("- {p} (pruned)"));
+    }
+    for (sub_name, entries) in cats.submodule_sections() {
+        details.push(format!("[submodule {sub_name}]"));
+        for e in entries {
+            details.push(format!("  {e}"));
+        }
+    }
+    details
+}
+
 /// Parse combined stdout+stderr from `git fetch` into a compressed GitResult.
 ///
 /// Git fetch writes its output to stderr. The parser handles:
@@ -104,142 +275,40 @@ fn parse_fetch(input: &str) -> GitResult {
         return GitResult::new("fetch".to_string(), "up to date".to_string(), Vec::new());
     }
 
-    let mut remote = String::new();
-    let mut new_branches: Vec<String> = Vec::new();
-    let mut new_tags: Vec<String> = Vec::new();
-    let mut updated: Vec<String> = Vec::new();
-    let mut pruned: Vec<String> = Vec::new();
-    let mut forced: Vec<String> = Vec::new();
-    let mut submodule_sections: Vec<(String, Vec<String>)> = Vec::new();
-    let mut current_submodule: Option<String> = None;
-
-    for line in &lines {
-        let trimmed = line.trim();
-
-        // Skip progress/noise lines
-        if trimmed.starts_with("remote:") || trimmed.starts_with("Unpacking") || trimmed.is_empty()
-        {
-            continue;
-        }
-
-        // Submodule header
-        if let Some(sub) = trimmed.strip_prefix("Fetching submodule ") {
-            current_submodule = Some(sub.to_string());
-            continue;
-        }
-
-        // From line — extract remote (only first one for primary remote)
-        if let Some(rest) = trimmed.strip_prefix("From ") {
-            if current_submodule.is_none() && remote.is_empty() {
-                remote = rest.to_string();
-            }
-            continue;
-        }
-
-        // New branch
-        if trimmed.contains("[new branch]") {
-            if let Some(name) = extract_ref_name(trimmed) {
-                if let Some(ref sub) = current_submodule {
-                    add_to_submodule(&mut submodule_sections, sub, &format!("new branch: {name}"));
-                } else {
-                    new_branches.push(name);
-                }
-            }
-            continue;
-        }
-
-        // New tag
-        if trimmed.contains("[new tag]") {
-            if let Some(name) = extract_ref_name(trimmed) {
-                new_tags.push(name);
-            }
-            continue;
-        }
-
-        // Deleted/pruned
-        if trimmed.contains("[deleted]") {
-            if let Some(name) = extract_pruned_ref(trimmed) {
-                pruned.push(name);
-            }
-            continue;
-        }
-
-        // Forced update
-        if trimmed.contains("(forced update)") {
-            if let Some(name) = extract_updated_ref(trimmed) {
-                forced.push(name);
-            }
-            continue;
-        }
-
-        // Regular update (abc..def ref -> origin/ref)
-        if trimmed.contains("->") && (trimmed.contains("..") || trimmed.contains("...")) {
-            if let Some(name) = extract_updated_ref(trimmed) {
-                if let Some(ref sub) = current_submodule {
-                    add_to_submodule(&mut submodule_sections, sub, &format!("updated: {name}"));
-                } else {
-                    updated.push(name);
-                }
-            }
-            continue;
-        }
-    }
+    let cats = classify_lines(lines.iter().copied());
 
     // Build summary parts
     let mut parts: Vec<String> = Vec::new();
-    if !updated.is_empty() {
-        parts.push(format!("{} updated", updated.len()));
+    if !cats.updated.is_empty() {
+        parts.push(format!("{} updated", cats.updated.len()));
     }
-    if !new_branches.is_empty() {
+    if !cats.new_branches.is_empty() {
         parts.push(format!(
             "{} new branch{}",
-            new_branches.len(),
-            if new_branches.len() == 1 { "" } else { "es" }
+            cats.new_branches.len(),
+            if cats.new_branches.len() == 1 { "" } else { "es" }
         ));
     }
-    if !new_tags.is_empty() {
+    if !cats.new_tags.is_empty() {
         parts.push(format!(
             "{} new tag{}",
-            new_tags.len(),
-            if new_tags.len() == 1 { "" } else { "s" }
+            cats.new_tags.len(),
+            if cats.new_tags.len() == 1 { "" } else { "s" }
         ));
     }
-    if !pruned.is_empty() {
-        parts.push(format!("{} pruned", pruned.len()));
+    if !cats.pruned.is_empty() {
+        parts.push(format!("{} pruned", cats.pruned.len()));
     }
-    if !forced.is_empty() {
-        parts.push(format!("{} forced", forced.len()));
+    if !cats.forced.is_empty() {
+        parts.push(format!("{} forced", cats.forced.len()));
     }
 
-    if parts.is_empty() && submodule_sections.is_empty() {
+    if parts.is_empty() && cats.submodule_map.is_empty() {
         return GitResult::new("fetch".to_string(), "up to date".to_string(), Vec::new());
     }
 
-    // Build detail lines
-    let mut details: Vec<String> = Vec::new();
-    for b in &new_branches {
-        details.push(format!("+ {b} (new branch)"));
-    }
-    for t in &new_tags {
-        details.push(format!("+ {t} (new tag)"));
-    }
-    for u in &updated {
-        details.push(format!("~ {u}"));
-    }
-    for f in &forced {
-        details.push(format!("! {f} (forced)"));
-    }
-    for p in &pruned {
-        details.push(format!("- {p} (pruned)"));
-    }
-    for (sub_name, entries) in &submodule_sections {
-        details.push(format!("[submodule {sub_name}]"));
-        for e in entries {
-            details.push(format!("  {e}"));
-        }
-    }
-
-    let display_summary = build_summary(&remote, &parts);
+    let details = build_details(&cats);
+    let display_summary = build_summary(&cats.remote, &parts);
 
     GitResult::new("fetch".to_string(), display_summary, details)
 }
@@ -290,15 +359,6 @@ fn extract_pruned_ref(line: &str) -> Option<String> {
     let target = line[arrow_pos + 2..].trim();
     let name = target.strip_prefix("origin/").unwrap_or(target);
     Some(name.to_string())
-}
-
-/// Add an entry to a submodule section, creating the section if it doesn't exist.
-fn add_to_submodule(sections: &mut Vec<(String, Vec<String>)>, sub: &str, entry: &str) {
-    if let Some(section) = sections.iter_mut().find(|(name, _)| name == sub) {
-        section.1.push(entry.to_string());
-    } else {
-        sections.push((sub.to_string(), vec![entry.to_string()]));
-    }
 }
 
 // ============================================================================
@@ -491,6 +551,47 @@ From github.com:upstream/repo
         );
     }
 
+    /// Regression: refs following a submodule block must not be attributed to
+    /// the previous submodule when a top-level `From` line resets context.
+    #[test]
+    fn test_parse_fetch_submodule_then_toplevel() {
+        let input = "\
+Fetching submodule lib/core
+From github.com:user/core
+   aaa1111..bbb2222  main       -> origin/main
+From github.com:user/repo
+   ccc3333..ddd4444  release    -> origin/release
+";
+        let result = parse_fetch(input);
+        // Top-level "release" update counted in summary (submodule updates go in details only)
+        assert!(
+            result.summary.contains("1 updated"),
+            "expected '1 updated' in summary (only top-level counted), got: {}",
+            result.summary
+        );
+        // "release" must appear at the top level with "~ " prefix
+        let details_str = result.details.join("\n");
+        assert!(
+            details_str.contains("~ release"),
+            "expected top-level '~ release' in details, got: {details_str}"
+        );
+        // The top-level update must NOT be inside a submodule section
+        let mut in_submodule_core = false;
+        for line in result.details.iter() {
+            if line.contains("[submodule lib/core]") {
+                in_submodule_core = true;
+            } else if line.starts_with('[') {
+                in_submodule_core = false;
+            }
+            if in_submodule_core {
+                assert!(
+                    !line.contains("release"),
+                    "top-level 'release' ref incorrectly attributed to submodule: {line}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_extract_ref_name_new_branch() {
         let line = " * [new branch]      feature/x  -> origin/feature/x";
@@ -528,19 +629,22 @@ From github.com:upstream/repo
 
     #[test]
     fn test_add_to_submodule_creates_section() {
-        let mut sections: Vec<(String, Vec<String>)> = Vec::new();
-        add_to_submodule(&mut sections, "lib/core", "updated: main");
-        assert_eq!(sections.len(), 1);
-        assert_eq!(sections[0].0, "lib/core");
-        assert_eq!(sections[0].1, vec!["updated: main"]);
+        let mut cats = FetchCategories::new();
+        cats.add_submodule_entry("lib/core", "updated: main".to_string());
+        assert_eq!(cats.submodule_order.len(), 1);
+        assert_eq!(cats.submodule_order[0], "lib/core");
+        assert_eq!(
+            cats.submodule_map["lib/core"],
+            vec!["updated: main".to_string()]
+        );
     }
 
     #[test]
     fn test_add_to_submodule_appends_to_existing() {
-        let mut sections: Vec<(String, Vec<String>)> = Vec::new();
-        add_to_submodule(&mut sections, "lib/core", "updated: main");
-        add_to_submodule(&mut sections, "lib/core", "new branch: feature");
-        assert_eq!(sections.len(), 1);
-        assert_eq!(sections[0].1.len(), 2);
+        let mut cats = FetchCategories::new();
+        cats.add_submodule_entry("lib/core", "updated: main".to_string());
+        cats.add_submodule_entry("lib/core", "new branch: feature".to_string());
+        assert_eq!(cats.submodule_order.len(), 1);
+        assert_eq!(cats.submodule_map["lib/core"].len(), 2);
     }
 }

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -1,0 +1,532 @@
+//! Git fetch compression.
+//!
+//! Parses `git fetch` output (written to stderr by git) into a structured
+//! summary: updated branches, new branches/tags, pruned refs, forced updates,
+//! and submodule fetches. Progress/noise lines (`remote: ...`, `Unpacking ...`)
+//! are stripped.
+
+use std::process::ExitCode;
+
+use crate::cmd::{extract_output_format, user_has_flag, OutputFormat};
+use crate::output::canonical::GitResult;
+use crate::runner::CommandRunner;
+
+use super::{map_exit_code, run_passthrough};
+
+/// Run `git fetch` with output compression.
+///
+/// Flag-aware passthrough: `--dry-run`, `-q`, `--quiet` pass through unmodified.
+pub(super) fn run_fetch(
+    global_flags: &[String],
+    args: &[String],
+    show_stats: bool,
+) -> anyhow::Result<ExitCode> {
+    if user_has_flag(args, &["--dry-run", "-q", "--quiet"]) {
+        return run_passthrough(global_flags, "fetch", args, show_stats);
+    }
+
+    let (filtered_args, output_format) = extract_output_format(args);
+
+    let mut full_args: Vec<String> = global_flags.to_vec();
+    full_args.push("fetch".to_string());
+    full_args.extend_from_slice(&filtered_args);
+
+    let runner = CommandRunner::new(None);
+    let arg_refs: Vec<&str> = full_args.iter().map(|s| s.as_str()).collect();
+    let output = runner.run("git", &arg_refs)?;
+
+    if output.exit_code != Some(0) {
+        // On failure, pass through stderr
+        if !output.stderr.is_empty() {
+            eprint!("{}", output.stderr);
+        }
+        if !output.stdout.is_empty() {
+            print!("{}", output.stdout);
+        }
+        return Ok(map_exit_code(output.exit_code));
+    }
+
+    // Git fetch writes its output to stderr; combine both for parsing
+    let combined = format!("{}\n{}", output.stderr, output.stdout);
+    let result = parse_fetch(&combined);
+
+    let result_str = match output_format {
+        OutputFormat::Json => {
+            let json = serde_json::to_string_pretty(&result)
+                .map_err(|e| anyhow::anyhow!("failed to serialize result: {e}"))?;
+            println!("{json}");
+            json
+        }
+        OutputFormat::Text => {
+            let s = result.to_string();
+            println!("{s}");
+            s
+        }
+    };
+
+    if show_stats {
+        let (orig, comp) = crate::process::count_token_pair(&combined, &result_str);
+        crate::process::report_token_stats(orig, comp, "");
+    }
+
+    if crate::analytics::is_analytics_enabled() {
+        crate::analytics::try_record_command(
+            combined,
+            result_str,
+            format!("skim git fetch {}", args.join(" ")),
+            crate::analytics::CommandType::Git,
+            output.duration,
+            None,
+        );
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+/// Parse combined stdout+stderr from `git fetch` into a compressed GitResult.
+///
+/// Git fetch writes its output to stderr. The parser handles:
+/// - Updated branches/refs (`abc..def branch -> origin/branch`)
+/// - New branches (`* [new branch] name -> origin/name`)
+/// - New tags (`* [new tag] v1.0 -> v1.0`)
+/// - Pruned refs (`- [deleted] (none) -> origin/old-branch`)
+/// - Forced updates (`+ abc...def branch -> origin/branch (forced update)`)
+/// - Submodule fetches (`Fetching submodule lib/core`)
+/// - Progress/noise lines stripped (`remote: ...`, `Unpacking ...`)
+fn parse_fetch(input: &str) -> GitResult {
+    let lines: Vec<&str> = input.lines().collect();
+
+    if lines.iter().all(|l| l.trim().is_empty()) {
+        return GitResult::new(
+            "fetch".to_string(),
+            "up to date".to_string(),
+            Vec::new(),
+        );
+    }
+
+    let mut remote = String::new();
+    let mut new_branches: Vec<String> = Vec::new();
+    let mut new_tags: Vec<String> = Vec::new();
+    let mut updated: Vec<String> = Vec::new();
+    let mut pruned: Vec<String> = Vec::new();
+    let mut forced: Vec<String> = Vec::new();
+    let mut submodule_sections: Vec<(String, Vec<String>)> = Vec::new();
+    let mut current_submodule: Option<String> = None;
+
+    for line in &lines {
+        let trimmed = line.trim();
+
+        // Skip progress/noise lines
+        if trimmed.starts_with("remote:") || trimmed.starts_with("Unpacking") || trimmed.is_empty()
+        {
+            continue;
+        }
+
+        // Submodule header
+        if let Some(sub) = trimmed.strip_prefix("Fetching submodule ") {
+            current_submodule = Some(sub.to_string());
+            continue;
+        }
+
+        // From line — extract remote (only first one for primary remote)
+        if let Some(rest) = trimmed.strip_prefix("From ") {
+            if current_submodule.is_none() && remote.is_empty() {
+                remote = rest.to_string();
+            }
+            continue;
+        }
+
+        // New branch
+        if trimmed.contains("[new branch]") {
+            if let Some(name) = extract_ref_name(trimmed) {
+                if let Some(ref sub) = current_submodule {
+                    add_to_submodule(
+                        &mut submodule_sections,
+                        sub,
+                        &format!("new branch: {name}"),
+                    );
+                } else {
+                    new_branches.push(name);
+                }
+            }
+            continue;
+        }
+
+        // New tag
+        if trimmed.contains("[new tag]") {
+            if let Some(name) = extract_ref_name(trimmed) {
+                new_tags.push(name);
+            }
+            continue;
+        }
+
+        // Deleted/pruned
+        if trimmed.contains("[deleted]") {
+            if let Some(name) = extract_pruned_ref(trimmed) {
+                pruned.push(name);
+            }
+            continue;
+        }
+
+        // Forced update
+        if trimmed.contains("(forced update)") {
+            if let Some(name) = extract_updated_ref(trimmed) {
+                forced.push(name);
+            }
+            continue;
+        }
+
+        // Regular update (abc..def ref -> origin/ref)
+        if trimmed.contains("->") && (trimmed.contains("..") || trimmed.contains("...")) {
+            if let Some(name) = extract_updated_ref(trimmed) {
+                if let Some(ref sub) = current_submodule {
+                    add_to_submodule(&mut submodule_sections, sub, &format!("updated: {name}"));
+                } else {
+                    updated.push(name);
+                }
+            }
+            continue;
+        }
+    }
+
+    // Build summary parts
+    let mut parts: Vec<String> = Vec::new();
+    if !updated.is_empty() {
+        parts.push(format!(
+            "{} updated",
+            updated.len()
+        ));
+    }
+    if !new_branches.is_empty() {
+        parts.push(format!(
+            "{} new branch{}",
+            new_branches.len(),
+            if new_branches.len() == 1 { "" } else { "es" }
+        ));
+    }
+    if !new_tags.is_empty() {
+        parts.push(format!(
+            "{} new tag{}",
+            new_tags.len(),
+            if new_tags.len() == 1 { "" } else { "s" }
+        ));
+    }
+    if !pruned.is_empty() {
+        parts.push(format!("{} pruned", pruned.len()));
+    }
+    if !forced.is_empty() {
+        parts.push(format!("{} forced", forced.len()));
+    }
+
+    if parts.is_empty() && submodule_sections.is_empty() {
+        return GitResult::new(
+            "fetch".to_string(),
+            "up to date".to_string(),
+            Vec::new(),
+        );
+    }
+
+    // Build detail lines
+    let mut details: Vec<String> = Vec::new();
+    for b in &new_branches {
+        details.push(format!("+ {b} (new branch)"));
+    }
+    for t in &new_tags {
+        details.push(format!("+ {t} (new tag)"));
+    }
+    for u in &updated {
+        details.push(format!("~ {u}"));
+    }
+    for f in &forced {
+        details.push(format!("! {f} (forced)"));
+    }
+    for p in &pruned {
+        details.push(format!("- {p} (pruned)"));
+    }
+    for (sub_name, entries) in &submodule_sections {
+        details.push(format!("[submodule {sub_name}]"));
+        for e in entries {
+            details.push(format!("  {e}"));
+        }
+    }
+
+    let display_summary = build_summary(&remote, &parts);
+
+    GitResult::new("fetch".to_string(), display_summary, details)
+}
+
+fn build_summary(remote: &str, parts: &[String]) -> String {
+    if parts.is_empty() {
+        String::new()
+    } else if remote.is_empty() {
+        parts.join(", ")
+    } else {
+        format!("from {remote}: {}", parts.join(", "))
+    }
+}
+
+// ============================================================================
+// Ref extraction helpers
+// ============================================================================
+
+/// Extract the local ref name from a line like:
+///   `* [new branch] feature/x -> origin/feature/x`
+///   `* [new tag]    v2.3.0    -> v2.3.0`
+fn extract_ref_name(line: &str) -> Option<String> {
+    let arrow_pos = line.find("->")?;
+    let target = line[arrow_pos + 2..].trim();
+    // Strip "origin/" prefix if present
+    let name = target.strip_prefix("origin/").unwrap_or(target);
+    Some(name.to_string())
+}
+
+/// Extract the local ref name from an updated ref line like:
+///   `abc1234..def5678 main -> origin/main`
+///   `+ ccc3333...ddd4444 feature/z -> origin/feature/z  (forced update)`
+fn extract_updated_ref(line: &str) -> Option<String> {
+    let arrow_pos = line.find("->")?;
+    let target = line[arrow_pos + 2..].trim();
+    // Strip trailing "(forced update)" and whitespace
+    let target = target
+        .trim_end_matches(")")
+        .trim_end();
+    let target = if let Some(pos) = target.rfind('(') {
+        target[..pos].trim()
+    } else {
+        target
+    };
+    let name = target.strip_prefix("origin/").unwrap_or(target);
+    Some(name.to_string())
+}
+
+/// Extract the pruned ref name from a deleted line like:
+///   `- [deleted] (none) -> origin/old-branch`
+fn extract_pruned_ref(line: &str) -> Option<String> {
+    let arrow_pos = line.find("->")?;
+    let target = line[arrow_pos + 2..].trim();
+    let name = target.strip_prefix("origin/").unwrap_or(target);
+    Some(name.to_string())
+}
+
+/// Add an entry to a submodule section, creating the section if it doesn't exist.
+fn add_to_submodule(sections: &mut Vec<(String, Vec<String>)>, sub: &str, entry: &str) {
+    if let Some(section) = sections.iter_mut().find(|(name, _)| name == sub) {
+        section.1.push(entry.to_string());
+    } else {
+        sections.push((sub.to_string(), vec![entry.to_string()]));
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str) -> String {
+        let path = format!(
+            "{}/tests/fixtures/cmd/git/{name}",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"))
+    }
+
+    // ========================================================================
+    // parse_fetch tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_fetch_empty() {
+        let result = parse_fetch("");
+        assert_eq!(result.summary, "up to date");
+        assert!(result.details.is_empty());
+    }
+
+    #[test]
+    fn test_parse_fetch_whitespace_only() {
+        let result = parse_fetch("   \n\n  \n");
+        assert_eq!(result.summary, "up to date");
+        assert!(result.details.is_empty());
+    }
+
+    #[test]
+    fn test_parse_fetch_up_to_date_fixture() {
+        let input = fixture("fetch_up_to_date.txt");
+        let result = parse_fetch(&input);
+        assert_eq!(result.summary, "up to date");
+    }
+
+    #[test]
+    fn test_parse_fetch_with_updates() {
+        let input = fixture("fetch_refs.txt");
+        let result = parse_fetch(&input);
+        // Should have: 2 updated, 2 new branches, 1 new tag
+        assert!(
+            result.summary.contains("2 updated"),
+            "expected '2 updated' in summary, got: {}",
+            result.summary
+        );
+        assert!(
+            result.summary.contains("2 new branches"),
+            "expected '2 new branches' in summary, got: {}",
+            result.summary
+        );
+        assert!(
+            result.summary.contains("1 new tag"),
+            "expected '1 new tag' in summary, got: {}",
+            result.summary
+        );
+        assert!(result.summary.contains("github.com:user/repo"), "expected remote in summary");
+    }
+
+    #[test]
+    fn test_parse_fetch_progress_stripped() {
+        let input = fixture("fetch_refs.txt");
+        let result = parse_fetch(&input);
+        // Progress lines must not appear in output
+        let rendered = result.to_string();
+        assert!(
+            !rendered.contains("remote:"),
+            "remote: progress lines must be stripped"
+        );
+        assert!(
+            !rendered.contains("Unpacking"),
+            "Unpacking lines must be stripped"
+        );
+    }
+
+    #[test]
+    fn test_parse_fetch_new_branches_in_details() {
+        let input = fixture("fetch_refs.txt");
+        let result = parse_fetch(&input);
+        let details_str = result.details.join("\n");
+        assert!(
+            details_str.contains("feature/x") || details_str.contains("feature/y"),
+            "expected new branch names in details, got: {details_str}"
+        );
+    }
+
+    #[test]
+    fn test_parse_fetch_new_branches_only() {
+        let input = "From github.com:user/repo\n * [new branch]      feat/a     -> origin/feat/a\n * [new branch]      feat/b     -> origin/feat/b\n";
+        let result = parse_fetch(input);
+        assert!(
+            result.summary.contains("2 new branches"),
+            "expected '2 new branches', got: {}",
+            result.summary
+        );
+        assert!(!result.summary.contains("updated"), "should not mention updated");
+    }
+
+    #[test]
+    fn test_parse_fetch_with_prune() {
+        let input = fixture("fetch_with_prune.txt");
+        let result = parse_fetch(&input);
+        assert!(
+            result.summary.contains("1 updated"),
+            "expected '1 updated', got: {}",
+            result.summary
+        );
+        assert!(
+            result.summary.contains("2 pruned"),
+            "expected '2 pruned', got: {}",
+            result.summary
+        );
+        let details_str = result.details.join("\n");
+        assert!(
+            details_str.contains("old-branch") || details_str.contains("stale-feature"),
+            "expected pruned branch names in details"
+        );
+    }
+
+    #[test]
+    fn test_parse_fetch_forced_update() {
+        let input = fixture("fetch_forced.txt");
+        let result = parse_fetch(&input);
+        assert!(
+            result.summary.contains("1 forced"),
+            "expected '1 forced', got: {}",
+            result.summary
+        );
+        let details_str = result.details.join("\n");
+        assert!(
+            details_str.contains("feature/z"),
+            "expected forced branch name in details, got: {details_str}"
+        );
+        assert!(
+            details_str.contains("forced"),
+            "expected 'forced' label in details"
+        );
+    }
+
+    #[test]
+    fn test_parse_fetch_submodules() {
+        let input = fixture("fetch_submodules.txt");
+        let result = parse_fetch(&input);
+        let details_str = result.details.join("\n");
+        assert!(
+            details_str.contains("lib/core") || details_str.contains("lib/utils"),
+            "expected submodule names in details, got: {details_str}"
+        );
+    }
+
+    #[test]
+    fn test_extract_ref_name_new_branch() {
+        let line = " * [new branch]      feature/x  -> origin/feature/x";
+        let result = extract_ref_name(line);
+        assert_eq!(result, Some("feature/x".to_string()));
+    }
+
+    #[test]
+    fn test_extract_ref_name_new_tag() {
+        let line = " * [new tag]         v2.3.0     -> v2.3.0";
+        let result = extract_ref_name(line);
+        assert_eq!(result, Some("v2.3.0".to_string()));
+    }
+
+    #[test]
+    fn test_extract_updated_ref_normal() {
+        let line = "   abc1234..def5678  main       -> origin/main";
+        let result = extract_updated_ref(line);
+        assert_eq!(result, Some("main".to_string()));
+    }
+
+    #[test]
+    fn test_extract_updated_ref_forced() {
+        let line = " + ccc3333...ddd4444 feature/z  -> origin/feature/z  (forced update)";
+        let result = extract_updated_ref(line);
+        assert_eq!(result, Some("feature/z".to_string()));
+    }
+
+    #[test]
+    fn test_extract_pruned_ref() {
+        let line = " - [deleted]         (none)     -> origin/old-branch";
+        let result = extract_pruned_ref(line);
+        assert_eq!(result, Some("old-branch".to_string()));
+    }
+
+    #[test]
+    fn test_add_to_submodule_creates_section() {
+        let mut sections: Vec<(String, Vec<String>)> = Vec::new();
+        add_to_submodule(&mut sections, "lib/core", "updated: main");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].0, "lib/core");
+        assert_eq!(sections[0].1, vec!["updated: main"]);
+    }
+
+    #[test]
+    fn test_add_to_submodule_appends_to_existing() {
+        let mut sections: Vec<(String, Vec<String>)> = Vec::new();
+        add_to_submodule(&mut sections, "lib/core", "updated: main");
+        add_to_submodule(&mut sections, "lib/core", "new branch: feature");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].1.len(), 2);
+    }
+}

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -101,11 +101,7 @@ fn parse_fetch(input: &str) -> GitResult {
     let lines: Vec<&str> = input.lines().collect();
 
     if lines.iter().all(|l| l.trim().is_empty()) {
-        return GitResult::new(
-            "fetch".to_string(),
-            "up to date".to_string(),
-            Vec::new(),
-        );
+        return GitResult::new("fetch".to_string(), "up to date".to_string(), Vec::new());
     }
 
     let mut remote = String::new();
@@ -144,11 +140,7 @@ fn parse_fetch(input: &str) -> GitResult {
         if trimmed.contains("[new branch]") {
             if let Some(name) = extract_ref_name(trimmed) {
                 if let Some(ref sub) = current_submodule {
-                    add_to_submodule(
-                        &mut submodule_sections,
-                        sub,
-                        &format!("new branch: {name}"),
-                    );
+                    add_to_submodule(&mut submodule_sections, sub, &format!("new branch: {name}"));
                 } else {
                     new_branches.push(name);
                 }
@@ -220,11 +212,7 @@ fn parse_fetch(input: &str) -> GitResult {
     }
 
     if parts.is_empty() && submodule_sections.is_empty() {
-        return GitResult::new(
-            "fetch".to_string(),
-            "up to date".to_string(),
-            Vec::new(),
-        );
+        return GitResult::new("fetch".to_string(), "up to date".to_string(), Vec::new());
     }
 
     // Build detail lines
@@ -375,7 +363,10 @@ mod tests {
             "expected '1 new tag' in summary, got: {}",
             result.summary
         );
-        assert!(result.summary.contains("github.com:user/repo"), "expected remote in summary");
+        assert!(
+            result.summary.contains("github.com:user/repo"),
+            "expected remote in summary"
+        );
     }
 
     #[test]
@@ -414,7 +405,10 @@ mod tests {
             "expected '2 new branches', got: {}",
             result.summary
         );
-        assert!(!result.summary.contains("updated"), "should not mention updated");
+        assert!(
+            !result.summary.contains("updated"),
+            "should not mention updated"
+        );
     }
 
     #[test]

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -74,18 +74,18 @@ impl FetchCategories {
 
     /// Add an entry to a submodule section in O(1) time.
     fn add_submodule_entry(&mut self, sub: &str, entry: String) {
-        if !self.submodule_map.contains_key(sub) {
+        let entries = self.submodule_map.entry(sub.to_string()).or_insert_with(|| {
             self.submodule_order.push(sub.to_string());
-            self.submodule_map.insert(sub.to_string(), Vec::new());
-        }
-        self.submodule_map.get_mut(sub).unwrap().push(entry);
+            Vec::new()
+        });
+        entries.push(entry);
     }
 
     /// Iterate submodule sections in the order they were first encountered.
-    fn submodule_sections(&self) -> impl Iterator<Item = (&str, &Vec<String>)> {
+    fn submodule_sections(&self) -> impl Iterator<Item = (&str, &[String])> {
         self.submodule_order
             .iter()
-            .filter_map(|name| self.submodule_map.get(name).map(|v| (name.as_str(), v)))
+            .filter_map(|name| self.submodule_map.get(name).map(|v| (name.as_str(), v.as_slice())))
     }
 }
 

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -74,18 +74,23 @@ impl FetchCategories {
 
     /// Add an entry to a submodule section in O(1) time.
     fn add_submodule_entry(&mut self, sub: &str, entry: String) {
-        let entries = self.submodule_map.entry(sub.to_string()).or_insert_with(|| {
-            self.submodule_order.push(sub.to_string());
-            Vec::new()
-        });
+        let entries = self
+            .submodule_map
+            .entry(sub.to_string())
+            .or_insert_with(|| {
+                self.submodule_order.push(sub.to_string());
+                Vec::new()
+            });
         entries.push(entry);
     }
 
     /// Iterate submodule sections in the order they were first encountered.
     fn submodule_sections(&self) -> impl Iterator<Item = (&str, &[String])> {
-        self.submodule_order
-            .iter()
-            .filter_map(|name| self.submodule_map.get(name).map(|v| (name.as_str(), v.as_slice())))
+        self.submodule_order.iter().filter_map(|name| {
+            self.submodule_map
+                .get(name)
+                .map(|v| (name.as_str(), v.as_slice()))
+        })
     }
 }
 
@@ -104,9 +109,7 @@ fn classify_lines<'a>(lines: impl Iterator<Item = &'a str>) -> FetchCategories {
 
     for trimmed in lines.map(str::trim) {
         // Skip progress/noise lines
-        if trimmed.starts_with("remote:")
-            || trimmed.starts_with("Unpacking")
-            || trimmed.is_empty()
+        if trimmed.starts_with("remote:") || trimmed.starts_with("Unpacking") || trimmed.is_empty()
         {
             continue;
         }
@@ -239,7 +242,11 @@ fn parse_fetch(input: &str) -> GitResult {
         parts.push(format!(
             "{} new branch{}",
             cats.new_branches.len(),
-            if cats.new_branches.len() == 1 { "" } else { "es" }
+            if cats.new_branches.len() == 1 {
+                ""
+            } else {
+                "es"
+            }
         ));
     }
     if !cats.new_tags.is_empty() {

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -196,10 +196,7 @@ fn parse_fetch(input: &str) -> GitResult {
     // Build summary parts
     let mut parts: Vec<String> = Vec::new();
     if !updated.is_empty() {
-        parts.push(format!(
-            "{} updated",
-            updated.len()
-        ));
+        parts.push(format!("{} updated", updated.len()));
     }
     if !new_branches.is_empty() {
         parts.push(format!(
@@ -290,14 +287,9 @@ fn extract_ref_name(line: &str) -> Option<String> {
 fn extract_updated_ref(line: &str) -> Option<String> {
     let arrow_pos = line.find("->")?;
     let target = line[arrow_pos + 2..].trim();
-    // Strip trailing "(forced update)" and whitespace
-    let target = target
-        .trim_end_matches(")")
-        .trim_end();
-    let target = if let Some(pos) = target.rfind('(') {
-        target[..pos].trim()
-    } else {
-        target
+    let target = match target.rfind('(') {
+        Some(pos) => target[..pos].trim(),
+        None => target,
     };
     let name = target.strip_prefix("origin/").unwrap_or(target);
     Some(name.to_string())
@@ -474,6 +466,34 @@ mod tests {
         assert!(
             details_str.contains("lib/core") || details_str.contains("lib/utils"),
             "expected submodule names in details, got: {details_str}"
+        );
+    }
+
+    #[test]
+    fn test_parse_fetch_multiple_remotes() {
+        // git fetch --all produces multiple From blocks
+        let input = "\
+From github.com:user/repo
+   abc1234..def5678  main       -> origin/main
+From github.com:upstream/repo
+ * [new branch]      release    -> upstream/release
+";
+        let result = parse_fetch(input);
+        // First remote captured in summary
+        assert!(
+            result.summary.contains("github.com:user/repo"),
+            "expected first remote in summary, got: {}",
+            result.summary
+        );
+        // Both updates tracked
+        let details_str = result.details.join("\n");
+        assert!(
+            details_str.contains("main"),
+            "expected main in details, got: {details_str}"
+        );
+        assert!(
+            details_str.contains("release"),
+            "expected release in details, got: {details_str}"
         );
     }
 

--- a/crates/rskim/src/cmd/git/log.rs
+++ b/crates/rskim/src/cmd/git/log.rs
@@ -31,7 +31,7 @@ pub(super) fn run_log(
 
     full_args.extend_from_slice(&filtered_args);
 
-    run_parsed_command(&full_args, show_stats, output_format, parse_log)
+    run_parsed_command(&full_args, show_stats, output_format, false, parse_log)
 }
 
 /// Parse formatted `git log` output into a compressed GitResult.

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -225,10 +225,15 @@ fn run_passthrough(
 ///
 /// Callers are responsible for baking global flags into `subcmd_args` before
 /// calling this function.
-fn run_parsed_command<F>(
+///
+/// When `combine_stderr` is `true`, the parser receives `stderr + stdout`
+/// combined. Git fetch writes its output to stderr, so fetch uses `true`;
+/// all other subcommands use `false` (stdout only).
+pub(super) fn run_parsed_command<F>(
     subcmd_args: &[String],
     show_stats: bool,
     output_format: OutputFormat,
+    combine_stderr: bool,
     parser: F,
 ) -> anyhow::Result<ExitCode>
 where
@@ -249,7 +254,14 @@ where
         return Ok(map_exit_code(output.exit_code));
     }
 
-    let result = parser(&output.stdout);
+    // Git fetch writes to stderr; other subcommands write to stdout.
+    let raw: String = if combine_stderr {
+        format!("{}\n{}", output.stderr, output.stdout)
+    } else {
+        output.stdout
+    };
+
+    let result = parser(&raw);
     let result_str = match output_format {
         OutputFormat::Json => {
             let json = serde_json::to_string_pretty(&result)
@@ -265,7 +277,7 @@ where
     };
 
     if show_stats {
-        let (orig, comp) = crate::process::count_token_pair(&output.stdout, &result_str);
+        let (orig, comp) = crate::process::count_token_pair(&raw, &result_str);
         crate::process::report_token_stats(orig, comp, "");
     }
 
@@ -273,7 +285,7 @@ where
     // Guard to avoid allocations when analytics are disabled.
     if crate::analytics::is_analytics_enabled() {
         crate::analytics::try_record_command(
-            output.stdout,
+            raw,
             result_str,
             format!("skim git {}", subcmd_args.join(" ")),
             crate::analytics::CommandType::Git,

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -12,6 +12,7 @@
 
 // Private: only accessed via run() dispatch in this module
 mod diff;
+mod fetch;
 mod log;
 mod status;
 
@@ -49,12 +50,13 @@ pub(crate) fn run(args: &[String]) -> anyhow::Result<ExitCode> {
     match subcmd.as_str() {
         "status" => status::run_status(&global_flags, subcmd_args, show_stats),
         "diff" => diff::run_diff(&global_flags, subcmd_args, show_stats),
+        "fetch" => fetch::run_fetch(&global_flags, subcmd_args, show_stats),
         "log" => log::run_log(&global_flags, subcmd_args, show_stats),
         other => {
             let safe_other = crate::cmd::sanitize_for_display(other);
             anyhow::bail!(
                 "unknown git subcommand: '{safe_other}'\n\n\
-                 Supported: status, diff, log\n\
+                 Supported: status, diff, fetch, log\n\
                  Run 'skim git --help' for usage"
             );
         }
@@ -66,13 +68,14 @@ pub(crate) fn run(args: &[String]) -> anyhow::Result<ExitCode> {
 // ============================================================================
 
 fn print_help() {
-    println!("skim git <status|diff|log> [args...]");
+    println!("skim git <status|diff|fetch|log> [args...]");
     println!();
     println!("  Compress git command output for LLM context windows.");
     println!();
     println!("Subcommands:");
     println!("  status    Show compressed working tree status");
     println!("  diff      AST-aware diff with full function boundaries");
+    println!("  fetch     Show compressed fetch summary (new branches, tags, pruned)");
     println!("  log       Show compressed commit log");
     println!();
     println!("Global git flags (before subcommand):");
@@ -90,6 +93,8 @@ fn print_help() {
     println!("  skim git diff --cached");
     println!("  skim git diff --mode structure");
     println!("  skim git diff main..feature --json");
+    println!("  skim git fetch");
+    println!("  skim git fetch --prune");
     println!("  skim git log -n 5");
     println!("  skim git diff --help                   Diff-specific options");
 }

--- a/crates/rskim/src/cmd/git/status.rs
+++ b/crates/rskim/src/cmd/git/status.rs
@@ -30,7 +30,7 @@ pub(super) fn run_status(
     ]);
     full_args.extend_from_slice(&filtered_args);
 
-    run_parsed_command(&full_args, show_stats, output_format, parse_status)
+    run_parsed_command(&full_args, show_stats, output_format, false, parse_status)
 }
 
 /// Accumulated per-category file lists from a porcelain v2 status parse.

--- a/crates/rskim/src/cmd/infra/aws.rs
+++ b/crates/rskim/src/cmd/infra/aws.rs
@@ -79,7 +79,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["aws: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/aws.rs
+++ b/crates/rskim/src/cmd/infra/aws.rs
@@ -79,7 +79,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["aws: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["aws: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/curl.rs
+++ b/crates/rskim/src/cmd/infra/curl.rs
@@ -62,7 +62,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["curl: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["curl: structured parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/curl.rs
+++ b/crates/rskim/src/cmd/infra/curl.rs
@@ -62,7 +62,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["curl: structured parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/gh.rs
+++ b/crates/rskim/src/cmd/infra/gh.rs
@@ -79,7 +79,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["gh: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["gh: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/gh.rs
+++ b/crates/rskim/src/cmd/infra/gh.rs
@@ -79,7 +79,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["gh: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/wget.rs
+++ b/crates/rskim/src/cmd/infra/wget.rs
@@ -63,7 +63,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     }
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["wget: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["wget: structured parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/infra/wget.rs
+++ b/crates/rskim/src/cmd/infra/wget.rs
@@ -63,7 +63,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<InfraResult> {
     }
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["wget: structured parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/eslint.rs
+++ b/crates/rskim/src/cmd/lint/eslint.rs
@@ -66,7 +66,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["eslint: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/eslint.rs
+++ b/crates/rskim/src/cmd/lint/eslint.rs
@@ -66,7 +66,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["eslint: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["eslint: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/golangci.rs
+++ b/crates/rskim/src/cmd/lint/golangci.rs
@@ -67,7 +67,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["golangci-lint: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/golangci.rs
+++ b/crates/rskim/src/cmd/lint/golangci.rs
@@ -67,7 +67,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["golangci-lint: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["golangci-lint: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/mypy.rs
+++ b/crates/rskim/src/cmd/lint/mypy.rs
@@ -62,7 +62,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["mypy: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/mypy.rs
+++ b/crates/rskim/src/cmd/lint/mypy.rs
@@ -62,7 +62,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["mypy: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["mypy: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/prettier.rs
+++ b/crates/rskim/src/cmd/lint/prettier.rs
@@ -70,7 +70,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["prettier: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["prettier: structured parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/prettier.rs
+++ b/crates/rskim/src/cmd/lint/prettier.rs
@@ -70,7 +70,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["prettier: structured parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/ruff.rs
+++ b/crates/rskim/src/cmd/lint/ruff.rs
@@ -67,7 +67,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["ruff: JSON parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/ruff.rs
+++ b/crates/rskim/src/cmd/lint/ruff.rs
@@ -67,7 +67,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     let combined = combine_stdout_stderr(output);
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["ruff: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["ruff: JSON parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/rustfmt.rs
+++ b/crates/rskim/src/cmd/lint/rustfmt.rs
@@ -67,7 +67,7 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     }
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["rustfmt: diff parse failed, using regex".to_string()]);
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/lint/rustfmt.rs
+++ b/crates/rskim/src/cmd/lint/rustfmt.rs
@@ -67,7 +67,10 @@ fn parse_impl(output: &CommandOutput) -> ParseResult<LintResult> {
     }
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["rustfmt: diff parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["rustfmt: diff parse failed, using regex".to_string()],
+        );
     }
 
     ParseResult::Passthrough(combined.into_owned())

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -223,7 +223,7 @@ fn compress_log(input: &str, flags: &LogFlags) -> ParseResult<LogResult> {
 
     // Try Tier 2: regex-based log formats
     if let Some(result) = try_parse_regex_logs(input, flags) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["log: no structured entries found, using regex".to_string()]);
     }
 
     // Tier 3: passthrough

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -223,7 +223,10 @@ fn compress_log(input: &str, flags: &LogFlags) -> ParseResult<LogResult> {
 
     // Try Tier 2: regex-based log formats
     if let Some(result) = try_parse_regex_logs(input, flags) {
-        return ParseResult::Degraded(result, vec!["log: no structured entries found, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["log: no structured entries found, using regex".to_string()],
+        );
     }
 
     // Tier 3: passthrough

--- a/crates/rskim/src/cmd/pkg/cargo.rs
+++ b/crates/rskim/src/cmd/pkg/cargo.rs
@@ -92,7 +92,7 @@ fn parse_audit(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = super::combine_output(output);
     if let Some(result) = try_parse_audit_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["cargo audit: structured parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/cargo.rs
+++ b/crates/rskim/src/cmd/pkg/cargo.rs
@@ -92,7 +92,10 @@ fn parse_audit(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = super::combine_output(output);
     if let Some(result) = try_parse_audit_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["cargo audit: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["cargo audit: structured parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/audit.rs
+++ b/crates/rskim/src/cmd/pkg/npm/audit.rs
@@ -51,7 +51,10 @@ fn parse_audit(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = combine_output(output);
     if let Some(result) = try_parse_audit_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["npm audit: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["npm audit: JSON parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/audit.rs
+++ b/crates/rskim/src/cmd/pkg/npm/audit.rs
@@ -51,7 +51,7 @@ fn parse_audit(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = combine_output(output);
     if let Some(result) = try_parse_audit_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["npm audit: JSON parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/install.rs
+++ b/crates/rskim/src/cmd/pkg/npm/install.rs
@@ -55,7 +55,7 @@ fn parse_install(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = combine_output(output);
     if let Some(result) = try_parse_install_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["npm install: structured parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/install.rs
+++ b/crates/rskim/src/cmd/pkg/npm/install.rs
@@ -55,7 +55,10 @@ fn parse_install(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = combine_output(output);
     if let Some(result) = try_parse_install_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["npm install: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["npm install: structured parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/ls.rs
+++ b/crates/rskim/src/cmd/pkg/npm/ls.rs
@@ -44,7 +44,7 @@ fn parse_ls(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex (count package lines)
     let combined = combine_output(output);
     if let Some(result) = try_parse_ls_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["npm ls: JSON parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/ls.rs
+++ b/crates/rskim/src/cmd/pkg/npm/ls.rs
@@ -44,7 +44,10 @@ fn parse_ls(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex (count package lines)
     let combined = combine_output(output);
     if let Some(result) = try_parse_ls_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["npm ls: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["npm ls: JSON parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/outdated.rs
+++ b/crates/rskim/src/cmd/pkg/npm/outdated.rs
@@ -39,7 +39,10 @@ fn parse_outdated(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex (count non-header table lines)
     let combined = combine_output(output);
     if let Some(result) = try_parse_outdated_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["npm outdated: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["npm outdated: JSON parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/npm/outdated.rs
+++ b/crates/rskim/src/cmd/pkg/npm/outdated.rs
@@ -39,7 +39,7 @@ fn parse_outdated(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex (count non-header table lines)
     let combined = combine_output(output);
     if let Some(result) = try_parse_outdated_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["npm outdated: JSON parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/pip.rs
+++ b/crates/rskim/src/cmd/pkg/pip.rs
@@ -239,7 +239,7 @@ fn parse_list(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = super::combine_output(output);
     if let Some(result) = try_parse_list_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["pip: structured parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/pkg/pip.rs
+++ b/crates/rskim/src/cmd/pkg/pip.rs
@@ -239,7 +239,10 @@ fn parse_list(output: &CommandOutput) -> ParseResult<PkgResult> {
     // Tier 2: Regex
     let combined = super::combine_output(output);
     if let Some(result) = try_parse_list_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["pip: structured parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["pip: structured parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/rewrite.rs
+++ b/crates/rskim/src/cmd/rewrite.rs
@@ -216,7 +216,14 @@ const REWRITE_RULES: &[RewriteRule] = &[
     RewriteRule {
         prefix: &["git", "diff"],
         rewrite_to: &["skim", "git", "diff"],
-        skip_if_flag_prefix: &["--stat", "--shortstat", "--numstat", "--name-only", "--name-status", "--check"],
+        skip_if_flag_prefix: &[
+            "--stat",
+            "--shortstat",
+            "--numstat",
+            "--name-only",
+            "--name-status",
+            "--check",
+        ],
         category: RewriteCategory::Git,
     },
     RewriteRule {

--- a/crates/rskim/src/cmd/rewrite.rs
+++ b/crates/rskim/src/cmd/rewrite.rs
@@ -216,7 +216,13 @@ const REWRITE_RULES: &[RewriteRule] = &[
     RewriteRule {
         prefix: &["git", "diff"],
         rewrite_to: &["skim", "git", "diff"],
-        skip_if_flag_prefix: &["--stat", "--name-only", "--name-status", "--check"],
+        skip_if_flag_prefix: &["--stat", "--shortstat", "--numstat", "--name-only", "--name-status", "--check"],
+        category: RewriteCategory::Git,
+    },
+    RewriteRule {
+        prefix: &["git", "fetch"],
+        rewrite_to: &["skim", "git", "fetch"],
+        skip_if_flag_prefix: &["--dry-run", "-q", "--quiet"],
         category: RewriteCategory::Git,
     },
     RewriteRule {
@@ -2092,6 +2098,16 @@ mod tests {
     }
 
     #[test]
+    fn test_git_diff_with_shortstat_skipped() {
+        assert!(try_rewrite(&["git", "diff", "--shortstat"]).is_none());
+    }
+
+    #[test]
+    fn test_git_diff_with_numstat_skipped() {
+        assert!(try_rewrite(&["git", "diff", "--numstat"]).is_none());
+    }
+
+    #[test]
     fn test_git_log_with_format_skipped() {
         assert!(try_rewrite(&["git", "log", "--format=%H"]).is_none());
     }
@@ -2104,6 +2120,41 @@ mod tests {
     #[test]
     fn test_git_log_with_oneline_skipped() {
         assert!(try_rewrite(&["git", "log", "--oneline"]).is_none());
+    }
+
+    // ========================================================================
+    // git fetch
+    // ========================================================================
+
+    #[test]
+    fn test_git_fetch() {
+        let result = try_rewrite(&["git", "fetch"]);
+        assert!(result.is_some());
+        let r = result.unwrap();
+        assert_eq!(r.tokens, vec!["skim", "git", "fetch"]);
+    }
+
+    #[test]
+    fn test_git_fetch_with_remote_extra_args_preserved() {
+        let result = try_rewrite(&["git", "fetch", "origin", "main"]);
+        assert!(result.is_some());
+        let r = result.unwrap();
+        assert_eq!(r.tokens, vec!["skim", "git", "fetch", "origin", "main"]);
+    }
+
+    #[test]
+    fn test_git_fetch_dry_run_skipped() {
+        assert!(try_rewrite(&["git", "fetch", "--dry-run"]).is_none());
+    }
+
+    #[test]
+    fn test_git_fetch_quiet_skipped() {
+        assert!(try_rewrite(&["git", "fetch", "-q"]).is_none());
+    }
+
+    #[test]
+    fn test_git_fetch_quiet_long_skipped() {
+        assert!(try_rewrite(&["git", "fetch", "--quiet"]).is_none());
     }
 
     // ========================================================================

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -105,7 +105,7 @@ fn parse_impl(output: &CommandOutput, is_nextest: bool) -> ParseResult<TestResul
     };
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["cargo test: no libtest JSON events found, using regex".to_string()]);
     }
 
     // Tier 3: passthrough

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -105,7 +105,10 @@ fn parse_impl(output: &CommandOutput, is_nextest: bool) -> ParseResult<TestResul
     };
 
     if let Some(result) = try_parse_regex(&combined) {
-        return ParseResult::Degraded(result, vec!["cargo test: no libtest JSON events found, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["cargo test: no libtest JSON events found, using regex".to_string()],
+        );
     }
 
     // Tier 3: passthrough

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -154,7 +154,10 @@ fn parse(output: &str) -> ParseResult<TestResult> {
 
     // Tier 2: Regex fallback
     if let Some(result) = try_parse_regex(output) {
-        return ParseResult::Degraded(result, vec!["go test: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["go test: JSON parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -154,7 +154,7 @@ fn parse(output: &str) -> ParseResult<TestResult> {
 
     // Tier 2: Regex fallback
     if let Some(result) = try_parse_regex(output) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["go test: JSON parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough
@@ -558,8 +558,8 @@ mod tests {
 
             // Verify marker indicates regex fallback
             assert!(
-                markers.contains(&"regex fallback".to_string()),
-                "expected 'regex fallback' marker, got: {markers:?}"
+                markers.contains(&"go test: JSON parse failed, using regex".to_string()),
+                "expected 'go test: JSON parse failed, using regex' marker, got: {markers:?}"
             );
 
             // Verify duration was extracted from summary line

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -171,7 +171,10 @@ fn parse(raw: &str) -> ParseResult<TestResult> {
 
     // Tier 2: Try regex fallback
     if let Some(result) = try_parse_regex(raw) {
-        return ParseResult::Degraded(result, vec!["vitest: JSON parse failed, using regex".to_string()]);
+        return ParseResult::Degraded(
+            result,
+            vec!["vitest: JSON parse failed, using regex".to_string()],
+        );
     }
 
     // Tier 3: Passthrough

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -171,7 +171,7 @@ fn parse(raw: &str) -> ParseResult<TestResult> {
 
     // Tier 2: Try regex fallback
     if let Some(result) = try_parse_regex(raw) {
-        return ParseResult::Degraded(result, vec!["regex fallback".to_string()]);
+        return ParseResult::Degraded(result, vec!["vitest: JSON parse failed, using regex".to_string()]);
     }
 
     // Tier 3: Passthrough
@@ -665,7 +665,7 @@ mod tests {
             assert_eq!(test_result.summary.pass, 3);
             assert_eq!(test_result.summary.fail, 0);
             assert_eq!(test_result.summary.skip, 0);
-            assert!(markers.contains(&"regex fallback".to_string()));
+            assert!(markers.contains(&"vitest: JSON parse failed, using regex".to_string()));
         }
     }
 

--- a/crates/rskim/src/debug.rs
+++ b/crates/rskim/src/debug.rs
@@ -1,0 +1,55 @@
+//! Debug-mode flag for conditional warning emission.
+//!
+//! Controls whether `emit_markers()` writes degradation warnings to stderr.
+//! Disabled by default — enable with `--debug` CLI flag or `SKIM_DEBUG` env var.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Process-wide flag that enables debug output.
+/// Set via [`force_enable_debug`] at startup, before any background threads
+/// are spawned. Checked by [`is_debug_enabled`].
+static DEBUG_FORCE_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enable debug output for the lifetime of this process.
+///
+/// Thread-safe alternative to `std::env::set_var("SKIM_DEBUG", "1")`.
+/// Call this early in `main()` when `--debug` is detected.
+pub(crate) fn force_enable_debug() {
+    DEBUG_FORCE_ENABLED.store(true, Ordering::Relaxed);
+}
+
+/// Check if debug output is enabled.
+///
+/// Returns `true` when:
+/// - [`force_enable_debug`] has been called (e.g., `--debug` flag), OR
+/// - `SKIM_DEBUG` env var is set to a truthy value
+///   (`1`, `true`, or `yes`, case-insensitive).
+///
+/// Any other value (including `0`, `false`, `no`) keeps debug disabled.
+/// Unsetting the variable also keeps debug disabled (the default).
+pub(crate) fn is_debug_enabled() -> bool {
+    if DEBUG_FORCE_ENABLED.load(Ordering::Relaxed) {
+        return true;
+    }
+    std::env::var("SKIM_DEBUG")
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_debug_disabled_by_default() {
+        // Don't call force_enable_debug; env var not set in normal test runs.
+        // Just verify the function exists and returns a bool.
+        let _ = is_debug_enabled();
+    }
+
+    #[test]
+    fn test_force_enable_debug() {
+        force_enable_debug();
+        assert!(is_debug_enabled());
+    }
+}

--- a/crates/rskim/src/debug.rs
+++ b/crates/rskim/src/debug.rs
@@ -2,38 +2,61 @@
 //!
 //! Controls whether `emit_markers()` writes degradation warnings to stderr.
 //! Disabled by default — enable with `--debug` CLI flag or `SKIM_DEBUG` env var.
+//!
+//! # Startup sequence
+//!
+//! Call [`init_debug_from_env`] once in `main()` before any threads are spawned.
+//! After that, [`is_debug_enabled`] is a single atomic load with no syscalls.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Process-wide flag that enables debug output.
-/// Set via [`force_enable_debug`] at startup, before any background threads
-/// are spawned. Checked by [`is_debug_enabled`].
+/// Written with `Release` ordering so all subsequent `Acquire` loads observe
+/// the store even on weakly-ordered architectures.
 static DEBUG_FORCE_ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Enable debug output for the lifetime of this process.
 ///
 /// Thread-safe alternative to `std::env::set_var("SKIM_DEBUG", "1")`.
-/// Call this early in `main()` when `--debug` is detected.
+/// Call this early in `main()` when `--debug` is detected, before spawning
+/// any background threads.
 pub(crate) fn force_enable_debug() {
-    DEBUG_FORCE_ENABLED.store(true, Ordering::Relaxed);
+    DEBUG_FORCE_ENABLED.store(true, Ordering::Release);
+}
+
+/// Initialise the debug flag from the `SKIM_DEBUG` environment variable.
+///
+/// Call once in `main()` before spawning any threads.  After this call,
+/// [`is_debug_enabled`] never touches the environment again — it is a single
+/// atomic load.
+pub(crate) fn init_debug_from_env() {
+    let enabled = std::env::var("SKIM_DEBUG")
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+    if enabled {
+        force_enable_debug();
+    }
 }
 
 /// Check if debug output is enabled.
 ///
-/// Returns `true` when:
-/// - [`force_enable_debug`] has been called (e.g., `--debug` flag), OR
-/// - `SKIM_DEBUG` env var is set to a truthy value
-///   (`1`, `true`, or `yes`, case-insensitive).
+/// Returns `true` when [`force_enable_debug`] or [`init_debug_from_env`] has
+/// been called (i.e., `--debug` flag or a truthy `SKIM_DEBUG` env var was
+/// detected at startup).
 ///
-/// Any other value (including `0`, `false`, `no`) keeps debug disabled.
-/// Unsetting the variable also keeps debug disabled (the default).
+/// This is a pure atomic load — no allocations, no syscalls.
 pub(crate) fn is_debug_enabled() -> bool {
-    if DEBUG_FORCE_ENABLED.load(Ordering::Relaxed) {
-        return true;
-    }
-    std::env::var("SKIM_DEBUG")
-        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
-        .unwrap_or(false)
+    DEBUG_FORCE_ENABLED.load(Ordering::Acquire)
+}
+
+/// Reset the debug flag to `false`.
+///
+/// Only available in test builds.  Call at the start of any test that invokes
+/// [`force_enable_debug`] so it does not poison the state of later tests that
+/// run in the same process.
+#[cfg(test)]
+pub(crate) fn reset_debug_for_tests() {
+    DEBUG_FORCE_ENABLED.store(false, Ordering::Release);
 }
 
 #[cfg(test)]
@@ -42,7 +65,16 @@ mod tests {
 
     #[test]
     fn test_force_enable_debug() {
+        reset_debug_for_tests();
         force_enable_debug();
         assert!(is_debug_enabled());
+        reset_debug_for_tests();
+    }
+
+    #[test]
+    fn test_reset_clears_flag() {
+        force_enable_debug();
+        reset_debug_for_tests();
+        assert!(!is_debug_enabled());
     }
 }

--- a/crates/rskim/src/debug.rs
+++ b/crates/rskim/src/debug.rs
@@ -41,13 +41,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_is_debug_disabled_by_default() {
-        // Don't call force_enable_debug; env var not set in normal test runs.
-        // Just verify the function exists and returns a bool.
-        let _ = is_debug_enabled();
-    }
-
-    #[test]
     fn test_force_enable_debug() {
         force_enable_debug();
         assert!(is_debug_enabled());

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -476,6 +476,10 @@ fn main() -> ExitCode {
         analytics::force_disable_analytics();
     }
 
+    // Initialise debug flag from SKIM_DEBUG env var once, before any threads
+    // are spawned. After this call, is_debug_enabled() is a pure atomic load.
+    debug::init_debug_from_env();
+
     // Extract --debug before routing so it applies to all subcommands.
     if std::env::args().any(|a| a == "--debug") {
         debug::force_enable_debug();

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -13,6 +13,7 @@ mod analytics;
 mod cache;
 mod cascade;
 mod cmd;
+mod debug;
 mod multi;
 mod output;
 mod process;
@@ -296,6 +297,10 @@ struct Args {
     /// Disable analytics recording for this invocation
     #[arg(long, help = "Disable analytics recording")]
     disable_analytics: bool,
+
+    /// Enable debug output (warnings/notices on stderr)
+    #[arg(long, global = true)]
+    debug: bool,
 }
 
 /// Build the clap `Command` from `Args` for use by shell completion generation.
@@ -469,6 +474,11 @@ fn main() -> ExitCode {
     // instead of env::set_var to avoid unsoundness in multi-threaded context.
     if std::env::args().any(|a| a == "--disable-analytics") {
         analytics::force_disable_analytics();
+    }
+
+    // Extract --debug before routing so it applies to all subcommands.
+    if std::env::args().any(|a| a == "--debug") {
+        debug::force_enable_debug();
     }
 
     let result: anyhow::Result<ExitCode> = match resolve_invocation() {
@@ -709,6 +719,7 @@ mod tests {
             "--clear-cache",
             "--show-stats",
             "--disable-analytics",
+            "--debug",
         ];
 
         for flag in boolean_flags {

--- a/crates/rskim/src/output/mod.rs
+++ b/crates/rskim/src/output/mod.rs
@@ -537,6 +537,31 @@ mod tests {
         crate::debug::reset_debug_for_tests();
     }
 
+    #[test]
+    fn test_emit_markers_degraded_silent_without_debug() {
+        crate::debug::reset_debug_for_tests();
+        let markers = vec!["issue one".to_string(), "issue two".to_string()];
+        let result: ParseResult<String> = ParseResult::Degraded("content".to_string(), markers);
+        let mut buf = Vec::new();
+        result.emit_markers(&mut buf).unwrap();
+        assert!(
+            buf.is_empty(),
+            "Degraded should write nothing when debug is disabled"
+        );
+    }
+
+    #[test]
+    fn test_emit_markers_passthrough_silent_without_debug() {
+        crate::debug::reset_debug_for_tests();
+        let result: ParseResult<String> = ParseResult::Passthrough("raw".to_string());
+        let mut buf = Vec::new();
+        result.emit_markers(&mut buf).unwrap();
+        assert!(
+            buf.is_empty(),
+            "Passthrough should write nothing when debug is disabled"
+        );
+    }
+
     // ========================================================================
     // PassthroughCleaner tests
     // ========================================================================

--- a/crates/rskim/src/output/mod.rs
+++ b/crates/rskim/src/output/mod.rs
@@ -504,6 +504,7 @@ mod tests {
 
     #[test]
     fn test_emit_markers_degraded_writes_warnings() {
+        crate::debug::reset_debug_for_tests();
         crate::debug::force_enable_debug();
         let markers = vec!["issue one".to_string(), "issue two".to_string()];
         let result: ParseResult<String> = ParseResult::Degraded("content".to_string(), markers);
@@ -518,10 +519,12 @@ mod tests {
             output.contains("[skim:warning] issue two"),
             "expected warning for second marker, got: {output}"
         );
+        crate::debug::reset_debug_for_tests();
     }
 
     #[test]
     fn test_emit_markers_passthrough_writes_notice() {
+        crate::debug::reset_debug_for_tests();
         crate::debug::force_enable_debug();
         let result: ParseResult<String> = ParseResult::Passthrough("raw".to_string());
         let mut buf = Vec::new();
@@ -531,6 +534,7 @@ mod tests {
             output.contains("[skim:notice]"),
             "expected notice in output, got: {output}"
         );
+        crate::debug::reset_debug_for_tests();
     }
 
     // ========================================================================

--- a/crates/rskim/src/output/mod.rs
+++ b/crates/rskim/src/output/mod.rs
@@ -70,19 +70,25 @@ impl<T: AsRef<str>> ParseResult<T> {
     /// Write degradation markers to the given writer.
     ///
     /// - `Full`: writes nothing
-    /// - `Degraded`: writes each marker as a warning line
-    /// - `Passthrough`: writes a notice line
+    /// - `Degraded`: writes each marker as `[skim:warning]` line (only when debug enabled)
+    /// - `Passthrough`: writes a `[skim:notice]` line (only when debug enabled)
+    ///
+    /// When debug mode is disabled (the default), this is a no-op for all tiers.
+    /// Enable with `--debug` CLI flag or `SKIM_DEBUG=1` env var.
     pub(crate) fn emit_markers(&self, writer: &mut impl Write) -> io::Result<()> {
+        if !crate::debug::is_debug_enabled() {
+            return Ok(());
+        }
         match self {
             ParseResult::Full(_) => Ok(()),
             ParseResult::Degraded(_, markers) => {
                 for marker in markers {
-                    writeln!(writer, "[warning] {marker}")?;
+                    writeln!(writer, "[skim:warning] {marker}")?;
                 }
                 Ok(())
             }
             ParseResult::Passthrough(_) => {
-                writeln!(writer, "[notice] output passed through without parsing")
+                writeln!(writer, "[skim:notice] output passed through without parsing")
             }
         }
     }
@@ -495,29 +501,31 @@ mod tests {
 
     #[test]
     fn test_emit_markers_degraded_writes_warnings() {
+        crate::debug::force_enable_debug();
         let markers = vec!["issue one".to_string(), "issue two".to_string()];
         let result: ParseResult<String> = ParseResult::Degraded("content".to_string(), markers);
         let mut buf = Vec::new();
         result.emit_markers(&mut buf).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(
-            output.contains("[warning] issue one"),
+            output.contains("[skim:warning] issue one"),
             "expected warning for first marker, got: {output}"
         );
         assert!(
-            output.contains("[warning] issue two"),
+            output.contains("[skim:warning] issue two"),
             "expected warning for second marker, got: {output}"
         );
     }
 
     #[test]
     fn test_emit_markers_passthrough_writes_notice() {
+        crate::debug::force_enable_debug();
         let result: ParseResult<String> = ParseResult::Passthrough("raw".to_string());
         let mut buf = Vec::new();
         result.emit_markers(&mut buf).unwrap();
         let output = String::from_utf8(buf).unwrap();
         assert!(
-            output.contains("[notice]"),
+            output.contains("[skim:notice]"),
             "expected notice in output, got: {output}"
         );
     }

--- a/crates/rskim/src/output/mod.rs
+++ b/crates/rskim/src/output/mod.rs
@@ -88,7 +88,10 @@ impl<T: AsRef<str>> ParseResult<T> {
                 Ok(())
             }
             ParseResult::Passthrough(_) => {
-                writeln!(writer, "[skim:notice] output passed through without parsing")
+                writeln!(
+                    writer,
+                    "[skim:notice] output passed through without parsing"
+                )
             }
         }
     }

--- a/crates/rskim/tests/cli_e2e_exit_codes.rs
+++ b/crates/rskim/tests/cli_e2e_exit_codes.rs
@@ -73,11 +73,11 @@ fn test_exit_code_cargo_nextest_fail_via_stdin() {
     // regex match). Exit code is 0 from synthetic stdin exit code.
     let fixture = include_str!("fixtures/cmd/test/cargo_nextest_fail.txt");
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(fixture)
         .assert()
         .code(0)
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 #[test]
@@ -86,11 +86,11 @@ fn test_exit_code_cargo_passthrough_garbage() {
     // so the process exits 0.
     let fixture = include_str!("fixtures/cmd/test/cargo_passthrough.txt");
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(fixture)
         .assert()
         .code(0)
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_e2e_lint_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_lint_parsers.rs
@@ -5,8 +5,8 @@
 //!
 //! Tier behavior reference (from emit_markers in output/mod.rs):
 //! - Full: no stderr markers
-//! - Degraded: "[warning] ..." on stderr
-//! - Passthrough: "[notice] output passed through without parsing" on stderr
+//! - Degraded: "[skim:warning] ..." on stderr (only with --debug)
+//! - Passthrough: "[skim:notice] output passed through without parsing" on stderr (only with --debug)
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -51,12 +51,12 @@ fn test_eslint_tier1_json_fail() {
 fn test_eslint_tier2_regex_degraded() {
     let fixture = include_str!("fixtures/cmd/lint/eslint_text.txt");
     skim_cmd()
-        .args(["lint", "eslint"])
+        .args(["--debug", "lint", "eslint"])
         .write_stdin(fixture)
         .assert()
         .success()
         .stdout(predicate::str::contains("LINT:"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -66,12 +66,12 @@ fn test_eslint_tier2_regex_degraded() {
 #[test]
 fn test_eslint_tier3_passthrough_garbage() {
     skim_cmd()
-        .args(["lint", "eslint"])
+        .args(["--debug", "lint", "eslint"])
         .write_stdin("random garbage not eslint output\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("random garbage"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -126,12 +126,12 @@ fn test_ruff_tier1_json_fail() {
 fn test_ruff_tier2_regex_degraded() {
     let fixture = include_str!("fixtures/cmd/lint/ruff_text.txt");
     skim_cmd()
-        .args(["lint", "ruff"])
+        .args(["--debug", "lint", "ruff"])
         .write_stdin(fixture)
         .assert()
         .success()
         .stdout(predicate::str::contains("LINT:"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -141,12 +141,12 @@ fn test_ruff_tier2_regex_degraded() {
 #[test]
 fn test_ruff_tier3_passthrough_garbage() {
     skim_cmd()
-        .args(["lint", "ruff"])
+        .args(["--debug", "lint", "ruff"])
         .write_stdin("random garbage not ruff output\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("random garbage"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -189,12 +189,12 @@ fn test_mypy_tier1_json_fail() {
 fn test_mypy_tier2_regex_degraded() {
     let fixture = include_str!("fixtures/cmd/lint/mypy_text.txt");
     skim_cmd()
-        .args(["lint", "mypy"])
+        .args(["--debug", "lint", "mypy"])
         .write_stdin(fixture)
         .assert()
         .success()
         .stdout(predicate::str::contains("LINT:"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -204,12 +204,12 @@ fn test_mypy_tier2_regex_degraded() {
 #[test]
 fn test_mypy_tier3_passthrough_garbage() {
     skim_cmd()
-        .args(["lint", "mypy"])
+        .args(["--debug", "lint", "mypy"])
         .write_stdin("random garbage not mypy output\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("random garbage"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -253,12 +253,12 @@ fn test_golangci_tier1_json_fail() {
 fn test_golangci_tier2_regex_degraded() {
     let fixture = include_str!("fixtures/cmd/lint/golangci_text.txt");
     skim_cmd()
-        .args(["lint", "golangci"])
+        .args(["--debug", "lint", "golangci"])
         .write_stdin(fixture)
         .assert()
         .success()
         .stdout(predicate::str::contains("LINT:"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -268,12 +268,12 @@ fn test_golangci_tier2_regex_degraded() {
 #[test]
 fn test_golangci_tier3_passthrough_garbage() {
     skim_cmd()
-        .args(["lint", "golangci"])
+        .args(["--debug", "lint", "golangci"])
         .write_stdin("random garbage not golangci output\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("random garbage"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_e2e_pkg_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_pkg_parsers.rs
@@ -5,8 +5,8 @@
 //!
 //! Tier behavior reference:
 //! - Full: no stderr markers
-//! - Degraded: "[warning] ..." on stderr
-//! - Passthrough: "[notice] output passed through without parsing" on stderr
+//! - Degraded: "[skim:warning] ..." on stderr (only with --debug)
+//! - Passthrough: "[skim:notice] output passed through without parsing" on stderr (only with --debug)
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -74,13 +74,13 @@ fn test_npm_install_tier1_json() {
 fn test_npm_install_tier2_regex() {
     let fixture = include_str!("fixtures/cmd/pkg/npm_install_text.txt");
     skim_cmd()
-        .args(["pkg", "npm", "install"])
+        .args(["--debug", "pkg", "npm", "install"])
         .write_stdin(fixture)
         .assert()
         .success()
         .stdout(predicate::str::contains("PKG INSTALL | npm"))
         .stdout(predicate::str::contains("added: 127"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -90,12 +90,12 @@ fn test_npm_install_tier2_regex() {
 #[test]
 fn test_npm_install_passthrough() {
     skim_cmd()
-        .args(["pkg", "npm", "install"])
+        .args(["--debug", "pkg", "npm", "install"])
         .write_stdin("completely unparseable output")
         .assert()
         .success()
         .stdout(predicate::str::contains("completely unparseable"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -322,12 +322,12 @@ fn test_cargo_audit_clean_json() {
 fn test_cargo_audit_tier2_regex() {
     let text = "Crate:   buffer-utils\nVersion: 0.3.1\nTitle:   Buffer overflow\nID:      RUSTSEC-2024-0001";
     skim_cmd()
-        .args(["pkg", "cargo", "audit"])
+        .args(["--debug", "pkg", "cargo", "audit"])
         .write_stdin(text)
         .assert()
         .success()
         .stdout(predicate::str::contains("PKG AUDIT | cargo"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -337,10 +337,10 @@ fn test_cargo_audit_tier2_regex() {
 #[test]
 fn test_cargo_audit_passthrough() {
     skim_cmd()
-        .args(["pkg", "cargo", "audit"])
+        .args(["--debug", "pkg", "cargo", "audit"])
         .write_stdin("completely unparseable output")
         .assert()
         .success()
         .stdout(predicate::str::contains("completely unparseable"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }

--- a/crates/rskim/tests/cli_e2e_test_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_test_parsers.rs
@@ -5,8 +5,8 @@
 //!
 //! Tier behavior reference (from emit_markers in output/mod.rs):
 //! - Full: no stderr markers
-//! - Degraded: "[warning] ..." on stderr
-//! - Passthrough: "[notice] output passed through without parsing" on stderr
+//! - Degraded: "[skim:warning] ..." on stderr (only with --debug)
+//! - Passthrough: "[skim:notice] output passed through without parsing" on stderr (only with --debug)
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -59,13 +59,13 @@ fn test_cargo_nextest_pass_passthrough_via_stdin() {
     // Without "nextest" in args, nextest output hits passthrough tier
     let fixture = include_str!("fixtures/cmd/test/cargo_nextest_pass.txt");
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(fixture)
         .assert()
         .success()
         // Content is passed through as-is
         .stdout(predicate::str::contains("PASS"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 #[test]
@@ -73,13 +73,13 @@ fn test_cargo_nextest_fail_passthrough_via_stdin() {
     // Without "nextest" in args, nextest output hits passthrough tier
     let fixture = include_str!("fixtures/cmd/test/cargo_nextest_fail.txt");
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(fixture)
         .assert()
         // Exit code 0 from synthetic stdin exit code
         .code(0)
         .stdout(predicate::str::contains("FAIL"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -93,12 +93,12 @@ fn test_cargo_tier2_regex_degraded() {
     // so the process exits 0 when tests pass.
     let text_input = "test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured";
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(text_input)
         .assert()
         .success()
         .stdout(predicate::str::contains("PASS: 5"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -109,24 +109,24 @@ fn test_cargo_tier2_regex_degraded() {
 fn test_cargo_tier3_passthrough_garbage_input() {
     let fixture = include_str!("fixtures/cmd/test/cargo_passthrough.txt");
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(fixture)
         .assert()
         // Passthrough preserves raw content on stdout
         .stdout(predicate::str::contains("This is not cargo test output"))
-        // Passthrough emits [notice] on stderr
-        .stderr(predicate::str::contains("[notice]"));
+        // Passthrough emits [skim:notice] on stderr when --debug is set
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 #[test]
 fn test_cargo_passthrough_preserves_raw_content() {
     let garbage = "completely unparseable output\nno json, no regex match\n";
     skim_cmd()
-        .args(["test", "cargo"])
+        .args(["--debug", "test", "cargo"])
         .write_stdin(garbage)
         .assert()
         .stdout(predicate::str::contains("completely unparseable output"))
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -177,24 +177,24 @@ fn test_vitest_tier2_regex_pipe_format() {
     // Pipe-format summary triggers tier 2 regex
     let input = "Tests  3 passed | 0 failed | 3 total\n";
     skim_cmd()
-        .args(["test", "vitest"])
+        .args(["--debug", "test", "vitest"])
         .write_stdin(input)
         .assert()
         .success()
         .stdout(predicate::str::contains("PASS: 3"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 #[test]
 fn test_vitest_tier2_regex_fail_fixture() {
     let fixture = include_str!("fixtures/cmd/test/vitest_regex_fail.txt");
     skim_cmd()
-        .args(["test", "vitest"])
+        .args(["--debug", "test", "vitest"])
         .write_stdin(fixture)
         .assert()
         .code(predicate::ne(0))
         .stdout(predicate::str::contains("FAIL: 1"))
-        .stderr(predicate::str::contains("[warning]"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -204,10 +204,10 @@ fn test_vitest_tier2_regex_fail_fixture() {
 #[test]
 fn test_vitest_tier3_passthrough_garbage() {
     skim_cmd()
-        .args(["test", "vitest"])
+        .args(["--debug", "test", "vitest"])
         .write_stdin("random garbage not vitest output\n")
         .assert()
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================
@@ -260,10 +260,10 @@ fn test_pytest_tier1_mixed() {
 #[test]
 fn test_pytest_passthrough_garbage() {
     skim_cmd()
-        .args(["test", "pytest"])
+        .args(["--debug", "test", "pytest"])
         .write_stdin("random garbage not pytest output\n")
         .assert()
-        .stderr(predicate::str::contains("[notice]"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 #[test]
@@ -274,4 +274,36 @@ fn test_pytest_passthrough_preserves_raw() {
         .write_stdin(garbage)
         .assert()
         .stdout(predicate::str::contains("some unrecognized tool output"));
+}
+
+// ============================================================================
+// Silent stderr without --debug
+// ============================================================================
+
+/// Verify that degraded/passthrough output produces NO stderr markers when
+/// --debug is not set (the default). This is a subprocess-isolated test so
+/// AtomicBool state from other tests does not interfere.
+#[test]
+fn test_vitest_degraded_silent_without_debug() {
+    let input = "Tests  3 passed | 0 failed | 3 total\n";
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS: 3"))
+        // No --debug flag: stderr must contain no skim markers
+        .stderr(predicate::str::contains("[skim:warning]").not())
+        .stderr(predicate::str::contains("[skim:notice]").not());
+}
+
+#[test]
+fn test_vitest_passthrough_silent_without_debug() {
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin("random garbage not vitest output\n")
+        .assert()
+        // No --debug flag: no markers on stderr
+        .stderr(predicate::str::contains("[skim:notice]").not())
+        .stderr(predicate::str::contains("[skim:warning]").not());
 }

--- a/crates/rskim/tests/cli_git.rs
+++ b/crates/rskim/tests/cli_git.rs
@@ -148,16 +148,6 @@ fn test_skim_git_fetch_in_repo() {
         );
 }
 
-#[test]
-fn test_skim_git_help_includes_fetch() {
-    Command::cargo_bin("skim")
-        .unwrap()
-        .args(["git", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("fetch"));
-}
-
 // ============================================================================
 // Error cases
 // ============================================================================

--- a/crates/rskim/tests/cli_git.rs
+++ b/crates/rskim/tests/cli_git.rs
@@ -142,10 +142,7 @@ fn test_skim_git_fetch_in_repo() {
         .args(["git", "fetch"])
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("[fetch]")
-                .or(predicate::str::contains("up to date")),
-        );
+        .stdout(predicate::str::contains("[fetch]").or(predicate::str::contains("up to date")));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_git.rs
+++ b/crates/rskim/tests/cli_git.rs
@@ -20,6 +20,7 @@ fn test_skim_git_help() {
         .success()
         .stdout(predicate::str::contains("status"))
         .stdout(predicate::str::contains("diff"))
+        .stdout(predicate::str::contains("fetch"))
         .stdout(predicate::str::contains("log"));
 }
 
@@ -125,6 +126,36 @@ fn test_skim_git_log_oneline_passthrough() {
         .args(["git", "log", "--oneline", "-n", "3"])
         .assert()
         .success();
+}
+
+// ============================================================================
+// Fetch
+// ============================================================================
+
+/// Run `skim git fetch` against the skim repo. Since skim may have no
+/// configured remotes or may be up-to-date, we accept either "[fetch]" output
+/// or "up to date".
+#[test]
+fn test_skim_git_fetch_in_repo() {
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["git", "fetch"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("[fetch]")
+                .or(predicate::str::contains("up to date")),
+        );
+}
+
+#[test]
+fn test_skim_git_help_includes_fetch() {
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["git", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fetch"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_test_vitest.rs
+++ b/crates/rskim/tests/cli_test_vitest.rs
@@ -105,6 +105,7 @@ fn test_skim_test_vitest_stdin_regex_fallback() {
 
     Command::cargo_bin("skim")
         .unwrap()
+        .arg("--debug")
         .arg("test")
         .arg("vitest")
         .write_stdin(input)
@@ -112,7 +113,7 @@ fn test_skim_test_vitest_stdin_regex_fallback() {
         .failure() // fail > 0
         .stdout(predicate::str::contains("PASS: 5"))
         .stdout(predicate::str::contains("FAIL: 1"))
-        .stderr(predicate::str::contains("regex fallback"));
+        .stderr(predicate::str::contains("[skim:warning]"));
 }
 
 // ============================================================================
@@ -125,13 +126,14 @@ fn test_skim_test_vitest_stdin_passthrough() {
 
     Command::cargo_bin("skim")
         .unwrap()
+        .arg("--debug")
         .arg("test")
         .arg("vitest")
         .write_stdin(input)
         .assert()
         .failure()
         .stdout(predicate::str::contains("completely unparseable output"))
-        .stderr(predicate::str::contains("notice"));
+        .stderr(predicate::str::contains("[skim:notice]"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/fixtures/cmd/git/fetch_forced.txt
+++ b/crates/rskim/tests/fixtures/cmd/git/fetch_forced.txt
@@ -1,0 +1,3 @@
+From github.com:user/repo
+ + ccc3333...ddd4444 feature/z  -> origin/feature/z  (forced update)
+   abc1234..def5678  main       -> origin/main

--- a/crates/rskim/tests/fixtures/cmd/git/fetch_refs.txt
+++ b/crates/rskim/tests/fixtures/cmd/git/fetch_refs.txt
@@ -1,0 +1,11 @@
+remote: Enumerating objects: 15, done.
+remote: Counting objects: 100% (15/15), done.
+remote: Compressing objects: 100% (8/8), done.
+remote: Total 10 (delta 5), reused 7 (delta 3), pack-reused 0
+Unpacking objects: 100% (10/10), 2.50 KiB | 512.00 KiB/s, done.
+From github.com:user/repo
+   abc1234..def5678  main       -> origin/main
+   111aaaa..222bbbb  develop    -> origin/develop
+ * [new branch]      feature/x  -> origin/feature/x
+ * [new branch]      feature/y  -> origin/feature/y
+ * [new tag]         v2.3.0     -> v2.3.0

--- a/crates/rskim/tests/fixtures/cmd/git/fetch_submodules.txt
+++ b/crates/rskim/tests/fixtures/cmd/git/fetch_submodules.txt
@@ -1,0 +1,6 @@
+Fetching submodule lib/core
+From github.com:user/core
+   aaa1111..bbb2222  main       -> origin/main
+Fetching submodule lib/utils
+From github.com:user/utils
+ * [new branch]      release    -> origin/release

--- a/crates/rskim/tests/fixtures/cmd/git/fetch_with_prune.txt
+++ b/crates/rskim/tests/fixtures/cmd/git/fetch_with_prune.txt
@@ -1,0 +1,4 @@
+From github.com:user/repo
+ - [deleted]         (none)     -> origin/old-branch
+ - [deleted]         (none)     -> origin/stale-feature
+   abc1234..def5678  main       -> origin/main


### PR DESCRIPTION
## Summary

- **Debug-gated warnings**: stderr markers (`[warning]`/`[notice]`) are now silent by default. Enable with `--debug` flag or `SKIM_DEBUG=1` env var. Prefixes changed to `[skim:warning]`/`[skim:notice]` for agent disambiguation. JSON envelope output is unaffected.
- **Enriched degradation markers**: All 23 parser files now emit context-specific warnings (e.g., `"eslint: JSON parse failed, using regex"`) instead of the opaque `"regex fallback"`.
- **Git fetch compression**: New `skim git fetch` subcommand parses ref listings, new branches/tags, pruned refs, forced updates, and submodule fetches into a compact summary (~70% noise reduction).
- **Diff skip-flag fix**: Added missing `--shortstat`/`--numstat` to `git diff` rewrite skip-flags.

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Debug module | `debug.rs`, `main.rs` | AtomicBool + env var pattern (matches analytics) |
| Warning gating | `output/mod.rs` | `emit_markers()` gated on `is_debug_enabled()` |
| Marker enrichment | 23 parser files | `"regex fallback"` → context-specific strings |
| Git fetch | `git/fetch.rs`, `git/mod.rs` | Parser + dispatch + submodule support |
| Rewrite rules | `rewrite.rs` | Fetch rule + diff `--shortstat`/`--numstat` fix |
| Tests | 4 E2E + cli_git.rs + unit tests | ~35 new tests, 23 updated assertions |
| Docs | `CLAUDE.md` | `SKIM_DEBUG` env var, fetch in subcommand list |

## Test plan

- [x] `cargo test --workspace` — 2302 tests passing, 0 failures
- [x] `cargo clippy -p rskim -- -D warnings` — clean
- [x] Manual: `skim test cargo -- --lib -p rskim` — stderr silent (no warnings)
- [x] Manual: `skim --debug test cargo -- --lib -p rskim` — `[skim:notice]` on stderr
- [x] Manual: `SKIM_DEBUG=1 skim test cargo -- --lib -p rskim` — same as --debug
- [x] Manual: `skim git fetch` — compressed output (`[fetch] up to date`)
- [x] Manual: `skim git fetch -q` — passthrough (no `[fetch]` prefix)
- [x] Snyk SAST — 0 issues