### PR TITLE
fix(rewrite): hook safety — npx fallback, passthrough, tiered compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +791,35 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -857,6 +930,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +997,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "strip-ansi-escapes",
  "tempfile",
@@ -1005,6 +1088,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1175,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1222,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ predicates = "3.0"
 tempfile = "3.0"
 insta = "1.39"
 criterion = "0.5"
+serial_test = "3.0"
 
 [workspace.metadata.dist]
 cargo-dist-version = "0.14.0"

--- a/crates/rskim/Cargo.toml
+++ b/crates/rskim/Cargo.toml
@@ -40,3 +40,4 @@ assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
+serial_test = { workspace = true }

--- a/crates/rskim/src/cmd/init/helpers.rs
+++ b/crates/rskim/src/cmd/init/helpers.rs
@@ -166,6 +166,15 @@ skim <file>                    # structural overview (default)
 skim <file> --mode=signatures  # API surface only
 skim 'src/**/*.ts'             # multi-file scan
 ```
+
+### Troubleshooting
+
+If a command's output seems incomplete or too compressed, prefix with
+`SKIM_PASSTHROUGH=1` to bypass compression and see full raw output:
+
+```
+SKIM_PASSTHROUGH=1 npx vitest run tests/
+```
 <!-- skim-end -->"#,
         version = version
     )
@@ -275,6 +284,28 @@ mod tests {
         // Strong directive language
         assert!(content.contains("ALWAYS prefer"));
         assert!(content.contains("Use Read only when"));
+        // Troubleshooting section must be present
+        assert!(content.contains("SKIM_PASSTHROUGH"));
+    }
+
+    #[test]
+    fn test_guidance_content_has_troubleshooting() {
+        let content = guidance_content("2.5.1");
+        assert!(
+            content.contains("Troubleshooting"),
+            "guidance_content must include a Troubleshooting section"
+        );
+        assert!(
+            content.contains("SKIM_PASSTHROUGH=1"),
+            "guidance_content must mention SKIM_PASSTHROUGH=1"
+        );
+        // Troubleshooting section must appear before the end marker
+        let trouble_pos = content.find("Troubleshooting").unwrap();
+        let end_pos = content.find("<!-- skim-end -->").unwrap();
+        assert!(
+            trouble_pos < end_pos,
+            "Troubleshooting must appear before <!-- skim-end -->"
+        );
     }
 
     #[test]

--- a/crates/rskim/src/cmd/init/helpers.rs
+++ b/crates/rskim/src/cmd/init/helpers.rs
@@ -309,6 +309,17 @@ mod tests {
     }
 
     #[test]
+    fn test_guidance_content_troubleshooting_has_code_example() {
+        let content = guidance_content("2.5.1");
+        // The troubleshooting section must contain a code block with the exact
+        // example command shown in the docs.
+        assert!(
+            content.contains("SKIM_PASSTHROUGH=1 npx vitest"),
+            "guidance_content troubleshooting section must include code example: SKIM_PASSTHROUGH=1 npx vitest"
+        );
+    }
+
+    #[test]
     fn test_guidance_content_mdc_has_frontmatter() {
         let content = guidance_content_mdc("2.1.0");
         assert!(

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -280,7 +280,7 @@ where
         let runner = CommandRunner::new(Some(std::time::Duration::from_secs(300)));
         let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-        match runner.run_with_env(program, &args_str, env_overrides) {
+        match runner.run_with_env_node_fallback(program, &args_str, env_overrides) {
             Ok(out) => out,
             Err(e) => {
                 let msg = e.to_string();

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -461,16 +461,13 @@ mod tests {
     use super::*;
 
     // ========================================================================
-    // check_passthrough_value
+    // check_passthrough_value / stderr hint guard
     // ========================================================================
 
-    // ========================================================================
-    // stderr hint behavior (pure-function tests via check_passthrough_value)
-    // ========================================================================
-
-    /// Verify that passthrough mode does not emit the hint (it bypasses compression
-    /// entirely). We test this indirectly by confirming passthrough detection
-    /// works correctly for the guard condition in run_parsed_command_with_mode.
+    /// Verify that passthrough mode detection works correctly for the guard
+    /// in `run_parsed_command_with_mode`. Passthrough returns early before
+    /// the hint is emitted; the `!result.is_passthrough()` guard ensures the
+    /// hint fires only for Full/Degraded results.
     #[test]
     fn test_no_stderr_hint_when_passthrough_mode() {
         // Passthrough mode returns early before the hint is emitted.

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -280,7 +280,7 @@ where
         let runner = CommandRunner::new(Some(std::time::Duration::from_secs(300)));
         let args_str: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-        match runner.run_with_env_node_fallback(program, &args_str, env_overrides) {
+        match runner.run_with_env(program, &args_str, env_overrides) {
             Ok(out) => out,
             Err(e) => {
                 let msg = e.to_string();
@@ -297,12 +297,14 @@ where
     // Passthrough mode: bypass all compression and forward raw output.
     let code = output.exit_code.unwrap_or(1);
     if is_passthrough_mode() {
-        let mut handle = io::stdout().lock();
-        write!(handle, "{}", output.stdout)?;
+        let mut out = io::stdout().lock();
+        write!(out, "{}", output.stdout)?;
+        out.flush()?;
         if !output.stderr.is_empty() {
-            write!(handle, "{}", output.stderr)?;
+            let mut err = io::stderr().lock();
+            write!(err, "{}", output.stderr)?;
+            err.flush()?;
         }
-        handle.flush()?;
         return Ok(ExitCode::from(code.clamp(0, 255) as u8));
     }
 

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -32,6 +32,29 @@ use std::process::ExitCode;
 use crate::output::ParseResult;
 use crate::runner::{CommandOutput, CommandRunner};
 
+// ============================================================================
+// SKIM_PASSTHROUGH helpers
+// ============================================================================
+
+/// Check if `SKIM_PASSTHROUGH` is set to a truthy value (`1`, `true`, or `yes`,
+/// case-insensitive).
+///
+/// When passthrough mode is active, all compression is bypassed and raw output
+/// is forwarded unchanged. Useful for debugging or when the compressed output
+/// is too aggressive for a particular workflow.
+pub(crate) fn is_passthrough_mode() -> bool {
+    check_passthrough_value(std::env::var("SKIM_PASSTHROUGH").ok())
+}
+
+/// Pure function version of [`is_passthrough_mode`] — avoids process-wide env var
+/// mutation in tests.
+///
+/// Returns `true` for `"1"`, `"true"`, `"yes"` (case-insensitive).
+pub(crate) fn check_passthrough_value(val: Option<String>) -> bool {
+    val.map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 /// Known subcommands that the pre-parse router will recognize.
 ///
 /// IMPORTANT: Only register subcommands we will actually implement.
@@ -271,6 +294,18 @@ where
         }
     };
 
+    // Passthrough mode: bypass all compression and forward raw output.
+    let code = output.exit_code.unwrap_or(1);
+    if is_passthrough_mode() {
+        let mut handle = io::stdout().lock();
+        write!(handle, "{}", output.stdout)?;
+        if !output.stderr.is_empty() {
+            write!(handle, "{}", output.stderr)?;
+        }
+        handle.flush()?;
+        return Ok(ExitCode::from(code.clamp(0, 255) as u8));
+    }
+
     // Strip ANSI escape codes from output before parsing. Even with NO_COLOR=1
     // set on the child process, some tools may still emit escape sequences.
     // This is a cheap, universally useful safety net for all parsers.
@@ -417,6 +452,28 @@ pub(crate) fn sanitize_for_display(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ========================================================================
+    // check_passthrough_value
+    // ========================================================================
+
+    #[test]
+    fn test_check_passthrough_truthy_values() {
+        for v in &["1", "true", "yes", "True", "YES", "tRuE"] {
+            assert!(
+                check_passthrough_value(Some((*v).to_string())),
+                "expected truthy for {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_passthrough_falsy_values() {
+        assert!(!check_passthrough_value(Some("0".to_string())));
+        assert!(!check_passthrough_value(Some("false".to_string())));
+        assert!(!check_passthrough_value(Some("no".to_string())));
+        assert!(!check_passthrough_value(None));
+    }
 
     #[test]
     fn test_extract_json_flag_present() {

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -344,6 +344,13 @@ where
         }
     };
 
+    // Hint: when output was compressed (not passthrough) and the exit code was
+    // non-zero, tell the user how to see full raw output. Passthrough results
+    // are already uncompressed so the hint is not needed there.
+    if code != 0 && !result.is_passthrough() {
+        eprintln!("[skim] compressed output (exit {code}). SKIM_PASSTHROUGH=1 for full output.");
+    }
+
     if show_stats {
         let (orig, comp) = crate::process::count_token_pair(&output.stdout, &compressed);
         crate::process::report_token_stats(orig, comp, "");
@@ -456,6 +463,23 @@ mod tests {
     // ========================================================================
     // check_passthrough_value
     // ========================================================================
+
+    // ========================================================================
+    // stderr hint behavior (pure-function tests via check_passthrough_value)
+    // ========================================================================
+
+    /// Verify that passthrough mode does not emit the hint (it bypasses compression
+    /// entirely). We test this indirectly by confirming passthrough detection
+    /// works correctly for the guard condition in run_parsed_command_with_mode.
+    #[test]
+    fn test_no_stderr_hint_when_passthrough_mode() {
+        // Passthrough mode returns early before the hint is emitted.
+        // The guard `!result.is_passthrough()` in run_parsed_command_with_mode
+        // ensures the hint only fires for compressed (Full/Degraded) results.
+        // This test validates the passthrough predicate is correct.
+        assert!(check_passthrough_value(Some("1".to_string())));
+        assert!(check_passthrough_value(Some("true".to_string())));
+    }
 
     #[test]
     fn test_check_passthrough_truthy_values() {

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -69,6 +69,12 @@ pub(super) const HOOK_TIMEOUT_SECS: u64 = 5;
 pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode> {
     use crate::cmd::hooks::{protocol_for_agent, HookSupport};
 
+    // SKIM_PASSTHROUGH=1 disables all hook rewriting — the agent sees no hook response,
+    // which is equivalent to a passthrough (the original command runs unchanged).
+    if crate::cmd::is_passthrough_mode() {
+        return Ok(ExitCode::SUCCESS);
+    }
+
     // Watchdog: self-terminate after HOOK_TIMEOUT_SECS to prevent hanging the agent.
     // Uses a detached thread so it doesn't interfere with normal processing.
     // On timeout: log warning, exit 0 (passthrough — agent sees empty stdout).

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -35,13 +35,9 @@ pub(crate) fn run(
         let raw_args_ref: Vec<&str> = raw_args.iter().map(|s| s.as_str()).collect();
         let runner = CommandRunner::new(None);
         let output = runner.run("go", &raw_args_ref)?;
-        let combined = if output.stderr.is_empty() {
-            output.stdout
-        } else {
-            format!("{}\n{}", output.stdout, output.stderr)
-        };
-        println!("{combined}");
-        return Ok(ExitCode::FAILURE);
+        print!("{}", crate::cmd::combine_output(&output));
+        let code = output.exit_code.unwrap_or(1).clamp(0, 255) as u8;
+        return Ok(ExitCode::from(code));
     }
 
     let mut go_args: Vec<String> = vec!["test".to_string()];

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -95,6 +95,9 @@ pub(crate) fn run(
             let _ = parsed.emit_markers(&mut stderr);
 
             if result.summary.fail > 0 {
+                eprintln!(
+                    "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
+                );
                 ExitCode::FAILURE
             } else {
                 ExitCode::SUCCESS

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -34,7 +34,14 @@ pub(crate) fn run(
         raw_args.extend_from_slice(args);
         let raw_args_ref: Vec<&str> = raw_args.iter().map(|s| s.as_str()).collect();
         let runner = CommandRunner::new(None);
-        let output = runner.run("go", &raw_args_ref)?;
+        let output = runner.run("go", &raw_args_ref).map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("failed to execute") {
+                anyhow::anyhow!("{}\nHint: install Go from https://go.dev/dl/", msg)
+            } else {
+                e
+            }
+        })?;
         print!("{}", crate::cmd::combine_output(&output));
         let code = output.exit_code.unwrap_or(1).clamp(0, 255) as u8;
         return Ok(ExitCode::from(code));
@@ -93,19 +100,11 @@ pub(crate) fn run(
             if result.summary.fail > 0 {
                 // Append raw failure context so the agent can see actual error
                 // messages without needing to re-run with SKIM_PASSTHROUGH=1.
+                // Pass the actual exit code (e.g. 2 for compilation errors) so
+                // the hint reflects the real status rather than a hardcoded 1.
                 use super::shared;
-                let stripped = crate::output::strip_ansi(&combined);
-                let tail = shared::last_n_lines(&stripped, shared::MAX_FAILURE_CONTEXT_LINES);
-                if !tail.is_empty() {
-                    println!(
-                        "\n--- failure context (last {} lines) ---",
-                        tail.lines().count()
-                    );
-                    println!("{tail}");
-                }
-                eprintln!(
-                    "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
-                );
+                let actual_exit = output.exit_code.unwrap_or(1);
+                shared::emit_failure_context(&combined, actual_exit);
                 ExitCode::FAILURE
             } else {
                 ExitCode::SUCCESS

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -95,6 +95,18 @@ pub(crate) fn run(
             let _ = parsed.emit_markers(&mut stderr);
 
             if result.summary.fail > 0 {
+                // Append raw failure context so the agent can see actual error
+                // messages without needing to re-run with SKIM_PASSTHROUGH=1.
+                use super::shared;
+                let stripped = crate::output::strip_ansi(&combined);
+                let tail = shared::last_n_lines(&stripped, shared::MAX_FAILURE_CONTEXT_LINES);
+                if !tail.is_empty() {
+                    println!(
+                        "\n--- failure context (last {} lines) ---",
+                        tail.lines().count()
+                    );
+                    println!("{tail}");
+                }
                 eprintln!(
                     "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
                 );

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -28,6 +28,22 @@ pub(crate) fn run(
     show_stats: bool,
     analytics_enabled: bool,
 ) -> anyhow::Result<ExitCode> {
+    // Passthrough mode: run `go test` without flag injections and forward raw output.
+    if crate::cmd::is_passthrough_mode() {
+        let mut raw_args: Vec<String> = vec!["test".to_string()];
+        raw_args.extend_from_slice(args);
+        let raw_args_ref: Vec<&str> = raw_args.iter().map(|s| s.as_str()).collect();
+        let runner = CommandRunner::new(None);
+        let output = runner.run("go", &raw_args_ref)?;
+        let combined = if output.stderr.is_empty() {
+            output.stdout
+        } else {
+            format!("{}\n{}", output.stdout, output.stderr)
+        };
+        println!("{combined}");
+        return Ok(ExitCode::FAILURE);
+    }
+
     let mut go_args: Vec<String> = vec!["test".to_string()];
 
     // Inject -json before any `--` separator, unless the user already specified

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -502,9 +502,10 @@ fn flush_failure(
 
 /// Emit the parsed result to stdout/stderr.
 ///
-/// `cleaned_output` is the ANSI-stripped combined output used to extract the
-/// failure context tail (last [`shared::MAX_FAILURE_CONTEXT_LINES`] lines).
-/// This mirrors the pattern used by go.rs and vitest.rs.
+/// When failures are present, delegates to [`shared::emit_failure_context`]
+/// to append the last [`shared::MAX_FAILURE_CONTEXT_LINES`] lines of
+/// `cleaned_output` so the agent can read error details without re-running
+/// with `SKIM_PASSTHROUGH=1`.
 fn emit_result(
     result: &ParseResult<TestResult>,
     output: &CommandOutput,
@@ -523,25 +524,10 @@ fn emit_result(
             result.emit_markers(&mut err)?;
 
             if tr.summary.fail > 0 {
-                // Append raw failure context so the agent can see actual error
-                // messages without needing to re-run with SKIM_PASSTHROUGH=1.
-                let tail =
-                    shared::last_n_lines(cleaned_output, shared::MAX_FAILURE_CONTEXT_LINES);
-                if !tail.is_empty() {
-                    writeln!(
-                        out,
-                        "\n--- failure context (last {} lines) ---",
-                        tail.lines().count()
-                    )?;
-                    writeln!(out, "{tail}")?;
-                }
-                eprintln!(
-                    "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
-                );
+                shared::emit_failure_context(cleaned_output, 1);
             }
         }
         ParseResult::Passthrough(raw) => {
-            // Write raw output as-is
             write!(out, "{raw}")?;
             result.emit_markers(&mut err)?;
         }

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -29,6 +29,8 @@ use crate::output::canonical::{TestEntry, TestOutcome, TestResult, TestSummary};
 use crate::output::{strip_ansi, ParseResult};
 use crate::runner::{CommandOutput, CommandRunner};
 
+use super::shared;
+
 // ============================================================================
 // Public entry point
 // ============================================================================
@@ -45,6 +47,23 @@ pub(crate) fn run(
     show_stats: bool,
     analytics_enabled: bool,
 ) -> anyhow::Result<ExitCode> {
+    // Passthrough mode: bypass compression and forward raw output unchanged.
+    if crate::cmd::is_passthrough_mode() {
+        if !io::stdin().is_terminal() {
+            let stdin_output = read_stdin()?;
+            if !stdin_output.stdout.trim().is_empty() {
+                print!("{}", stdin_output.stdout);
+                return Ok(ExitCode::FAILURE);
+            }
+        }
+        let final_args = build_args(args);
+        let arg_refs: Vec<&str> = final_args.iter().map(String::as_str).collect();
+        let output = run_pytest(&arg_refs)?;
+        print!("{}", crate::cmd::combine_output(&output));
+        let code = output.exit_code.unwrap_or(1).clamp(0, 255) as u8;
+        return Ok(ExitCode::from(code));
+    }
+
     // Intercept --help/-h: show skim's pytest help, then forward to real pytest
     // so the user sees both skim's flags and pytest's own options.
     if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
@@ -75,7 +94,7 @@ pub(crate) fn run(
     let cleaned = strip_ansi(&combined);
     let result = parse(&cleaned);
 
-    emit_result(&result, &output)?;
+    emit_result(&result, &output, &cleaned)?;
 
     if show_stats {
         let (orig, comp) = crate::process::count_token_pair(&cleaned, result.content());
@@ -482,7 +501,15 @@ fn flush_failure(
 // ============================================================================
 
 /// Emit the parsed result to stdout/stderr.
-fn emit_result(result: &ParseResult<TestResult>, output: &CommandOutput) -> anyhow::Result<()> {
+///
+/// `cleaned_output` is the ANSI-stripped combined output used to extract the
+/// failure context tail (last [`shared::MAX_FAILURE_CONTEXT_LINES`] lines).
+/// This mirrors the pattern used by go.rs and vitest.rs.
+fn emit_result(
+    result: &ParseResult<TestResult>,
+    output: &CommandOutput,
+    cleaned_output: &str,
+) -> anyhow::Result<()> {
     use std::io::Write;
 
     let stdout = io::stdout();
@@ -491,12 +518,27 @@ fn emit_result(result: &ParseResult<TestResult>, output: &CommandOutput) -> anyh
     let mut err = stderr.lock();
 
     match result {
-        ParseResult::Full(tr) => {
-            writeln!(out, "{tr}")?;
-        }
-        ParseResult::Degraded(tr, _markers) => {
+        ParseResult::Full(tr) | ParseResult::Degraded(tr, _) => {
             writeln!(out, "{tr}")?;
             result.emit_markers(&mut err)?;
+
+            if tr.summary.fail > 0 {
+                // Append raw failure context so the agent can see actual error
+                // messages without needing to re-run with SKIM_PASSTHROUGH=1.
+                let tail =
+                    shared::last_n_lines(cleaned_output, shared::MAX_FAILURE_CONTEXT_LINES);
+                if !tail.is_empty() {
+                    writeln!(
+                        out,
+                        "\n--- failure context (last {} lines) ---",
+                        tail.lines().count()
+                    )?;
+                    writeln!(out, "{tail}")?;
+                }
+                eprintln!(
+                    "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
+                );
+            }
         }
         ParseResult::Passthrough(raw) => {
             // Write raw output as-is

--- a/crates/rskim/src/cmd/test/shared.rs
+++ b/crates/rskim/src/cmd/test/shared.rs
@@ -118,6 +118,41 @@ pub(super) fn scrape_failures(text: &str, kind: TestKind) -> Vec<TestEntry> {
     entries
 }
 
+// ============================================================================
+// Raw failure context helpers (Fix B)
+// ============================================================================
+
+/// Maximum number of raw output lines to append as failure context.
+///
+/// This gives the agent enough signal to understand why a test failed
+/// without overwhelming the context window. Full output is always
+/// available via `SKIM_PASSTHROUGH=1`.
+pub(super) const MAX_FAILURE_CONTEXT_LINES: usize = 50;
+
+/// Return the last `n` lines of `text` as a `&str` slice.
+///
+/// Scans backward through the bytes looking for newline characters. When the
+/// `n`-th newline from the end is found, returns everything after it. Falls
+/// back to the full input when `text` has fewer than `n` newlines.
+///
+/// The returned slice borrows from `text` — no allocation.
+pub(super) fn last_n_lines(text: &str, n: usize) -> &str {
+    if n == 0 {
+        return "";
+    }
+    let mut count = 0;
+    for (i, byte) in text.as_bytes().iter().enumerate().rev() {
+        if *byte == b'\n' {
+            count += 1;
+            if count == n {
+                return &text[i + 1..];
+            }
+        }
+    }
+    // Fewer than `n` newlines → return the whole input
+    text
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +277,73 @@ mod tests {
             entries.is_empty(),
             "no failures should return empty: {entries:?}"
         );
+    }
+
+    // ========================================================================
+    // last_n_lines tests
+    // ========================================================================
+
+    #[test]
+    fn test_last_n_lines_fewer_than_n() {
+        // 3 lines, n=50 → full input returned
+        let text = "line1\nline2\nline3";
+        assert_eq!(last_n_lines(text, 50), text);
+    }
+
+    #[test]
+    fn test_last_n_lines_exact_n() {
+        // 50 lines, n=50 → full input
+        let text = (0..50).map(|i| format!("line{i}")).collect::<Vec<_>>().join("\n");
+        let result = last_n_lines(&text, 50);
+        assert_eq!(result, text);
+    }
+
+    #[test]
+    fn test_last_n_lines_more_than_n() {
+        // 100 lines (0..99), n=50 → last 50 lines
+        let lines: Vec<String> = (0..100).map(|i| format!("line{i}")).collect();
+        let text = lines.join("\n");
+        let result = last_n_lines(&text, 50);
+        // Last 50 lines are lines 50..99
+        let expected = lines[50..].join("\n");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_last_n_lines_empty() {
+        assert_eq!(last_n_lines("", 50), "");
+    }
+
+    #[test]
+    fn test_last_n_lines_no_newlines() {
+        // Single line with no newlines → full input returned
+        let text = "single line no newlines";
+        assert_eq!(last_n_lines(text, 50), text);
+    }
+
+    #[test]
+    fn test_last_n_lines_n_zero_returns_empty() {
+        let text = "line1\nline2\nline3";
+        assert_eq!(last_n_lines(text, 0), "");
+    }
+
+    #[test]
+    fn test_last_n_lines_trailing_newline() {
+        // Text ending with newline: "line1\nline2\n" — the trailing newline means
+        // the last "line" is empty. last_n_lines(text, 1) returns everything
+        // after the first-from-the-end newline, which is "".
+        let text = "line1\nline2\n";
+        let result = last_n_lines(text, 1);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_last_n_lines_windows_line_endings() {
+        // \r\n — only \n is counted as a newline delimiter; \r is data.
+        // "line1\r\nline2\r\nline3" has 2 \n chars.
+        let text = "line1\r\nline2\r\nline3";
+        // n=2 → find 2nd \n from end, which is after "line1\r", return "line2\r\nline3"
+        let result = last_n_lines(text, 2);
+        assert_eq!(result, "line2\r\nline3");
     }
 }

--- a/crates/rskim/src/cmd/test/shared.rs
+++ b/crates/rskim/src/cmd/test/shared.rs
@@ -158,9 +158,7 @@ pub(super) fn emit_failure_context(raw_output: &str, exit_code: i32) {
         );
         println!("{tail}");
     }
-    eprintln!(
-        "[skim] compressed output (exit {exit_code}). SKIM_PASSTHROUGH=1 for full output."
-    );
+    eprintln!("[skim] compressed output (exit {exit_code}). SKIM_PASSTHROUGH=1 for full output.");
 }
 
 /// Return the last `n` lines of `text` as a `&str` slice.
@@ -327,7 +325,10 @@ mod tests {
     #[test]
     fn test_last_n_lines_exact_n() {
         // 50 lines, n=50 → full input
-        let text = (0..50).map(|i| format!("line{i}")).collect::<Vec<_>>().join("\n");
+        let text = (0..50)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
         let result = last_n_lines(&text, 50);
         assert_eq!(result, text);
     }

--- a/crates/rskim/src/cmd/test/shared.rs
+++ b/crates/rskim/src/cmd/test/shared.rs
@@ -119,7 +119,7 @@ pub(super) fn scrape_failures(text: &str, kind: TestKind) -> Vec<TestEntry> {
 }
 
 // ============================================================================
-// Raw failure context helpers (Fix B)
+// Raw failure context helpers
 // ============================================================================
 
 /// Maximum number of raw output lines to append as failure context.
@@ -128,6 +128,40 @@ pub(super) fn scrape_failures(text: &str, kind: TestKind) -> Vec<TestEntry> {
 /// without overwhelming the context window. Full output is always
 /// available via `SKIM_PASSTHROUGH=1`.
 pub(super) const MAX_FAILURE_CONTEXT_LINES: usize = 50;
+
+/// Append raw failure context to stdout and emit a compressed-output hint to
+/// stderr.
+///
+/// Called by test-runner handlers (vitest, go, …) when `summary.fail > 0` so
+/// the agent can read the actual error messages without re-running with
+/// `SKIM_PASSTHROUGH=1`.
+///
+/// # Performance
+/// Applies [`last_n_lines`] first (zero-allocation `&str` slice) and then runs
+/// [`crate::output::strip_ansi`] only on the ~50-line tail, limiting the ANSI
+/// strip allocation to the tail rather than the full output string.
+///
+/// # Parameters
+/// - `raw_output`: the full raw output string from the test runner.
+/// - `exit_code`: the actual process exit code (e.g. `1` for test failures,
+///   `2` for compilation errors in `go test`). Used in the stderr hint so the
+///   caller knows the precise exit status to reproduce.
+pub(super) fn emit_failure_context(raw_output: &str, exit_code: i32) {
+    // Take the tail first (zero-allocation slice), then strip ANSI only on
+    // those ~50 lines instead of the entire output buffer.
+    let tail_raw = last_n_lines(raw_output, MAX_FAILURE_CONTEXT_LINES);
+    let tail = crate::output::strip_ansi(tail_raw);
+    if !tail.is_empty() {
+        println!(
+            "\n--- failure context (last {} lines) ---",
+            tail.lines().count()
+        );
+        println!("{tail}");
+    }
+    eprintln!(
+        "[skim] compressed output (exit {exit_code}). SKIM_PASSTHROUGH=1 for full output."
+    );
+}
 
 /// Return the last `n` lines of `text` as a `&str` slice.
 ///

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -162,12 +162,14 @@ fn run_vitest(program: &str, args: &[String]) -> anyhow::Result<String> {
     let arg_refs: Vec<&str> = final_args.iter().map(String::as_str).collect();
 
     let runner = CommandRunner::new(None);
-    let output = runner.run_with_node_fallback(program, &arg_refs).map_err(|e| {
-        anyhow::anyhow!(
-            "failed to run {program}: {e}\n\
+    let output = runner
+        .run_with_node_fallback(program, &arg_refs)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to run {program}: {e}\n\
              Hint: Install {program} locally (npm install -D {program}) or globally"
-        )
-    })?;
+            )
+        })?;
 
     // Combine stdout and stderr — vitest may emit JSON to either depending on
     // version and configuration.

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -76,6 +76,9 @@ pub(crate) fn run(
             let _ = result.emit_markers(&mut handle);
 
             if test_result.summary.fail > 0 {
+                eprintln!(
+                    "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
+                );
                 ExitCode::FAILURE
             } else {
                 ExitCode::SUCCESS

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -38,23 +38,17 @@ pub(crate) fn run(
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: bypass compression, run the raw command and forward output.
     if crate::cmd::is_passthrough_mode() {
-        let raw_output = if stdin_has_data() {
-            read_stdin()?
-        } else {
-            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-            let runner = CommandRunner::new(None);
-            let output = runner.run_with_node_fallback(program, &arg_refs)?;
-            let mut combined = output.stdout;
-            if !output.stderr.is_empty() {
-                if !combined.is_empty() {
-                    combined.push('\n');
-                }
-                combined.push_str(&output.stderr);
-            }
-            combined
-        };
-        println!("{raw_output}");
-        return Ok(ExitCode::FAILURE);
+        if stdin_has_data() {
+            let raw_output = read_stdin()?;
+            println!("{raw_output}");
+            return Ok(ExitCode::FAILURE);
+        }
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let runner = CommandRunner::new(None);
+        let output = runner.run_with_node_fallback(program, &arg_refs)?;
+        let code = output.exit_code.unwrap_or(1).clamp(0, 255) as u8;
+        print!("{}", crate::cmd::combine_output(&output));
+        return Ok(ExitCode::from(code));
     }
 
     let start = std::time::Instant::now();
@@ -97,9 +91,7 @@ pub(crate) fn run(
         }
         ParseResult::Passthrough(raw) => {
             println!("{raw}");
-            let stderr = io::stderr();
-            let mut handle = stderr.lock();
-            let _ = result.emit_markers(&mut handle);
+            let _ = result.emit_markers(&mut io::stderr().lock());
             ExitCode::FAILURE
         }
     };

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -36,6 +36,27 @@ pub(crate) fn run(
     show_stats: bool,
     analytics_enabled: bool,
 ) -> anyhow::Result<ExitCode> {
+    // Passthrough mode: bypass compression, run the raw command and forward output.
+    if crate::cmd::is_passthrough_mode() {
+        let raw_output = if stdin_has_data() {
+            read_stdin()?
+        } else {
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let runner = CommandRunner::new(None);
+            let output = runner.run(program, &arg_refs)?;
+            let mut combined = output.stdout;
+            if !output.stderr.is_empty() {
+                if !combined.is_empty() {
+                    combined.push('\n');
+                }
+                combined.push_str(&output.stderr);
+            }
+            combined
+        };
+        println!("{raw_output}");
+        return Ok(ExitCode::FAILURE);
+    }
+
     let start = std::time::Instant::now();
     let raw_output = if stdin_has_data() {
         read_stdin()?

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -41,6 +41,9 @@ pub(crate) fn run(
         if stdin_has_data() {
             let raw_output = read_stdin()?;
             println!("{raw_output}");
+            // Stdin passthrough has no child process, so there is no exit code to
+            // preserve. FAILURE is the conservative default — callers who need a
+            // specific exit code should use the spawned-process path instead.
             return Ok(ExitCode::FAILURE);
         }
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -72,18 +75,7 @@ pub(crate) fn run(
             if test_result.summary.fail > 0 {
                 // Append raw failure context so the agent can see actual error
                 // messages without needing to re-run with SKIM_PASSTHROUGH=1.
-                let stripped = crate::output::strip_ansi(&raw_output);
-                let tail = shared::last_n_lines(&stripped, shared::MAX_FAILURE_CONTEXT_LINES);
-                if !tail.is_empty() {
-                    println!(
-                        "\n--- failure context (last {} lines) ---",
-                        tail.lines().count()
-                    );
-                    println!("{tail}");
-                }
-                eprintln!(
-                    "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
-                );
+                shared::emit_failure_context(&raw_output, 1);
                 ExitCode::FAILURE
             } else {
                 ExitCode::SUCCESS

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -20,7 +20,7 @@ use crate::output::canonical::{TestEntry, TestOutcome, TestResult, TestSummary};
 use crate::output::ParseResult;
 use crate::runner::CommandRunner;
 
-use super::shared::{scrape_failures, TestKind};
+use super::shared::{self, scrape_failures, TestKind};
 
 // ============================================================================
 // Public entry point
@@ -76,6 +76,17 @@ pub(crate) fn run(
             let _ = result.emit_markers(&mut handle);
 
             if test_result.summary.fail > 0 {
+                // Append raw failure context so the agent can see actual error
+                // messages without needing to re-run with SKIM_PASSTHROUGH=1.
+                let stripped = crate::output::strip_ansi(&raw_output);
+                let tail = shared::last_n_lines(&stripped, shared::MAX_FAILURE_CONTEXT_LINES);
+                if !tail.is_empty() {
+                    println!(
+                        "\n--- failure context (last {} lines) ---",
+                        tail.lines().count()
+                    );
+                    println!("{tail}");
+                }
                 eprintln!(
                     "[skim] compressed output (exit 1). SKIM_PASSTHROUGH=1 for full output."
                 );

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -43,7 +43,7 @@ pub(crate) fn run(
         } else {
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
             let runner = CommandRunner::new(None);
-            let output = runner.run(program, &arg_refs)?;
+            let output = runner.run_with_node_fallback(program, &arg_refs)?;
             let mut combined = output.stdout;
             if !output.stderr.is_empty() {
                 if !combined.is_empty() {
@@ -164,10 +164,10 @@ fn run_vitest(program: &str, args: &[String]) -> anyhow::Result<String> {
     let arg_refs: Vec<&str> = final_args.iter().map(String::as_str).collect();
 
     let runner = CommandRunner::new(None);
-    let output = runner.run(program, &arg_refs).map_err(|e| {
+    let output = runner.run_with_node_fallback(program, &arg_refs).map_err(|e| {
         anyhow::anyhow!(
             "failed to run {program}: {e}\n\
-             Hint: Install {program} with: npm install -D {program}"
+             Hint: Install {program} locally (npm install -D {program}) or globally"
         )
     })?;
 

--- a/crates/rskim/src/runner.rs
+++ b/crates/rskim/src/runner.rs
@@ -167,7 +167,7 @@ impl CommandRunner {
         env_vars: &[(&str, &str)],
     ) -> anyhow::Result<CommandOutput> {
         match self.run_with_env(program, args, env_vars) {
-            Ok(out) => return Ok(out),
+            Ok(out) => Ok(out),
             Err(original_err) => {
                 // Absolute or relative paths — no fallback; caller was explicit.
                 if program.contains('/') {

--- a/crates/rskim/src/runner.rs
+++ b/crates/rskim/src/runner.rs
@@ -667,6 +667,19 @@ mod tests {
     #[test]
     fn test_node_fallback_local_bin_found() {
         use std::os::unix::fs::PermissionsExt;
+
+        /// RAII guard that restores the process cwd on drop, even on panic.
+        ///
+        /// `set_current_dir` is process-wide, so concurrent tests could see the
+        /// wrong cwd.  The guard ensures we always restore, preventing cascading
+        /// failures when this test panics.
+        struct CwdGuard(std::path::PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+
         // Create a temp directory simulating a project with ./node_modules/.bin/fake-tool
         let tmp = tempfile::tempdir().expect("failed to create tempdir");
         let bin_dir = tmp.path().join("node_modules").join(".bin");
@@ -675,16 +688,15 @@ mod tests {
         std::fs::write(&script, b"#!/bin/sh\necho 'from-local-bin'\n").unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        // Change cwd to the temp dir so the local bin path is discoverable
-        let original_dir = std::env::current_dir().unwrap();
+        // Change cwd to the temp dir so the local bin path is discoverable.
+        // The CwdGuard restores the original dir on drop (including panic unwind).
+        let _guard = CwdGuard(std::env::current_dir().unwrap());
         std::env::set_current_dir(tmp.path()).unwrap();
 
         let runner = CommandRunner::new(None);
         // `fake-tool` is not in PATH, but ./node_modules/.bin/fake-tool exists
         let result = runner.run_with_node_fallback("fake-tool", &[]).unwrap();
         assert_eq!(result.stdout.trim(), "from-local-bin");
-
-        std::env::set_current_dir(original_dir).unwrap();
     }
 
     #[cfg(unix)]

--- a/crates/rskim/src/runner.rs
+++ b/crates/rskim/src/runner.rs
@@ -169,6 +169,19 @@ impl CommandRunner {
         match self.run_with_env(program, args, env_vars) {
             Ok(out) => Ok(out),
             Err(original_err) => {
+                // Only attempt Node.js fallback resolution when the program was
+                // not found on PATH (SpawnFailed). Other errors — Timeout,
+                // PipeCaptureFailed, ReaderPanicked, Io — mean the program was
+                // found and launched; retrying via npx makes no sense and could
+                // mask real failures.
+                let is_spawn_failure = original_err
+                    .downcast_ref::<RunnerError>()
+                    .map(|e| matches!(e, RunnerError::SpawnFailed { .. }))
+                    .unwrap_or(false);
+                if !is_spawn_failure {
+                    return Err(original_err);
+                }
+
                 // Absolute or relative paths — no fallback; caller was explicit.
                 if program.contains('/') {
                     return Err(original_err);
@@ -665,20 +678,9 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn test_node_fallback_local_bin_found() {
         use std::os::unix::fs::PermissionsExt;
-
-        /// RAII guard that restores the process cwd on drop, even on panic.
-        ///
-        /// `set_current_dir` is process-wide, so concurrent tests could see the
-        /// wrong cwd.  The guard ensures we always restore, preventing cascading
-        /// failures when this test panics.
-        struct CwdGuard(std::path::PathBuf);
-        impl Drop for CwdGuard {
-            fn drop(&mut self) {
-                let _ = std::env::set_current_dir(&self.0);
-            }
-        }
 
         // Create a temp directory simulating a project with ./node_modules/.bin/fake-tool
         let tmp = tempfile::tempdir().expect("failed to create tempdir");
@@ -688,15 +690,19 @@ mod tests {
         std::fs::write(&script, b"#!/bin/sh\necho 'from-local-bin'\n").unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        // Change cwd to the temp dir so the local bin path is discoverable.
-        // The CwdGuard restores the original dir on drop (including panic unwind).
-        let _guard = CwdGuard(std::env::current_dir().unwrap());
+        // `set_current_dir` is process-wide. `#[serial]` ensures no other test
+        // runs concurrently in this process while cwd is modified. The original
+        // cwd is restored on exit so subsequent tests are unaffected.
+        let original_dir = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
-
-        let runner = CommandRunner::new(None);
-        // `fake-tool` is not in PATH, but ./node_modules/.bin/fake-tool exists
-        let result = runner.run_with_node_fallback("fake-tool", &[]).unwrap();
-        assert_eq!(result.stdout.trim(), "from-local-bin");
+        let result = std::panic::catch_unwind(|| {
+            let runner = CommandRunner::new(None);
+            // `fake-tool` is not in PATH, but ./node_modules/.bin/fake-tool exists
+            runner.run_with_node_fallback("fake-tool", &[]).unwrap()
+        });
+        std::env::set_current_dir(&original_dir).unwrap();
+        let output = result.expect("test panicked");
+        assert_eq!(output.stdout.trim(), "from-local-bin");
     }
 
     #[cfg(unix)]

--- a/crates/rskim/src/runner.rs
+++ b/crates/rskim/src/runner.rs
@@ -141,6 +141,58 @@ impl CommandRunner {
         })
     }
 
+    /// Try to spawn `program` with cascading resolution:
+    /// 1. Direct PATH lookup (`Command::new(program)`)
+    /// 2. `./node_modules/.bin/{program}` (local Node.js install)
+    /// 3. `npx --no-install {program}` (npx local-only resolver)
+    ///
+    /// If `program` contains a `/` it is treated as an explicit path — no
+    /// fallback is attempted (the caller has a specific binary in mind).
+    ///
+    /// Returns the original spawn error when all strategies are exhausted.
+    pub(crate) fn run_with_node_fallback(
+        &self,
+        program: &str,
+        args: &[&str],
+    ) -> anyhow::Result<CommandOutput> {
+        self.run_with_env_node_fallback(program, args, &[])
+    }
+
+    /// Variant of [`run_with_node_fallback`] that also forwards environment
+    /// variable overrides to every candidate.
+    pub(crate) fn run_with_env_node_fallback(
+        &self,
+        program: &str,
+        args: &[&str],
+        env_vars: &[(&str, &str)],
+    ) -> anyhow::Result<CommandOutput> {
+        match self.run_with_env(program, args, env_vars) {
+            Ok(out) => return Ok(out),
+            Err(original_err) => {
+                // Absolute or relative paths — no fallback; caller was explicit.
+                if program.contains('/') {
+                    return Err(original_err);
+                }
+
+                // Strategy 2: ./node_modules/.bin/{program}
+                let local_bin = format!("./node_modules/.bin/{program}");
+                if std::path::Path::new(&local_bin).exists() {
+                    if let Ok(out) = self.run_with_env(&local_bin, args, env_vars) {
+                        return Ok(out);
+                    }
+                }
+
+                // Strategy 3: npx --no-install {program}
+                let mut npx_args: Vec<&str> = vec!["--no-install", program];
+                npx_args.extend_from_slice(args);
+                match self.run_with_env("npx", &npx_args, env_vars) {
+                    Ok(out) => Ok(out),
+                    Err(_) => Err(original_err),
+                }
+            }
+        }
+    }
+
     /// Wait for the child process, killing it if the timeout is exceeded.
     ///
     /// Uses polling with exponential backoff (1ms → 50ms cap) when a timeout
@@ -535,5 +587,132 @@ mod tests {
             "Expected 'byte limit' in error, got: {}",
             err
         );
+    }
+
+    // ========================================================================
+    // Node fallback tests
+    // ========================================================================
+
+    #[cfg(unix)]
+    #[test]
+    fn test_node_fallback_direct_success_no_fallback() {
+        // `echo` is always in PATH — succeeds on the first attempt.
+        let runner = CommandRunner::new(None);
+        let result = runner.run_with_node_fallback("echo", &["hello"]).unwrap();
+        assert_eq!(result.stdout.trim(), "hello");
+        assert_eq!(result.exit_code, Some(0));
+    }
+
+    #[test]
+    fn test_node_fallback_absolute_path_no_fallback() {
+        // Absolute path — no fallback should be tried (contains '/').
+        let runner = CommandRunner::new(None);
+        let err = runner
+            .run_with_node_fallback("/nonexistent-binary-1234", &[])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to execute"),
+            "Expected 'failed to execute', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_node_fallback_relative_path_no_fallback() {
+        // Relative path (contains '/') — no fallback.
+        let runner = CommandRunner::new(None);
+        let err = runner
+            .run_with_node_fallback("./nonexistent-binary-5678", &[])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to execute"),
+            "Expected 'failed to execute', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_node_fallback_all_fail_preserves_original_error() {
+        // A program not in PATH or node_modules:
+        // - Strategy 1: spawn fails (not in PATH)
+        // - Strategy 2: ./node_modules/.bin/... doesn't exist
+        // - Strategy 3: npx may or may not be available
+        //
+        // When npx is unavailable, we get the original Err(SpawnFailed).
+        // When npx is available but cannot resolve the package, we get Ok with
+        // non-zero exit code (npx ran and reported failure).
+        // Either outcome is acceptable — the key property is that the original
+        // program (__skim_nonexistent_9999__) was never successfully executed.
+        let runner = CommandRunner::new(None);
+        match runner.run_with_node_fallback("__skim_nonexistent_9999__", &[]) {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("failed to execute") || msg.contains("__skim_nonexistent"),
+                    "Expected original spawn error, got: {msg}"
+                );
+            }
+            Ok(output) => {
+                // npx was found but returned non-zero — acceptable fallback behavior.
+                assert_ne!(
+                    output.exit_code,
+                    Some(0),
+                    "Unexpected success running nonexistent program via npx"
+                );
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_node_fallback_local_bin_found() {
+        use std::os::unix::fs::PermissionsExt;
+        // Create a temp directory simulating a project with ./node_modules/.bin/fake-tool
+        let tmp = tempfile::tempdir().expect("failed to create tempdir");
+        let bin_dir = tmp.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let script = bin_dir.join("fake-tool");
+        std::fs::write(&script, b"#!/bin/sh\necho 'from-local-bin'\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        // Change cwd to the temp dir so the local bin path is discoverable
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let runner = CommandRunner::new(None);
+        // `fake-tool` is not in PATH, but ./node_modules/.bin/fake-tool exists
+        let result = runner.run_with_node_fallback("fake-tool", &[]).unwrap();
+        assert_eq!(result.stdout.trim(), "from-local-bin");
+
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_node_fallback_npx_no_install_flag() {
+        // Verify that --no-install is passed to npx.
+        // When npx is available: --no-install prevents downloading, so npx exits
+        // non-zero (package not found locally). When npx is not available, the
+        // original spawn error is returned as Err.
+        // Either way, the unknown program must never succeed (exit code != 0).
+        let runner = CommandRunner::new(None);
+        match runner.run_with_node_fallback("__skim_nonexistent_npx_test_8888__", &[]) {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("failed to execute") || msg.contains("__skim_nonexistent"),
+                    "Expected spawn error, got: {msg}"
+                );
+            }
+            Ok(output) => {
+                // npx ran but returned non-zero — this is correct: --no-install
+                // prevented downloading the package.
+                assert_ne!(
+                    output.exit_code,
+                    Some(0),
+                    "--no-install should cause npx to fail for unknown packages"
+                );
+            }
+        }
     }
 }

--- a/crates/rskim/src/runner.rs
+++ b/crates/rskim/src/runner.rs
@@ -727,4 +727,46 @@ mod tests {
             }
         }
     }
+
+    // ========================================================================
+    // run_with_env_node_fallback: env forwarding tests
+    // ========================================================================
+
+    /// Verify that `run_with_env_node_fallback` forwards env overrides to the
+    /// spawned process on every fallback candidate. Uses `printenv` (always in
+    /// PATH on Unix) with an injected variable to confirm forwarding.
+    #[cfg(unix)]
+    #[test]
+    fn test_node_fallback_env_vars_forwarded() {
+        let runner = CommandRunner::new(None);
+        let env_overrides = &[("SKIM_TEST_ENV_FORWARD", "hello_from_skim")];
+        // printenv KEY prints the value of KEY if set, exits 0; exits non-zero if unset.
+        let result = runner
+            .run_with_env_node_fallback("printenv", &["SKIM_TEST_ENV_FORWARD"], env_overrides)
+            .unwrap();
+        assert_eq!(
+            result.stdout.trim(),
+            "hello_from_skim",
+            "env override must be forwarded to the child process"
+        );
+        assert_eq!(result.exit_code, Some(0));
+    }
+
+    /// Verify that original args are passed unchanged to the spawned process by
+    /// `run_with_env_node_fallback`. Uses `echo` (always in PATH on Unix) with
+    /// specific arguments to confirm they appear verbatim in the output.
+    #[cfg(unix)]
+    #[test]
+    fn test_node_fallback_args_preserved() {
+        let runner = CommandRunner::new(None);
+        let result = runner
+            .run_with_env_node_fallback("echo", &["arg_one", "arg_two", "arg_three"], &[])
+            .unwrap();
+        let out = result.stdout.trim();
+        assert!(
+            out.contains("arg_one") && out.contains("arg_two") && out.contains("arg_three"),
+            "all args must be preserved in output, got: {out:?}"
+        );
+        assert_eq!(result.exit_code, Some(0));
+    }
 }

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -714,16 +714,17 @@ fn test_passthrough_direct_vitest_no_json_injection() {
         .output()
         .unwrap();
 
-    // Passthrough forwards the raw input and exits with the original exit code.
+    // Passthrough forwards the raw input unchanged.
     let stdout = String::from_utf8(output.stdout).unwrap();
+    // Raw text must contain source markers from the fixture.
     assert!(
-        stdout.contains("Tests") || stdout.contains("passed"),
+        stdout.contains("Tests") && stdout.contains("passed"),
         "passthrough must forward the raw input, got: {stdout}"
     );
-    // Must NOT contain parsed JSON-injected output markers.
+    // Must NOT contain skim-structured output markers.
     assert!(
-        !stdout.contains("PASS:") || stdout.contains("passed"),
-        "passthrough must not reformat the input"
+        !stdout.contains("PASS:"),
+        "passthrough must not reformat the input into skim structured output, got: {stdout}"
     );
 }
 
@@ -731,7 +732,7 @@ fn test_passthrough_direct_vitest_no_json_injection() {
 /// Pipe a failing vitest JSON fixture and verify the raw content is forwarded
 /// to stdout without parsing or reformatting.
 #[test]
-fn test_passthrough_preserves_exit_code() {
+fn test_passthrough_forwards_raw_content() {
     // The vitest passthrough handler returns ExitCode::FAILURE when stdin has
     // data (exit code 1 is conservative — the tool status is unknown). The
     // important property is that raw content is forwarded without compression.

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -670,6 +670,93 @@ fn test_rewrite_hook_passthrough_zero_stderr() {
 }
 
 // ============================================================================
+// SKIM_PASSTHROUGH=1 in hook mode (Fix C)
+// ============================================================================
+
+/// Verify that SKIM_PASSTHROUGH=1 makes the hook return immediately with empty
+/// stdout, even for a command that would normally be rewritten. The agent sees
+/// no hook response — equivalent to a transparent passthrough.
+#[test]
+fn test_passthrough_hook_skips_rewrite() {
+    let input = serde_json::json!({
+        "tool_input": {
+            "command": "cargo test"
+        }
+    });
+    let output = skim_cmd()
+        .args(["rewrite", "--hook"])
+        .env("SKIM_PASSTHROUGH", "1")
+        .write_stdin(serde_json::to_string(&input).unwrap())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "SKIM_PASSTHROUGH=1 hook mode must exit 0"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "SKIM_PASSTHROUGH=1 hook mode must produce empty stdout, got: {stdout}"
+    );
+}
+
+/// Verify that SKIM_PASSTHROUGH=1 with `skim test vitest` does NOT inject
+/// --reporter=json. Plain text piped in is forwarded unchanged without JSON
+/// transformation.
+#[test]
+fn test_passthrough_direct_vitest_no_json_injection() {
+    let plain_text = "Tests  3 passed | 0 failed | 3 total\n";
+    let output = skim_cmd()
+        .args(["test", "vitest"])
+        .env("SKIM_PASSTHROUGH", "1")
+        .write_stdin(plain_text)
+        .output()
+        .unwrap();
+
+    // Passthrough forwards the raw input and exits with the original exit code.
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("Tests") || stdout.contains("passed"),
+        "passthrough must forward the raw input, got: {stdout}"
+    );
+    // Must NOT contain parsed JSON-injected output markers.
+    assert!(
+        !stdout.contains("PASS:") || stdout.contains("passed"),
+        "passthrough must not reformat the input"
+    );
+}
+
+/// Verify that SKIM_PASSTHROUGH=1 forwards raw output unchanged.
+/// Pipe a failing vitest JSON fixture and verify the raw content is forwarded
+/// to stdout without parsing or reformatting.
+#[test]
+fn test_passthrough_preserves_exit_code() {
+    // The vitest passthrough handler returns ExitCode::FAILURE when stdin has
+    // data (exit code 1 is conservative — the tool status is unknown). The
+    // important property is that raw content is forwarded without compression.
+    let fixture = include_str!("fixtures/vitest/vitest_fail.json");
+    let output = skim_cmd()
+        .args(["test", "vitest"])
+        .env("SKIM_PASSTHROUGH", "1")
+        .write_stdin(fixture)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Raw JSON forwarded unchanged — must contain the source numFailedTests field.
+    assert!(
+        stdout.contains("numFailedTests"),
+        "passthrough must forward raw fixture content, got: {stdout}"
+    );
+    // Passthrough must NOT produce any skim-formatted output.
+    assert!(
+        !stdout.contains("FAIL:") && !stdout.contains("PASS:"),
+        "passthrough must not compress/reformat output, got: {stdout}"
+    );
+}
+
+// ============================================================================
 // Lint rewrite rules (#104)
 // ============================================================================
 

--- a/crates/rskim/tests/cli_e2e_test_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_test_parsers.rs
@@ -353,3 +353,19 @@ fn test_no_stderr_hint_on_passthrough() {
         .assert()
         .stderr(predicate::str::contains("[skim] compressed output").not());
 }
+
+/// Pipe a failing vitest JSON fixture through stdin to `skim test vitest`,
+/// capture stderr, and assert it contains BOTH `[skim] compressed output`
+/// AND `SKIM_PASSTHROUGH=1`. This validates the full hint message format,
+/// not just the prefix.
+#[test]
+fn test_stderr_hint_contains_passthrough_instruction() {
+    let fixture = include_str!("fixtures/vitest/vitest_fail.json");
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin(fixture)
+        .assert()
+        .code(predicate::ne(0))
+        .stderr(predicate::str::contains("[skim] compressed output"))
+        .stderr(predicate::str::contains("SKIM_PASSTHROUGH=1"));
+}

--- a/crates/rskim/tests/cli_e2e_test_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_test_parsers.rs
@@ -307,3 +307,49 @@ fn test_vitest_passthrough_silent_without_debug() {
         .stderr(predicate::str::contains("[skim:notice]").not())
         .stderr(predicate::str::contains("[skim:warning]").not());
 }
+
+// ============================================================================
+// stderr hint on compressed failure (Fix E)
+// ============================================================================
+
+/// Pipe a failing vitest JSON fixture through stdin to `skim test vitest`,
+/// capture stderr, verify it contains `[skim] compressed output` (the hint
+/// that tells the user how to see full raw output).
+#[test]
+fn test_stderr_hint_on_compressed_failure() {
+    let fixture = include_str!("fixtures/vitest/vitest_fail.json");
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin(fixture)
+        .assert()
+        .code(predicate::ne(0))
+        .stderr(predicate::str::contains("[skim] compressed output"));
+}
+
+/// Pipe a passing vitest JSON fixture through stdin, capture stderr, verify
+/// it does NOT contain `[skim]` (hint must only fire on non-zero exit codes).
+#[test]
+fn test_no_stderr_hint_on_success() {
+    let fixture = include_str!("fixtures/vitest/vitest_pass.json");
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin(fixture)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[skim]").not());
+}
+
+/// Pipe unparseable output through stdin (triggers Passthrough tier), capture
+/// stderr, verify the hint is NOT emitted. Passthrough output is uncompressed
+/// so the hint is not needed.
+#[test]
+fn test_no_stderr_hint_on_passthrough() {
+    // Unparseable input triggers tier 3 passthrough.
+    // stdin path uses synthetic exit_code Some(0), so process exits 0.
+    // The hint must NOT fire because result.is_passthrough() is true.
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin("completely unparseable garbage output that matches nothing\n")
+        .assert()
+        .stderr(predicate::str::contains("[skim] compressed output").not());
+}

--- a/crates/rskim/tests/cli_e2e_test_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_test_parsers.rs
@@ -369,3 +369,78 @@ fn test_stderr_hint_contains_passthrough_instruction() {
         .stderr(predicate::str::contains("[skim] compressed output"))
         .stderr(predicate::str::contains("SKIM_PASSTHROUGH=1"));
 }
+
+// ============================================================================
+// Go test: passthrough exec path (#49)
+// ============================================================================
+//
+// NOTE: `skim test go` does NOT read from stdin. Unlike vitest/cargo, the go
+// handler always spawns the `go` binary directly (with `-json` injection or
+// without it in SKIM_PASSTHROUGH mode). There is no stdin-reading code path.
+// The unit tests in src/cmd/test/go.rs cover the three-tier parse() function
+// exhaustively. The E2E test below verifies the passthrough exec path
+// dispatches to `go` and surfaces the install hint when `go` is absent.
+
+/// Verify that `skim test go` with SKIM_PASSTHROUGH=1 attempts to exec `go`
+/// and surfaces the install hint when the binary is not available.
+///
+/// This test is skipped when `go` is installed because the exec succeeds (or
+/// fails for a different reason — missing package args) and the install hint
+/// is not emitted. The intent is to exercise the passthrough exec code path
+/// on CI environments where `go` is not present.
+#[test]
+fn test_go_passthrough_exec_path_surfaces_install_hint() {
+    // Skip this test if `go` is installed — the exec path succeeds and the
+    // "install Go" hint is not emitted.
+    if std::process::Command::new("go")
+        .arg("version")
+        .output()
+        .is_ok()
+    {
+        return;
+    }
+
+    // With SKIM_PASSTHROUGH=1 and no `go` binary, the passthrough branch
+    // tries runner.run("go", &["test"]) which fails with "failed to execute".
+    // The go::run() function maps that error to include the install hint.
+    let output = skim_cmd()
+        .args(["test", "go"])
+        .env("SKIM_PASSTHROUGH", "1")
+        .output()
+        .unwrap();
+
+    // Process must exit non-zero (go binary not found).
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "expected non-zero exit when go is not installed"
+    );
+
+    // The error output must contain the install hint injected by go::run().
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("https://go.dev/dl/"),
+        "expected Go install hint in error output, got: {stderr}"
+    );
+}
+
+// ============================================================================
+// Vitest: failure context banner (#49)
+// ============================================================================
+
+/// Pipe a failing vitest JSON fixture through stdin to `skim test vitest`
+/// and assert that stdout contains the `--- failure context` banner.
+///
+/// When skim compresses a failing test run, it appends raw tail lines
+/// under a banner so the agent can see the actual failure details without
+/// needing to re-run with SKIM_PASSTHROUGH=1.
+#[test]
+fn test_vitest_failure_context_banner_present() {
+    let fixture = include_str!("fixtures/vitest/vitest_fail.json");
+    skim_cmd()
+        .args(["test", "vitest"])
+        .write_stdin(fixture)
+        .assert()
+        .code(predicate::ne(0))
+        .stdout(predicate::str::contains("--- failure context"));
+}

--- a/crates/rskim/tests/cli_test_pytest.rs
+++ b/crates/rskim/tests/cli_test_pytest.rs
@@ -152,6 +152,88 @@ fn test_piped_passthrough_for_garbage() {
 }
 
 // ============================================================================
+// Passthrough mode (SKIM_PASSTHROUGH=1)
+// ============================================================================
+
+/// When SKIM_PASSTHROUGH=1 and input is piped, raw output is forwarded unchanged
+/// (no compression header, no PASS:/FAIL: counts).
+#[test]
+fn test_piped_passthrough_mode_skips_compression() {
+    let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["test", "pytest"])
+        .env("SKIM_PASSTHROUGH", "1")
+        .write_stdin(fixture)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Must forward the raw pytest output (contains the original summary line)
+    assert!(
+        stdout.contains("passed") || stdout.contains("failed"),
+        "passthrough should forward raw pytest output, got: {stdout}"
+    );
+
+    // Must NOT contain the compressed format headers
+    assert!(
+        !stdout.contains("PASS:") && !stdout.contains("FAIL:"),
+        "passthrough must not emit compressed PASS:/FAIL: counts, got: {stdout}"
+    );
+}
+
+// ============================================================================
+// Failure context
+// ============================================================================
+
+/// When pytest reports failures, the compressed output must include a raw
+/// failure context tail so the agent can diagnose failures without re-running.
+#[test]
+fn test_failure_context_appended_on_failures() {
+    let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["test", "pytest"])
+        .write_stdin(fixture)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Compressed header must be present
+    assert!(
+        stdout.contains("FAIL: 1"),
+        "expected FAIL: 1 in compressed output, got: {stdout}"
+    );
+
+    // Failure context separator must appear
+    assert!(
+        stdout.contains("--- failure context"),
+        "expected failure context block in output, got: {stdout}"
+    );
+}
+
+/// When all tests pass there must be no failure context tail.
+#[test]
+fn test_failure_context_absent_on_all_pass() {
+    let fixture = include_str!("fixtures/cmd/test/pytest_pass.txt");
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["test", "pytest"])
+        .write_stdin(fixture)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("--- failure context"),
+        "failure context must not appear when all tests pass, got: {stdout}"
+    );
+}
+
+// ============================================================================
 // Unknown runner
 // ============================================================================
 

--- a/crates/rskim/tests/cli_test_pytest.rs
+++ b/crates/rskim/tests/cli_test_pytest.rs
@@ -66,78 +66,42 @@ fn test_piped_all_pass() {
 #[test]
 fn test_piped_with_failures() {
     let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
-    let output = Command::cargo_bin("skim")
+    Command::cargo_bin("skim")
         .unwrap()
         .args(["test", "pytest"])
         .write_stdin(fixture)
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Should show 2 passed, 1 failed
-    assert!(
-        stdout.contains("PASS: 2"),
-        "expected PASS: 2 in output, got: {stdout}"
-    );
-    assert!(
-        stdout.contains("FAIL: 1"),
-        "expected FAIL: 1 in output, got: {stdout}"
-    );
-
-    // Should include the failure detail
-    assert!(
-        stdout.contains("test_divide") || stdout.contains("test_math"),
-        "expected failure test name in output, got: {stdout}"
-    );
+        .assert()
+        .code(predicate::ne(0))
+        .stdout(predicate::str::contains("PASS: 2"))
+        .stdout(predicate::str::contains("FAIL: 1"))
+        .stdout(predicate::str::contains("test_divide").or(predicate::str::contains("test_math")));
 }
 
 #[test]
 fn test_piped_mixed() {
     let fixture = include_str!("fixtures/cmd/test/pytest_mixed.txt");
-    let output = Command::cargo_bin("skim")
+    Command::cargo_bin("skim")
         .unwrap()
         .args(["test", "pytest"])
         .write_stdin(fixture)
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    assert!(
-        stdout.contains("PASS: 4"),
-        "expected PASS: 4, got: {stdout}"
-    );
-    assert!(
-        stdout.contains("FAIL: 1"),
-        "expected FAIL: 1, got: {stdout}"
-    );
-    assert!(
-        stdout.contains("SKIP: 1"),
-        "expected SKIP: 1, got: {stdout}"
-    );
+        .assert()
+        .code(predicate::ne(0))
+        .stdout(predicate::str::contains("PASS: 4"))
+        .stdout(predicate::str::contains("FAIL: 1"))
+        .stdout(predicate::str::contains("SKIP: 1"));
 }
 
 #[test]
 fn test_piped_all_failures() {
     let fixture = include_str!("fixtures/cmd/test/pytest_all_fail.txt");
-    let output = Command::cargo_bin("skim")
+    Command::cargo_bin("skim")
         .unwrap()
         .args(["test", "pytest"])
         .write_stdin(fixture)
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    assert!(
-        stdout.contains("PASS: 0"),
-        "expected PASS: 0 in output, got: {stdout}"
-    );
-    assert!(
-        stdout.contains("FAIL: 3"),
-        "expected FAIL: 3 in output, got: {stdout}"
-    );
+        .assert()
+        .code(predicate::ne(0))
+        .stdout(predicate::str::contains("PASS: 0"))
+        .stdout(predicate::str::contains("FAIL: 3"));
 }
 
 #[test]
@@ -160,27 +124,17 @@ fn test_piped_passthrough_for_garbage() {
 #[test]
 fn test_piped_passthrough_mode_skips_compression() {
     let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
-    let output = Command::cargo_bin("skim")
+    Command::cargo_bin("skim")
         .unwrap()
         .args(["test", "pytest"])
         .env("SKIM_PASSTHROUGH", "1")
         .write_stdin(fixture)
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Must forward the raw pytest output (contains the original summary line)
-    assert!(
-        stdout.contains("passed") || stdout.contains("failed"),
-        "passthrough should forward raw pytest output, got: {stdout}"
-    );
-
-    // Must NOT contain the compressed format headers
-    assert!(
-        !stdout.contains("PASS:") && !stdout.contains("FAIL:"),
-        "passthrough must not emit compressed PASS:/FAIL: counts, got: {stdout}"
-    );
+        .assert()
+        // Raw pytest output contains "passed" or "failed"
+        .stdout(predicate::str::contains("passed").or(predicate::str::contains("failed")))
+        // Compressed PASS:/FAIL: counts must not appear
+        .stdout(predicate::str::contains("PASS:").not())
+        .stdout(predicate::str::contains("FAIL:").not());
 }
 
 // ============================================================================
@@ -192,45 +146,27 @@ fn test_piped_passthrough_mode_skips_compression() {
 #[test]
 fn test_failure_context_appended_on_failures() {
     let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
-    let output = Command::cargo_bin("skim")
+    Command::cargo_bin("skim")
         .unwrap()
         .args(["test", "pytest"])
         .write_stdin(fixture)
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Compressed header must be present
-    assert!(
-        stdout.contains("FAIL: 1"),
-        "expected FAIL: 1 in compressed output, got: {stdout}"
-    );
-
-    // Failure context separator must appear
-    assert!(
-        stdout.contains("--- failure context"),
-        "expected failure context block in output, got: {stdout}"
-    );
+        .assert()
+        .code(predicate::ne(0))
+        .stdout(predicate::str::contains("FAIL: 1"))
+        .stdout(predicate::str::contains("--- failure context"));
 }
 
 /// When all tests pass there must be no failure context tail.
 #[test]
 fn test_failure_context_absent_on_all_pass() {
     let fixture = include_str!("fixtures/cmd/test/pytest_pass.txt");
-    let output = Command::cargo_bin("skim")
+    Command::cargo_bin("skim")
         .unwrap()
         .args(["test", "pytest"])
         .write_stdin(fixture)
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    assert!(
-        !stdout.contains("--- failure context"),
-        "failure context must not appear when all tests pass, got: {stdout}"
-    );
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--- failure context").not());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes a real incident where an AI agent ran `npx vitest run ...`, the skim rewrite hook intercepted it, but vitest wasn't in PATH — causing silent failure and a 60+ second agent retry loop.

### Changes

- **SKIM_PASSTHROUGH env var** — Universal bypass for all compression. Works in hook (skips rewrite entirely) and direct invocation (prints raw output). Covers vitest, go, pytest, and the generic handler.
- **Cascading spawn fallback** — When a Node.js tool isn't in PATH, tries `./node_modules/.bin/{tool}` then `npx --no-install {tool}` before failing with a clear install hint. Scoped to vitest/jest call sites only (not applied globally).
- **Tiered test compression** — On test failures, appends last 50 lines of ANSI-stripped raw output after the structured summary. Gives agents the assertion text and stack traces they need to debug.
- **stderr hint on failure** — `[skim] compressed output (exit N). SKIM_PASSTHROUGH=1 for full output.` emitted to stderr when compression loses detail.
- **Troubleshooting docs** — `skim init` guidance now includes SKIM_PASSTHROUGH instructions.

### Review resolution

All blocking issues from code review resolved:
- Stderr no longer mixed into stdout in passthrough mode
- Node fallback only fires on spawn failures (not timeouts/pipe errors)
- Failure context extracted to `shared::emit_failure_context()` (DRY)
- `strip_ansi` applied after `last_n_lines` (perf: allocate ~50 lines, not full output)
- Pytest parity: passthrough + failure context + stderr hint added
- Tautological test assertion fixed, misleading test renamed

## Test plan

- [x] 2800 tests passing, 0 failures
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 33 net new tests covering all 5 features
- [x] E2E acceptance tests for hook passthrough, vitest passthrough, go passthrough, failure context banner, stderr hints
- [x] Unit tests for `check_passthrough_value`, `last_n_lines`, `emit_failure_context`, node fallback cascading