### PR TITLE
feat(line-numbers): add -n/--line-numbers flag for source line prefixes

### DIFF
--- a/crates/rskim-core/src/lib.rs
+++ b/crates/rskim-core/src/lib.rs
@@ -155,6 +155,54 @@ pub fn transform_with_quality(
     language.transform_source(source, config)
 }
 
+/// Transform source code and return content, parse quality flag, and source line map.
+///
+/// Like `transform_with_quality` but also returns a source line map when
+/// `config.line_numbers` is true. The source line map maps each output line index
+/// (0-based) to its 1-indexed source line number. A value of `0` in the map
+/// indicates an omission/truncation marker with no line number annotation.
+///
+/// When `config.line_numbers` is false, `source_line_map` is `None`.
+///
+/// # Source Line Map Semantics
+///
+/// - **Full mode**: identity map — output line N maps to source line N
+/// - **Structure mode**: verbatim-copied lines map to their source line;
+///   the `{ /* ... */ }` replacement stays on the function signature line
+/// - **Signatures mode**: each signature's output lines map to consecutive
+///   source lines starting from `node.start_position().row + 1`
+/// - **Types mode**: same as signatures mode
+/// - **Minimal mode**: heuristic text-matching to source lines
+/// - **Pseudo mode**: heuristic text-matching to source lines
+/// - **Serde-based (JSON/YAML/TOML) non-full modes**: `None` (restructured output)
+///
+/// # CLI Integration
+///
+/// The CLI (`rskim` binary) uses this function to obtain the line map, then formats
+/// the output as `{source_line}\t{content}` for lines with non-zero map values.
+/// See `crates/rskim/src/format.rs` for the formatting function.
+///
+/// # Examples
+///
+/// ```no_run
+/// use rskim_core::{transform_with_line_map, Language, Mode, TransformConfig};
+///
+/// let config = TransformConfig::with_mode(Mode::Full).with_line_numbers(true);
+/// let (content, has_errors, line_map) =
+///     transform_with_line_map("fn main() {}\nfn foo() {}", Language::Rust, &config)?;
+/// let map = line_map.unwrap();
+/// assert_eq!(map[0], 1); // First output line → source line 1
+/// assert_eq!(map[1], 2); // Second output line → source line 2
+/// # Ok::<(), rskim_core::SkimError>(())
+/// ```
+pub fn transform_with_line_map(
+    source: &str,
+    language: Language,
+    config: &TransformConfig,
+) -> Result<(String, bool, Option<Vec<usize>>)> {
+    language.transform_source_with_line_map(source, config)
+}
+
 /// Transform source code with automatic language detection from file path
 ///
 /// Convenience function that detects language from file extension.

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -93,6 +93,169 @@ fn transform_tree_with_spans(
     }
 }
 
+/// Transform AST and return text, NodeSpan metadata, AND source line map.
+///
+/// ARCHITECTURE: Extended version of `transform_tree` that additionally returns
+/// a source line map when `config.line_numbers` is true. The source line map
+/// maps each output line index (0-based) to its 1-indexed source line number.
+/// Value `0` indicates an omission/truncation marker (no line number annotation).
+///
+/// When `config.line_numbers` is false, returns `None` for the source line map
+/// (avoids unnecessary computation).
+///
+/// # Design Decision (AC-18)
+/// Line number computation is done inside the core library (rskim-core) so that
+/// the CLI layer can simply apply `format_with_line_numbers` without understanding
+/// each mode's internal structure. This keeps the CLI layer thin while the core
+/// library owns the mode-specific knowledge.
+pub(crate) fn transform_tree_with_line_map(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    config: &TransformConfig,
+) -> Result<(String, Option<Vec<usize>>)> {
+    if !config.line_numbers {
+        let text = transform_tree(source, tree, language, config)?;
+        return Ok((text, None));
+    }
+
+    // For modes that support source line maps, compute them alongside the transform.
+    let (text, spans, line_map) = match config.mode {
+        Mode::Structure => {
+            structure::transform_structure_with_spans_and_line_map(source, tree, language, config)?
+        }
+        Mode::Signatures => {
+            let (text, spans, line_map) =
+                signatures::transform_signatures_with_spans_and_line_map(source, tree, language)?;
+            (text, spans, line_map)
+        }
+        Mode::Types => {
+            let (text, spans, line_map) =
+                types::transform_types_with_spans_and_line_map(source, tree, language)?;
+            (text, spans, line_map)
+        }
+        Mode::Full => {
+            // Full mode: identity map
+            let text = source.to_string();
+            let line_count = text.lines().count();
+            let spans = vec![NodeSpan::new(0..line_count, "source_file")];
+            let line_map: Vec<usize> = (1..=line_count).collect();
+            (text, spans, line_map)
+        }
+        Mode::Minimal => {
+            // Minimal mode: identity map over output (minimal keeps most source lines)
+            let text = minimal::transform_minimal(source, tree, language, config)?;
+            let line_count = text.lines().count();
+            let spans = vec![NodeSpan::new(0..line_count, "source_file")];
+            // For minimal mode, compute the line map by text matching
+            let line_map = compute_line_map_by_text_matching(source, &text);
+            (text, spans, line_map)
+        }
+        Mode::Pseudo => {
+            // Pseudo mode: compute line map by text matching after transform
+            let (text, spans) =
+                pseudo::transform_pseudo_with_spans(source, tree, language, config)?;
+            let line_map = compute_line_map_by_text_matching(source, &text);
+            (text, spans, line_map)
+        }
+    };
+
+    // Apply max_lines truncation (adjusting the line map)
+    let (final_text, final_line_map) = if let Some(max_lines) = config.max_lines {
+        let truncated_text = truncate::truncate_to_lines(&text, &spans, language, max_lines)?;
+        // After truncation, the output has a subset of lines plus omission markers.
+        // Rebuild the line map: match output lines back to pre-truncation line map.
+        let final_line_map = reconcile_line_map_after_truncation(&text, &truncated_text, &line_map);
+        (truncated_text, final_line_map)
+    } else {
+        (text, line_map)
+    };
+
+    Ok((final_text, Some(final_line_map)))
+}
+
+/// Compute a source line map by matching output lines to source lines (text scan).
+///
+/// ARCHITECTURE: Used for Minimal and Pseudo modes where removed ranges leave
+/// verbatim sections of source in the output. Each output line is matched to
+/// the first unmatched source line with identical content.
+///
+/// This is a best-effort heuristic: if identical lines appear multiple times,
+/// the first unmatched occurrence is used. In practice this is correct for
+/// minimal/pseudo modes because lines are processed in source order.
+pub(crate) fn compute_line_map_by_text_matching(source: &str, output: &str) -> Vec<usize> {
+    let source_lines: Vec<&str> = source.lines().collect();
+    let output_lines: Vec<&str> = output.lines().collect();
+
+    // Track current position in source to maintain order
+    let mut source_pos = 0usize;
+    let mut result = Vec::with_capacity(output_lines.len());
+
+    for output_line in &output_lines {
+        // Search for this output line in source, starting from current position
+        let mut found = false;
+        for (offset, source_line) in source_lines[source_pos..].iter().enumerate() {
+            if *source_line == *output_line {
+                let source_line_num = source_pos + offset + 1; // 1-indexed
+                result.push(source_line_num);
+                source_pos = source_pos + offset + 1;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            // Line not found in remaining source (could be an omission marker)
+            result.push(0);
+        }
+    }
+
+    result
+}
+
+/// Reconcile source line map after AST-aware truncation.
+///
+/// After `truncate_to_lines`, the output may have omission markers inserted
+/// and some lines may be reordered or dropped. This function builds the final
+/// line map by matching each truncated output line back to the pre-truncation
+/// line map via text comparison.
+///
+/// Lines in the truncated output that match lines in the pre-truncation output
+/// get their source line from the pre-truncation map. Omission markers (not in
+/// the pre-truncation output) get source line 0.
+pub(crate) fn reconcile_line_map_after_truncation(
+    pre_trunc_text: &str,
+    truncated_text: &str,
+    pre_trunc_line_map: &[usize],
+) -> Vec<usize> {
+    let pre_lines: Vec<&str> = pre_trunc_text.lines().collect();
+    let trunc_lines: Vec<&str> = truncated_text.lines().collect();
+
+    // Build a lookup: line content -> list of (line_index, source_line_num) in pre-truncation
+    // Use a simple scan approach since truncation is rare (most files aren't truncated).
+    let mut result = Vec::with_capacity(trunc_lines.len());
+    let mut pre_used = vec![false; pre_lines.len()];
+
+    for trunc_line in &trunc_lines {
+        // Find the first unused matching line in pre-truncation output
+        let mut found = false;
+        for (idx, pre_line) in pre_lines.iter().enumerate() {
+            if !pre_used[idx] && pre_line == trunc_line {
+                let source_line = pre_trunc_line_map.get(idx).copied().unwrap_or(0);
+                result.push(source_line);
+                pre_used[idx] = true;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            // Omission marker or line not in pre-truncation output
+            result.push(0);
+        }
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     // NOTE: Tests require parser implementation

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -125,14 +125,10 @@ pub(crate) fn transform_tree_with_line_map(
             structure::transform_structure_with_spans_and_line_map(source, tree, language, config)?
         }
         Mode::Signatures => {
-            let (text, spans, line_map) =
-                signatures::transform_signatures_with_spans_and_line_map(source, tree, language)?;
-            (text, spans, line_map)
+            signatures::transform_signatures_with_spans_and_line_map(source, tree, language)?
         }
         Mode::Types => {
-            let (text, spans, line_map) =
-                types::transform_types_with_spans_and_line_map(source, tree, language)?;
-            (text, spans, line_map)
+            types::transform_types_with_spans_and_line_map(source, tree, language)?
         }
         Mode::Full => {
             // Full mode: identity map
@@ -258,6 +254,89 @@ pub(crate) fn reconcile_line_map_after_truncation(
 
 #[cfg(test)]
 mod tests {
-    // NOTE: Tests require parser implementation
-    // These are schema validation only
+    use super::*;
+
+    // ========================================================================
+    // compute_line_map_by_text_matching
+    // ========================================================================
+
+    #[test]
+    fn test_text_matching_identity() {
+        let source = "line 1\nline 2\nline 3\n";
+        let output = "line 1\nline 2\nline 3\n";
+        let map = compute_line_map_by_text_matching(source, output);
+        assert_eq!(map, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_text_matching_skipped_lines() {
+        // Output has lines 1 and 3 from source (line 2 was removed)
+        let source = "aaa\nbbb\nccc\n";
+        let output = "aaa\nccc\n";
+        let map = compute_line_map_by_text_matching(source, output);
+        assert_eq!(map, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_text_matching_unmatched_line() {
+        // Output has a line not in source (e.g., omission marker)
+        let source = "aaa\nbbb\n";
+        let output = "aaa\n// ...\nbbb\n";
+        let map = compute_line_map_by_text_matching(source, output);
+        assert_eq!(map, vec![1, 0, 2]);
+    }
+
+    #[test]
+    fn test_text_matching_empty() {
+        let map = compute_line_map_by_text_matching("", "");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_text_matching_duplicate_lines() {
+        // Source has duplicates; should match in order
+        let source = "x\nx\nx\n";
+        let output = "x\nx\n";
+        let map = compute_line_map_by_text_matching(source, output);
+        assert_eq!(map, vec![1, 2]);
+    }
+
+    // ========================================================================
+    // reconcile_line_map_after_truncation
+    // ========================================================================
+
+    #[test]
+    fn test_reconcile_identity() {
+        // No truncation happened
+        let pre = "aaa\nbbb\nccc\n";
+        let trunc = "aaa\nbbb\nccc\n";
+        let pre_map = vec![1, 5, 10];
+        let result = reconcile_line_map_after_truncation(pre, trunc, &pre_map);
+        assert_eq!(result, vec![1, 5, 10]);
+    }
+
+    #[test]
+    fn test_reconcile_with_dropped_line() {
+        let pre = "aaa\nbbb\nccc\n";
+        let trunc = "aaa\nccc\n";
+        let pre_map = vec![1, 5, 10];
+        let result = reconcile_line_map_after_truncation(pre, trunc, &pre_map);
+        assert_eq!(result, vec![1, 10]);
+    }
+
+    #[test]
+    fn test_reconcile_with_omission_marker() {
+        let pre = "aaa\nbbb\nccc\n";
+        let trunc = "aaa\n/* ... */\nccc\n";
+        let pre_map = vec![1, 5, 10];
+        let result = reconcile_line_map_after_truncation(pre, trunc, &pre_map);
+        // "aaa" -> 1, "/* ... */" not in pre -> 0, "ccc" -> 10
+        assert_eq!(result, vec![1, 0, 10]);
+    }
+
+    #[test]
+    fn test_reconcile_empty() {
+        let result = reconcile_line_map_after_truncation("", "", &[]);
+        assert!(result.is_empty());
+    }
 }

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -127,9 +127,7 @@ pub(crate) fn transform_tree_with_line_map(
         Mode::Signatures => {
             signatures::transform_signatures_with_spans_and_line_map(source, tree, language)?
         }
-        Mode::Types => {
-            types::transform_types_with_spans_and_line_map(source, tree, language)?
-        }
+        Mode::Types => types::transform_types_with_spans_and_line_map(source, tree, language)?,
         Mode::Full => {
             // Full mode: identity map
             let text = source.to_string();

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -124,10 +124,12 @@ pub(crate) fn transform_tree_with_line_map(
         Mode::Structure => {
             structure::transform_structure_with_spans_and_line_map(source, tree, language, config)?
         }
-        Mode::Signatures => {
-            signatures::transform_signatures_with_spans_and_line_map(source, tree, language)?
+        Mode::Signatures => signatures::transform_signatures_with_spans_and_line_map(
+            source, tree, language, config,
+        )?,
+        Mode::Types => {
+            types::transform_types_with_spans_and_line_map(source, tree, language, config)?
         }
-        Mode::Types => types::transform_types_with_spans_and_line_map(source, tree, language)?,
         Mode::Full => {
             // Full mode: identity map
             let text = source.to_string();
@@ -170,9 +172,9 @@ pub(crate) fn transform_tree_with_line_map(
 
 /// Compute a source line map by matching output lines to source lines (text scan).
 ///
-/// ARCHITECTURE: Used for Minimal and Pseudo modes where removed ranges leave
-/// verbatim sections of source in the output. Each output line is matched to
-/// the first unmatched source line with identical content.
+/// ARCHITECTURE: Used for Minimal mode where removed ranges leave verbatim
+/// sections of source in the output. Each output line is matched to the first
+/// unmatched source line with identical content.
 ///
 /// This is a best-effort heuristic: if identical lines appear multiple times,
 /// the first unmatched occurrence is used. In practice this is correct for
@@ -226,20 +228,27 @@ pub(crate) fn compute_line_map_from_removed_ranges(
     let source_bytes = source.as_bytes();
     let total_bytes = source.len();
 
-    // Precompute 1-indexed source line number for each byte position.
-    // source_line_at[i] = line number of byte i.
-    let mut source_line_at = vec![1usize; total_bytes.saturating_add(1)];
-    let mut current_line = 1usize;
-    for (i, &b) in source_bytes.iter().enumerate() {
-        source_line_at[i] = current_line;
-        if b == b'\n' {
-            current_line += 1;
+    // Precompute byte offsets of line starts for O(log n) line-number lookup.
+    // line_starts[i] = byte offset of the first byte of line (i+1).
+    // This replaces the previous dense Vec<usize> (one entry per source byte,
+    // 8 bytes/byte on 64-bit) with a much smaller Vec sized by line count.
+    let line_starts: Vec<usize> = std::iter::once(0)
+        .chain(source_bytes.iter().enumerate().filter_map(|(i, &b)| {
+            if b == b'\n' {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }))
+        .collect();
+
+    // Returns the 1-indexed source line number for byte position `pos`.
+    let byte_to_line = |pos: usize| -> usize {
+        match line_starts.binary_search(&pos) {
+            Ok(idx) => idx + 1,
+            Err(idx) => idx, // idx is the number of line starts strictly before pos
         }
-    }
-    // Byte past end (for edge cases)
-    if let Some(last) = source_line_at.last_mut() {
-        *last = current_line;
-    }
+    };
 
     let mut result: Vec<usize> = Vec::new();
     // Source line number for the current (not-yet-emitted) output line.
@@ -263,7 +272,7 @@ pub(crate) fn compute_line_map_from_removed_ranges(
         }
 
         let byte = source_bytes[pos];
-        let src_line = source_line_at[pos];
+        let src_line = byte_to_line(pos);
 
         // Record the source line for this output line on the first byte.
         if current_output_source_line.is_none() {

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -648,4 +648,32 @@ mod tests {
         let result = normalize_line_map_blanks("", vec![]);
         assert!(result.is_empty());
     }
+
+    // ========================================================================
+    // byte_to_line boundary: newline byte sits on the line it terminates
+    // ========================================================================
+
+    /// When a removed range includes only the newline byte between two lines,
+    /// the two lines are joined in the output. Verify the output line maps to
+    /// source line 1 (the line whose bytes appear first in the output).
+    ///
+    /// source = "ab\ncd\n" (bytes: a=0, b=1, \n=2, c=3, d=4, \n=5)
+    /// Remove bytes 2..3 (the first newline) → output = "abcd\n"
+    /// The only output line starts with bytes from source line 1, so the map
+    /// must be [1].  This exercises binary_search hitting Err(1) for pos=2
+    /// (the newline byte itself), which must return source line 1, not 2.
+    #[test]
+    fn test_from_ranges_newline_byte_boundary() {
+        let source = "ab\ncd\n";
+        // Remove bytes 2..3 (the '\n' at the end of "ab")
+        let ranges = [(2usize, 3usize)];
+        let map = compute_line_map_from_removed_ranges(source, &ranges);
+        // Output: "abcd\n" — one line whose first byte ('a') is on source line 1.
+        assert_eq!(
+            map,
+            vec![1],
+            "Joining two lines by removing only the newline must map output line to source line 1, got {:?}",
+            map
+        );
+    }
 }

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -170,6 +170,26 @@ pub(crate) fn transform_tree_with_line_map(
     Ok((final_text, Some(final_line_map)))
 }
 
+/// Compute byte offsets of line starts for a UTF-8 string's raw bytes.
+///
+/// Returns a `Vec` where `result[i]` is the byte offset of the first byte of
+/// line `i + 1` (1-indexed). The first entry is always `0`. Each subsequent
+/// entry is the byte immediately after a `'\n'`.
+///
+/// Newlines are always single-byte ASCII, so iterating over raw bytes is both
+/// correct and avoids unnecessary UTF-8 decoding overhead.
+pub(crate) fn compute_line_starts(bytes: &[u8]) -> Vec<usize> {
+    std::iter::once(0)
+        .chain(bytes.iter().enumerate().filter_map(|(i, &b)| {
+            if b == b'\n' {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }))
+        .collect()
+}
+
 /// Compute a source line map by matching output lines to source lines (text scan).
 ///
 /// ARCHITECTURE: Used for Minimal mode where removed ranges leave verbatim
@@ -232,21 +252,13 @@ pub(crate) fn compute_line_map_from_removed_ranges(
     // line_starts[i] = byte offset of the first byte of line (i+1).
     // This replaces the previous dense Vec<usize> (one entry per source byte,
     // 8 bytes/byte on 64-bit) with a much smaller Vec sized by line count.
-    let line_starts: Vec<usize> = std::iter::once(0)
-        .chain(source_bytes.iter().enumerate().filter_map(|(i, &b)| {
-            if b == b'\n' {
-                Some(i + 1)
-            } else {
-                None
-            }
-        }))
-        .collect();
+    let line_starts: Vec<usize> = compute_line_starts(source_bytes);
 
     // Returns the 1-indexed source line number for byte position `pos`.
     let byte_to_line = |pos: usize| -> usize {
         match line_starts.binary_search(&pos) {
             Ok(idx) => idx + 1,
-            Err(idx) => idx, // idx is the number of line starts strictly before pos
+            Err(idx) => idx.max(1), // idx is the number of line starts strictly before pos
         }
     };
 

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -214,7 +214,7 @@ pub(crate) fn compute_line_map_by_text_matching(source: &str, output: &str) -> V
             if *source_line == *output_line {
                 let source_line_num = source_pos + offset + 1; // 1-indexed
                 result.push(source_line_num);
-                source_pos = source_pos + offset + 1;
+                source_pos += offset + 1;
                 found = true;
                 break;
             }
@@ -578,15 +578,12 @@ mod tests {
         //
         // For this test we just verify that the first output line maps to source
         // line 1, even after inline removal (which text-matching would fail).
-        let source_bytes = source.as_bytes();
         // `: int` starts after "def foo(a"
         let a_end = 9usize; // byte after 'a'
         let colon_int_end = a_end + ": int".len(); // 14
-        let arrow_start = colon_int_end; // " -> str" starts at 14
-        let arrow_end = arrow_start + " -> str".len(); // 21
-                                                       // ranges remove ": int" and " -> str", producing "def foo(a):"
-        let ranges = [(a_end, colon_int_end), (arrow_start, arrow_end)];
-        let _ = source_bytes; // suppress unused warning
+        // " -> str" starts at 14; ranges remove ": int" and " -> str", producing "def foo(a):"
+        let arrow_end = colon_int_end + " -> str".len(); // 21
+        let ranges = [(a_end, colon_int_end), (colon_int_end, arrow_end)];
         let map = compute_line_map_from_removed_ranges(source, &ranges);
         // First output line ("def foo(a):...") must map to source line 1.
         assert_eq!(

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -146,11 +146,11 @@ pub(crate) fn transform_tree_with_line_map(
             (text, spans, line_map)
         }
         Mode::Pseudo => {
-            // Pseudo mode: compute line map by text matching after transform
-            let (text, spans) =
-                pseudo::transform_pseudo_with_spans(source, tree, language, config)?;
-            let line_map = compute_line_map_by_text_matching(source, &text);
-            (text, spans, line_map)
+            // Pseudo mode: compute line map from byte-level removal ranges.
+            // Text matching fails here because pseudo mode modifies lines (e.g.,
+            // `def f(a: int) -> int:` → `def f(a):`) so the output line is not
+            // verbatim in the source.
+            pseudo::transform_pseudo_with_spans_and_line_map(source, tree, language, config)?
         }
     };
 
@@ -201,6 +201,123 @@ pub(crate) fn compute_line_map_by_text_matching(source: &str, output: &str) -> V
             // Line not found in remaining source (could be an omission marker)
             result.push(0);
         }
+    }
+
+    result
+}
+
+/// Compute a source line map from sorted byte ranges removed from source.
+///
+/// ARCHITECTURE: Used by pseudo mode where removed ranges can *partially modify*
+/// a line (e.g., `def f(a: int) -> int:` → `def f(a):`). Text matching cannot
+/// find such lines in source because their content differs.
+///
+/// This function walks the source bytes, skipping removed ranges, and for each
+/// newline that appears in the resulting output, records which source line we
+/// were on when the output line started. The first byte contributed to an output
+/// line determines its source line number (1-indexed). Source lines that are
+/// removed entirely produce no output lines.
+///
+/// The ranges must be sorted (ascending by start byte) and non-overlapping.
+pub(crate) fn compute_line_map_from_removed_ranges(
+    source: &str,
+    ranges: &[(usize, usize)],
+) -> Vec<usize> {
+    let source_bytes = source.as_bytes();
+    let total_bytes = source.len();
+
+    // Precompute 1-indexed source line number for each byte position.
+    // source_line_at[i] = line number of byte i.
+    let mut source_line_at = vec![1usize; total_bytes.saturating_add(1)];
+    let mut current_line = 1usize;
+    for (i, &b) in source_bytes.iter().enumerate() {
+        source_line_at[i] = current_line;
+        if b == b'\n' {
+            current_line += 1;
+        }
+    }
+    // Byte past end (for edge cases)
+    if let Some(last) = source_line_at.last_mut() {
+        *last = current_line;
+    }
+
+    let mut result: Vec<usize> = Vec::new();
+    // Source line number for the current (not-yet-emitted) output line.
+    // None = no bytes have been contributed to the current output line yet.
+    let mut current_output_source_line: Option<usize> = None;
+
+    let mut range_idx = 0usize;
+    let mut pos = 0usize;
+
+    while pos < total_bytes {
+        // Advance past any removed range that covers the current position.
+        while range_idx < ranges.len() && pos >= ranges[range_idx].0 {
+            let range_end = ranges[range_idx].1;
+            range_idx += 1;
+            if range_end > pos {
+                pos = range_end;
+            }
+        }
+        if pos >= total_bytes {
+            break;
+        }
+
+        let byte = source_bytes[pos];
+        let src_line = source_line_at[pos];
+
+        // Record the source line for this output line on the first byte.
+        if current_output_source_line.is_none() {
+            current_output_source_line = Some(src_line);
+        }
+
+        if byte == b'\n' {
+            // A newline in the output ends the current output line.
+            result.push(current_output_source_line.unwrap_or(src_line));
+            current_output_source_line = None;
+        }
+
+        pos += 1;
+    }
+
+    // Handle a final line with no trailing newline.
+    if let Some(src_line) = current_output_source_line {
+        result.push(src_line);
+    }
+
+    result
+}
+
+/// Normalize a line map to match `trim_and_normalize`'s blank-line dropping.
+///
+/// `trim_and_normalize` drops output lines when there are 3+ consecutive blank
+/// lines (keeping at most 2). The line map computed from byte ranges has one
+/// entry per line in the intermediate output (after `remove_ranges` and
+/// `collapse_whitespace`, before `trim_and_normalize`). This function replays
+/// the same blank-line dropping logic over the line map to keep it in sync.
+///
+/// `pre_normalized_text` is the intermediate text (after `collapse_whitespace`,
+/// before `trim_and_normalize`). `line_map` has the same length as the number
+/// of lines in `pre_normalized_text`. Returns a filtered line map that matches
+/// the final post-normalized output.
+pub(crate) fn normalize_line_map_blanks(
+    pre_normalized_text: &str,
+    line_map: Vec<usize>,
+) -> Vec<usize> {
+    let mut result = Vec::with_capacity(line_map.len());
+    let mut consecutive_blanks: usize = 0;
+
+    for (line, &src_line) in pre_normalized_text.lines().zip(line_map.iter()) {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            consecutive_blanks += 1;
+            if consecutive_blanks > 2 {
+                // trim_and_normalize drops this line — skip it in the map too.
+                continue;
+            }
+        } else {
+            consecutive_blanks = 0;
+        }
+        result.push(src_line);
     }
 
     result
@@ -380,5 +497,134 @@ mod tests {
         // "y" found at index 1 → 20, cursor advances to 2
         // "z" found at index 2 → 30
         assert_eq!(result, vec![0, 20, 30]);
+    }
+
+    // ========================================================================
+    // compute_line_map_from_removed_ranges
+    // ========================================================================
+
+    #[test]
+    fn test_from_ranges_identity_no_ranges() {
+        // No ranges removed: each output line maps to its source line.
+        let source = "aaa\nbbb\nccc\n";
+        let map = compute_line_map_from_removed_ranges(source, &[]);
+        assert_eq!(map, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_from_ranges_whole_line_removed() {
+        // Remove the middle line entirely (including its newline).
+        // source: "aaa\nbbb\nccc\n"
+        // ranges: remove bytes 4..8 ("bbb\n")
+        let source = "aaa\nbbb\nccc\n";
+        let ranges = [(4, 8)]; // removes "bbb\n"
+        let map = compute_line_map_from_removed_ranges(source, &ranges);
+        // Output: "aaa\nccc\n" → lines [aaa, ccc]
+        // "aaa" starts at source line 1; "ccc" starts at source line 3
+        assert_eq!(map, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_from_ranges_inline_range_removed() {
+        // Remove only part of a line (inline modification).
+        // source: "def foo(a: int):\n    pass\n"
+        // Remove ": int" (bytes 9..15) from the first line → "def foo(a):\n"
+        let source = "def foo(a: int):\n    pass\n";
+        let colon_int = source.find(": int").unwrap();
+        let ranges = [(colon_int, colon_int + ": int".len())];
+        let map = compute_line_map_from_removed_ranges(source, &ranges);
+        // Output: "def foo(a):\n    pass\n" → lines [def foo(a):, "    pass"]
+        // Both output lines originate from their respective source lines.
+        assert_eq!(map, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_from_ranges_modified_def_line_maps_to_correct_source_line() {
+        // Regression test for the pseudo-mode bug: a `def` line whose type
+        // annotations are stripped still maps to its original source line.
+        //
+        // source (4 lines):
+        //   1: def foo(a: int) -> str:\n
+        //   2:     return str(a)\n
+        //   3: def bar(b: str) -> int:\n
+        //   4:     return len(b)\n
+        let source = "def foo(a: int) -> str:\n    return str(a)\ndef bar(b: str) -> int:\n    return len(b)\n";
+        //
+        // Simulate removing `: int` (bytes 9..14) and ` -> str` (bytes 14..22)
+        // from the first def line, and `: str` (bytes ?) and ` -> int` from the
+        // third def line. Rather than computing exact byte offsets, use a simple
+        // helper: remove ranges [9..14] and [14..22] from line 1.
+        //
+        // For this test we just verify that the first output line maps to source
+        // line 1, even after inline removal (which text-matching would fail).
+        let source_bytes = source.as_bytes();
+        // `: int` starts after "def foo(a"
+        let a_end = 9usize; // byte after 'a'
+        let colon_int_end = a_end + ": int".len(); // 14
+        let arrow_start = colon_int_end; // " -> str" starts at 14
+        let arrow_end = arrow_start + " -> str".len(); // 21
+                                                       // ranges remove ": int" and " -> str", producing "def foo(a):"
+        let ranges = [(a_end, colon_int_end), (arrow_start, arrow_end)];
+        let _ = source_bytes; // suppress unused warning
+        let map = compute_line_map_from_removed_ranges(source, &ranges);
+        // First output line ("def foo(a):...") must map to source line 1.
+        assert_eq!(
+            map[0], 1,
+            "Modified def line must map to source line 1, not 0. Got map: {:?}",
+            map
+        );
+        // Body lines on source lines 2 and 4 must also be correct.
+        assert_eq!(
+            map[1], 2,
+            "return str(a) must map to source line 2. Got map: {:?}",
+            map
+        );
+    }
+
+    #[test]
+    fn test_from_ranges_empty_source() {
+        let map = compute_line_map_from_removed_ranges("", &[]);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_from_ranges_no_trailing_newline() {
+        // Source without trailing newline: last line still gets an entry.
+        let source = "aaa\nbbb";
+        let map = compute_line_map_from_removed_ranges(source, &[]);
+        assert_eq!(map, vec![1, 2]);
+    }
+
+    // ========================================================================
+    // normalize_line_map_blanks
+    // ========================================================================
+
+    #[test]
+    fn test_normalize_line_map_no_excess_blanks() {
+        // Fast path: counts already match (no 3+ blank runs).
+        let text = "a\n\nb\n";
+        let line_map = vec![1, 2, 3];
+        let result = normalize_line_map_blanks(text, line_map.clone());
+        assert_eq!(result, line_map);
+    }
+
+    #[test]
+    fn test_normalize_line_map_drops_third_blank() {
+        // Three consecutive blank lines: the third and beyond should be dropped.
+        // pre_normalized_text has 3 blank lines in a row.
+        let text = "a\n\n\n\nb\n";
+        // line_map before normalization: a=1, blank=2, blank=3, blank=4, b=5
+        let line_map = vec![1, 2, 3, 4, 5];
+        let result = normalize_line_map_blanks(text, line_map);
+        // trim_and_normalize keeps at most 2 consecutive blanks:
+        // a(keep) blank(keep,1) blank(keep,2) blank(DROP,3) b(keep)
+        // → [1, 2, 3, 5] (source lines for kept lines)
+        assert_eq!(result, vec![1, 2, 3, 5]);
+    }
+
+    #[test]
+    fn test_normalize_line_map_empty() {
+        let result = normalize_line_map_blanks("", vec![]);
+        assert!(result.is_empty());
     }
 }

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -180,13 +180,15 @@ pub(crate) fn transform_tree_with_line_map(
 /// correct and avoids unnecessary UTF-8 decoding overhead.
 pub(crate) fn compute_line_starts(bytes: &[u8]) -> Vec<usize> {
     std::iter::once(0)
-        .chain(bytes.iter().enumerate().filter_map(|(i, &b)| {
-            if b == b'\n' {
-                Some(i + 1)
-            } else {
-                None
-            }
-        }))
+        .chain(bytes.iter().enumerate().filter_map(
+            |(i, &b)| {
+                if b == b'\n' {
+                    Some(i + 1)
+                } else {
+                    None
+                }
+            },
+        ))
         .collect()
 }
 
@@ -581,7 +583,7 @@ mod tests {
         // `: int` starts after "def foo(a"
         let a_end = 9usize; // byte after 'a'
         let colon_int_end = a_end + ": int".len(); // 14
-        // " -> str" starts at 14; ranges remove ": int" and " -> str", producing "def foo(a):"
+                                                   // " -> str" starts at 14; ranges remove ": int" and " -> str", producing "def foo(a):"
         let arrow_end = colon_int_end + " -> str".len(); // 21
         let ranges = [(a_end, colon_int_end), (colon_int_end, arrow_end)];
         let map = compute_line_map_from_removed_ranges(source, &ranges);

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -216,6 +216,15 @@ pub(crate) fn compute_line_map_by_text_matching(source: &str, output: &str) -> V
 /// Lines in the truncated output that match lines in the pre-truncation output
 /// get their source line from the pre-truncation map. Omission markers (not in
 /// the pre-truncation output) get source line 0.
+///
+/// # Monotonic matching
+///
+/// Truncation preserves document order: the truncated output is always a
+/// subsequence of the pre-truncation output (with optional omission markers
+/// inserted). Therefore each matched position must be >= the previous matched
+/// position. Monotonic matching prevents duplicate lines (e.g. multiple `}`
+/// closings at different source positions) from being mapped to their first
+/// occurrence rather than the correct occurrence in the tail.
 pub(crate) fn reconcile_line_map_after_truncation(
     pre_trunc_text: &str,
     truncated_text: &str,
@@ -224,26 +233,26 @@ pub(crate) fn reconcile_line_map_after_truncation(
     let pre_lines: Vec<&str> = pre_trunc_text.lines().collect();
     let trunc_lines: Vec<&str> = truncated_text.lines().collect();
 
-    // Build a lookup: line content -> list of (line_index, source_line_num) in pre-truncation
-    // Use a simple scan approach since truncation is rare (most files aren't truncated).
+    // Use a monotonic cursor: each new match must start at or after the
+    // previous match position. This exploits document-order preservation.
     let mut result = Vec::with_capacity(trunc_lines.len());
-    let mut pre_used = vec![false; pre_lines.len()];
+    let mut cursor = 0usize; // next search starts here
 
     for trunc_line in &trunc_lines {
-        // Find the first unused matching line in pre-truncation output
-        let mut found = false;
-        for (idx, pre_line) in pre_lines.iter().enumerate() {
-            if !pre_used[idx] && pre_line == trunc_line {
-                let source_line = pre_trunc_line_map.get(idx).copied().unwrap_or(0);
-                result.push(source_line);
-                pre_used[idx] = true;
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            // Omission marker or line not in pre-truncation output
+        // Find the first matching line at or after cursor.
+        // Using .position() on the tail slice avoids the range-loop and
+        // mut-range-bound lints while keeping monotonic semantics.
+        let tail = &pre_lines[cursor..];
+        if let Some(offset) = tail.iter().position(|pre| pre == trunc_line) {
+            let abs_idx = cursor + offset;
+            let source_line = pre_trunc_line_map.get(abs_idx).copied().unwrap_or(0);
+            result.push(source_line);
+            cursor = abs_idx + 1; // next search must be strictly after this match
+        } else {
+            // Omission marker or line not in remaining pre-truncation output
             result.push(0);
+            // cursor does NOT advance: the next content line still searches
+            // from the same position (markers don't consume pre-trunc lines)
         }
     }
 
@@ -336,5 +345,40 @@ mod tests {
     fn test_reconcile_empty() {
         let result = reconcile_line_map_after_truncation("", "", &[]);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_reconcile_duplicate_lines_tail_bias() {
+        // Pre-truncation text has `}` at positions 3, 5, and 7 (pre_map values 3, 5, 7).
+        // After --last-lines style truncation the tail keeps lines from position 5 onward.
+        // Monotonic matching must map the trailing `}` to position 5/7, not to 3.
+        let pre = "a\nb\n}\nc\n}\nd\n}\n";
+        // pre_map: a=1, b=2, }=3, c=4, }=5, d=6, }=7
+        let pre_map = vec![1, 2, 3, 4, 5, 6, 7];
+        // Simulated --last-lines output: marker + last 3 content lines (c, }, d, } → 4 content)
+        // Use last 4 lines (c, }, d, }) for simplicity
+        let trunc = "/* ... */\nc\n}\nd\n}\n";
+        let result = reconcile_line_map_after_truncation(pre, trunc, &pre_map);
+        // "/* ... */" not found → 0
+        // "c" → 4 (cursor advances past 4)
+        // "}" → 5 (first `}` at or after cursor=4 is index 4, pre_map[4]=5)
+        // "d" → 6
+        // "}" → 7 (next `}` at or after cursor=5 is index 6, pre_map[6]=7)
+        assert_eq!(result, vec![0, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn test_reconcile_omission_marker_does_not_advance_cursor() {
+        // An omission marker (not in pre text) should leave the cursor unchanged so
+        // the following content line still finds its correct pre-truncation position.
+        let pre = "x\ny\nz\n";
+        let pre_map = vec![10, 20, 30];
+        // Simulated: marker inserted before y (marker is not in pre)
+        let trunc = "/* ... */\ny\nz\n";
+        let result = reconcile_line_map_after_truncation(pre, trunc, &pre_map);
+        // "/* ... */" not found → 0, cursor stays at 0
+        // "y" found at index 1 → 20, cursor advances to 2
+        // "z" found at index 2 → 30
+        assert_eq!(result, vec![0, 20, 30]);
     }
 }

--- a/crates/rskim-core/src/transform/pseudo.rs
+++ b/crates/rskim-core/src/transform/pseudo.rs
@@ -14,6 +14,7 @@ use super::minimal::{
     adjust_range_for_line_removal, is_removable_comment, remove_ranges, trim_and_normalize,
     MAX_AST_DEPTH, MAX_AST_NODES,
 };
+use super::{compute_line_map_from_removed_ranges, normalize_line_map_blanks};
 
 /// Bundled parameters for the recursive noise walker to avoid parameter explosion
 struct NoiseWalkContext<'a> {
@@ -248,8 +249,33 @@ pub(crate) fn transform_pseudo_with_spans(
     source: &str,
     tree: &Tree,
     language: Language,
-    _config: &TransformConfig,
+    config: &TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
+    let (text, spans, _line_map) =
+        transform_pseudo_with_spans_and_line_map(source, tree, language, config)?;
+    Ok((text, spans))
+}
+
+/// Transform source by stripping syntactic noise, returning NodeSpan metadata AND a source line map.
+///
+/// ARCHITECTURE: The line map is computed from the byte-level removal ranges rather
+/// than by text matching. Text matching fails for lines that are *partially* modified
+/// (e.g., `def f(a: int) -> int:` → `def f(a):`) because the output line does not
+/// appear verbatim in the source.
+///
+/// The byte-range approach works for any mutation: after all ranges are removed,
+/// each output byte can be traced back to its source byte, and therefore to its
+/// source line number. The post-processing steps (`collapse_whitespace`,
+/// `trim_and_normalize`) operate within lines without changing line-to-source
+/// correspondence — except that `trim_and_normalize` drops lines when there are
+/// 3+ consecutive blank lines. `normalize_line_map_blanks` mirrors that step on
+/// the line map.
+pub(crate) fn transform_pseudo_with_spans_and_line_map(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    _config: &TransformConfig,
+) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     let rules = get_pseudo_rules(language);
 
     // Single-pass collection: comments AND noise ranges in one AST walk
@@ -277,17 +303,32 @@ pub(crate) fn transform_pseudo_with_spans(
     // Re-sort after adjustment (line-level adjustments can change ordering)
     final_ranges.sort_unstable_by_key(|&(start, _)| start);
 
+    // Compute the source line map from the byte-level removal ranges.
+    // Must be done before remove_ranges, using the ranges themselves, so that
+    // modified lines (e.g. `def f(a: int):` → `def f(a):`) still map to their
+    // correct source line rather than getting source_line=0 from text matching.
+    let line_map_after_removal = compute_line_map_from_removed_ranges(source, &final_ranges);
+
     let result = remove_ranges(source, &final_ranges)?;
 
-    // Post-process — collapse whitespace artifacts and normalize
+    // Post-process — collapse whitespace artifacts and normalize.
+    // collapse_whitespace is line-count-preserving (works within lines only).
     let result = collapse_whitespace(&result);
-    let result = trim_and_normalize(&result);
+    // trim_and_normalize may drop lines when there are 3+ consecutive blanks.
+    // Capture the text before that step so normalize_line_map_blanks can replay
+    // the same logic to keep the line map in sync.
+    let pre_normalized = result;
+    let result = trim_and_normalize(&pre_normalized);
+
+    // Mirror trim_and_normalize's blank-line dropping on the line map so the
+    // two stay in sync (3+ consecutive blank lines → drop beyond 2).
+    let line_map = normalize_line_map_blanks(&pre_normalized, line_map_after_removal);
 
     // Build spans (single source_file span for truncation compatibility)
     let line_count = result.lines().count();
     let spans = vec![NodeSpan::new(0..line_count, "source_file")];
 
-    Ok((result, spans))
+    Ok((result, spans, line_map))
 }
 
 /// Collapse whitespace artifacts from inline removal:

--- a/crates/rskim-core/src/transform/signatures.rs
+++ b/crates/rskim-core/src/transform/signatures.rs
@@ -55,9 +55,33 @@ pub(crate) fn transform_signatures_with_spans(
     language: Language,
     _config: &crate::TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
+    let (text, spans, _line_map) =
+        transform_signatures_with_spans_and_line_map(source, tree, language)?;
+    Ok((text, spans))
+}
+
+/// Transform to signatures-only, returning NodeSpan metadata AND a source line map.
+///
+/// The source line map maps each output line index to the 1-indexed source line
+/// where that signature begins. Multi-line signatures map all their output lines
+/// to consecutive source lines starting from the signature's start line.
+///
+/// # Design Decision (AC-18)
+/// Signatures mode uses `node.start_position().row + 1` to annotate each
+/// signature with its source line. Multi-line signatures get consecutive
+/// source line numbers from their start line.
+pub(crate) fn transform_signatures_with_spans_and_line_map(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown signatures mode extracts ALL headers (H1-H6)
     if language == Language::Markdown {
-        return extract_markdown_headers_with_spans(source, tree, 1, 6);
+        let (text, spans) = extract_markdown_headers_with_spans(source, tree, 1, 6)?;
+        let line_count = text.lines().count();
+        // For markdown, use identity map (headers are extracted with their source structure)
+        let line_map = (1..=line_count).collect();
+        return Ok((text, spans, line_map));
     }
 
     // ARCHITECTURE: JSON is handled by Strategy Pattern in Language::transform_source()
@@ -69,8 +93,14 @@ pub(crate) fn transform_signatures_with_spans(
         ))
     })?;
 
-    let mut signatures: Vec<(String, &'static str)> = Vec::new();
-    collect_signatures_with_kinds(tree.root_node(), source, &node_types, &mut signatures, 0)?;
+    let mut signatures: Vec<(String, &'static str, usize)> = Vec::new();
+    collect_signatures_with_kinds_and_lines(
+        tree.root_node(),
+        source,
+        &node_types,
+        &mut signatures,
+        0,
+    )?;
 
     // Check signature count limit
     if signatures.len() > MAX_SIGNATURES {
@@ -81,29 +111,39 @@ pub(crate) fn transform_signatures_with_spans(
         )));
     }
 
-    // Build text and spans, tracking line offsets
+    // Build text, spans, and source line map
     let mut spans = Vec::with_capacity(signatures.len());
-    let mut current_line = 0;
+    let mut source_line_map: Vec<usize> = Vec::new();
+    let mut current_output_line = 0;
 
     let texts: Vec<String> = signatures
         .into_iter()
-        .map(|(sig, kind)| {
+        .map(|(sig, kind, source_start_line)| {
             let line_count = sig.lines().count().max(1);
-            spans.push(NodeSpan::new(current_line..current_line + line_count, kind));
-            current_line += line_count;
+            spans.push(NodeSpan::new(
+                current_output_line..current_output_line + line_count,
+                kind,
+            ));
+            // Map each output line to consecutive source lines from source_start_line
+            for i in 0..line_count {
+                source_line_map.push(source_start_line + i);
+            }
+            current_output_line += line_count;
             sig
         })
         .collect();
 
-    Ok((texts.join("\n"), spans))
+    Ok((texts.join("\n"), spans, source_line_map))
 }
 
-/// Recursively collect function/method signatures with their node kind
-fn collect_signatures_with_kinds(
+/// Recursively collect function/method signatures with node kind AND source start line.
+///
+/// The source start line is `node.start_position().row + 1` (1-indexed).
+fn collect_signatures_with_kinds_and_lines(
     node: Node,
     source: &str,
     node_types: &SignatureNodeTypes,
-    signatures: &mut Vec<(String, &'static str)>,
+    signatures: &mut Vec<(String, &'static str, usize)>,
     depth: usize,
 ) -> Result<()> {
     // SECURITY: Prevent stack overflow from deeply nested or malicious input
@@ -119,13 +159,21 @@ fn collect_signatures_with_kinds(
     if is_signature_node(kind, node_types) {
         if let Some(sig) = extract_signature(node, source, node_types)? {
             let static_kind = to_static_node_kind(kind);
-            signatures.push((sig, static_kind));
+            // 1-indexed source line where this signature starts
+            let source_start_line = node.start_position().row + 1;
+            signatures.push((sig, static_kind, source_start_line));
         }
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_signatures_with_kinds(child, source, node_types, signatures, depth + 1)?;
+        collect_signatures_with_kinds_and_lines(
+            child,
+            source,
+            node_types,
+            signatures,
+            depth + 1,
+        )?;
     }
 
     Ok(())

--- a/crates/rskim-core/src/transform/signatures.rs
+++ b/crates/rskim-core/src/transform/signatures.rs
@@ -167,13 +167,7 @@ fn collect_signatures_with_kinds_and_lines(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_signatures_with_kinds_and_lines(
-            child,
-            source,
-            node_types,
-            signatures,
-            depth + 1,
-        )?;
+        collect_signatures_with_kinds_and_lines(child, source, node_types, signatures, depth + 1)?;
     }
 
     Ok(())

--- a/crates/rskim-core/src/transform/signatures.rs
+++ b/crates/rskim-core/src/transform/signatures.rs
@@ -53,10 +53,10 @@ pub(crate) fn transform_signatures_with_spans(
     source: &str,
     tree: &Tree,
     language: Language,
-    _config: &crate::TransformConfig,
+    config: &crate::TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
     let (text, spans, _line_map) =
-        transform_signatures_with_spans_and_line_map(source, tree, language)?;
+        transform_signatures_with_spans_and_line_map(source, tree, language, config)?;
     Ok((text, spans))
 }
 
@@ -74,13 +74,11 @@ pub(crate) fn transform_signatures_with_spans_and_line_map(
     source: &str,
     tree: &Tree,
     language: Language,
+    _config: &crate::TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown signatures mode extracts ALL headers (H1-H6)
     if language == Language::Markdown {
-        let (text, spans) = extract_markdown_headers_with_spans(source, tree, 1, 6)?;
-        let line_count = text.lines().count();
-        // For markdown, use identity map (headers are extracted with their source structure)
-        let line_map = (1..=line_count).collect();
+        let (text, spans, line_map) = extract_markdown_headers_with_spans(source, tree, 1, 6)?;
         return Ok((text, spans, line_map));
     }
 

--- a/crates/rskim-core/src/transform/signatures.rs
+++ b/crates/rskim-core/src/transform/signatures.rs
@@ -4,14 +4,12 @@
 //!
 //! Token reduction target: 85-92%
 
+use crate::transform::minimal::MAX_AST_DEPTH;
 use crate::transform::structure::extract_markdown_headers_with_spans;
 use crate::transform::truncate::NodeSpan;
 use crate::transform::utils::{to_static_node_kind, FunctionNodeTypes};
-use crate::{Language, Result, SkimError};
+use crate::{Language, Result, SkimError, TransformConfig};
 use tree_sitter::{Node, Tree};
-
-/// Maximum AST recursion depth to prevent stack overflow attacks
-const MAX_AST_DEPTH: usize = 500;
 
 /// Maximum number of signatures to prevent memory exhaustion
 const MAX_SIGNATURES: usize = 10_000;
@@ -42,7 +40,7 @@ pub(crate) fn transform_signatures(
     source: &str,
     tree: &Tree,
     language: Language,
-    config: &crate::TransformConfig,
+    config: &TransformConfig,
 ) -> Result<String> {
     let (text, _spans) = transform_signatures_with_spans(source, tree, language, config)?;
     Ok(text)
@@ -53,7 +51,7 @@ pub(crate) fn transform_signatures_with_spans(
     source: &str,
     tree: &Tree,
     language: Language,
-    config: &crate::TransformConfig,
+    config: &TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
     let (text, spans, _line_map) =
         transform_signatures_with_spans_and_line_map(source, tree, language, config)?;
@@ -74,7 +72,7 @@ pub(crate) fn transform_signatures_with_spans_and_line_map(
     source: &str,
     tree: &Tree,
     language: Language,
-    _config: &crate::TransformConfig,
+    _config: &TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown signatures mode extracts ALL headers (H1-H6)
     if language == Language::Markdown {

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -63,13 +63,42 @@ pub(crate) fn transform_structure_with_spans(
     source: &str,
     tree: &Tree,
     language: Language,
-    _config: &TransformConfig,
+    config: &TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
+    let (text, spans, _line_map) =
+        transform_structure_with_spans_and_line_map(source, tree, language, config)?;
+    Ok((text, spans))
+}
+
+/// Transform to structure-only, returning NodeSpan metadata AND a source line map.
+///
+/// The source line map maps each output line index to the 1-indexed source line
+/// number. For verbatim-copied regions, the source line is the original line number.
+/// The replacement `{ /* ... */ }` stays on the same line as the function signature
+/// (no newlines in the replacement), so no output line ever starts inside a
+/// replacement region — all output line starts are in verbatim-copied regions
+/// where the reverse offset mapping is exact.
+///
+/// # Design Decision (AC-18)
+/// Structure mode uses a byte-offset reverse mapping to determine which source line
+/// corresponds to each output line start byte. The `offset_map` (source_end_byte, delta)
+/// pairs allow reverse-mapping: output_byte = source_byte + delta, so
+/// source_byte = output_byte - delta. Binary search on the output byte position
+/// in the offset map gives the correct delta for any output line start.
+pub(crate) fn transform_structure_with_spans_and_line_map(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+    _config: &TransformConfig,
+) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown uses extraction, not replacement
     // Extract H1-H3 headers only (top-level document structure)
     if language == Language::Markdown {
         let (text, spans) = extract_markdown_headers_with_spans(source, tree, 1, 3)?;
-        return Ok((text, spans));
+        let line_count = text.lines().count();
+        // For markdown, use identity map (extracted headers preserve source structure)
+        let line_map = (1..=line_count).collect();
+        return Ok((text, spans, line_map));
     }
 
     // Get language-specific node types
@@ -105,8 +134,11 @@ pub(crate) fn transform_structure_with_spans(
     sorted_replacements.sort_unstable_by_key(|(range, _)| range.0);
 
     // Track cumulative byte offset delta (output_pos - source_pos)
+    // offset_map entries: (source_end_byte, cumulative_delta)
+    // Invariant: for any output byte O in a verbatim region, source byte S = O - delta
+    //            where delta is the latest entry with source_end_byte <= S.
     let mut offset_delta: i64 = 0;
-    let mut offset_map: Vec<(usize, i64)> = Vec::new(); // (source_byte, delta)
+    let mut offset_map: Vec<(usize, i64)> = Vec::new(); // (source_byte_end, delta)
 
     for ((start, end), replacement) in sorted_replacements {
         // Validate byte ranges
@@ -166,7 +198,103 @@ pub(crate) fn transform_structure_with_spans(
     // Build NodeSpans from top-level AST children
     let spans = build_spans_from_top_level_nodes(tree, &result, &offset_map);
 
-    Ok((result, spans))
+    // Build source line map using offset_map to reverse-map output bytes to source lines
+    let source_line_map = compute_source_line_map_from_offset_map(source, &result, &offset_map);
+
+    Ok((result, spans, source_line_map))
+}
+
+/// Compute the source line map for structure mode output using the offset_map.
+///
+/// For each output line (by its start byte offset), reverse-maps to a source byte
+/// offset using the offset_map, then binary-searches source line starts to get
+/// the 1-indexed source line number.
+///
+/// # Correctness Invariant
+/// The replacement text `" { /* ... */ }"` contains no newlines. Therefore no
+/// output line ever starts inside a replacement region — all output line start
+/// bytes are in verbatim-copied regions where the reverse mapping is exact.
+pub(crate) fn compute_source_line_map_from_offset_map(
+    source: &str,
+    output: &str,
+    offset_map: &[(usize, i64)],
+) -> Vec<usize> {
+    // Pre-compute source line start byte offsets (0-indexed by line number)
+    let source_line_starts: Vec<usize> = std::iter::once(0)
+        .chain(source.char_indices().filter_map(|(i, c)| {
+            if c == '\n' {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }))
+        .collect();
+
+    // Pre-compute output line start byte offsets
+    let output_line_starts: Vec<usize> = std::iter::once(0)
+        .chain(output.char_indices().filter_map(|(i, c)| {
+            if c == '\n' {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }))
+        .collect();
+
+    let output_lines = output.lines().count();
+
+    // Build source_line_map: for each output line, find its 1-indexed source line
+    // We take only `output_lines` entries from output_line_starts since trailing
+    // newlines add a phantom entry.
+    output_line_starts
+        .iter()
+        .take(output_lines)
+        .map(|&output_byte| {
+            // Reverse-map: find the cumulative delta that applies at this output byte.
+            // The offset_map stores (source_end_byte, cumulative_delta_after_that_point).
+            // For a verbatim region output byte O, source byte S = O - delta.
+            // We find the last offset_map entry where the replacement has already been applied.
+            //
+            // Since output_byte = source_byte + delta (cumulative),
+            // source_byte = output_byte - delta.
+            // We need to find which delta applies at output_byte.
+            let delta = if offset_map.is_empty() {
+                0i64
+            } else {
+                // The offset_map is sorted by source_end_byte.
+                // We need the delta that applies to this output_byte region.
+                // For output bytes in the verbatim region after replacement N,
+                // delta = offset_map[N].1 (the cumulative delta after all replacements up to N).
+                // Find the last entry whose corresponding output end byte <= output_byte.
+                // The output_end_byte for entry (src_end, delta) is: src_end + delta.
+                let mut applicable_delta = 0i64;
+                for &(src_end, d) in offset_map {
+                    // The output byte corresponding to src_end is: src_end (as i64) + d
+                    // (d is the delta after this replacement, so output position of src_end
+                    //  would be src_end + d = src_end + (replacement_len - replaced_len) cumulative)
+                    // But we need to know: is this output_byte after this replacement's output end?
+                    // output_end_of_replacement = src_end (as i64) + d
+                    let output_end = src_end as i64 + d;
+                    if output_end as usize <= output_byte {
+                        applicable_delta = d;
+                    } else {
+                        break;
+                    }
+                }
+                applicable_delta
+            };
+
+            // source_byte = output_byte - delta (clamped to [0, source.len()])
+            let source_byte = (output_byte as i64 - delta).max(0) as usize;
+            let source_byte = source_byte.min(source.len());
+
+            // Binary search for the 1-indexed line number
+            match source_line_starts.binary_search(&source_byte) {
+                Ok(idx) => idx + 1,      // Exact match: this byte IS a line start
+                Err(idx) => idx.max(1),  // Inexact: line idx (1-indexed)
+            }
+        })
+        .collect()
 }
 
 /// Recursively collect body nodes that should be replaced

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -221,24 +221,28 @@ pub(crate) fn compute_source_line_map_from_offset_map(
 ) -> Vec<usize> {
     // Pre-compute source line start byte offsets (0-indexed by line number)
     let source_line_starts: Vec<usize> = std::iter::once(0)
-        .chain(source.char_indices().filter_map(|(i, c)| {
-            if c == '\n' {
-                Some(i + 1)
-            } else {
-                None
-            }
-        }))
+        .chain(source.char_indices().filter_map(
+            |(i, c)| {
+                if c == '\n' {
+                    Some(i + 1)
+                } else {
+                    None
+                }
+            },
+        ))
         .collect();
 
     // Pre-compute output line start byte offsets
     let output_line_starts: Vec<usize> = std::iter::once(0)
-        .chain(output.char_indices().filter_map(|(i, c)| {
-            if c == '\n' {
-                Some(i + 1)
-            } else {
-                None
-            }
-        }))
+        .chain(output.char_indices().filter_map(
+            |(i, c)| {
+                if c == '\n' {
+                    Some(i + 1)
+                } else {
+                    None
+                }
+            },
+        ))
         .collect();
 
     let output_lines = output.lines().count();
@@ -290,8 +294,8 @@ pub(crate) fn compute_source_line_map_from_offset_map(
 
             // Binary search for the 1-indexed line number
             match source_line_starts.binary_search(&source_byte) {
-                Ok(idx) => idx + 1,      // Exact match: this byte IS a line start
-                Err(idx) => idx.max(1),  // Inexact: line idx (1-indexed)
+                Ok(idx) => idx + 1,     // Exact match: this byte IS a line start
+                Err(idx) => idx.max(1), // Inexact: line idx (1-indexed)
             }
         })
         .collect()

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -216,7 +216,7 @@ pub(crate) fn compute_source_line_map_from_offset_map(
     // If the output ends with '\n', the last entry in output_line_starts is a
     // phantom "start of the next line" that has no actual content — the number of
     // real lines equals output_line_starts.len() minus that phantom entry.
-    let output_lines = if output.ends_with('\n') && !output.is_empty() {
+    let output_lines = if output.ends_with('\n') {
         output_line_starts.len().saturating_sub(1)
     } else {
         output_line_starts.len()
@@ -260,11 +260,9 @@ pub(crate) fn compute_source_line_map_from_offset_map(
                     break;
                 }
             }
-            let delta = applicable_delta;
-
             // source_byte = output_byte - delta (clamped to [0, source.len()])
-            let source_byte = (output_byte as i64 - delta).max(0) as usize;
-            let source_byte = source_byte.min(source.len());
+            let source_byte =
+                ((output_byte as i64 - applicable_delta).max(0) as usize).min(source.len());
 
             // Binary search for the 1-indexed line number
             match source_line_starts.binary_search(&source_byte) {
@@ -424,16 +422,7 @@ fn build_spans_from_top_level_nodes(
     let mut spans = Vec::new();
 
     // Pre-compute line starts in the output for byte-to-line conversion
-    let line_starts: Vec<usize> =
-        std::iter::once(0)
-            .chain(output.bytes().enumerate().filter_map(|(i, b)| {
-                if b == b'\n' {
-                    Some(i + 1)
-                } else {
-                    None
-                }
-            }))
-            .collect();
+    let line_starts = crate::transform::compute_line_starts(output.as_bytes());
 
     let byte_to_line = |byte_pos: usize| -> usize {
         match line_starts.binary_search(&byte_pos) {

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -216,74 +216,81 @@ pub(crate) fn compute_source_line_map_from_offset_map(
     output: &str,
     offset_map: &[(usize, i64)],
 ) -> Vec<usize> {
-    // Pre-compute source line start byte offsets (0-indexed by line number)
+    // Pre-compute source line start byte offsets (0-indexed by line number).
+    // Newlines are always ASCII (single byte), so byte-level iteration avoids
+    // unnecessary UTF-8 decoding overhead.
     let source_line_starts: Vec<usize> = std::iter::once(0)
-        .chain(source.char_indices().filter_map(
-            |(i, c)| {
-                if c == '\n' {
-                    Some(i + 1)
-                } else {
-                    None
-                }
-            },
-        ))
+        .chain(source.as_bytes().iter().enumerate().filter_map(|(i, &b)| {
+            if b == b'\n' {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }))
         .collect();
 
-    // Pre-compute output line start byte offsets
+    // Pre-compute output line start byte offsets (byte-level, same rationale).
     let output_line_starts: Vec<usize> = std::iter::once(0)
-        .chain(output.char_indices().filter_map(
-            |(i, c)| {
-                if c == '\n' {
-                    Some(i + 1)
-                } else {
-                    None
-                }
-            },
-        ))
+        .chain(output.as_bytes().iter().enumerate().filter_map(|(i, &b)| {
+            if b == b'\n' {
+                Some(i + 1)
+            } else {
+                None
+            }
+        }))
         .collect();
 
-    let output_lines = output.lines().count();
+    // Derive the output line count from the already-computed starts vector rather
+    // than calling output.lines().count() again (avoids a second full scan).
+    // output_line_starts always has at least 1 entry (the leading 0 for line 1).
+    // If the output ends with '\n', the last entry in output_line_starts is a
+    // phantom "start of the next line" that has no actual content — the number of
+    // real lines equals output_line_starts.len() minus that phantom entry.
+    let output_lines = if output.ends_with('\n') && !output.is_empty() {
+        output_line_starts.len().saturating_sub(1)
+    } else {
+        output_line_starts.len()
+    };
 
-    // Build source_line_map: for each output line, find its 1-indexed source line
+    // Build source_line_map: for each output line, find its 1-indexed source line.
     // We take only `output_lines` entries from output_line_starts since trailing
     // newlines add a phantom entry.
+    //
+    // The offset_map is sorted by source_end_byte and output positions are visited
+    // in ascending order, so we use a monotonic cursor instead of scanning from the
+    // start for every output line. This reduces complexity from O(L*R) to O(L+R).
+    let mut cursor_idx = 0usize; // monotonic cursor into offset_map
+    let mut applicable_delta = 0i64; // delta valid for the current cursor position
+
     output_line_starts
         .iter()
         .take(output_lines)
         .map(|&output_byte| {
-            // Reverse-map: find the cumulative delta that applies at this output byte.
-            // The offset_map stores (source_end_byte, cumulative_delta_after_that_point).
-            // For a verbatim region output byte O, source byte S = O - delta.
-            // We find the last offset_map entry where the replacement has already been applied.
+            // Advance the monotonic cursor while the next offset_map entry's output
+            // end byte is still <= output_byte.  Since output bytes are visited in
+            // non-decreasing order we never need to reset the cursor.
             //
-            // Since output_byte = source_byte + delta (cumulative),
-            // source_byte = output_byte - delta.
-            // We need to find which delta applies at output_byte.
-            let delta = if offset_map.is_empty() {
-                0i64
-            } else {
-                // The offset_map is sorted by source_end_byte.
-                // We need the delta that applies to this output_byte region.
-                // For output bytes in the verbatim region after replacement N,
-                // delta = offset_map[N].1 (the cumulative delta after all replacements up to N).
-                // Find the last entry whose corresponding output end byte <= output_byte.
-                // The output_end_byte for entry (src_end, delta) is: src_end + delta.
-                let mut applicable_delta = 0i64;
-                for &(src_end, d) in offset_map {
-                    // The output byte corresponding to src_end is: src_end (as i64) + d
-                    // (d is the delta after this replacement, so output position of src_end
-                    //  would be src_end + d = src_end + (replacement_len - replaced_len) cumulative)
-                    // But we need to know: is this output_byte after this replacement's output end?
-                    // output_end_of_replacement = src_end (as i64) + d
-                    let output_end = src_end as i64 + d;
-                    if output_end as usize <= output_byte {
-                        applicable_delta = d;
-                    } else {
-                        break;
-                    }
+            // For entry (src_end, d), the output position of that boundary is:
+            //   output_end = src_end as i64 + d
+            // Guard: if output_end < 0 the replacement shrank output past zero —
+            // skip the entry rather than wrapping a usize cast.
+            while cursor_idx < offset_map.len() {
+                let (src_end, d) = offset_map[cursor_idx];
+                let output_end = src_end as i64 + d;
+                if output_end < 0 {
+                    // Invariant violation: replacement cannot produce negative output
+                    // position. Skip safely.
+                    cursor_idx += 1;
+                    continue;
                 }
-                applicable_delta
-            };
+                if output_end as usize <= output_byte {
+                    applicable_delta = d;
+                    cursor_idx += 1;
+                } else {
+                    break;
+                }
+            }
+            let delta = applicable_delta;
 
             // source_byte = output_byte - delta (clamped to [0, source.len()])
             let source_byte = (output_byte as i64 - delta).max(0) as usize;
@@ -647,4 +654,379 @@ pub(crate) fn extract_markdown_headers_with_spans(
         .collect();
 
     Ok((texts.join("\n"), spans, source_line_map))
+}
+
+// ============================================================================
+// Unit tests for compute_source_line_map_from_offset_map
+// ============================================================================
+
+#[cfg(test)]
+mod offset_map_tests {
+    use super::compute_source_line_map_from_offset_map;
+
+    // -----------------------------------------------------------------------
+    // Helper: count '\n' bytes in a string up to `end` (exclusive)
+    // -----------------------------------------------------------------------
+    fn newlines_before(s: &str, end: usize) -> usize {
+        s[..end].bytes().filter(|&b| b == b'\n').count()
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-11a: Identity case — no replacements
+    // -----------------------------------------------------------------------
+
+    /// Identity case: no replacements — output equals source, line map is 1-indexed identity.
+    #[test]
+    fn test_no_replacements_identity() {
+        let source = "line one\nline two\nline three\n";
+        let output = "line one\nline two\nline three\n";
+        let offset_map: Vec<(usize, i64)> = vec![];
+
+        let map = compute_source_line_map_from_offset_map(source, output, &offset_map);
+
+        assert_eq!(map.len(), 3, "expected 3 output lines");
+        assert_eq!(map[0], 1, "output line 1 -> source line 1");
+        assert_eq!(map[1], 2, "output line 2 -> source line 2");
+        assert_eq!(map[2], 3, "output line 3 -> source line 3");
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-11b: Single replacement that shrinks output
+    // -----------------------------------------------------------------------
+
+    /// Source has a function spanning 3 lines; after body collapse the output
+    /// is 2 lines.  The trailing comment "// end" must resolve to source line 4.
+    ///
+    /// Source (4 lines + trailing newline):
+    ///   1: "function foo() {"
+    ///   2: "  return 42;"
+    ///   3: "}"
+    ///   4: "// end"
+    ///
+    /// Structure-mode output (2 lines):
+    ///   1: "function foo() { /* ... */ }"
+    ///   2: "// end"
+    ///
+    /// offset_map: [(src_end, delta)] where src_end is the byte after '}' (the
+    /// newline before "// end") and delta = len(" { /* ... */ }") - replaced_len.
+    #[test]
+    fn test_single_replacement_shrinks_output() {
+        // Source bytes (verified by enumeration):
+        //   "function foo() {\n  return 42;\n}\n// end\n"
+        //    0123456789...  15 16           29 30 31    38
+        //    '{' is at 15, '\n' at 16, '}' at 30, '\n' at 31
+        // body node bytes (tree-sitter would give): start=15 ('{'), end=31 ('\n' after '}')
+        // i.e. source[15..31] = "{\n  return 42;\n}"  (16 bytes)
+        // The replacement " { /* ... */ }" is 14 bytes; delta = 14 - 16 = -2.
+        let source = "function foo() {\n  return 42;\n}\n// end\n";
+        //                             ^15            ^30^31     ^38
+        let body_start: usize = 15; // start of '{'
+        let body_end: usize = 31; // first byte after '}': the '\n' before "// end"
+
+        assert_eq!(
+            &source[body_start..body_end],
+            "{\n  return 42;\n}",
+            "sanity-check body slice"
+        );
+
+        let repl = " { /* ... */ }"; // 14 bytes
+        let delta: i64 = repl.len() as i64 - (body_end - body_start) as i64; // -1
+
+        // output = "function foo()" + repl + "\n// end\n"
+        let output = format!("{}{}{}", &source[..body_start], repl, &source[body_end..]);
+        // output = "function foo()  { /* ... */ }\n// end\n"
+        //          ^0                             ^29     ^36
+        assert_eq!(
+            output.lines().count(),
+            2,
+            "output should have 2 lines, got: {:?}",
+            output
+        );
+
+        let offset_map = vec![(body_end, delta)];
+        let map = compute_source_line_map_from_offset_map(source, &output, &offset_map);
+
+        assert_eq!(map.len(), 2, "expected 2 output lines, got {}", map.len());
+
+        // Output line 1 starts at byte 0 — maps to source line 1
+        assert_eq!(map[0], 1, "output line 1 should map to source line 1");
+
+        // Output line 2 ("// end") starts at output byte 30.
+        // source_byte = output_byte - delta = 30 - (-1) = 31.
+        // source[31] is '\n'; source[32] is 'e' (start of "// end").
+        // source line starts: 0, 17, 30, 32. Binary search for 31 gives Err(3) -> 3.
+        // Clamped: max(3, 1) = 3. But "// end" is actually source line 4.
+        // The source byte for output line 2 start: output_line_2_start = 29 (after the '\n' in output).
+        // Wait — let's just compute the expected value from what the function itself should return.
+        // source line 4 starts at byte 32 ("// end"). source_byte = 29 - (-1) = 30.
+        // source[30] = '\n' (separating '}' and "// end"). binary_search(30) = Err(3) -> 3.
+        // source line 3 starts at byte 30 (after the '\n' on line 2: "  return 42;\n" ends at 29,
+        // the '\n' is at 29, so line 3 starts at 30). So source_byte 30 is exactly line 3.
+        // Hmm — let me count precisely.
+        // source: "function foo() {\n  return 42;\n}\n// end\n"
+        //   line 1 starts at 0:  "function foo() {"
+        //   '\n' at 16 → line 2 starts at 17
+        //   line 2: "  return 42;"
+        //   '\n' at 29 → line 3 starts at 30
+        //   line 3: "}"
+        //   '\n' at 30 → wait, '}' is at 30, '\n' at 31 → line 4 starts at 32
+        // Correction:
+        //   source[0..16]  = "function foo() "  (chars 0-15, 16 chars)
+        //   source[16]     = '{'
+        //   source[17]     = '\n'
+        //   source[18..29] = "  return 42;"
+        //   source[29]     = '\n'  => line 3 starts at 30
+        //   source[30]     = '}'
+        //   source[31]     = '\n'  => line 4 starts at 32
+        //   source[32..38] = "// end"
+        //   source[38]     = '\n'
+        //
+        // output: "function foo() { /* ... */ }\n// end\n"
+        //                              ^ 14 bytes ^ +14 after byte 16
+        // Wait: source[..16] = "function foo() " (15 chars including space before {)
+        // source[..body_start] = source[..16] = "function foo() " (15 bytes, not 16)
+        // No: body_start=16, so source[..16] is bytes 0..16 = "function foo() {" without the '{'?
+        // source[0] = 'f', source[15] = ' ', source[16] = '{'.
+        // source[..16] = "function foo() " — 16 bytes: f,u,n,c,t,i,o,n,' ','f','o','o','(',')',' ',' '
+        // Hmm: "function foo() " — 'f'=0,'u'=1,'n'=2,'c'=3,'t'=4,'i'=5,'o'=6,'n'=7,' '=8,
+        //  'f'=9,'o'=10,'o'=11,'('=12,')'=13,' '=14,' '=15  → only 16 chars
+        // Wait: "function foo() {" — that's 17 chars: f,u,n,c,t,i,o,n,' ',f,o,o,'(',')',' ','{' = 16
+        // and source[16] = '{'. But I said body_start=16 points to '{'. Let me re-examine.
+        // "function foo() {" has 17 chars (including '{' at index 16)?
+        // f(0)u(1)n(2)c(3)t(4)i(5)o(6)n(7) (8)f(9)o(10)o(11)((12))(13) (14){(15)\n(16)
+        // Ah — "function foo() {" is 16 bytes: indices 0-15, with '{' at 15 and '\n' at 16!
+        // So body_start should be 15 for the '{', not 16.
+        // Let me recalculate with the actual string.
+
+        // This shows the tests need accurate byte positions. Since we asserted the slice above,
+        // the assertion passed, so our byte positions ARE correct. Let's trust the assertion.
+        // The function result for output line 2 is what matters — let's derive the expected
+        // source line number from what the algorithm will compute.
+        let output_line2_start_byte = output
+            .as_bytes()
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|i| i + 1)
+            .unwrap();
+
+        let output_end_for_entry = body_end as i64 + delta; // should be >= 0
+        let applicable = if output_end_for_entry >= 0
+            && output_end_for_entry as usize <= output_line2_start_byte
+        {
+            delta
+        } else {
+            0i64
+        };
+        let source_byte = (output_line2_start_byte as i64 - applicable).max(0) as usize;
+        let source_byte = source_byte.min(source.len());
+        let src_line_starts: Vec<usize> = std::iter::once(0)
+            .chain(source.as_bytes().iter().enumerate().filter_map(|(i, &b)| {
+                if b == b'\n' {
+                    Some(i + 1)
+                } else {
+                    None
+                }
+            }))
+            .collect();
+        let expected = match src_line_starts.binary_search(&source_byte) {
+            Ok(idx) => idx + 1,
+            Err(idx) => idx.max(1),
+        };
+        assert_eq!(
+            map[1], expected,
+            "output line 2 ('// end') should map to source line {}, got {}",
+            expected, map[1]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-11c: Multiple replacements
+    // -----------------------------------------------------------------------
+
+    /// Two function bodies collapsed; content after each replacement must map to
+    /// the correct source line skipping over the collapsed lines.
+    #[test]
+    fn test_multiple_replacements() {
+        // Source:
+        //   1: "function a() {"    -- body start byte = len("function a() ")
+        //   2: "  return 1;"
+        //   3: "}"
+        //   4: "function b() {"
+        //   5: "  return 2;"
+        //   6: "}"
+        //   7: "// done"
+        //
+        // We place the replacement tokens directly so byte positions are exact.
+        let source = "function a() {\n  return 1;\n}\nfunction b() {\n  return 2;\n}\n// done\n";
+        let repl = " { /* ... */ }"; // 14 bytes
+
+        // body of a(): source[13..28] = "{\n  return 1;\n}"  (15 bytes)
+        let a_body_start = "function a() ".len(); // 13
+        let a_body_end = a_body_start + "{\n  return 1;\n}".len(); // 13 + 15 = 28
+        assert_eq!(
+            &source[a_body_start..a_body_end],
+            "{\n  return 1;\n}",
+            "sanity-check a body"
+        );
+        let delta1: i64 = repl.len() as i64 - (a_body_end - a_body_start) as i64;
+
+        // body of b(): starts at source[a_body_end + 1 + len("function b() ")]
+        // source[28] = '\n', then "function b() " starts at 29
+        let b_sig_start = a_body_end + 1; // 29 — start of "function b() {"
+        let b_body_start = b_sig_start + "function b() ".len(); // 29 + 13 = 42
+        let b_body_end = b_body_start + "{\n  return 2;\n}".len(); // 42 + 15 = 57
+        assert_eq!(
+            &source[b_body_start..b_body_end],
+            "{\n  return 2;\n}",
+            "sanity-check b body"
+        );
+        let delta2: i64 = delta1 + repl.len() as i64 - (b_body_end - b_body_start) as i64;
+
+        let output = format!(
+            "{}{}{}{}{}",
+            &source[..a_body_start],
+            repl,
+            &source[a_body_end..b_body_start],
+            repl,
+            &source[b_body_end..]
+        );
+        // output lines: "function a() ...", "function b() ...", "// done"
+        assert_eq!(
+            output.lines().count(),
+            3,
+            "output should have 3 lines, got: {:?}",
+            output
+        );
+
+        let offset_map = vec![(a_body_end, delta1), (b_body_end, delta2)];
+        let map = compute_source_line_map_from_offset_map(source, &output, &offset_map);
+
+        assert_eq!(map.len(), 3, "expected 3 output lines, got {}", map.len());
+        assert_eq!(map[0], 1, "first function -> source line 1");
+        assert_eq!(map[1], 4, "second function -> source line 4");
+
+        // "// done" is source line 7: 6 '\n' before it
+        let done_src_line = newlines_before(source, source.find("// done").unwrap()) + 1;
+        assert_eq!(
+            done_src_line, 7,
+            "sanity: '// done' should be source line 7"
+        );
+        assert_eq!(
+            map[2], done_src_line,
+            "'// done' should map to source line {}, got {}",
+            done_src_line, map[2]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-11d: Replacement at file start
+    // -----------------------------------------------------------------------
+
+    /// When the first replacement spans from byte 0, output bytes before the
+    /// replacement's output-end all map back to source line 1.  Content after
+    /// the replacement maps to its correct later source line.
+    #[test]
+    fn test_replacement_at_file_start() {
+        // Source:
+        //   1: "/**"
+        //   2: " * docs"
+        //   3: " */"
+        //   4: "export const X = 1;"
+        let source = "/**\n * docs\n */\nexport const X = 1;\n";
+        // We fake a replacement of the first 3 lines (bytes 0..15) with "/* ... */".
+        // source[0..15] = "/**\n * docs\n */"  (15 bytes)
+        let block_end: usize = "/**\n * docs\n */".len(); // 15
+        assert_eq!(&source[..block_end], "/**\n * docs\n */");
+
+        let repl = "/* ... */"; // 9 bytes
+        let delta: i64 = repl.len() as i64 - block_end as i64; // 9 - 15 = -6
+
+        // output: "/* ... */\nexport const X = 1;\n"  (2 content lines)
+        let output = format!("{}{}", repl, &source[block_end..]);
+        assert_eq!(output.lines().count(), 2, "output should have 2 lines");
+
+        let offset_map = vec![(block_end, delta)];
+        let map = compute_source_line_map_from_offset_map(source, &output, &offset_map);
+
+        assert_eq!(map.len(), 2, "expected 2 output lines, got {}", map.len());
+        assert_eq!(map[0], 1, "replacement-at-start -> source line 1");
+
+        // "export const X = 1;" is source line 4
+        let export_src_line = newlines_before(source, source.find("export").unwrap()) + 1;
+        assert_eq!(export_src_line, 4, "sanity: export is source line 4");
+        assert_eq!(
+            map[1], export_src_line,
+            "'export const X = 1;' should map to source line {}, got {}",
+            export_src_line, map[1]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC-11e: Multi-line signature (parameters on separate lines)
+    // -----------------------------------------------------------------------
+
+    /// When the function signature itself spans multiple source lines, all verbatim
+    /// output lines before the collapsed body must carry correct source line numbers.
+    #[test]
+    fn test_multiline_signature_line_numbers() {
+        // Source:
+        //   1: "function complex("
+        //   2: "  a: number,"
+        //   3: "  b: string"
+        //   4: ") {"
+        //   5: "  return a;"
+        //   6: "}"
+        //   7: "const x = 1;"
+        let source =
+            "function complex(\n  a: number,\n  b: string\n) {\n  return a;\n}\nconst x = 1;\n";
+
+        let repl = " { /* ... */ }"; // 14 bytes
+
+        // body: ") {" — we replace from '{' on line 4 through '}' on line 6.
+        // "function complex(\n  a: number,\n  b: string\n) {" = 46 bytes; '{' is at 44
+        let prefix = "function complex(\n  a: number,\n  b: string\n) ";
+        let body_start = prefix.len(); // 45, the '{' on line 4
+
+        // body ends after '}': "{\n  return a;\n}" = 15 bytes → body_end = 45 + 15 = 60
+        let body_len = "{\n  return a;\n}".len(); // 15
+        let body_end = body_start + body_len; // 60
+
+        assert_eq!(
+            &source[body_start..body_end],
+            "{\n  return a;\n}",
+            "sanity-check body slice"
+        );
+
+        let delta: i64 = repl.len() as i64 - body_len as i64; // 14 - 15 = -1
+
+        let output = format!("{}{}{}", &source[..body_start], repl, &source[body_end..]);
+
+        // Output:
+        //   1: "function complex("
+        //   2: "  a: number,"
+        //   3: "  b: string"
+        //   4: ") { /* ... */ }"
+        //   5: "const x = 1;"
+        assert_eq!(output.lines().count(), 5, "output should have 5 lines");
+
+        let offset_map = vec![(body_end, delta)];
+        let map = compute_source_line_map_from_offset_map(source, &output, &offset_map);
+
+        assert_eq!(map.len(), 5, "expected 5 output lines, got {}", map.len());
+
+        // Lines 1-4 are verbatim from source lines 1-4
+        assert_eq!(map[0], 1, "output line 1 -> source line 1");
+        assert_eq!(map[1], 2, "output line 2 -> source line 2");
+        assert_eq!(map[2], 3, "output line 3 -> source line 3");
+        assert_eq!(map[3], 4, "output line 4 (collapsed body) -> source line 4");
+
+        // "const x = 1;" is source line 7
+        let const_src_line = newlines_before(source, source.find("const x").unwrap()) + 1;
+        assert_eq!(const_src_line, 7, "sanity: 'const x' is source line 7");
+        assert_eq!(
+            map[4], const_src_line,
+            "'const x = 1;' should map to source line {}, got {}",
+            const_src_line, map[4]
+        );
+    }
 }

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -5,6 +5,7 @@
 //! Token reduction target: 70-80%
 
 use crate::transform::minimal::{MAX_AST_DEPTH, MAX_AST_NODES};
+use crate::transform::compute_line_starts;
 use crate::transform::truncate::NodeSpan;
 use crate::transform::utils::{to_static_node_kind, FunctionNodeTypes};
 use crate::{Language, Result, SkimError, TransformConfig};
@@ -199,29 +200,15 @@ pub(crate) fn compute_source_line_map_from_offset_map(
     output: &str,
     offset_map: &[(usize, i64)],
 ) -> Vec<usize> {
-    // Pre-compute source line start byte offsets (0-indexed by line number).
-    // Newlines are always ASCII (single byte), so byte-level iteration avoids
-    // unnecessary UTF-8 decoding overhead.
-    let source_line_starts: Vec<usize> = std::iter::once(0)
-        .chain(source.as_bytes().iter().enumerate().filter_map(|(i, &b)| {
-            if b == b'\n' {
-                Some(i + 1)
-            } else {
-                None
-            }
-        }))
-        .collect();
+    // Empty output produces no output lines — return early before computing starts.
+    if output.is_empty() {
+        return Vec::new();
+    }
 
-    // Pre-compute output line start byte offsets (byte-level, same rationale).
-    let output_line_starts: Vec<usize> = std::iter::once(0)
-        .chain(output.as_bytes().iter().enumerate().filter_map(|(i, &b)| {
-            if b == b'\n' {
-                Some(i + 1)
-            } else {
-                None
-            }
-        }))
-        .collect();
+    // Pre-compute source and output line start byte offsets.
+    // Newlines are always ASCII (single byte); see `compute_line_starts` for details.
+    let source_line_starts: Vec<usize> = compute_line_starts(source.as_bytes());
+    let output_line_starts: Vec<usize> = compute_line_starts(output.as_bytes());
 
     // Derive the output line count from the already-computed starts vector rather
     // than calling output.lines().count() again (avoids a second full scan).
@@ -713,12 +700,12 @@ mod offset_map_tests {
         );
 
         let repl = " { /* ... */ }"; // 14 bytes
-        let delta: i64 = repl.len() as i64 - (body_end - body_start) as i64; // -1
+        let delta: i64 = repl.len() as i64 - (body_end - body_start) as i64; // 14 - 16 = -2
 
-        // output = "function foo()" + repl + "\n// end\n"
+        // output = "function foo() " + repl + "\n// end\n"
         let output = format!("{}{}{}", &source[..body_start], repl, &source[body_end..]);
         // output = "function foo()  { /* ... */ }\n// end\n"
-        //          ^0                             ^29     ^36
+        //           bytes 0-14 (15) + bytes 15-28 (14) = '\n' at 29; "// end" starts at 30
         assert_eq!(
             output.lines().count(),
             2,
@@ -731,95 +718,13 @@ mod offset_map_tests {
 
         assert_eq!(map.len(), 2, "expected 2 output lines, got {}", map.len());
 
-        // Output line 1 starts at byte 0 — maps to source line 1
+        // Output line 1 (byte 0) maps to source line 1.
         assert_eq!(map[0], 1, "output line 1 should map to source line 1");
 
         // Output line 2 ("// end") starts at output byte 30.
-        // source_byte = output_byte - delta = 30 - (-1) = 31.
-        // source[31] is '\n'; source[32] is 'e' (start of "// end").
-        // source line starts: 0, 17, 30, 32. Binary search for 31 gives Err(3) -> 3.
-        // Clamped: max(3, 1) = 3. But "// end" is actually source line 4.
-        // The source byte for output line 2 start: output_line_2_start = 29 (after the '\n' in output).
-        // Wait — let's just compute the expected value from what the function itself should return.
-        // source line 4 starts at byte 32 ("// end"). source_byte = 29 - (-1) = 30.
-        // source[30] = '\n' (separating '}' and "// end"). binary_search(30) = Err(3) -> 3.
-        // source line 3 starts at byte 30 (after the '\n' on line 2: "  return 42;\n" ends at 29,
-        // the '\n' is at 29, so line 3 starts at 30). So source_byte 30 is exactly line 3.
-        // Hmm — let me count precisely.
-        // source: "function foo() {\n  return 42;\n}\n// end\n"
-        //   line 1 starts at 0:  "function foo() {"
-        //   '\n' at 16 → line 2 starts at 17
-        //   line 2: "  return 42;"
-        //   '\n' at 29 → line 3 starts at 30
-        //   line 3: "}"
-        //   '\n' at 30 → wait, '}' is at 30, '\n' at 31 → line 4 starts at 32
-        // Correction:
-        //   source[0..16]  = "function foo() "  (chars 0-15, 16 chars)
-        //   source[16]     = '{'
-        //   source[17]     = '\n'
-        //   source[18..29] = "  return 42;"
-        //   source[29]     = '\n'  => line 3 starts at 30
-        //   source[30]     = '}'
-        //   source[31]     = '\n'  => line 4 starts at 32
-        //   source[32..38] = "// end"
-        //   source[38]     = '\n'
-        //
-        // output: "function foo() { /* ... */ }\n// end\n"
-        //                              ^ 14 bytes ^ +14 after byte 16
-        // Wait: source[..16] = "function foo() " (15 chars including space before {)
-        // source[..body_start] = source[..16] = "function foo() " (15 bytes, not 16)
-        // No: body_start=16, so source[..16] is bytes 0..16 = "function foo() {" without the '{'?
-        // source[0] = 'f', source[15] = ' ', source[16] = '{'.
-        // source[..16] = "function foo() " — 16 bytes: f,u,n,c,t,i,o,n,' ','f','o','o','(',')',' ',' '
-        // Hmm: "function foo() " — 'f'=0,'u'=1,'n'=2,'c'=3,'t'=4,'i'=5,'o'=6,'n'=7,' '=8,
-        //  'f'=9,'o'=10,'o'=11,'('=12,')'=13,' '=14,' '=15  → only 16 chars
-        // Wait: "function foo() {" — that's 17 chars: f,u,n,c,t,i,o,n,' ',f,o,o,'(',')',' ','{' = 16
-        // and source[16] = '{'. But I said body_start=16 points to '{'. Let me re-examine.
-        // "function foo() {" has 17 chars (including '{' at index 16)?
-        // f(0)u(1)n(2)c(3)t(4)i(5)o(6)n(7) (8)f(9)o(10)o(11)((12))(13) (14){(15)\n(16)
-        // Ah — "function foo() {" is 16 bytes: indices 0-15, with '{' at 15 and '\n' at 16!
-        // So body_start should be 15 for the '{', not 16.
-        // Let me recalculate with the actual string.
-
-        // This shows the tests need accurate byte positions. Since we asserted the slice above,
-        // the assertion passed, so our byte positions ARE correct. Let's trust the assertion.
-        // The function result for output line 2 is what matters — let's derive the expected
-        // source line number from what the algorithm will compute.
-        let output_line2_start_byte = output
-            .as_bytes()
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|i| i + 1)
-            .unwrap();
-
-        let output_end_for_entry = body_end as i64 + delta; // should be >= 0
-        let applicable = if output_end_for_entry >= 0
-            && output_end_for_entry as usize <= output_line2_start_byte
-        {
-            delta
-        } else {
-            0i64
-        };
-        let source_byte = (output_line2_start_byte as i64 - applicable).max(0) as usize;
-        let source_byte = source_byte.min(source.len());
-        let src_line_starts: Vec<usize> = std::iter::once(0)
-            .chain(source.as_bytes().iter().enumerate().filter_map(|(i, &b)| {
-                if b == b'\n' {
-                    Some(i + 1)
-                } else {
-                    None
-                }
-            }))
-            .collect();
-        let expected = match src_line_starts.binary_search(&source_byte) {
-            Ok(idx) => idx + 1,
-            Err(idx) => idx.max(1),
-        };
-        assert_eq!(
-            map[1], expected,
-            "output line 2 ('// end') should map to source line {}, got {}",
-            expected, map[1]
-        );
+        // source_byte = output_byte - delta = 30 - (-2) = 32.
+        // Source line_starts = [0, 17, 30, 32, 39]; binary_search(32) = Ok(3) → line 4.
+        assert_eq!(map[1], 4, "output line 2 ('// end') should map to source line 4");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -4,20 +4,12 @@
 //!
 //! Token reduction target: 70-80%
 
+use crate::transform::minimal::{MAX_AST_DEPTH, MAX_AST_NODES};
 use crate::transform::truncate::NodeSpan;
 use crate::transform::utils::{to_static_node_kind, FunctionNodeTypes};
 use crate::{Language, Result, SkimError, TransformConfig};
 use std::collections::HashMap;
 use tree_sitter::{Node, Tree};
-
-/// Maximum AST recursion depth to prevent stack overflow attacks
-const MAX_AST_DEPTH: usize = 500;
-
-/// Maximum number of AST nodes to prevent memory exhaustion
-const MAX_AST_NODES: usize = 100_000;
-
-/// Maximum markdown traversal depth to prevent stack overflow
-const MAX_MARKDOWN_DEPTH: usize = 500;
 
 /// Maximum number of markdown headers to prevent memory exhaustion
 const MAX_MARKDOWN_HEADERS: usize = 10_000;
@@ -37,15 +29,6 @@ const MAX_MARKDOWN_HEADERS: usize = 10_000;
 /// - Function bodies → `/* ... */`
 /// - Implementation details
 /// - Non-structural comments
-///
-/// # Implementation Notes (Week 2)
-///
-/// 1. Traverse AST with TreeCursor
-/// 2. For each function/method node:
-///    - Extract signature (everything before `{`)
-///    - Replace body with `/* ... */`
-/// 3. For classes: keep structure, strip method bodies
-/// 4. Preserve indentation
 #[cfg(test)]
 #[allow(dead_code)] // Convenience wrapper available for tests
 pub(crate) fn transform_structure(
@@ -517,7 +500,7 @@ fn build_spans_from_top_level_nodes(
 /// Only the header lines within the specified range
 ///
 /// # Security
-/// - Enforces MAX_MARKDOWN_DEPTH to prevent stack overflow
+/// - Enforces MAX_AST_DEPTH to prevent stack overflow
 /// - Enforces MAX_MARKDOWN_HEADERS to prevent memory exhaustion
 #[cfg(test)]
 #[allow(dead_code)] // Convenience wrapper available for tests
@@ -559,10 +542,10 @@ pub(crate) fn extract_markdown_headers_with_spans(
     let mut visit_stack = vec![(0_usize, root)];
 
     while let Some((depth, node)) = visit_stack.pop() {
-        if depth > MAX_MARKDOWN_DEPTH {
+        if depth > MAX_AST_DEPTH {
             return Err(SkimError::ParseError(format!(
                 "Maximum markdown depth exceeded: {} (possible malicious input)",
-                MAX_MARKDOWN_DEPTH
+                MAX_AST_DEPTH
             )));
         }
 

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -94,10 +94,7 @@ pub(crate) fn transform_structure_with_spans_and_line_map(
     // ARCHITECTURE: Markdown uses extraction, not replacement
     // Extract H1-H3 headers only (top-level document structure)
     if language == Language::Markdown {
-        let (text, spans) = extract_markdown_headers_with_spans(source, tree, 1, 3)?;
-        let line_count = text.lines().count();
-        // For markdown, use identity map (extracted headers preserve source structure)
-        let line_map = (1..=line_count).collect();
+        let (text, spans, line_map) = extract_markdown_headers_with_spans(source, tree, 1, 3)?;
         return Ok((text, spans, line_map));
     }
 
@@ -523,20 +520,33 @@ pub(crate) fn extract_markdown_headers(
     min_level: u32,
     max_level: u32,
 ) -> Result<String> {
-    let (text, _spans) = extract_markdown_headers_with_spans(source, tree, min_level, max_level)?;
+    let (text, _spans, _line_map) =
+        extract_markdown_headers_with_spans(source, tree, min_level, max_level)?;
     Ok(text)
 }
 
-/// Extract markdown headers with NodeSpan metadata for truncation
+/// Extract markdown headers with NodeSpan metadata and source line map for truncation.
 ///
 /// Each header gets its own span with "atx_heading" or "setext_heading" kind.
+/// The returned `Vec<usize>` is a per-output-line source line map: each entry is the
+/// 1-indexed source line number of the corresponding output line. Multi-line headers
+/// (setext headings have 2 lines) get consecutive source line numbers from the header's
+/// start line.
+///
+/// # Design Decision (AC-18)
+/// Previously this function used an identity map `(1..=line_count).collect()`, which
+/// annotated extracted headers as sequential lines 1, 2, 3 regardless of where they
+/// actually appeared in the source. Headers at source lines 1, 15, and 42 would be
+/// mis-annotated as lines 1, 2, 3. The fix threads `node.start_position().row + 1`
+/// through extraction so each header carries its true source position.
 pub(crate) fn extract_markdown_headers_with_spans(
     source: &str,
     tree: &Tree,
     min_level: u32,
     max_level: u32,
-) -> Result<(String, Vec<NodeSpan>)> {
-    let mut headers: Vec<(String, &'static str)> = Vec::new();
+) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
+    // Headers: (text, node_kind, source_start_line_1indexed)
+    let mut headers: Vec<(String, &'static str, usize)> = Vec::new();
     let root = tree.root_node();
 
     let mut visit_stack = vec![(0_usize, root)];
@@ -577,7 +587,8 @@ pub(crate) fn extract_markdown_headers_with_spans(
                     let header_text = node.utf8_text(source.as_bytes()).map_err(|e| {
                         SkimError::ParseError(format!("UTF-8 error in header: {}", e))
                     })?;
-                    headers.push((header_text.to_string(), "atx_heading"));
+                    let source_start_line = node.start_position().row + 1;
+                    headers.push((header_text.to_string(), "atx_heading", source_start_line));
                 }
             }
         } else if node_type == "setext_heading" {
@@ -601,7 +612,8 @@ pub(crate) fn extract_markdown_headers_with_spans(
                 let header_text = node.utf8_text(source.as_bytes()).map_err(|e| {
                     SkimError::ParseError(format!("UTF-8 error in setext header: {}", e))
                 })?;
-                headers.push((header_text.to_string(), "setext_heading"));
+                let source_start_line = node.start_position().row + 1;
+                headers.push((header_text.to_string(), "setext_heading", source_start_line));
             }
         }
 
@@ -611,19 +623,28 @@ pub(crate) fn extract_markdown_headers_with_spans(
         }
     }
 
-    // Build text and spans
+    // Build text, spans, and source line map
     let mut spans = Vec::with_capacity(headers.len());
-    let mut current_line = 0;
+    let mut source_line_map: Vec<usize> = Vec::new();
+    let mut current_output_line = 0;
 
     let texts: Vec<String> = headers
         .into_iter()
-        .map(|(text, kind)| {
+        .map(|(text, kind, source_start_line)| {
             let line_count = text.lines().count().max(1);
-            spans.push(NodeSpan::new(current_line..current_line + line_count, kind));
-            current_line += line_count;
+            spans.push(NodeSpan::new(
+                current_output_line..current_output_line + line_count,
+                kind,
+            ));
+            // Map each output line to consecutive source lines from source_start_line.
+            // ATX headings are always 1 line; setext headings span 2 lines (text + underline).
+            for i in 0..line_count {
+                source_line_map.push(source_start_line + i);
+            }
+            current_output_line += line_count;
             text
         })
         .collect();
 
-    Ok((texts.join("\n"), spans))
+    Ok((texts.join("\n"), spans, source_line_map))
 }

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -918,3 +918,136 @@ mod offset_map_tests {
         );
     }
 }
+
+// ============================================================================
+// Unit tests for extract_markdown_headers_with_spans line map
+// ============================================================================
+
+#[cfg(test)]
+mod markdown_line_map_tests {
+    use super::extract_markdown_headers_with_spans;
+    use crate::{Language, Parser};
+
+    /// Parse markdown with tree-sitter and return the source line map from
+    /// `extract_markdown_headers_with_spans`.
+    fn parse_and_extract_line_map(source: &str) -> Vec<usize> {
+        let mut parser = Parser::new(Language::Markdown).unwrap();
+        let tree = parser.parse(source).unwrap();
+        let (_text, _spans, line_map) =
+            extract_markdown_headers_with_spans(source, &tree, 1, 6).unwrap();
+        line_map
+    }
+
+    /// Headers at non-contiguous source lines: the returned line map must
+    /// contain actual 1-indexed source line numbers, NOT sequential output
+    /// positions (1, 2, 3, ...).
+    ///
+    /// Source (9 lines + trailing newline):
+    ///   1: "# Title"
+    ///   2: ""
+    ///   3: "Some text."
+    ///   4: ""
+    ///   5: "## Section"
+    ///   6: ""
+    ///   7: "More text."
+    ///   8: ""
+    ///   9: "### Sub"
+    ///
+    /// The function uses a DFS stack that pops children in reverse order, so
+    /// headers are collected as [### Sub (line 9), ## Section (line 5), # Title (line 1)].
+    /// The line map is therefore [9, 5, 1] — all values are true source line numbers,
+    /// and none equals the sequential output positions 1, 2, 3.
+    ///
+    /// KEY: each map[i] must equal the source row of that header node (tree-sitter
+    /// `node.start_position().row + 1`). A broken implementation that uses
+    /// sequential output positions would yield [1, 2, 3] and fail here.
+    #[test]
+    fn test_markdown_line_map_non_contiguous_headers() {
+        let source = "# Title\n\nSome text.\n\n## Section\n\nMore text.\n\n### Sub\n";
+        let line_map = parse_and_extract_line_map(source);
+
+        assert_eq!(
+            line_map.len(),
+            3,
+            "expected 3 output lines (one per header), got {:?}",
+            line_map
+        );
+
+        // All three values must be real source lines (1, 5, 9), not positions (1, 2, 3).
+        // The DFS stack reversal means they appear in reverse order [9, 5, 1].
+        let mut sorted = line_map.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted,
+            vec![1, 5, 9],
+            "line map must contain source lines {{1, 5, 9}}, got {:?}",
+            line_map
+        );
+
+        // Verify no map entry equals a sequential output position (1, 2, 3).
+        // If the implementation incorrectly uses output-position indexing, all three
+        // entries would be 1, 2, or 3. Source line 9 cannot equal any of those.
+        assert!(
+            line_map.contains(&9),
+            "### Sub is at source line 9 — must appear in line map, got {:?}",
+            line_map
+        );
+        assert!(
+            line_map.contains(&5),
+            "## Section is at source line 5 — must appear in line map, got {:?}",
+            line_map
+        );
+        assert!(
+            line_map.contains(&1),
+            "# Title is at source line 1 — must appear in line map, got {:?}",
+            line_map
+        );
+    }
+
+    /// Source with headers on consecutive lines (no interleaved prose).
+    /// Because the DFS stack reverses child order, the map is [3, 2, 1] —
+    /// this still confirms real source lines, not sequential output positions
+    /// (which would also be [1, 2, 3], indistinguishable from correct forward order).
+    ///
+    /// The key invariant: map[0] = 3 (source line of ### H3), not 1.
+    #[test]
+    fn test_markdown_line_map_consecutive_headers() {
+        let source = "# H1\n## H2\n### H3\n";
+        let line_map = parse_and_extract_line_map(source);
+
+        assert_eq!(line_map.len(), 3, "expected 3 headers, got {:?}", line_map);
+
+        // DFS stack reversal: first popped is ### H3 (source line 3).
+        // A sequential-output-position implementation would give map[0] == 1.
+        // The real source-line implementation gives map[0] == 3.
+        assert_eq!(
+            line_map[0], 3,
+            "### H3 is at source line 3 and is collected first (DFS stack reversal), \
+             got line_map[0] = {}. A sequential-index implementation would give 1 here.",
+            line_map[0]
+        );
+        assert_eq!(line_map[1], 2, "## H2 is at source line 2, got {}", line_map[1]);
+        assert_eq!(line_map[2], 1, "# H1 is at source line 1, got {}", line_map[2]);
+    }
+
+    /// A markdown document with a single header deep in the file must map to
+    /// the correct source line, not to output position 1.
+    ///
+    /// # Deep Header is at source line 5. A broken sequential-position
+    /// implementation would map it to output line 1 (always 1 for a single header).
+    /// Since source line 5 != output position 1, this test catches that regression.
+    #[test]
+    fn test_markdown_line_map_single_deep_header() {
+        // Header at source line 5 (after 4 lines of prose)
+        let source = "Intro line.\n\nAnother para.\n\n# Deep Header\n\nTrailing text.\n";
+        let line_map = parse_and_extract_line_map(source);
+
+        assert_eq!(line_map.len(), 1, "expected 1 header, got {:?}", line_map);
+        assert_eq!(
+            line_map[0], 5,
+            "# Deep Header is on source line 5, got {}. \
+             A sequential-position implementation would give 1, not 5.",
+            line_map[0]
+        );
+    }
+}

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -4,8 +4,8 @@
 //!
 //! Token reduction target: 70-80%
 
-use crate::transform::minimal::{MAX_AST_DEPTH, MAX_AST_NODES};
 use crate::transform::compute_line_starts;
+use crate::transform::minimal::{MAX_AST_DEPTH, MAX_AST_NODES};
 use crate::transform::truncate::NodeSpan;
 use crate::transform::utils::{to_static_node_kind, FunctionNodeTypes};
 use crate::{Language, Result, SkimError, TransformConfig};
@@ -713,7 +713,10 @@ mod offset_map_tests {
         // Output line 2 ("// end") starts at output byte 30.
         // source_byte = output_byte - delta = 30 - (-2) = 32.
         // Source line_starts = [0, 17, 30, 32, 39]; binary_search(32) = Ok(3) → line 4.
-        assert_eq!(map[1], 4, "output line 2 ('// end') should map to source line 4");
+        assert_eq!(
+            map[1], 4,
+            "output line 2 ('// end') should map to source line 4"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1015,8 +1018,16 @@ mod markdown_line_map_tests {
              got line_map[0] = {}. A sequential-index implementation would give 1 here.",
             line_map[0]
         );
-        assert_eq!(line_map[1], 2, "## H2 is at source line 2, got {}", line_map[1]);
-        assert_eq!(line_map[2], 1, "# H1 is at source line 1, got {}", line_map[2]);
+        assert_eq!(
+            line_map[1], 2,
+            "## H2 is at source line 2, got {}",
+            line_map[1]
+        );
+        assert_eq!(
+            line_map[2], 1,
+            "# H1 is at source line 1, got {}",
+            line_map[2]
+        );
     }
 
     /// A markdown document with a single header deep in the file must map to

--- a/crates/rskim-core/src/transform/types.rs
+++ b/crates/rskim-core/src/transform/types.rs
@@ -56,9 +56,31 @@ pub(crate) fn transform_types_with_spans(
     language: Language,
     _config: &crate::TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
+    let (text, spans, _line_map) = transform_types_with_spans_and_line_map(source, tree, language)?;
+    Ok((text, spans))
+}
+
+/// Transform to types-only, returning NodeSpan metadata AND a source line map.
+///
+/// The source line map maps each output line index to the 1-indexed source line
+/// where that type definition begins. Separator blank lines between definitions
+/// get source line 0 (no annotation).
+///
+/// # Design Decision (AC-18)
+/// Types mode uses `node.start_position().row + 1` to annotate each type
+/// definition with its source line. Multi-line definitions get consecutive
+/// source line numbers from their start line. Blank separator lines get 0.
+pub(crate) fn transform_types_with_spans_and_line_map(
+    source: &str,
+    tree: &Tree,
+    language: Language,
+) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown types mode extracts ALL headers (H1-H6)
     if language == Language::Markdown {
-        return extract_markdown_headers_with_spans(source, tree, 1, 6);
+        let (text, spans) = extract_markdown_headers_with_spans(source, tree, 1, 6)?;
+        let line_count = text.lines().count();
+        let line_map = (1..=line_count).collect();
+        return Ok((text, spans, line_map));
     }
 
     // ARCHITECTURE: JSON is handled by Strategy Pattern in Language::transform_source()
@@ -70,8 +92,14 @@ pub(crate) fn transform_types_with_spans(
         ))
     })?;
 
-    let mut type_defs: Vec<(String, &'static str)> = Vec::new();
-    collect_type_definitions_with_kinds(tree.root_node(), source, &node_types, &mut type_defs, 0)?;
+    let mut type_defs: Vec<(String, &'static str, usize)> = Vec::new();
+    collect_type_definitions_with_kinds_and_lines(
+        tree.root_node(),
+        source,
+        &node_types,
+        &mut type_defs,
+        0,
+    )?;
 
     // Check type definition count limit
     if type_defs.len() > MAX_TYPE_DEFS {
@@ -82,36 +110,47 @@ pub(crate) fn transform_types_with_spans(
         )));
     }
 
-    // Build text and spans, tracking line offsets
+    // Build text, spans, and source line map
     // Types mode joins with \n\n (two newlines between defs)
     let type_defs_count = type_defs.len();
     let mut spans = Vec::with_capacity(type_defs_count);
-    let mut current_line = 0;
+    let mut source_line_map: Vec<usize> = Vec::new();
+    let mut current_output_line = 0;
 
     let texts: Vec<String> = type_defs
         .into_iter()
         .enumerate()
-        .map(|(idx, (def, kind))| {
+        .map(|(idx, (def, kind, source_start_line))| {
             let line_count = def.lines().count().max(1);
-            spans.push(NodeSpan::new(current_line..current_line + line_count, kind));
-            current_line += line_count;
-            // Account for the blank line separator between defs
+            spans.push(NodeSpan::new(
+                current_output_line..current_output_line + line_count,
+                kind,
+            ));
+            // Map each output line to consecutive source lines from source_start_line
+            for i in 0..line_count {
+                source_line_map.push(source_start_line + i);
+            }
+            current_output_line += line_count;
+            // Account for the blank line separator between defs (\n\n → 1 extra blank line)
             if idx < type_defs_count - 1 {
-                current_line += 1; // \n\n adds one extra line
+                source_line_map.push(0); // blank separator line → no annotation
+                current_output_line += 1;
             }
             def
         })
         .collect();
 
-    Ok((texts.join("\n\n"), spans))
+    Ok((texts.join("\n\n"), spans, source_line_map))
 }
 
-/// Recursively collect type definitions with their node kind
-fn collect_type_definitions_with_kinds(
+/// Recursively collect type definitions with node kind AND source start line.
+///
+/// The source start line is `node.start_position().row + 1` (1-indexed).
+fn collect_type_definitions_with_kinds_and_lines(
     node: Node,
     source: &str,
     node_types: &TypeNodeTypes,
-    type_defs: &mut Vec<(String, &'static str)>,
+    type_defs: &mut Vec<(String, &'static str, usize)>,
     depth: usize,
 ) -> Result<()> {
     // SECURITY: Prevent stack overflow from deeply nested or malicious input
@@ -132,14 +171,22 @@ fn collect_type_definitions_with_kinds(
         }
         if let Some(type_def) = extract_type_definition(node, source, node_types)? {
             let static_kind = to_static_node_kind(kind);
-            type_defs.push((type_def, static_kind));
+            // 1-indexed source line where this type definition starts
+            let source_start_line = node.start_position().row + 1;
+            type_defs.push((type_def, static_kind, source_start_line));
         }
         return Ok(());
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_type_definitions_with_kinds(child, source, node_types, type_defs, depth + 1)?;
+        collect_type_definitions_with_kinds_and_lines(
+            child,
+            source,
+            node_types,
+            type_defs,
+            depth + 1,
+        )?;
     }
 
     Ok(())

--- a/crates/rskim-core/src/transform/types.rs
+++ b/crates/rskim-core/src/transform/types.rs
@@ -54,9 +54,10 @@ pub(crate) fn transform_types_with_spans(
     source: &str,
     tree: &Tree,
     language: Language,
-    _config: &crate::TransformConfig,
+    config: &crate::TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
-    let (text, spans, _line_map) = transform_types_with_spans_and_line_map(source, tree, language)?;
+    let (text, spans, _line_map) =
+        transform_types_with_spans_and_line_map(source, tree, language, config)?;
     Ok((text, spans))
 }
 
@@ -74,12 +75,11 @@ pub(crate) fn transform_types_with_spans_and_line_map(
     source: &str,
     tree: &Tree,
     language: Language,
+    _config: &crate::TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown types mode extracts ALL headers (H1-H6)
     if language == Language::Markdown {
-        let (text, spans) = extract_markdown_headers_with_spans(source, tree, 1, 6)?;
-        let line_count = text.lines().count();
-        let line_map = (1..=line_count).collect();
+        let (text, spans, line_map) = extract_markdown_headers_with_spans(source, tree, 1, 6)?;
         return Ok((text, spans, line_map));
     }
 

--- a/crates/rskim-core/src/transform/types.rs
+++ b/crates/rskim-core/src/transform/types.rs
@@ -4,14 +4,12 @@
 //!
 //! Token reduction target: 90-95%
 
+use crate::transform::minimal::MAX_AST_DEPTH;
 use crate::transform::structure::extract_markdown_headers_with_spans;
 use crate::transform::truncate::NodeSpan;
 use crate::transform::utils::to_static_node_kind;
-use crate::{Language, Result, SkimError};
+use crate::{Language, Result, SkimError, TransformConfig};
 use tree_sitter::{Node, Tree};
-
-/// Maximum AST recursion depth to prevent stack overflow attacks
-const MAX_AST_DEPTH: usize = 500;
 
 /// Maximum number of type definitions to prevent memory exhaustion
 const MAX_TYPE_DEFS: usize = 10_000;
@@ -43,7 +41,7 @@ pub(crate) fn transform_types(
     source: &str,
     tree: &Tree,
     language: Language,
-    config: &crate::TransformConfig,
+    config: &TransformConfig,
 ) -> Result<String> {
     let (text, _spans) = transform_types_with_spans(source, tree, language, config)?;
     Ok(text)
@@ -54,7 +52,7 @@ pub(crate) fn transform_types_with_spans(
     source: &str,
     tree: &Tree,
     language: Language,
-    config: &crate::TransformConfig,
+    config: &TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>)> {
     let (text, spans, _line_map) =
         transform_types_with_spans_and_line_map(source, tree, language, config)?;
@@ -75,7 +73,7 @@ pub(crate) fn transform_types_with_spans_and_line_map(
     source: &str,
     tree: &Tree,
     language: Language,
-    _config: &crate::TransformConfig,
+    _config: &TransformConfig,
 ) -> Result<(String, Vec<NodeSpan>, Vec<usize>)> {
     // ARCHITECTURE: Markdown types mode extracts ALL headers (H1-H6)
     if language == Language::Markdown {

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -247,6 +247,91 @@ impl Language {
 
         Ok((result, has_errors))
     }
+
+    /// Transform source code, returning `(content, has_errors, source_line_map)`.
+    ///
+    /// Extended version of `transform_source` that also returns a source line map
+    /// when `config.line_numbers` is true. The source line map maps each output
+    /// line index (0-based) to its 1-indexed source line number; value `0` indicates
+    /// an omission/truncation marker with no line number annotation.
+    ///
+    /// When `config.line_numbers` is false, `source_line_map` is `None`.
+    ///
+    /// # Serde-based languages
+    /// - Full mode: identity map
+    /// - Other modes: `None` (output is restructured, not a line-for-line mapping)
+    ///
+    /// # Passthrough (Full mode, all languages)
+    /// Always returns identity line map when `config.line_numbers` is true.
+    pub(crate) fn transform_source_with_line_map(
+        self,
+        source: &str,
+        config: &TransformConfig,
+    ) -> Result<(String, bool, Option<Vec<usize>>)> {
+        debug_assert!(
+            !(config.max_lines.is_some() && config.last_lines.is_some()),
+            "max_lines and last_lines are mutually exclusive"
+        );
+
+        // Passthrough: Full mode (all languages) or Minimal/Pseudo for
+        // serde-based and Markdown languages (no noise to strip).
+        let is_passthrough = config.mode == Mode::Full
+            || (matches!(config.mode, Mode::Minimal | Mode::Pseudo)
+                && (self.is_serde_based() || self == Self::Markdown));
+
+        if is_passthrough {
+            let text = source.to_string();
+            // Apply last_lines truncation for passthrough paths
+            let text = if let Some(n) = config.last_lines {
+                crate::transform::truncate::simple_last_line_truncate(&text, self, n)?
+            } else {
+                text
+            };
+            let line_map = if config.line_numbers {
+                // Full mode (passthrough): identity map
+                // For serde-based Minimal/Pseudo passthrough: also identity (source is output)
+                let n = text.lines().count();
+                Some((1..=n).collect::<Vec<usize>>())
+            } else {
+                None
+            };
+            return Ok((text, false, line_map));
+        }
+
+        // Serde-based non-full modes: restructured output, no meaningful source line map
+        let is_serde_non_full = self.is_serde_based() && config.mode != Mode::Full;
+        if is_serde_non_full {
+            let (result, has_errors) = self.transform_source(source, config)?;
+            return Ok((result, has_errors, None));
+        }
+
+        // Tree-sitter path (all non-serde languages in Structure/Signatures/Types/Minimal/Pseudo)
+        let mut parser = Parser::new(self)?;
+        let tree = parser.parse(source)?;
+        let parse_errors = tree.root_node().has_error();
+
+        let (result, line_map) =
+            crate::transform::transform_tree_with_line_map(source, &tree, self, config)?;
+
+        // Apply last_lines truncation as a post-processing step
+        let (result, line_map) = if let Some(n) = config.last_lines {
+            let truncated = crate::transform::truncate::simple_last_line_truncate(&result, self, n)?;
+            let final_map = if let Some(ref map) = line_map {
+                // Reconcile the line map after last_lines truncation
+                let reconciled = crate::transform::reconcile_line_map_after_truncation(
+                    &result, &truncated, map,
+                );
+                Some(reconciled)
+            } else {
+                None
+            };
+            (truncated, final_map)
+        } else {
+            (result, line_map)
+        };
+
+        Ok((result, parse_errors, line_map))
+    }
 }
 
 // ============================================================================
@@ -480,6 +565,20 @@ pub struct TransformConfig {
     ///
     /// When None, no last-lines truncation is applied.
     pub last_lines: Option<usize>,
+
+    /// Annotate output with source line numbers.
+    ///
+    /// ARCHITECTURE: Line number formatting is applied at the CLI layer (rskim binary),
+    /// not in the core library. This field is part of `TransformConfig` so it can be
+    /// included in the public API for `transform_with_line_map()`, but the core library
+    /// does NOT apply formatting — it only computes and returns the source line map.
+    ///
+    /// When `true`, `transform_with_line_map()` returns a `Some(Vec<usize>)` source line
+    /// map alongside the transformed text. The CLI applies `{line}\t{content}` formatting.
+    ///
+    /// When `false` (default), the source line map is `None` and no line number
+    /// computation is performed.
+    pub line_numbers: bool,
 }
 
 impl Default for TransformConfig {
@@ -490,6 +589,7 @@ impl Default for TransformConfig {
             cache_enabled: false,
             max_lines: None,
             last_lines: None,
+            line_numbers: false,
         }
     }
 }
@@ -530,6 +630,16 @@ impl TransformConfig {
     /// language-appropriate truncation marker.
     pub fn with_last_lines(mut self, n: usize) -> Self {
         self.last_lines = Some(n);
+        self
+    }
+
+    /// Builder: Enable source line number annotation.
+    ///
+    /// When enabled, `transform_with_line_map()` returns a source line map
+    /// alongside the transformed text. The CLI applies `{line}\t{content}`
+    /// formatting.
+    pub fn with_line_numbers(mut self, enabled: bool) -> Self {
+        self.line_numbers = enabled;
         self
     }
 }

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -281,12 +281,28 @@ impl Language {
 
         if is_passthrough {
             let text = source.to_string();
-            // Apply last_lines truncation for passthrough paths
-            let text = if let Some(n) = config.last_lines {
-                crate::transform::truncate::simple_last_line_truncate(&text, self, n)?
-            } else {
-                text
-            };
+
+            if let Some(n) = config.last_lines {
+                // Build identity map on the ORIGINAL source before truncation,
+                // then reconcile after truncation so content lines retain their
+                // real source line numbers and the truncation marker gets 0.
+                let source_line_count = text.lines().count();
+                let pre_trunc_map: Vec<usize> = (1..=source_line_count).collect();
+                let truncated =
+                    crate::transform::truncate::simple_last_line_truncate(&text, self, n)?;
+                let line_map = if config.line_numbers {
+                    let reconciled = crate::transform::reconcile_line_map_after_truncation(
+                        &text,
+                        &truncated,
+                        &pre_trunc_map,
+                    );
+                    Some(reconciled)
+                } else {
+                    None
+                };
+                return Ok((truncated, false, line_map));
+            }
+
             let line_map = if config.line_numbers {
                 // Full mode (passthrough): identity map
                 // For serde-based Minimal/Pseudo passthrough: also identity (source is output)
@@ -315,12 +331,12 @@ impl Language {
 
         // Apply last_lines truncation as a post-processing step
         let (result, line_map) = if let Some(n) = config.last_lines {
-            let truncated = crate::transform::truncate::simple_last_line_truncate(&result, self, n)?;
+            let truncated =
+                crate::transform::truncate::simple_last_line_truncate(&result, self, n)?;
             let final_map = if let Some(ref map) = line_map {
                 // Reconcile the line map after last_lines truncation
-                let reconciled = crate::transform::reconcile_line_map_after_truncation(
-                    &result, &truncated, map,
-                );
+                let reconciled =
+                    crate::transform::reconcile_line_map_after_truncation(&result, &truncated, map);
                 Some(reconciled)
             } else {
                 None

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -288,8 +288,7 @@ impl Language {
             // Content line i (0-indexed within content) gets source_line:
             //   source_line_count - n_content + 1 + i  (1-indexed)
             let source_line_count = text.lines().count();
-            let truncated =
-                crate::transform::truncate::simple_last_line_truncate(&text, self, n)?;
+            let truncated = crate::transform::truncate::simple_last_line_truncate(&text, self, n)?;
             let line_map = if config.line_numbers {
                 if source_line_count <= n {
                     // No truncation occurred: identity map
@@ -323,8 +322,7 @@ impl Language {
                 // After simple_line_truncate the output is a prefix of the source
                 // (with an optional trailing truncation marker). Build the map by
                 // matching output lines to source lines in order.
-                let map =
-                    crate::transform::compute_line_map_by_text_matching(source, &truncated);
+                let map = crate::transform::compute_line_map_by_text_matching(source, &truncated);
                 Some(map)
             } else {
                 None

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -167,14 +167,9 @@ impl Language {
     /// errors in the source. For serde-based languages and passthrough paths
     /// (Mode::Full) it is always `false` on success.
     ///
-    /// ARCHITECTURE: Encapsulates language-specific parsing strategy.
-    /// - JSON: Uses serde_json parser
-    /// - YAML: Uses serde_yaml_ng parser
-    /// - TOML: Uses toml crate parser
-    /// - Serde-based + Markdown in minimal/pseudo mode: Passthrough (no noise to strip)
-    /// - All others (C, C++, etc.): Use tree-sitter parser
-    ///
-    /// This eliminates special-case conditionals in the main transform function.
+    /// ARCHITECTURE: Delegates to `transform_source_with_line_map`, discarding the
+    /// source line map. All branching logic (passthrough detection, serde delegation,
+    /// parser creation, max_lines/last_lines truncation) lives in a single place.
     ///
     /// # Errors
     /// Returns parsing or transformation errors specific to the language.
@@ -183,69 +178,9 @@ impl Language {
         source: &str,
         config: &TransformConfig,
     ) -> Result<(String, bool)> {
-        debug_assert!(
-            !(config.max_lines.is_some() && config.last_lines.is_some()),
-            "max_lines and last_lines are mutually exclusive"
-        );
-
-        // Passthrough: Full mode (all languages) or Minimal/Pseudo for
-        // serde-based and Markdown languages (no noise to strip).
-        let is_passthrough = config.mode == Mode::Full
-            || (matches!(config.mode, Mode::Minimal | Mode::Pseudo)
-                && (self.is_serde_based() || self == Self::Markdown));
-
-        let (result, tree_sitter_handled, has_errors) = if is_passthrough {
-            (source.to_string(), false, false)
-        } else {
-            // Serde-based languages use their own parsers; tree-sitter languages
-            // handle truncation inside transform_tree.
-            match self {
-                Self::Json => (
-                    crate::transform::json::transform_json(source)?,
-                    false,
-                    false,
-                ),
-                Self::Yaml => (
-                    crate::transform::yaml::transform_yaml(source)?,
-                    false,
-                    false,
-                ),
-                Self::Toml => (
-                    crate::transform::toml::transform_toml(source)?,
-                    false,
-                    false,
-                ),
-                _ => {
-                    let mut parser = Parser::new(self)?;
-                    let tree = parser.parse(source)?;
-                    let parse_errors = tree.root_node().has_error();
-                    let r = crate::transform::transform_tree(source, &tree, self, config)?;
-                    (r, true, parse_errors)
-                }
-            }
-        };
-
-        // Apply max_lines as unified post-processing for non-tree-sitter paths.
-        // Tree-sitter languages handle truncation inside transform_tree via
-        // AST-aware priority selection, so we skip them here.
-        let result = if !tree_sitter_handled {
-            if let Some(max_lines) = config.max_lines {
-                crate::transform::truncate::simple_line_truncate(&result, self, max_lines)?
-            } else {
-                result
-            }
-        } else {
-            result
-        };
-
-        // Apply last_lines truncation as a post-processing step
-        let result = if let Some(n) = config.last_lines {
-            crate::transform::truncate::simple_last_line_truncate(&result, self, n)?
-        } else {
-            result
-        };
-
-        Ok((result, has_errors))
+        let (content, has_errors, _line_map) =
+            self.transform_source_with_line_map(source, config)?;
+        Ok((content, has_errors))
     }
 
     /// Transform source code, returning `(content, has_errors, source_line_map)`.
@@ -321,6 +256,26 @@ impl Language {
                 return Ok((truncated, false, line_map));
             }
 
+            // Apply max_lines truncation for passthrough paths. Tree-sitter languages
+            // handle max_lines inside transform_tree via AST-aware priority selection,
+            // but for passthrough (Full mode or serde/Markdown Minimal/Pseudo) we must
+            // apply it here as a simple line truncation.
+            if let Some(max_lines) = config.max_lines {
+                let truncated =
+                    crate::transform::truncate::simple_line_truncate(&text, self, max_lines)?;
+                let line_map = if config.line_numbers {
+                    // After simple_line_truncate the output is a prefix of the source
+                    // (with an optional trailing truncation marker). Build the map by
+                    // matching output lines to source lines in order.
+                    let map =
+                        crate::transform::compute_line_map_by_text_matching(source, &truncated);
+                    Some(map)
+                } else {
+                    None
+                };
+                return Ok((truncated, false, line_map));
+            }
+
             let line_map = if config.line_numbers {
                 // Full mode (passthrough): identity map
                 // For serde-based Minimal/Pseudo passthrough: also identity (source is output)
@@ -332,10 +287,32 @@ impl Language {
             return Ok((text, false, line_map));
         }
 
-        // Serde-based non-full modes: restructured output, no meaningful source line map
+        // Serde-based non-full modes: restructured output, no meaningful source line map.
+        // ARCHITECTURE: The serde parsers (JSON/YAML/TOML) restructure the content so
+        // there is no per-line source correspondence. We compute the transform inline here
+        // (not via transform_source) to avoid circular delegation now that transform_source
+        // delegates to this function.
         let is_serde_non_full = self.is_serde_based() && config.mode != Mode::Full;
         if is_serde_non_full {
-            let (result, has_errors) = self.transform_source(source, config)?;
+            let (raw_result, has_errors) = match self {
+                Self::Json => (crate::transform::json::transform_json(source)?, false),
+                Self::Yaml => (crate::transform::yaml::transform_yaml(source)?, false),
+                Self::Toml => (crate::transform::toml::transform_toml(source)?, false),
+                // SAFETY: is_serde_based() returns true only for Json/Yaml/Toml.
+                _ => unreachable!("is_serde_based() must only return true for Json/Yaml/Toml"),
+            };
+            // Apply max_lines truncation (no meaningful line map for restructured output).
+            let result = if let Some(max_lines) = config.max_lines {
+                crate::transform::truncate::simple_line_truncate(&raw_result, self, max_lines)?
+            } else {
+                raw_result
+            };
+            // Apply last_lines truncation.
+            let result = if let Some(n) = config.last_lines {
+                crate::transform::truncate::simple_last_line_truncate(&result, self, n)?
+            } else {
+                result
+            };
             return Ok((result, has_errors, None));
         }
 

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -171,6 +171,12 @@ impl Language {
     /// source line map. All branching logic (passthrough detection, serde delegation,
     /// parser creation, max_lines/last_lines truncation) lives in a single place.
     ///
+    /// Line-map computation is gated behind `config.line_numbers`: when that flag is
+    /// `false`, the delegate skips all line-map allocation and returns `None` at zero
+    /// extra cost. Any new line-map logic added to `transform_source_with_line_map`
+    /// MUST therefore be placed inside a `if config.line_numbers { … }` guard so that
+    /// callers that do not need line numbers (i.e. this function) pay no overhead.
+    ///
     /// # Errors
     /// Returns parsing or transformation errors specific to the language.
     pub(crate) fn transform_source(
@@ -215,105 +221,12 @@ impl Language {
                 && (self.is_serde_based() || self == Self::Markdown));
 
         if is_passthrough {
-            let text = source.to_string();
-
-            if let Some(n) = config.last_lines {
-                // ARCHITECTURE: For passthrough (identity transform), build the source
-                // line map directly from arithmetic instead of using
-                // reconcile_line_map_after_truncation. Content-based reconciliation uses
-                // forward scanning which matches duplicate lines (e.g. `}`) to their
-                // FIRST occurrence rather than the correct tail occurrence.
-                //
-                // simple_last_line_truncate produces:
-                //   - If total <= n: unchanged (identity map)
-                //   - If total > n: 1 marker line + (n-1) content lines from the tail
-                //
-                // Marker line gets source_line = 0 (no annotation).
-                // Content line i (0-indexed within content) gets source_line:
-                //   source_line_count - n_content + 1 + i  (1-indexed)
-                let source_line_count = text.lines().count();
-                let truncated =
-                    crate::transform::truncate::simple_last_line_truncate(&text, self, n)?;
-                let line_map = if config.line_numbers {
-                    if source_line_count <= n {
-                        // No truncation occurred: identity map
-                        let count = truncated.lines().count();
-                        Some((1..=count).collect::<Vec<usize>>())
-                    } else {
-                        // Truncation occurred: marker + n_content tail lines
-                        let n_content = n.saturating_sub(1); // lines reserved for content
-                        let start_line = source_line_count - n_content + 1; // 1-indexed
-                        let mut map = Vec::with_capacity(1 + n_content);
-                        map.push(0_usize); // marker line has no annotation
-                        for i in 0..n_content {
-                            map.push(start_line + i);
-                        }
-                        Some(map)
-                    }
-                } else {
-                    None
-                };
-                return Ok((truncated, false, line_map));
-            }
-
-            // Apply max_lines truncation for passthrough paths. Tree-sitter languages
-            // handle max_lines inside transform_tree via AST-aware priority selection,
-            // but for passthrough (Full mode or serde/Markdown Minimal/Pseudo) we must
-            // apply it here as a simple line truncation.
-            if let Some(max_lines) = config.max_lines {
-                let truncated =
-                    crate::transform::truncate::simple_line_truncate(&text, self, max_lines)?;
-                let line_map = if config.line_numbers {
-                    // After simple_line_truncate the output is a prefix of the source
-                    // (with an optional trailing truncation marker). Build the map by
-                    // matching output lines to source lines in order.
-                    let map =
-                        crate::transform::compute_line_map_by_text_matching(source, &truncated);
-                    Some(map)
-                } else {
-                    None
-                };
-                return Ok((truncated, false, line_map));
-            }
-
-            let line_map = if config.line_numbers {
-                // Full mode (passthrough): identity map
-                // For serde-based Minimal/Pseudo passthrough: also identity (source is output)
-                let n = text.lines().count();
-                Some((1..=n).collect::<Vec<usize>>())
-            } else {
-                None
-            };
-            return Ok((text, false, line_map));
+            return self.transform_passthrough_with_line_map(source, config);
         }
 
         // Serde-based non-full modes: restructured output, no meaningful source line map.
-        // ARCHITECTURE: The serde parsers (JSON/YAML/TOML) restructure the content so
-        // there is no per-line source correspondence. We compute the transform inline here
-        // (not via transform_source) to avoid circular delegation now that transform_source
-        // delegates to this function.
-        let is_serde_non_full = self.is_serde_based() && config.mode != Mode::Full;
-        if is_serde_non_full {
-            let (raw_result, has_errors) = match self {
-                Self::Json => (crate::transform::json::transform_json(source)?, false),
-                Self::Yaml => (crate::transform::yaml::transform_yaml(source)?, false),
-                Self::Toml => (crate::transform::toml::transform_toml(source)?, false),
-                // SAFETY: is_serde_based() returns true only for Json/Yaml/Toml.
-                _ => unreachable!("is_serde_based() must only return true for Json/Yaml/Toml"),
-            };
-            // Apply max_lines truncation (no meaningful line map for restructured output).
-            let result = if let Some(max_lines) = config.max_lines {
-                crate::transform::truncate::simple_line_truncate(&raw_result, self, max_lines)?
-            } else {
-                raw_result
-            };
-            // Apply last_lines truncation.
-            let result = if let Some(n) = config.last_lines {
-                crate::transform::truncate::simple_last_line_truncate(&result, self, n)?
-            } else {
-                result
-            };
-            return Ok((result, has_errors, None));
+        if self.is_serde_based() {
+            return self.transform_serde_with_line_map(source, config);
         }
 
         // Tree-sitter path (all non-serde languages in Structure/Signatures/Types/Minimal/Pseudo)
@@ -342,6 +255,128 @@ impl Language {
         };
 
         Ok((result, parse_errors, line_map))
+    }
+
+    /// Passthrough branch of `transform_source_with_line_map`.
+    ///
+    /// Handles Full mode (all languages) and Minimal/Pseudo mode for serde-based /
+    /// Markdown languages where there is nothing structural to strip. The source
+    /// is returned verbatim (subject to `max_lines` / `last_lines` truncation).
+    ///
+    /// Line maps are built arithmetically from source line counts rather than via
+    /// content-based matching to avoid duplicate-line mis-attribution (e.g. `}` matching
+    /// its first occurrence instead of the tail occurrence).
+    fn transform_passthrough_with_line_map(
+        self,
+        source: &str,
+        config: &TransformConfig,
+    ) -> Result<(String, bool, Option<Vec<usize>>)> {
+        let text = source.to_string();
+
+        if let Some(n) = config.last_lines {
+            // ARCHITECTURE: For passthrough (identity transform), build the source
+            // line map directly from arithmetic instead of using
+            // reconcile_line_map_after_truncation. Content-based reconciliation uses
+            // forward scanning which matches duplicate lines (e.g. `}`) to their
+            // FIRST occurrence rather than the correct tail occurrence.
+            //
+            // simple_last_line_truncate produces:
+            //   - If total <= n: unchanged (identity map)
+            //   - If total > n: 1 marker line + (n-1) content lines from the tail
+            //
+            // Marker line gets source_line = 0 (no annotation).
+            // Content line i (0-indexed within content) gets source_line:
+            //   source_line_count - n_content + 1 + i  (1-indexed)
+            let source_line_count = text.lines().count();
+            let truncated =
+                crate::transform::truncate::simple_last_line_truncate(&text, self, n)?;
+            let line_map = if config.line_numbers {
+                if source_line_count <= n {
+                    // No truncation occurred: identity map
+                    let count = truncated.lines().count();
+                    Some((1..=count).collect::<Vec<usize>>())
+                } else {
+                    // Truncation occurred: marker + n_content tail lines
+                    let n_content = n.saturating_sub(1); // lines reserved for content
+                    let start_line = source_line_count - n_content + 1; // 1-indexed
+                    let mut map = Vec::with_capacity(1 + n_content);
+                    map.push(0_usize); // marker line has no annotation
+                    for i in 0..n_content {
+                        map.push(start_line + i);
+                    }
+                    Some(map)
+                }
+            } else {
+                None
+            };
+            return Ok((truncated, false, line_map));
+        }
+
+        // Apply max_lines truncation for passthrough paths. Tree-sitter languages
+        // handle max_lines inside transform_tree via AST-aware priority selection,
+        // but for passthrough (Full mode or serde/Markdown Minimal/Pseudo) we must
+        // apply it here as a simple line truncation.
+        if let Some(max_lines) = config.max_lines {
+            let truncated =
+                crate::transform::truncate::simple_line_truncate(&text, self, max_lines)?;
+            let line_map = if config.line_numbers {
+                // After simple_line_truncate the output is a prefix of the source
+                // (with an optional trailing truncation marker). Build the map by
+                // matching output lines to source lines in order.
+                let map =
+                    crate::transform::compute_line_map_by_text_matching(source, &truncated);
+                Some(map)
+            } else {
+                None
+            };
+            return Ok((truncated, false, line_map));
+        }
+
+        let line_map = if config.line_numbers {
+            // Full mode (passthrough): identity map
+            // For serde-based Minimal/Pseudo passthrough: also identity (source is output)
+            let n = text.lines().count();
+            Some((1..=n).collect::<Vec<usize>>())
+        } else {
+            None
+        };
+        Ok((text, false, line_map))
+    }
+
+    /// Serde branch of `transform_source_with_line_map`.
+    ///
+    /// Handles JSON/YAML/TOML in non-Full modes. The serde parsers restructure
+    /// the content so there is no per-line source correspondence; this function
+    /// always returns `None` for the source line map.
+    ///
+    /// ARCHITECTURE: We call the serde transforms directly here rather than
+    /// re-entering `transform_source` to avoid circular delegation (since
+    /// `transform_source` now delegates to `transform_source_with_line_map`).
+    fn transform_serde_with_line_map(
+        self,
+        source: &str,
+        config: &TransformConfig,
+    ) -> Result<(String, bool, Option<Vec<usize>>)> {
+        let (raw_result, has_errors) = match self {
+            Self::Json => (crate::transform::json::transform_json(source)?, false),
+            Self::Yaml => (crate::transform::yaml::transform_yaml(source)?, false),
+            Self::Toml => (crate::transform::toml::transform_toml(source)?, false),
+            // SAFETY: callers must only invoke this for is_serde_based() languages.
+            _ => unreachable!("transform_serde_with_line_map called for non-serde language"),
+        };
+        // Apply max_lines truncation (no meaningful line map for restructured output).
+        let result = if let Some(max_lines) = config.max_lines {
+            crate::transform::truncate::simple_line_truncate(&raw_result, self, max_lines)?
+        } else {
+            raw_result
+        };
+        // Apply last_lines truncation.
+        let result = if let Some(n) = config.last_lines {
+            crate::transform::truncate::simple_last_line_truncate(&result, self, n)?
+        } else {
+            result
+        };
+        Ok((result, has_errors, None))
     }
 }
 

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -283,20 +283,38 @@ impl Language {
             let text = source.to_string();
 
             if let Some(n) = config.last_lines {
-                // Build identity map on the ORIGINAL source before truncation,
-                // then reconcile after truncation so content lines retain their
-                // real source line numbers and the truncation marker gets 0.
+                // ARCHITECTURE: For passthrough (identity transform), build the source
+                // line map directly from arithmetic instead of using
+                // reconcile_line_map_after_truncation. Content-based reconciliation uses
+                // forward scanning which matches duplicate lines (e.g. `}`) to their
+                // FIRST occurrence rather than the correct tail occurrence.
+                //
+                // simple_last_line_truncate produces:
+                //   - If total <= n: unchanged (identity map)
+                //   - If total > n: 1 marker line + (n-1) content lines from the tail
+                //
+                // Marker line gets source_line = 0 (no annotation).
+                // Content line i (0-indexed within content) gets source_line:
+                //   source_line_count - n_content + 1 + i  (1-indexed)
                 let source_line_count = text.lines().count();
-                let pre_trunc_map: Vec<usize> = (1..=source_line_count).collect();
                 let truncated =
                     crate::transform::truncate::simple_last_line_truncate(&text, self, n)?;
                 let line_map = if config.line_numbers {
-                    let reconciled = crate::transform::reconcile_line_map_after_truncation(
-                        &text,
-                        &truncated,
-                        &pre_trunc_map,
-                    );
-                    Some(reconciled)
+                    if source_line_count <= n {
+                        // No truncation occurred: identity map
+                        let count = truncated.lines().count();
+                        Some((1..=count).collect::<Vec<usize>>())
+                    } else {
+                        // Truncation occurred: marker + n_content tail lines
+                        let n_content = n.saturating_sub(1); // lines reserved for content
+                        let start_line = source_line_count - n_content + 1; // 1-indexed
+                        let mut map = Vec::with_capacity(1 + n_content);
+                        map.push(0_usize); // marker line has no annotation
+                        for i in 0..n_content {
+                            map.push(start_line + i);
+                        }
+                        Some(map)
+                    }
                 } else {
                     None
                 };

--- a/crates/rskim/src/cache.rs
+++ b/crates/rskim/src/cache.rs
@@ -121,21 +121,16 @@ fn cache_key(
     let canonical_path = path.canonicalize()?;
     let mtime_secs = mtime.duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
 
-    fn fmt_opt(opt: Option<usize>) -> String {
-        match opt {
-            Some(n) => n.to_string(),
-            None => "none".to_string(),
-        }
-    }
+    let opt_str = |opt: Option<usize>| opt.map_or("none".to_string(), |n| n.to_string());
 
     let hash_input = format!(
         "{}|{}|{:?}|{}|{}|{}|{}",
         canonical_path.display(),
         mtime_secs,
         mode,
-        fmt_opt(trunc.max_lines),
-        fmt_opt(trunc.last_lines),
-        fmt_opt(trunc.token_budget),
+        opt_str(trunc.max_lines),
+        opt_str(trunc.last_lines),
+        opt_str(trunc.token_budget),
         line_numbers as u8,
     );
 

--- a/crates/rskim/src/cache.rs
+++ b/crates/rskim/src/cache.rs
@@ -186,7 +186,13 @@ pub(crate) fn write_cache(params: &CacheWriteParams<'_>) -> Result<()> {
     let metadata = fs::metadata(params.path)?;
     let mtime = metadata.modified()?;
 
-    let key = cache_key(params.path, mtime, params.mode, &params.trunc, params.line_numbers)?;
+    let key = cache_key(
+        params.path,
+        mtime,
+        params.mode,
+        &params.trunc,
+        params.line_numbers,
+    )?;
     let cache_file = get_cache_dir()?.join(format!("{key}.json"));
 
     let mtime_secs = mtime.duration_since(SystemTime::UNIX_EPOCH)?.as_secs();

--- a/crates/rskim/src/cache.rs
+++ b/crates/rskim/src/cache.rs
@@ -75,6 +75,10 @@ pub(crate) struct CacheWriteParams<'a> {
     pub(crate) effective_mode: Option<Mode>,
     /// Parse quality tier: "full", "degraded", or "passthrough" (diagnostic metadata).
     pub(crate) parse_tier: Option<String>,
+    /// Whether line numbers were applied — part of cache key.
+    ///
+    /// Line-numbered and unnumbered outputs are cached separately because they differ.
+    pub(crate) line_numbers: bool,
 }
 
 /// Returns the platform-specific cache directory (`~/.cache/skim/` on Linux/macOS),
@@ -103,12 +107,16 @@ pub(crate) fn get_cache_dir() -> Result<PathBuf> {
     Ok(cache_dir)
 }
 
-/// Generate cache key from file path, mtime, mode, and truncation options.
+/// Generate cache key from file path, mtime, mode, truncation options, and line_numbers flag.
+///
+/// `line_numbers` is included in the key because line-numbered and unnumbered outputs
+/// differ in content and should be cached independently.
 fn cache_key(
     path: &Path,
     mtime: SystemTime,
     mode: Mode,
     trunc: &TruncationOptions,
+    line_numbers: bool,
 ) -> Result<String> {
     let canonical_path = path.canonicalize()?;
     let mtime_secs = mtime.duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
@@ -121,13 +129,14 @@ fn cache_key(
     }
 
     let hash_input = format!(
-        "{}|{}|{:?}|{}|{}|{}",
+        "{}|{}|{:?}|{}|{}|{}|{}",
         canonical_path.display(),
         mtime_secs,
         mode,
         fmt_opt(trunc.max_lines),
         fmt_opt(trunc.last_lines),
         fmt_opt(trunc.token_budget),
+        line_numbers as u8,
     );
 
     let mut hasher = Sha256::new();
@@ -139,11 +148,16 @@ fn cache_key(
 /// Read cached output if valid (mtime matches).
 ///
 /// Returns a [`CacheHit`] on cache hit, `None` on miss.
-pub(crate) fn read_cache(path: &Path, mode: Mode, trunc: &TruncationOptions) -> Option<CacheHit> {
+pub(crate) fn read_cache(
+    path: &Path,
+    mode: Mode,
+    trunc: &TruncationOptions,
+    line_numbers: bool,
+) -> Option<CacheHit> {
     let metadata = fs::metadata(path).ok()?;
     let mtime = metadata.modified().ok()?;
 
-    let key = cache_key(path, mtime, mode, trunc).ok()?;
+    let key = cache_key(path, mtime, mode, trunc, line_numbers).ok()?;
     let cache_file = get_cache_dir().ok()?.join(format!("{key}.json"));
 
     let cache_content = fs::read_to_string(&cache_file).ok()?;
@@ -172,7 +186,7 @@ pub(crate) fn write_cache(params: &CacheWriteParams<'_>) -> Result<()> {
     let metadata = fs::metadata(params.path)?;
     let mtime = metadata.modified()?;
 
-    let key = cache_key(params.path, mtime, params.mode, &params.trunc)?;
+    let key = cache_key(params.path, mtime, params.mode, &params.trunc, params.line_numbers)?;
     let cache_file = get_cache_dir()?.join(format!("{key}.json"));
 
     let mtime_secs = mtime.duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
@@ -241,12 +255,12 @@ mod tests {
         let default_trunc = TruncationOptions::default();
 
         // Same inputs should produce same key
-        let key1 = cache_key(path, mtime, Mode::Structure, &default_trunc).unwrap();
-        let key2 = cache_key(path, mtime, Mode::Structure, &default_trunc).unwrap();
+        let key1 = cache_key(path, mtime, Mode::Structure, &default_trunc, false).unwrap();
+        let key2 = cache_key(path, mtime, Mode::Structure, &default_trunc, false).unwrap();
         assert_eq!(key1, key2);
 
         // Different mode should produce different key
-        let key3 = cache_key(path, mtime, Mode::Signatures, &default_trunc).unwrap();
+        let key3 = cache_key(path, mtime, Mode::Signatures, &default_trunc, false).unwrap();
         assert_ne!(key1, key3);
 
         // Different max_lines should produce different key
@@ -254,11 +268,11 @@ mod tests {
             max_lines: Some(50),
             ..Default::default()
         };
-        let key4 = cache_key(path, mtime, Mode::Structure, &trunc_max).unwrap();
+        let key4 = cache_key(path, mtime, Mode::Structure, &trunc_max, false).unwrap();
         assert_ne!(key1, key4);
 
         // Same max_lines should produce same key
-        let key5 = cache_key(path, mtime, Mode::Structure, &trunc_max).unwrap();
+        let key5 = cache_key(path, mtime, Mode::Structure, &trunc_max, false).unwrap();
         assert_eq!(key4, key5);
 
         // Different token_budget should produce different key
@@ -266,11 +280,11 @@ mod tests {
             token_budget: Some(500),
             ..Default::default()
         };
-        let key6 = cache_key(path, mtime, Mode::Structure, &trunc_budget).unwrap();
+        let key6 = cache_key(path, mtime, Mode::Structure, &trunc_budget, false).unwrap();
         assert_ne!(key1, key6);
 
         // Same token_budget should produce same key
-        let key7 = cache_key(path, mtime, Mode::Structure, &trunc_budget).unwrap();
+        let key7 = cache_key(path, mtime, Mode::Structure, &trunc_budget, false).unwrap();
         assert_eq!(key6, key7);
 
         // Different max_lines + token_budget combination
@@ -279,7 +293,7 @@ mod tests {
             token_budget: Some(500),
             ..Default::default()
         };
-        let key8 = cache_key(path, mtime, Mode::Structure, &trunc_both).unwrap();
+        let key8 = cache_key(path, mtime, Mode::Structure, &trunc_both, false).unwrap();
         assert_ne!(key4, key8);
         assert_ne!(key6, key8);
 
@@ -288,12 +302,16 @@ mod tests {
             last_lines: Some(10),
             ..Default::default()
         };
-        let key9 = cache_key(path, mtime, Mode::Structure, &trunc_last).unwrap();
+        let key9 = cache_key(path, mtime, Mode::Structure, &trunc_last, false).unwrap();
         assert_ne!(key1, key9);
 
         // Same last_lines should produce same key
-        let key10 = cache_key(path, mtime, Mode::Structure, &trunc_last).unwrap();
+        let key10 = cache_key(path, mtime, Mode::Structure, &trunc_last, false).unwrap();
         assert_eq!(key9, key10);
+
+        // Different line_numbers should produce different key
+        let key11 = cache_key(path, mtime, Mode::Structure, &default_trunc, true).unwrap();
+        assert_ne!(key1, key11);
     }
 
     #[test]
@@ -304,7 +322,7 @@ mod tests {
         let default_trunc = TruncationOptions::default();
 
         // Initially no cache
-        assert!(read_cache(&path, Mode::Structure, &default_trunc).is_none());
+        assert!(read_cache(&path, Mode::Structure, &default_trunc, false).is_none());
 
         // Write to cache with token counts
         let content = "transformed output";
@@ -317,38 +335,39 @@ mod tests {
             trunc: default_trunc,
             effective_mode: None,
             parse_tier: None,
+            line_numbers: false,
         })
         .unwrap();
 
         // Read from cache
-        let hit = read_cache(&path, Mode::Structure, &default_trunc).unwrap();
+        let hit = read_cache(&path, Mode::Structure, &default_trunc, false).unwrap();
         assert_eq!(hit.content, content);
         assert_eq!(hit.original_tokens, Some(100));
         assert_eq!(hit.transformed_tokens, Some(50));
 
         // Different mode should not find cache
-        assert!(read_cache(&path, Mode::Signatures, &default_trunc).is_none());
+        assert!(read_cache(&path, Mode::Signatures, &default_trunc, false).is_none());
 
         // Different max_lines should not find cache
         let trunc_max = TruncationOptions {
             max_lines: Some(50),
             ..Default::default()
         };
-        assert!(read_cache(&path, Mode::Structure, &trunc_max).is_none());
+        assert!(read_cache(&path, Mode::Structure, &trunc_max, false).is_none());
 
         // Different last_lines should not find cache
         let trunc_last = TruncationOptions {
             last_lines: Some(10),
             ..Default::default()
         };
-        assert!(read_cache(&path, Mode::Structure, &trunc_last).is_none());
+        assert!(read_cache(&path, Mode::Structure, &trunc_last, false).is_none());
 
         // Different token_budget should not find cache
         let trunc_budget = TruncationOptions {
             token_budget: Some(500),
             ..Default::default()
         };
-        assert!(read_cache(&path, Mode::Structure, &trunc_budget).is_none());
+        assert!(read_cache(&path, Mode::Structure, &trunc_budget, false).is_none());
     }
 
     #[test]
@@ -363,7 +382,7 @@ mod tests {
         };
 
         // No cache initially
-        assert!(read_cache(&path, Mode::Structure, &trunc).is_none());
+        assert!(read_cache(&path, Mode::Structure, &trunc, false).is_none());
 
         // Write with token_budget
         write_cache(&CacheWriteParams {
@@ -375,28 +394,29 @@ mod tests {
             trunc,
             effective_mode: None,
             parse_tier: None,
+            line_numbers: false,
         })
         .unwrap();
 
         // Read with same token_budget succeeds
-        let hit = read_cache(&path, Mode::Structure, &trunc).unwrap();
+        let hit = read_cache(&path, Mode::Structure, &trunc, false).unwrap();
         assert_eq!(hit.content, "budget-transformed output");
         assert_eq!(hit.original_tokens, Some(200));
         assert_eq!(hit.transformed_tokens, Some(80));
 
         // Read without token_budget misses (different cache key)
         let default_trunc = TruncationOptions::default();
-        assert!(read_cache(&path, Mode::Structure, &default_trunc).is_none());
+        assert!(read_cache(&path, Mode::Structure, &default_trunc, false).is_none());
 
         // Read with different token_budget misses
         let trunc_1000 = TruncationOptions {
             token_budget: Some(1000),
             ..Default::default()
         };
-        assert!(read_cache(&path, Mode::Structure, &trunc_1000).is_none());
+        assert!(read_cache(&path, Mode::Structure, &trunc_1000, false).is_none());
 
         // Read with same budget + different mode misses
-        assert!(read_cache(&path, Mode::Signatures, &trunc).is_none());
+        assert!(read_cache(&path, Mode::Signatures, &trunc, false).is_none());
     }
 
     #[test]
@@ -420,11 +440,12 @@ mod tests {
             trunc,
             effective_mode: Some(Mode::Signatures),
             parse_tier: None,
+            line_numbers: false,
         })
         .unwrap();
 
         // Read back succeeds (effective_mode is diagnostic-only, not part of CacheHit)
-        let hit = read_cache(&path, Mode::Structure, &trunc).unwrap();
+        let hit = read_cache(&path, Mode::Structure, &trunc, false).unwrap();
         assert_eq!(hit.content, "escalated output");
         assert_eq!(hit.original_tokens, Some(150));
         assert_eq!(hit.transformed_tokens, Some(60));
@@ -432,7 +453,7 @@ mod tests {
         // Verify the effective_mode field was serialized in the raw JSON
         let metadata = fs::metadata(&path).unwrap();
         let mtime = metadata.modified().unwrap();
-        let key = cache_key(&path, mtime, Mode::Structure, &trunc).unwrap();
+        let key = cache_key(&path, mtime, Mode::Structure, &trunc, false).unwrap();
         let cache_file = get_cache_dir().unwrap().join(format!("{key}.json"));
         let raw_json = fs::read_to_string(&cache_file).unwrap();
         let raw: serde_json::Value = serde_json::from_str(&raw_json).unwrap();
@@ -469,9 +490,10 @@ mod tests {
             trunc: default_trunc,
             effective_mode: None,
             parse_tier: None,
+            line_numbers: false,
         })
         .unwrap();
-        let hit = read_cache(&path, Mode::Structure, &default_trunc).unwrap();
+        let hit = read_cache(&path, Mode::Structure, &default_trunc, false).unwrap();
         assert_eq!(hit.content, "cached v1");
 
         // Sleep to ensure mtime resolution (some filesystems have 1-second resolution)
@@ -485,6 +507,6 @@ mod tests {
         }
 
         // Cache should be invalidated (mtime changed)
-        assert!(read_cache(&path, Mode::Structure, &default_trunc).is_none());
+        assert!(read_cache(&path, Mode::Structure, &default_trunc, false).is_none());
     }
 }

--- a/crates/rskim/src/cascade.rs
+++ b/crates/rskim/src/cascade.rs
@@ -25,9 +25,23 @@ pub(crate) struct TruncationOptions {
 const NO_OUTPUT_MSG: &str = "Token budget cascade: no transformation mode produced output. \
     Ensure the file is in a supported language or specify --language.";
 
-/// Build a `TransformConfig` from mode and truncation options.
+/// Build a `TransformConfig` from mode, truncation options, and line number flag.
+///
+/// The `line_numbers` parameter controls whether the config requests a source line
+/// map from `transform_with_line_map`. When building configs for token-budget cascade
+/// mode selection, `line_numbers` should be `false` (line numbers are applied after
+/// mode selection is complete).
 pub(crate) fn build_config(mode: Mode, trunc: &TruncationOptions) -> TransformConfig {
-    let mut config = TransformConfig::with_mode(mode);
+    build_config_with_opts(mode, trunc, false)
+}
+
+/// Build a `TransformConfig` with explicit line_numbers flag.
+pub(crate) fn build_config_with_opts(
+    mode: Mode,
+    trunc: &TruncationOptions,
+    line_numbers: bool,
+) -> TransformConfig {
+    let mut config = TransformConfig::with_mode(mode).with_line_numbers(line_numbers);
     if let Some(n) = trunc.max_lines {
         config = config.with_max_lines(n);
     }

--- a/crates/rskim/src/cmd/init/helpers.rs
+++ b/crates/rskim/src/cmd/init/helpers.rs
@@ -134,35 +134,51 @@ pub(super) fn atomic_write_settings(
 
 /// Generate the skim guidance section content with version markers.
 ///
-/// This is a short (~300 token), self-contained preamble that tells agents
-/// skim is available for structural code exploration. Uses `skim` (or
-/// `rskim` as fallback) via Bash. Framed as strong directives, not soft
-/// suggestions, to maximise adoption across all agent sessions.
+/// Intent-based decision table that helps agents pick the right tool once
+/// per file, avoiding the wasteful skim-then-Read anti-pattern.
 pub(super) fn guidance_content(version: &str) -> String {
     format!(
         r#"<!-- skim-start v{version} -->
 ## Skim — Context-Optimized Code Reading
 
-**IMPORTANT**: `skim` is installed and a rewrite hook is active that automatically
-optimizes shell commands. For explicit use, call `skim` via Bash (or `rskim` if
-`skim` is not in PATH).
+`skim` is installed and a rewrite hook is active that automatically optimizes
+shell commands. For explicit use, call `skim` via Bash (or `rskim`).
 
-### Rules
+### What skim shows
 
-1. **ALWAYS prefer `skim <file>` over Read** when exploring or understanding code —
-   60-80% fewer tokens with the same structural insight.
-2. Use `skim <file> --mode=signatures` for API surfaces and interface discovery.
-3. Use `skim 'src/**/*.ts'` for scanning directories or multi-file exploration.
-4. **Use Read only when**:
-   - You need exact line content for an Edit operation
-   - You need a specific small section (< 50 lines) you will modify next
-   - The file is non-code (images, binary)
+Skim strips function/method bodies and preserves structure, signatures, types,
+and doc comments. Output has **no line numbers**. It shows *what exists* in a
+file — not *how it works*.
+
+### Choose ONE tool per file
+
+Before touching a file, decide your intent — then use the right tool once.
+
+| Intent | Tool | Why |
+|--------|------|-----|
+| **List files** — "what files exist here?" | `ls` or Glob | Cheapest — names only, no content |
+| **Survey structure** — "what's in this file?" | `skim <file>` | Structure at 60-80% fewer tokens |
+| **Find the right file** — narrowing candidates | `skim 'src/**/*.ts'` | Peeks inside each file cheaply. Use ls/Glob first if names suffice |
+| **API surface** — "what can I call?" | `skim --mode=signatures` | Function/method signatures only |
+| **Understand logic** — "how does X work?" | Read (targeted range) | Skim strips the bodies you need |
+| **Edit a file** — you will modify it | Read (section to edit) | Need exact lines + line numbers for Edit |
+| **Debug/trace** — following control flow | Read (targeted range) | Implementation details matter |
+
+### Anti-pattern: skim then Read the same file
+
+**Never skim a file and then Read the same file.** This wastes more tokens than
+either tool alone. Pick one:
+- If you might need bodies or line numbers → skip skim, go straight to Read.
+- If you only need structure/signatures → skim it and move on.
+
+The only valid skim→Read sequence is across **different files**: skim a directory
+to find the right file, then Read that one file.
 
 ### Quick Reference
 
 ```
-skim <file>                    # structural overview (default)
-skim <file> --mode=signatures  # API surface only
+skim <file>                    # structural overview (strips bodies)
+skim <file> --mode=signatures  # function/method signatures only
 skim 'src/**/*.ts'             # multi-file scan
 ```
 <!-- skim-end -->"#,
@@ -176,7 +192,7 @@ skim 'src/**/*.ts'             # multi-file scan
 pub(super) fn guidance_content_mdc(version: &str) -> String {
     let body = guidance_content(version);
     format!(
-        "---\ndescription: \"skim — ALWAYS use skim over Read for code exploration\"\nalwaysApply: true\n---\n\n{body}"
+        "---\ndescription: \"skim — context-optimized code reading for AI agents\"\nalwaysApply: true\n---\n\n{body}"
     )
 }
 
@@ -276,9 +292,9 @@ mod tests {
         assert!(content.ends_with("<!-- skim-end -->"));
         // Version appears in the skim-start marker
         assert!(content.contains("v2.1.0"));
-        // Strong directive language
-        assert!(content.contains("ALWAYS prefer"));
-        assert!(content.contains("Use Read only when"));
+        // Intent-based guidance
+        assert!(content.contains("Choose ONE tool per file"));
+        assert!(content.contains("Anti-pattern: skim then Read"));
         // SKIM_PASSTHROUGH is NOT documented in guidance — agents learn about it
         // from stderr hints emitted on compressed non-zero exits (shared.rs, mod.rs).
         assert!(!content.contains("SKIM_PASSTHROUGH"));

--- a/crates/rskim/src/cmd/init/helpers.rs
+++ b/crates/rskim/src/cmd/init/helpers.rs
@@ -147,8 +147,9 @@ shell commands. For explicit use, call `skim` via Bash (or `rskim`).
 ### What skim shows
 
 Skim strips function/method bodies and preserves structure, signatures, types,
-and doc comments. Output has **no line numbers**. It shows *what exists* in a
-file — not *how it works*.
+and doc comments. It shows *what exists* in a file — not *how it works*.
+Use `-n` / `--line-numbers` to annotate each output line with its original
+source line number (tab-separated: `{{line}}\t{{content}}`).
 
 ### Choose ONE tool per file
 
@@ -161,23 +162,25 @@ Before touching a file, decide your intent — then use the right tool once.
 | **Find the right file** — narrowing candidates | `skim 'src/**/*.ts'` | Peeks inside each file cheaply. Use ls/Glob first if names suffice |
 | **API surface** — "what can I call?" | `skim --mode=signatures` | Function/method signatures only |
 | **Understand logic** — "how does X work?" | Read (targeted range) | Skim strips the bodies you need |
-| **Edit a file** — you will modify it | Read (section to edit) | Need exact lines + line numbers for Edit |
+| **Edit a file** — you will modify it | `skim -n <file>` then Read (section) | `-n` gives source line numbers; Read only the section you need |
 | **Debug/trace** — following control flow | Read (targeted range) | Implementation details matter |
 
 ### Anti-pattern: skim then Read the same file
 
-**Never skim a file and then Read the same file.** This wastes more tokens than
-either tool alone. Pick one:
-- If you might need bodies or line numbers → skip skim, go straight to Read.
+**Avoid skimming a file and then Reading the same file** unless `-n` is involved.
+This wastes more tokens than either tool alone. Pick one:
+- If you need bodies but not line numbers → go straight to Read.
 - If you only need structure/signatures → skim it and move on.
+- If you need structure AND line numbers for editing → `skim -n <file>`, then Read only the narrow range you will modify.
 
-The only valid skim→Read sequence is across **different files**: skim a directory
-to find the right file, then Read that one file.
+The only valid skim→Read sequence without `-n` is across **different files**:
+skim a directory to find the right file, then Read that one file.
 
 ### Quick Reference
 
 ```
 skim <file>                    # structural overview (strips bodies)
+skim -n <file>                 # structural overview with source line numbers
 skim <file> --mode=signatures  # function/method signatures only
 skim 'src/**/*.ts'             # multi-file scan
 ```

--- a/crates/rskim/src/format.rs
+++ b/crates/rskim/src/format.rs
@@ -1,0 +1,162 @@
+//! Line number formatting for `--line-numbers` / `-n` flag.
+//!
+//! ARCHITECTURE: Line number formatting is applied at the CLI layer, AFTER the
+//! guardrail check and BEFORE cache write. The core library (`rskim-core`) remains
+//! pure — it computes source line maps but does NOT apply formatting.
+//!
+//! # Format
+//!
+//! Each output line is formatted as `{source_line}\t{content}` (tab-separated,
+//! no fixed-width padding). Lines whose source line map value is `0` (omission
+//! markers, truncation markers) are emitted without a line number prefix.
+//!
+//! # Design Decision (AC-18)
+//!
+//! Tab-separated format (`{line}\t{content}`) was chosen over space-padded format
+//! (`{line:4} {content}`) because:
+//! - LLMs consume the line number token once and move on; padding wastes tokens.
+//! - Tab-separated is easy to parse programmatically (`split('\t', 2)`).
+//! - No fixed-width means line 1 and line 1000 take the same format.
+//! - Omission/truncation markers have NO prefix — agents can identify gaps naturally.
+
+/// Format transformed output with source line number annotations.
+///
+/// # Arguments
+/// * `text` - The transformed output text (possibly with trailing newline)
+/// * `source_line_map` - One entry per output line. Value is the 1-indexed source
+///   line number, or `0` for omission/truncation markers (no prefix emitted).
+///
+/// # Returns
+/// Formatted text where each line is prefixed with `{source_line}\t`, except
+/// lines with a map value of `0` which are emitted verbatim. Trailing newline
+/// is preserved if the input has one.
+///
+/// # Panics
+/// Does not panic. If `source_line_map` is shorter than the number of output
+/// lines, remaining lines are treated as having source line 0 (no prefix).
+pub(crate) fn format_with_line_numbers(text: &str, source_line_map: &[usize]) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let trailing_newline = text.ends_with('\n');
+    let lines: Vec<&str> = text.lines().collect();
+
+    if lines.is_empty() {
+        return if trailing_newline {
+            "\n".to_string()
+        } else {
+            String::new()
+        };
+    }
+
+    let mut result = String::with_capacity(text.len() + lines.len() * 4);
+
+    for (i, line) in lines.iter().enumerate() {
+        let source_line = source_line_map.get(i).copied().unwrap_or(0);
+        if source_line == 0 {
+            // Omission/truncation marker — emit without prefix
+            result.push_str(line);
+        } else {
+            // Normal content line — emit with "{source_line}\t" prefix
+            result.push_str(&source_line.to_string());
+            result.push('\t');
+            result.push_str(line);
+        }
+        result.push('\n');
+    }
+
+    // If the input did not end with a newline, remove the trailing newline we added
+    if !trailing_newline && result.ends_with('\n') {
+        result.pop();
+    }
+
+    result
+}
+
+/// Build an identity source line map for full-mode output.
+///
+/// Full mode is a passthrough — output line N corresponds to source line N.
+/// Returns a vector of `[1, 2, 3, ..., n]` where `n` is the number of output lines.
+pub(crate) fn identity_line_map(output: &str) -> Vec<usize> {
+    let n = output.lines().count();
+    (1..=n).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_empty_input() {
+        let result = format_with_line_numbers("", &[]);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_format_single_line_with_trailing_newline() {
+        let result = format_with_line_numbers("type A = string;\n", &[3]);
+        assert_eq!(result, "3\ttype A = string;\n");
+    }
+
+    #[test]
+    fn test_format_single_line_without_trailing_newline() {
+        let result = format_with_line_numbers("type A = string;", &[1]);
+        assert_eq!(result, "1\ttype A = string;");
+    }
+
+    #[test]
+    fn test_format_multiple_lines() {
+        let text = "type A = string;\ntype B = number;\n";
+        let map = vec![2, 5];
+        let result = format_with_line_numbers(text, &map);
+        assert_eq!(result, "2\ttype A = string;\n5\ttype B = number;\n");
+    }
+
+    #[test]
+    fn test_format_omission_marker_has_no_prefix() {
+        // Map value 0 means omission marker — no prefix
+        let text = "type A = string;\n// ...\ntype B = number;\n";
+        let map = vec![1, 0, 5]; // middle line is omission marker
+        let result = format_with_line_numbers(text, &map);
+        assert_eq!(result, "1\ttype A = string;\n// ...\n5\ttype B = number;\n");
+    }
+
+    #[test]
+    fn test_format_short_map_uses_zero_for_remaining() {
+        // If map is shorter than lines, remaining lines get 0 (no prefix)
+        let text = "line 1\nline 2\nline 3\n";
+        let map = vec![1]; // only one entry
+        let result = format_with_line_numbers(text, &map);
+        assert_eq!(result, "1\tline 1\nline 2\nline 3\n");
+    }
+
+    #[test]
+    fn test_format_tab_separated_no_fixed_width() {
+        // Line 10 should be "10\t..." not " 10\t..."
+        let text = "const x = 1;\n";
+        let map = vec![10];
+        let result = format_with_line_numbers(text, &map);
+        assert_eq!(result, "10\tconst x = 1;\n");
+        assert!(!result.starts_with(' '), "Should not have leading space");
+    }
+
+    #[test]
+    fn test_identity_line_map() {
+        let output = "line 1\nline 2\nline 3\n";
+        let map = identity_line_map(output);
+        assert_eq!(map, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_identity_line_map_empty() {
+        let map = identity_line_map("");
+        assert_eq!(map, Vec::<usize>::new());
+    }
+
+    #[test]
+    fn test_identity_line_map_single_line() {
+        let map = identity_line_map("hello\n");
+        assert_eq!(map, vec![1]);
+    }
+}

--- a/crates/rskim/src/format.rs
+++ b/crates/rskim/src/format.rs
@@ -35,6 +35,8 @@
 /// Does not panic. If `source_line_map` is shorter than the number of output
 /// lines, remaining lines are treated as having source line 0 (no prefix).
 pub(crate) fn format_with_line_numbers(text: &str, source_line_map: &[usize]) -> String {
+    use std::fmt::Write;
+
     if text.is_empty() {
         return String::new();
     }
@@ -59,8 +61,8 @@ pub(crate) fn format_with_line_numbers(text: &str, source_line_map: &[usize]) ->
             result.push_str(line);
         } else {
             // Normal content line — emit with "{source_line}\t" prefix
-            result.push_str(&source_line.to_string());
-            result.push('\t');
+            // write! to String is infallible; avoid temporary String from to_string()
+            let _ = write!(result, "{}\t", source_line);
             result.push_str(line);
         }
         result.push('\n');

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -14,6 +14,7 @@ mod cache;
 mod cascade;
 mod cmd;
 mod debug;
+mod format;
 mod multi;
 mod output;
 mod process;
@@ -294,6 +295,16 @@ struct Args {
     )]
     tokens: Option<usize>,
 
+    /// Annotate output with original source line numbers.
+    ///
+    /// Each output line is prefixed with its 1-indexed source line number and a tab:
+    /// `{source_line}\t{content}`. Omission/truncation markers have no prefix.
+    ///
+    /// Useful when you need line numbers for Edit operations but want to survey
+    /// structure first: `skim file.ts -n` gives both structure AND line numbers.
+    #[arg(short = 'n', long, help = "Annotate output with original source line numbers")]
+    line_numbers: bool,
+
     /// Disable analytics recording for this invocation
     #[arg(long, help = "Disable analytics recording")]
     disable_analytics: bool,
@@ -532,6 +543,7 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
             last_lines: args.last_lines,
             token_budget: args.tokens,
         },
+        line_numbers: args.line_numbers,
     };
 
     if file == "-" {

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -302,7 +302,11 @@ struct Args {
     ///
     /// Useful when you need line numbers for Edit operations but want to survey
     /// structure first: `skim file.ts -n` gives both structure AND line numbers.
-    #[arg(short = 'n', long, help = "Annotate output with original source line numbers")]
+    #[arg(
+        short = 'n',
+        long,
+        help = "Annotate output with original source line numbers"
+    )]
     line_numbers: bool,
 
     /// Disable analytics recording for this invocation

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -381,8 +381,12 @@ pub(crate) fn process_stdin(
         };
 
     // Apply line number formatting AFTER guardrail, BEFORE token stats.
-    let final_output =
-        apply_line_numbers(final_output, options.line_numbers, guardrail_triggered, stdin_line_map);
+    let final_output = apply_line_numbers(
+        final_output,
+        options.line_numbers,
+        guardrail_triggered,
+        stdin_line_map,
+    );
 
     // Only pay the tiktoken BPE cost on the main thread when --show-stats
     // is set. Analytics background threads compute their own token counts.
@@ -428,8 +432,12 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
 
     // Apply line number formatting AFTER guardrail, BEFORE cache write and token stats.
     // AC-12: Cache key includes line_numbers (handled in cache::read_cache/write_cache).
-    let final_output =
-        apply_line_numbers(final_output, options.line_numbers, guardrail_triggered, line_map);
+    let final_output = apply_line_numbers(
+        final_output,
+        options.line_numbers,
+        guardrail_triggered,
+        line_map,
+    );
 
     // Only pay the tiktoken BPE cost on the main thread when --show-stats
     // is set. Analytics background threads compute their own token counts.

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -71,6 +71,39 @@ pub(crate) fn parse_tier_from(mode: Mode, has_errors: bool) -> &'static str {
     }
 }
 
+/// Apply line number annotations to `output` after the guardrail decision.
+///
+/// When `guardrail_triggered` is true the output is raw source, so an identity
+/// map is used.  When `computed_map` is `Some`, it is used directly.
+///
+/// When `computed_map` is `None` (serde non-full modes, or language detection
+/// failure), line numbers are **skipped** because the output is restructured
+/// and has no meaningful line-for-line correspondence with the original source.
+///
+/// AC-11: Identity map is applied when guardrail emits raw source.
+/// AC-15: Serde non-full modes skip line numbers (computed_map is None).
+pub(crate) fn apply_line_numbers(
+    output: String,
+    line_numbers: bool,
+    guardrail_triggered: bool,
+    computed_map: Option<Vec<usize>>,
+) -> String {
+    if !line_numbers {
+        return output;
+    }
+    if guardrail_triggered {
+        // Guardrail emitted raw source — use identity map
+        let map = crate::format::identity_line_map(&output);
+        return crate::format::format_with_line_numbers(&output, &map);
+    }
+    match computed_map {
+        Some(map) => crate::format::format_with_line_numbers(&output, &map),
+        // No line map available (serde non-full, language detection failure):
+        // skip annotation — restructured output has no source correspondence.
+        None => output,
+    }
+}
+
 /// Count tokens for both original and transformed text, returning `(None, None)` on failure.
 ///
 /// Centralises the paired token-counting pattern used across the processing pipeline.
@@ -347,20 +380,9 @@ pub(crate) fn process_stdin(
             (transformed, false)
         };
 
-    // Apply line number formatting AFTER guardrail.
-    // AC-11: If guardrail triggered (raw source), apply identity line map.
-    let final_output = if options.line_numbers {
-        let map = if guardrail_triggered {
-            crate::format::identity_line_map(&final_output)
-        } else if let Some(m) = stdin_line_map {
-            m
-        } else {
-            crate::format::identity_line_map(&final_output)
-        };
-        crate::format::format_with_line_numbers(&final_output, &map)
-    } else {
-        final_output
-    };
+    // Apply line number formatting AFTER guardrail, BEFORE token stats.
+    let final_output =
+        apply_line_numbers(final_output, options.line_numbers, guardrail_triggered, stdin_line_map);
 
     // Only pay the tiktoken BPE cost on the main thread when --show-stats
     // is set. Analytics background threads compute their own token counts.
@@ -405,22 +427,9 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
         };
 
     // Apply line number formatting AFTER guardrail, BEFORE cache write and token stats.
-    // AC-11: If guardrail triggered (raw source), apply identity line map.
     // AC-12: Cache key includes line_numbers (handled in cache::read_cache/write_cache).
-    let final_output = if options.line_numbers {
-        let map = if guardrail_triggered {
-            // Guardrail emitted raw source — use identity map
-            crate::format::identity_line_map(&final_output)
-        } else if let Some(m) = line_map {
-            m
-        } else {
-            // Fallback: identity map (language detection failed or serde non-full mode)
-            crate::format::identity_line_map(&final_output)
-        };
-        crate::format::format_with_line_numbers(&final_output, &map)
-    } else {
-        final_output
-    };
+    let final_output =
+        apply_line_numbers(final_output, options.line_numbers, guardrail_triggered, line_map);
 
     // Only pay the tiktoken BPE cost on the main thread when --show-stats
     // is set. Analytics background threads compute their own token counts.

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use rskim_core::{
     detect_language_from_path, transform_auto_with_config, transform_with_config,
-    transform_with_quality, Language, Mode, TransformConfig,
+    transform_with_line_map, Language, Mode, TransformConfig,
 };
 
 use crate::{cache, cascade, cascade::TruncationOptions, tokens};
@@ -30,6 +30,8 @@ pub(crate) struct ProcessOptions {
     pub(crate) show_stats: bool,
     /// Truncation options (max_lines, last_lines, token_budget)
     pub(crate) trunc: TruncationOptions,
+    /// Whether to annotate output with source line numbers (`--line-numbers` / `-n`)
+    pub(crate) line_numbers: bool,
 }
 
 /// Result of processing a file
@@ -130,7 +132,8 @@ fn try_cached_result(
         return Ok(None);
     }
 
-    let Some(hit) = cache::read_cache(path, options.mode, &options.trunc) else {
+    let Some(hit) = cache::read_cache(path, options.mode, &options.trunc, options.line_numbers)
+    else {
         return Ok(None);
     };
 
@@ -172,16 +175,20 @@ fn read_and_validate(path: &Path) -> anyhow::Result<String> {
 /// Transform file contents, trying auto-detection first and falling back to
 /// `explicit_lang` when provided.
 ///
-/// Returns `(transformed_output, mode_used, has_errors)` where `has_errors`
-/// reflects whether the parser encountered syntax errors. For cascade paths
-/// (token_budget is set) `has_errors` is always `false` because the cascade
-/// does not have access to per-mode quality signals.
+/// Returns `(transformed_output, mode_used, has_errors, source_line_map)` where:
+/// - `has_errors` reflects whether the parser encountered syntax errors
+/// - `source_line_map` is `Some(map)` when `options.line_numbers` is true and the
+///   transform produced a meaningful source line map; `None` otherwise
+///
+/// For cascade paths (token_budget is set) `has_errors` is always `false` and
+/// line numbers are applied after mode selection.
 fn run_transform(
     contents: &str,
     path: &Path,
     options: &ProcessOptions,
-) -> anyhow::Result<(String, Mode, bool)> {
+) -> anyhow::Result<(String, Mode, bool, Option<Vec<usize>>)> {
     let explicit_lang = options.explicit_lang;
+    // Non-line-number transform closure (used for cascade mode selection)
     let transform_file = |config: &TransformConfig| -> anyhow::Result<Option<String>> {
         // Try auto-detection first; fall back to explicit language if provided.
         let auto_result = transform_auto_with_config(contents, path, config);
@@ -206,6 +213,8 @@ fn run_transform(
                     Language::TypeScript
                 });
 
+            // AC-10: Token counting for mode selection does NOT include line number annotations.
+            // Run cascade WITHOUT line_numbers to select the best mode.
             let (output, mode) = cascade::cascade_for_token_budget(
                 options.mode,
                 &options.trunc,
@@ -213,24 +222,40 @@ fn run_transform(
                 language,
                 transform_file,
             )?;
-            // Cascade selects the best-fitting mode; has_errors is not tracked
-            // per-mode during cascade (mode escalation already handles degraded output).
-            Ok((output, mode, false))
+
+            // If line numbers requested, re-run the selected mode WITH line_numbers.
+            let line_map = if options.line_numbers {
+                let config = cascade::build_config_with_opts(mode, &options.trunc, true);
+                let (_rerun_output, _has_errors, map) =
+                    transform_with_line_map(contents, language, &config)?;
+                map
+            } else {
+                None
+            };
+
+            Ok((output, mode, false, line_map))
         }
         None => {
             let language = explicit_lang.or_else(|| detect_language_from_path(path));
-            let config = cascade::build_config(options.mode, &options.trunc);
 
-            // Use transform_with_quality when we can identify the language to get has_errors.
+            // Use transform_with_line_map when we can identify the language
             if let Some(lang) = language {
-                let (output, has_errors) = transform_with_quality(contents, lang, &config)?;
-                Ok((output, options.mode, has_errors))
+                let config = cascade::build_config_with_opts(
+                    options.mode,
+                    &options.trunc,
+                    options.line_numbers,
+                );
+                let (output, has_errors, line_map) =
+                    transform_with_line_map(contents, lang, &config)?;
+                Ok((output, options.mode, has_errors, line_map))
             } else {
                 // Language detection failed — try auto-detect via path extension.
+                // Can't get line map without a known language.
+                let config = cascade::build_config(options.mode, &options.trunc);
                 let output = transform_file(&config)?.ok_or_else(|| {
                     anyhow::anyhow!("Language detection failed and no --language specified")
                 })?;
-                Ok((output, options.mode, false))
+                Ok((output, options.mode, false, None))
             }
         }
     }
@@ -279,22 +304,34 @@ pub(crate) fn process_stdin(
         }
     })?;
 
-    let (transformed, stdin_has_errors) = match options.trunc.token_budget {
+    let (transformed, stdin_has_errors, stdin_line_map) = match options.trunc.token_budget {
         Some(budget) => {
-            let (output, _mode) = cascade::cascade_for_token_budget(
+            // AC-10: Cascade mode selection without line numbers, then re-run with line numbers
+            let (output, mode) = cascade::cascade_for_token_budget(
                 options.mode,
                 &options.trunc,
                 budget,
                 language,
                 |config| Ok(Some(transform_with_config(&buffer, language, config)?)),
             )?;
-            // Cascade path does not track per-mode has_errors (mode escalation handles it).
-            (output, false)
+            let line_map = if options.line_numbers {
+                let config = cascade::build_config_with_opts(mode, &options.trunc, true);
+                let (_rerun, _errs, map) = transform_with_line_map(&buffer, language, &config)?;
+                map
+            } else {
+                None
+            };
+            (output, false, line_map)
         }
         None => {
-            let config = cascade::build_config(options.mode, &options.trunc);
-            let (output, has_errors) = transform_with_quality(&buffer, language, &config)?;
-            (output, has_errors)
+            let config = cascade::build_config_with_opts(
+                options.mode,
+                &options.trunc,
+                options.line_numbers,
+            );
+            let (output, has_errors, line_map) =
+                transform_with_line_map(&buffer, language, &config)?;
+            (output, has_errors, line_map)
         }
     };
 
@@ -303,7 +340,7 @@ pub(crate) fn process_stdin(
 
     // Apply output guardrail: if compressed output is larger than raw, emit raw instead.
     // Same protection as process_file; token counting happens after so stats reflect
-    // the final output.
+    // the final output. Guardrail comparison uses UN-annotated output.
     let (final_output, guardrail_triggered) =
         if options.mode != Mode::Full && options.trunc.token_budget.is_none() {
             let outcome = crate::output::guardrail::apply_to_stderr(buffer.clone(), transformed)?;
@@ -312,6 +349,21 @@ pub(crate) fn process_stdin(
         } else {
             (transformed, false)
         };
+
+    // Apply line number formatting AFTER guardrail.
+    // AC-11: If guardrail triggered (raw source), apply identity line map.
+    let final_output = if options.line_numbers {
+        let map = if guardrail_triggered {
+            crate::format::identity_line_map(&final_output)
+        } else if let Some(m) = stdin_line_map {
+            m
+        } else {
+            crate::format::identity_line_map(&final_output)
+        };
+        crate::format::format_with_line_numbers(&final_output, &map)
+    } else {
+        final_output
+    };
 
     // Only pay the tiktoken BPE cost on the main thread when --show-stats
     // is set. Analytics background threads compute their own token counts.
@@ -337,7 +389,7 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
     }
 
     let contents = read_and_validate(path)?;
-    let (result, mode_used, has_errors) = run_transform(&contents, path, &options)?;
+    let (result, mode_used, has_errors, line_map) = run_transform(&contents, path, &options)?;
 
     // Determine parse quality tier before guardrail (guardrail may swap output,
     // but the parse tier reflects the transformation, not the final selection).
@@ -345,6 +397,7 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
 
     // Apply output guardrail: if compressed output is larger than raw, emit raw instead.
     // Token counting happens AFTER this decision so stats reflect the final output.
+    // Guardrail comparison uses UN-annotated output (before line number formatting).
     let (final_output, guardrail_triggered) =
         if options.mode != Mode::Full && options.trunc.token_budget.is_none() {
             let outcome = crate::output::guardrail::apply_to_stderr(contents.clone(), result)?;
@@ -354,6 +407,24 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
             (result, false)
         };
 
+    // Apply line number formatting AFTER guardrail, BEFORE cache write and token stats.
+    // AC-11: If guardrail triggered (raw source), apply identity line map.
+    // AC-12: Cache key includes line_numbers (handled in cache::read_cache/write_cache).
+    let final_output = if options.line_numbers {
+        let map = if guardrail_triggered {
+            // Guardrail emitted raw source — use identity map
+            crate::format::identity_line_map(&final_output)
+        } else if let Some(m) = line_map {
+            m
+        } else {
+            // Fallback: identity map (language detection failed or serde non-full mode)
+            crate::format::identity_line_map(&final_output)
+        };
+        crate::format::format_with_line_numbers(&final_output, &map)
+    } else {
+        final_output
+    };
+
     // Only pay the tiktoken BPE cost on the main thread when --show-stats
     // is set. Analytics background threads compute their own token counts.
     let (orig_tokens, trans_tokens) = if options.show_stats {
@@ -362,8 +433,8 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
         (None, None)
     };
 
-    // Cache the transform result (post-guardrail). Cache write failures are
-    // non-fatal; don't fail the transformation.
+    // Cache the transform result (post-guardrail, post-line-number-formatting).
+    // Cache write failures are non-fatal; don't fail the transformation.
     if options.use_cache {
         let effective_mode = (mode_used != options.mode).then_some(mode_used);
         let _ = cache::write_cache(&cache::CacheWriteParams {
@@ -375,6 +446,7 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
             trunc: options.trunc,
             effective_mode,
             parse_tier: parse_tier.map(str::to_string),
+            line_numbers: options.line_numbers,
         });
     }
 

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -324,11 +324,8 @@ pub(crate) fn process_stdin(
             (output, false, line_map)
         }
         None => {
-            let config = cascade::build_config_with_opts(
-                options.mode,
-                &options.trunc,
-                options.line_numbers,
-            );
+            let config =
+                cascade::build_config_with_opts(options.mode, &options.trunc, options.line_numbers);
             let (output, has_errors, line_map) =
                 transform_with_line_map(&buffer, language, &config)?;
             (output, has_errors, line_map)

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -257,16 +257,17 @@ fn run_transform(
             )?;
 
             // If line numbers requested, re-run the selected mode WITH line_numbers.
-            let line_map = if options.line_numbers {
+            // Use the re-run output directly as the final output (avoids double transform).
+            let (final_output, line_map) = if options.line_numbers {
                 let config = cascade::build_config_with_opts(mode, &options.trunc, true);
-                let (_rerun_output, _has_errors, map) =
+                let (rerun_output, _has_errors, map) =
                     transform_with_line_map(contents, language, &config)?;
-                map
+                (rerun_output, map)
             } else {
-                None
+                (output, None)
             };
 
-            Ok((output, mode, false, line_map))
+            Ok((final_output, mode, false, line_map))
         }
         None => {
             let language = explicit_lang.or_else(|| detect_language_from_path(path));
@@ -347,14 +348,15 @@ pub(crate) fn process_stdin(
                 language,
                 |config| Ok(Some(transform_with_config(&buffer, language, config)?)),
             )?;
-            let line_map = if options.line_numbers {
+            // Use the re-run output directly as the final output (avoids double transform).
+            let (cascade_output, line_map) = if options.line_numbers {
                 let config = cascade::build_config_with_opts(mode, &options.trunc, true);
-                let (_rerun, _errs, map) = transform_with_line_map(&buffer, language, &config)?;
-                map
+                let (rerun, _errs, map) = transform_with_line_map(&buffer, language, &config)?;
+                (rerun, map)
             } else {
-                None
+                (output, None)
             };
-            (output, false, line_map)
+            (cascade_output, false, line_map)
         }
         None => {
             let config =
@@ -556,5 +558,78 @@ mod tests {
         assert_eq!(parse_tier_from(Mode::Structure, false), "full");
         assert_eq!(parse_tier_from(Mode::Signatures, false), "full");
         assert_eq!(parse_tier_from(Mode::Types, false), "full");
+    }
+
+    // ========================================================================
+    // apply_line_numbers tests
+    // ========================================================================
+
+    /// Branch: line_numbers disabled — output is returned unchanged regardless of
+    /// guardrail_triggered or computed_map.
+    #[test]
+    fn apply_line_numbers_disabled_returns_output_unchanged() {
+        let output = "fn foo() {}\nfn bar() {}\n".to_string();
+        let result = apply_line_numbers(output.clone(), false, false, Some(vec![1, 2]));
+        assert_eq!(
+            result, output,
+            "disabled line numbers must not modify output"
+        );
+
+        let result2 = apply_line_numbers(output.clone(), false, true, None);
+        assert_eq!(
+            result2, output,
+            "disabled line numbers must not modify output even when guardrail triggered"
+        );
+    }
+
+    /// Branch: guardrail_triggered — identity map is applied regardless of computed_map.
+    #[test]
+    fn apply_line_numbers_guardrail_uses_identity_map() {
+        let output = "line one\nline two\n".to_string();
+        // computed_map is None here; the guardrail path must build its own identity map.
+        let result = apply_line_numbers(output.clone(), true, true, None);
+        // Identity map annotates each line with its 1-based output line number.
+        // format_with_line_numbers uses "<n>\t<content>" format.
+        assert!(
+            result.contains("1\t") && result.contains("2\t"),
+            "guardrail path must annotate both output lines; got: {result:?}"
+        );
+        // The raw content must still be present.
+        assert!(
+            result.contains("line one"),
+            "output text must survive annotation"
+        );
+    }
+
+    /// Branch: computed_map is None (serde non-full modes or language detection failure) —
+    /// output is returned unannotated even when line_numbers is true.
+    #[test]
+    fn apply_line_numbers_none_map_skips_annotation() {
+        let output = "key: value\n".to_string();
+        let result = apply_line_numbers(output.clone(), true, false, None);
+        assert_eq!(
+            result, output,
+            "None computed_map must skip line-number annotation"
+        );
+    }
+
+    /// Branch: computed_map is Some — the provided map is forwarded to
+    /// format_with_line_numbers to produce annotated output.
+    #[test]
+    fn apply_line_numbers_some_map_annotates_output() {
+        // Simulate a 2-line transform output that maps to source lines 1 and 5.
+        let output = "fn foo() {}\nfn bar() {}\n".to_string();
+        let map = vec![1usize, 5];
+        let result = apply_line_numbers(output.clone(), true, false, Some(map));
+        // The annotation must include the source line numbers from the provided map.
+        // format_with_line_numbers uses "<n>\t<content>" format.
+        assert!(
+            result.contains("1\t") && result.contains("5\t"),
+            "provided map line numbers must appear in output; got: {result:?}"
+        );
+        assert!(
+            result.contains("fn foo()"),
+            "content must survive annotation"
+        );
     }
 }

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -578,6 +578,36 @@ fn test_line_numbers_json_full_mode_applies_identity() {
     );
 }
 
+#[test]
+fn test_line_numbers_json_structure_mode_skips_annotation() {
+    // AC-15: Serde non-full modes skip line numbers because output is restructured
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    std::fs::write(&file, r#"{"key": "value", "nested": {"a": 1}}"#).unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=structure")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Serde structure mode: output is restructured, so no line number annotations
+    // should be applied. No tab-separated line numbers should appear.
+    let has_numbered = stdout.lines().any(|l| {
+        let parts: Vec<&str> = l.splitn(2, '\t').collect();
+        parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+    });
+    assert!(
+        !has_numbered,
+        "Serde non-full mode should skip line number annotation, got: {:?}",
+        stdout
+    );
+}
+
 // ============================================================================
 // AC-10: Token cascade interaction — line numbers applied after mode selection
 // ============================================================================

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -333,6 +333,9 @@ fn test_line_numbers_with_max_lines_omission_markers_no_prefix() {
 
 #[test]
 fn test_line_numbers_with_last_lines_truncation_marker_no_prefix() {
+    // AC-9 regression: before the bug fix, the truncation marker received
+    // prefix "1\t" and content lines got sequential numbers from 2 instead
+    // of their real source line numbers.
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.ts");
     let content: String = (1..=10).map(|i| format!("type T{i} = string;\n")).collect();
@@ -351,20 +354,49 @@ fn test_line_numbers_with_last_lines_truncation_marker_no_prefix() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let lines: Vec<&str> = stdout.lines().collect();
-    // Truncation markers (containing "...") should not have line numbers
-    // The actual content lines should have line numbers
-    let numbered_lines: Vec<&&str> = lines
+
+    // 1. Lines containing "... lines above" or "... lines truncated" must NOT
+    //    have a {num}\t prefix (their source_line is 0).
+    for line in &lines {
+        if line.contains("lines above") || line.contains("lines truncated") {
+            let has_number_prefix = {
+                let parts: Vec<&str> = line.splitn(2, '\t').collect();
+                parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+            };
+            assert!(
+                !has_number_prefix,
+                "Truncation marker must not have a line-number prefix, got: {:?}",
+                line
+            );
+        }
+    }
+
+    // 2. Numbered content lines must have the CORRECT source line numbers.
+    //    simple_last_line_truncate(n=3) reserves 1 slot for the marker, so
+    //    it keeps the last 2 content lines: source lines 9 and 10 of a 10-line file.
+    //    Before the bug fix, content lines got sequential numbers [1, 2] instead.
+    let content_line_nums: Vec<usize> = lines
         .iter()
-        .filter(|l| {
+        .filter_map(|l| {
             let parts: Vec<&str> = l.splitn(2, '\t').collect();
-            parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+            if parts.len() == 2 {
+                parts[0].parse::<usize>().ok()
+            } else {
+                None
+            }
         })
         .collect();
-    // We asked for last 3 lines, so we should have at most 3 numbered content lines
-    assert!(
-        numbered_lines.len() <= 3,
-        "Should have at most 3 numbered content lines, got {}",
-        numbered_lines.len()
+
+    assert_eq!(
+        content_line_nums.len(),
+        2,
+        "simple_last_line_truncate(n=3) yields 1 marker + 2 content lines, got: {:?}",
+        content_line_nums
+    );
+    assert_eq!(
+        content_line_nums,
+        vec![9, 10],
+        "Content lines should have real source line numbers 9 and 10 (not sequential from 1 or 2)"
     );
 }
 
@@ -643,5 +675,296 @@ fn test_line_numbers_with_token_cascade() {
     assert!(
         has_numbered,
         "Token cascade output should have line numbers"
+    );
+}
+
+// ============================================================================
+// AC-6: Pseudo mode — gaps in line numbering for removed body lines
+// ============================================================================
+
+#[test]
+fn test_line_numbers_pseudo_mode_gaps() {
+    // Pseudo mode keeps function bodies but strips type annotations, modifiers,
+    // decorators, etc. For Python this means doc-strings and class/def keywords
+    // are kept, but type annotations are stripped. The key behavior to verify
+    // is that when lines are removed, gaps appear in the line numbers (i.e., the
+    // line numbers are not sequential 1,2,3,... but reflect real source positions).
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.py");
+    // Line 1: def foo(x: int) -> str:   (type annotations stripped in pseudo)
+    // Line 2:     return str(x)
+    // Line 3: def bar(y: str) -> None:  (type annotations stripped in pseudo)
+    // Line 4:     pass
+    std::fs::write(
+        &file,
+        "def foo(x: int) -> str:\n    return str(x)\ndef bar(y: str) -> None:\n    pass\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=pseudo")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Pseudo mode should produce output");
+
+    // Collect all annotated line numbers
+    let line_nums: Vec<usize> = lines
+        .iter()
+        .filter_map(|l| {
+            let parts: Vec<&str> = l.splitn(2, '\t').collect();
+            if parts.len() == 2 {
+                parts[0].parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !line_nums.is_empty(),
+        "Should have at least one annotated line"
+    );
+
+    // Line numbers must be monotonically increasing (source order preserved)
+    for window in line_nums.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "Line numbers must be monotonically non-decreasing in pseudo mode: {:?}",
+            line_nums
+        );
+    }
+
+    // All line numbers must be valid source line numbers (1-indexed)
+    for &num in &line_nums {
+        assert!(num >= 1, "All line numbers should be >= 1, got: {}", num);
+    }
+}
+
+// ============================================================================
+// AC-7: Minimal mode — gaps in line numbering for removed comment lines
+// ============================================================================
+
+#[test]
+fn test_line_numbers_minimal_mode_gaps() {
+    // Minimal mode strips non-doc regular comments at module/class level.
+    // When comment lines are removed, the remaining output lines should show
+    // source line numbers that skip over the removed comment lines — gaps.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.py");
+    // Line 1: # regular comment (stripped by minimal)
+    // Line 2: x = 1
+    // Line 3: # another comment (stripped by minimal)
+    // Line 4: y = 2
+    std::fs::write(
+        &file,
+        "# regular comment\nx = 1\n# another comment\ny = 2\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=minimal")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Minimal mode should produce output");
+
+    // Collect all annotated (numbered) content lines
+    let annotated: Vec<(usize, &str)> = lines
+        .iter()
+        .filter_map(|l| {
+            let parts: Vec<&str> = l.splitn(2, '\t').collect();
+            if parts.len() == 2 {
+                if let Ok(num) = parts[0].parse::<usize>() {
+                    return Some((num, parts[1]));
+                }
+            }
+            None
+        })
+        .collect();
+
+    assert!(!annotated.is_empty(), "Should have annotated content lines");
+
+    // Line numbers must be monotonically non-decreasing
+    let nums: Vec<usize> = annotated.iter().map(|(n, _)| *n).collect();
+    for window in nums.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "Line numbers must be monotonically non-decreasing: {:?}",
+            nums
+        );
+    }
+
+    // If both "x = 1" and "y = 2" appear, they should have source line numbers 2 and 4.
+    // The comments (lines 1, 3) were removed, so there should be a gap.
+    let x_line = annotated.iter().find(|(_, content)| *content == "x = 1");
+    let y_line = annotated.iter().find(|(_, content)| *content == "y = 2");
+    if let (Some((x_num, _)), Some((y_num, _))) = (x_line, y_line) {
+        assert_eq!(*x_num, 2, "x = 1 should be at source line 2");
+        assert_eq!(*y_num, 4, "y = 2 should be at source line 4");
+        // There's a gap: line 3 (the second comment) was removed
+        assert!(
+            y_num - x_num > 1,
+            "Gap between x and y should reflect stripped comment at line 3: x={x_num}, y={y_num}"
+        );
+    }
+}
+
+// ============================================================================
+// AC-9 (strengthened): last_lines — correct source numbers, no prefix on marker
+// ============================================================================
+
+#[test]
+fn test_line_numbers_last_lines_correct_source_numbers() {
+    // Reproduces the AC-9 bug: passthrough (--mode=full) + --last-lines + -n.
+    // Before the fix, content lines got sequential numbers from 1, and the
+    // truncation marker got the prefix "1\t". After the fix:
+    // - Truncation marker ("... N lines above") has NO {num}\t prefix
+    // - Content lines have their REAL source line numbers (not sequential from 1)
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    // 5 lines: last 3 are lines 3, 4, 5 in source
+    std::fs::write(
+        &file,
+        "type A = string;\ntype B = number;\ntype C = boolean;\ntype D = object;\ntype E = any;\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--last-lines")
+        .arg("3")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Should produce output");
+
+    // Find the truncation marker line (contains "lines above" or "lines truncated")
+    let marker_lines: Vec<&&str> = lines
+        .iter()
+        .filter(|l| l.contains("lines above") || l.contains("lines truncated"))
+        .collect();
+    assert!(!marker_lines.is_empty(), "Should have a truncation marker");
+
+    for marker in &marker_lines {
+        // The truncation marker must NOT have a {num}\t prefix
+        let has_number_prefix = {
+            let parts: Vec<&str> = marker.splitn(2, '\t').collect();
+            parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+        };
+        assert!(
+            !has_number_prefix,
+            "Truncation marker should NOT have a line-number prefix, got: {:?}",
+            marker
+        );
+    }
+
+    // Find content lines (lines with a valid {num}\t prefix)
+    let content_lines: Vec<(usize, &str)> = lines
+        .iter()
+        .filter_map(|l| {
+            let parts: Vec<&str> = l.splitn(2, '\t').collect();
+            if parts.len() == 2 {
+                if let Ok(num) = parts[0].parse::<usize>() {
+                    return Some((num, parts[1]));
+                }
+            }
+            None
+        })
+        .collect();
+
+    // simple_last_line_truncate(n=3) reserves 1 slot for the marker, so it keeps
+    // the last 2 content lines: source lines 4 and 5 of a 5-line file.
+    // Before the bug fix, content lines got sequential numbers [1, 2] instead.
+    assert_eq!(
+        content_lines.len(),
+        2,
+        "simple_last_line_truncate(n=3) yields 1 marker + 2 content lines, got: {:?}",
+        content_lines
+    );
+    let nums: Vec<usize> = content_lines.iter().map(|(n, _)| *n).collect();
+    assert_eq!(
+        nums,
+        vec![4, 5],
+        "Content lines should have source line numbers 4 and 5 (not sequential from 1)"
+    );
+}
+
+// ============================================================================
+// AC-11: Guardrail identity map when compressed output is larger than raw
+// ============================================================================
+
+#[test]
+fn test_line_numbers_guardrail_identity_map() {
+    // The guardrail triggers when the compressed output is larger than the raw input.
+    // In that case, skim falls back to the raw source (identity map).
+    // A very small file (e.g., single assignment) is likely to trigger the guardrail
+    // because the structure mode adds overhead (e.g., "/* ... */") for minimal code.
+    // We verify that when -n is used and guardrail triggers, identity line numbers apply.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.py");
+    // Single variable assignment: minimal content, guardrail likely to trigger
+    std::fs::write(&file, "x = 1\n").unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Should produce output");
+
+    // Whether or not the guardrail triggers, all output lines should be valid:
+    // - If guardrail triggered: identity map applies, line 1 → "1\t..."
+    // - If guardrail did not trigger: compressed output with valid line numbers
+    // Either way, every non-empty annotated line should have a valid usize line number.
+    for line in &lines {
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        if parts.len() == 2 {
+            // If there's a tab separator, the left part must parse as usize
+            assert!(
+                parts[0].parse::<usize>().is_ok(),
+                "Left part of tab-separated line must be a valid line number, got: {:?}",
+                line
+            );
+        }
+        // Lines without a tab are omission markers (source_line=0 case) — that's OK
+    }
+
+    // The file has exactly 1 line. Either guardrail triggers and we get "1\tx = 1",
+    // or structure mode produces output. In both cases, at least one annotated line
+    // should exist.
+    let has_numbered = lines.iter().any(|l| {
+        let parts: Vec<&str> = l.splitn(2, '\t').collect();
+        parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+    });
+    assert!(
+        has_numbered,
+        "Output should have at least one numbered line (guardrail or normal path)"
     );
 }

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -23,11 +23,7 @@ fn skim_cmd() -> Command {
 fn test_line_numbers_flag_long_form() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.ts");
-    std::fs::write(
-        &file,
-        "import { foo } from 'bar';\ntype UserId = string;\n",
-    )
-    .unwrap();
+    std::fs::write(&file, "import { foo } from 'bar';\ntype UserId = string;\n").unwrap();
 
     let output = skim_cmd()
         .arg(file.to_str().unwrap())
@@ -89,9 +85,7 @@ fn test_line_numbers_tab_separated_no_fixed_width() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.ts");
     // Write 12 lines so we can check that line 10 is not space-padded
-    let content: String = (1..=12)
-        .map(|i| format!("const x{i} = {i};\n"))
-        .collect();
+    let content: String = (1..=12).map(|i| format!("const x{i} = {i};\n")).collect();
     std::fs::write(&file, &content).unwrap();
 
     let output = skim_cmd()
@@ -190,9 +184,7 @@ fn test_line_numbers_structure_mode_skips_body_lines() {
             // The body replacement line should still have a number
             let parts: Vec<&str> = line.splitn(2, '\t').collect();
             if parts.len() == 2 {
-                let num: usize = parts[0]
-                    .parse()
-                    .expect("Line number should parse as usize");
+                let num: usize = parts[0].parse().expect("Line number should parse as usize");
                 assert!(num >= 1, "Line number should be >= 1");
             }
         }
@@ -235,9 +227,10 @@ fn test_line_numbers_signatures_mode_annotates_source_lines() {
             "Each output line should be tab-separated: {:?}",
             line
         );
-        let _num: usize = parts[0]
-            .parse()
-            .expect(&format!("Line number should parse as usize, got: {:?}", parts[0]));
+        let _num: usize = parts[0].parse().expect(&format!(
+            "Line number should parse as usize, got: {:?}",
+            parts[0]
+        ));
     }
 }
 
@@ -281,12 +274,16 @@ fn test_line_numbers_types_mode_annotates_source_lines() {
             "Non-blank output line should be tab-separated: {:?}",
             line
         );
-        let _num: usize = parts[0]
-            .parse()
-            .expect(&format!("Line number should parse as usize, got: {:?}", parts[0]));
+        let _num: usize = parts[0].parse().expect(&format!(
+            "Line number should parse as usize, got: {:?}",
+            parts[0]
+        ));
         annotated_count += 1;
     }
-    assert!(annotated_count > 0, "At least one line should be annotated with a source line number");
+    assert!(
+        annotated_count > 0,
+        "At least one line should be annotated with a source line number"
+    );
 }
 
 // ============================================================================
@@ -298,9 +295,7 @@ fn test_line_numbers_with_max_lines_omission_markers_no_prefix() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.ts");
     // 10 lines of types
-    let content: String = (1..=10)
-        .map(|i| format!("type T{i} = string;\n"))
-        .collect();
+    let content: String = (1..=10).map(|i| format!("type T{i} = string;\n")).collect();
     std::fs::write(&file, &content).unwrap();
 
     let output = skim_cmd()
@@ -340,9 +335,7 @@ fn test_line_numbers_with_max_lines_omission_markers_no_prefix() {
 fn test_line_numbers_with_last_lines_truncation_marker_no_prefix() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.ts");
-    let content: String = (1..=10)
-        .map(|i| format!("type T{i} = string;\n"))
-        .collect();
+    let content: String = (1..=10).map(|i| format!("type T{i} = string;\n")).collect();
     std::fs::write(&file, &content).unwrap();
 
     let output = skim_cmd()
@@ -463,17 +456,17 @@ fn test_line_numbers_multifile_headers_no_prefix() {
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "Directory processing should succeed");
+    assert!(
+        output.status.success(),
+        "Directory processing should succeed"
+    );
     let stdout = String::from_utf8(output.stdout).unwrap();
     // File headers look like "==> file.ts <==" or similar
     // They should NOT have line number prefixes (digits followed by tab)
     for line in stdout.lines() {
         if line.contains("==>") || line.contains("<==") {
             // Header line — should not start with a digit (line number)
-            let starts_with_digit = line
-                .chars()
-                .next()
-                .map_or(false, |c| c.is_ascii_digit());
+            let starts_with_digit = line.chars().next().map_or(false, |c| c.is_ascii_digit());
             assert!(
                 !starts_with_digit,
                 "File headers should not have line number prefix: {:?}",
@@ -501,11 +494,7 @@ fn test_guidance_content_mentions_line_numbers_flag() {
     // The guidance content should mention -n or --line-numbers
     // We test via the library helper (not the CLI) for simplicity
     // This is an integration test that the content was updated
-    let output = skim_cmd()
-        .arg("init")
-        .arg("--help")
-        .output()
-        .unwrap();
+    let output = skim_cmd().arg("init").arg("--help").output().unwrap();
     // Just verify the command exists and works — guidance content is tested in unit tests
     assert!(output.status.success() || !output.stdout.is_empty() || !output.stderr.is_empty());
 }
@@ -621,5 +610,8 @@ fn test_line_numbers_with_token_cascade() {
         let parts: Vec<&str> = l.splitn(2, '\t').collect();
         parts.len() == 2 && parts[0].parse::<usize>().is_ok()
     });
-    assert!(has_numbered, "Token cascade output should have line numbers");
+    assert!(
+        has_numbered,
+        "Token cascade output should have line numbers"
+    );
 }

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -1,0 +1,625 @@
+//! CLI tests for --line-numbers / -n flag
+//!
+//! Tests the --line-numbers flag through the skim binary.
+//! Validates: format, source line annotation, mode interactions,
+//! truncation interactions, cascade interaction, caching, stdin, multi-file.
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+/// Get a command for the skim binary with clean env
+fn skim_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("skim").unwrap();
+    cmd.env_remove("SKIM_PASSTHROUGH");
+    cmd.env_remove("SKIM_DEBUG");
+    cmd
+}
+
+// ============================================================================
+// AC-1: Core line number annotation — format and basic behavior
+// ============================================================================
+
+#[test]
+fn test_line_numbers_flag_long_form() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(
+        &file,
+        "import { foo } from 'bar';\ntype UserId = string;\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--no-cache")
+        .arg("--mode=full")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Each line should have format: {num}\t{content}
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Should have output");
+    // First line should start with "1\t"
+    assert!(
+        lines[0].starts_with("1\t"),
+        "First line should start with '1\\t', got: {:?}",
+        lines[0]
+    );
+    // Second line should start with "2\t"
+    if lines.len() >= 2 {
+        assert!(
+            lines[1].starts_with("2\t"),
+            "Second line should start with '2\\t', got: {:?}",
+            lines[1]
+        );
+    }
+}
+
+#[test]
+fn test_line_numbers_flag_short_form() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(&file, "type A = string;\ntype B = number;\n").unwrap();
+
+    // -n is the short form
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("-n")
+        .arg("--no-cache")
+        .arg("--mode=full")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty());
+    assert!(
+        lines[0].starts_with("1\t"),
+        "Short form -n should annotate with line numbers"
+    );
+}
+
+#[test]
+fn test_line_numbers_tab_separated_no_fixed_width() {
+    // Format is {line}\t{content} — tab-separated, no fixed width padding
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    // Write 12 lines so we can check that line 10 is not space-padded
+    let content: String = (1..=12)
+        .map(|i| format!("const x{i} = {i};\n"))
+        .collect();
+    std::fs::write(&file, &content).unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--no-cache")
+        .arg("--mode=full")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    // Line 10 should be "10\t..." not " 10\t..."
+    let line10 = lines
+        .iter()
+        .find(|l| l.starts_with("10\t"))
+        .expect("Should have a line starting with '10\\t'");
+    assert!(
+        !line10.starts_with(" 10\t"),
+        "Should not have space padding: {:?}",
+        line10
+    );
+}
+
+// ============================================================================
+// AC-5: Full mode — identity mapping
+// ============================================================================
+
+#[test]
+fn test_line_numbers_full_mode_identity_mapping() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(
+        &file,
+        "import { foo } from 'bar';\ntype A = string;\nfunction hello(): void { return; }\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    // Full mode: output line N has source line N annotation
+    for (i, line) in lines.iter().enumerate() {
+        let expected_prefix = format!("{}\t", i + 1);
+        assert!(
+            line.starts_with(&expected_prefix),
+            "Line {} should start with {:?}, got: {:?}",
+            i + 1,
+            expected_prefix,
+            line
+        );
+    }
+}
+
+// ============================================================================
+// AC-2: Structure mode — non-contiguous line numbers
+// ============================================================================
+
+#[test]
+fn test_line_numbers_structure_mode_skips_body_lines() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    // Function body spans lines 3-5, but output replaces with /* ... */
+    std::fs::write(
+        &file,
+        "// comment\ntype A = string;\nfunction hello(name: string): void {\n  console.log(name);\n  return;\n}\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=structure")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Structure mode collapses bodies. With -n, the signature line should show
+    // the source line number where the function starts, not consecutive numbering.
+    // We just check that:
+    // 1. All numbered lines have format "{num}\t{content}"
+    // 2. Line numbers are present and 1-indexed
+    for line in stdout.lines() {
+        if line.contains("/* ... */") || line.is_empty() {
+            // The body replacement line should still have a number
+            let parts: Vec<&str> = line.splitn(2, '\t').collect();
+            if parts.len() == 2 {
+                let num: usize = parts[0]
+                    .parse()
+                    .expect("Line number should parse as usize");
+                assert!(num >= 1, "Line number should be >= 1");
+            }
+        }
+    }
+}
+
+// ============================================================================
+// AC-3: Signatures mode — source line annotation
+// ============================================================================
+
+#[test]
+fn test_line_numbers_signatures_mode_annotates_source_lines() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(
+        &file,
+        "import { x } from 'y';\ntype A = string;\nfunction foo(a: number): void { return; }\nfunction bar(): string { return 'hi'; }\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=signatures")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should have line numbers on output lines
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Signatures mode should produce output");
+    for line in &lines {
+        // Every line should be annotated with a source line number
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        assert_eq!(
+            parts.len(),
+            2,
+            "Each output line should be tab-separated: {:?}",
+            line
+        );
+        let _num: usize = parts[0]
+            .parse()
+            .expect(&format!("Line number should parse as usize, got: {:?}", parts[0]));
+    }
+}
+
+// ============================================================================
+// AC-4: Types mode — source line annotation
+// ============================================================================
+
+#[test]
+fn test_line_numbers_types_mode_annotates_source_lines() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(
+        &file,
+        "import { x } from 'y';\ntype UserId = string;\ntype User = { id: UserId; name: string };\nfunction foo(): void { return; }\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=types")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "Types mode should produce output");
+    let mut annotated_count = 0;
+    for line in &lines {
+        if line.is_empty() {
+            // Blank separator lines between type definitions are emitted without
+            // a line-number prefix (source_line = 0 in the map). This is by design.
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        assert_eq!(
+            parts.len(),
+            2,
+            "Non-blank output line should be tab-separated: {:?}",
+            line
+        );
+        let _num: usize = parts[0]
+            .parse()
+            .expect(&format!("Line number should parse as usize, got: {:?}", parts[0]));
+        annotated_count += 1;
+    }
+    assert!(annotated_count > 0, "At least one line should be annotated with a source line number");
+}
+
+// ============================================================================
+// AC-8: --max-lines truncation interaction
+// ============================================================================
+
+#[test]
+fn test_line_numbers_with_max_lines_omission_markers_no_prefix() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    // 10 lines of types
+    let content: String = (1..=10)
+        .map(|i| format!("type T{i} = string;\n"))
+        .collect();
+    std::fs::write(&file, &content).unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--max-lines")
+        .arg("5")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Omission markers should have no line number prefix
+    // They look like "// ..." or "/* ... */" etc.
+    // Lines with numbers should parse fine; omission marker lines should not start with a number\t
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty());
+    for line in &lines {
+        // If this looks like an omission marker (contains "..."), it should not be prefixed
+        if line.contains("/* ... */") || line.contains("// ...") || line.contains("# ...") {
+            let trimmed = line.trim_start();
+            assert!(
+                !trimmed.chars().next().map_or(false, |c| c.is_ascii_digit()),
+                "Omission markers should not have line number prefix: {:?}",
+                line
+            );
+        }
+    }
+}
+
+// ============================================================================
+// AC-9: --last-lines truncation interaction
+// ============================================================================
+
+#[test]
+fn test_line_numbers_with_last_lines_truncation_marker_no_prefix() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    let content: String = (1..=10)
+        .map(|i| format!("type T{i} = string;\n"))
+        .collect();
+    std::fs::write(&file, &content).unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--last-lines")
+        .arg("3")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    // Truncation markers (containing "...") should not have line numbers
+    // The actual content lines should have line numbers
+    let numbered_lines: Vec<&&str> = lines
+        .iter()
+        .filter(|l| {
+            let parts: Vec<&str> = l.splitn(2, '\t').collect();
+            parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+        })
+        .collect();
+    // We asked for last 3 lines, so we should have at most 3 numbered content lines
+    assert!(
+        numbered_lines.len() <= 3,
+        "Should have at most 3 numbered content lines, got {}",
+        numbered_lines.len()
+    );
+}
+
+// ============================================================================
+// AC-12: Caching — line_numbers in cache key
+// ============================================================================
+
+#[test]
+fn test_line_numbers_cached_separately_from_unnumbered() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(&file, "type A = string;\ntype B = number;\n").unwrap();
+
+    // Run without line numbers (caches result)
+    let output1 = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--mode=full")
+        .output()
+        .unwrap();
+    let stdout1 = String::from_utf8(output1.stdout).unwrap();
+
+    // Run with line numbers (should use different cache entry)
+    let output2 = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=full")
+        .output()
+        .unwrap();
+    let stdout2 = String::from_utf8(output2.stdout).unwrap();
+
+    // The two outputs should differ (one has line numbers, one doesn't)
+    assert_ne!(
+        stdout1, stdout2,
+        "Line-numbered and unnumbered outputs should differ"
+    );
+    // The line-numbered one should have tabs
+    assert!(
+        stdout2.contains('\t'),
+        "Line-numbered output should contain tab separators"
+    );
+}
+
+// ============================================================================
+// AC-14: Stdin
+// ============================================================================
+
+#[test]
+fn test_line_numbers_stdin() {
+    let output = skim_cmd()
+        .arg("-")
+        .arg("-l")
+        .arg("typescript")
+        .arg("--line-numbers")
+        .arg("--mode=full")
+        .write_stdin("type A = string;\ntype B = number;\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty());
+    assert!(
+        lines[0].starts_with("1\t"),
+        "Stdin output should be annotated with line numbers"
+    );
+}
+
+// ============================================================================
+// AC-13: Multi-file — file headers have no line number prefix
+// ============================================================================
+
+#[test]
+fn test_line_numbers_multifile_headers_no_prefix() {
+    let dir = TempDir::new().unwrap();
+    let file1 = dir.path().join("a.ts");
+    let file2 = dir.path().join("b.ts");
+    std::fs::write(&file1, "type A = string;\n").unwrap();
+    std::fs::write(&file2, "type B = number;\n").unwrap();
+
+    // Process two files independently by passing each as a separate invocation
+    // and checking that neither file's header (if printed) has a line number prefix.
+    // For multi-file test via glob, we use a directory instead of absolute glob.
+    let output = skim_cmd()
+        .arg(dir.path().to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--no-cache")
+        .arg("--mode=full")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Directory processing should succeed");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // File headers look like "==> file.ts <==" or similar
+    // They should NOT have line number prefixes (digits followed by tab)
+    for line in stdout.lines() {
+        if line.contains("==>") || line.contains("<==") {
+            // Header line — should not start with a digit (line number)
+            let starts_with_digit = line
+                .chars()
+                .next()
+                .map_or(false, |c| c.is_ascii_digit());
+            assert!(
+                !starts_with_digit,
+                "File headers should not have line number prefix: {:?}",
+                line
+            );
+        }
+    }
+    // At least some content lines should have line numbers
+    let has_numbered_lines = stdout.lines().any(|l| {
+        let parts: Vec<&str> = l.splitn(2, '\t').collect();
+        parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+    });
+    assert!(
+        has_numbered_lines,
+        "Multi-file output should have some numbered lines"
+    );
+}
+
+// ============================================================================
+// AC-16: Init guidance update
+// ============================================================================
+
+#[test]
+fn test_guidance_content_mentions_line_numbers_flag() {
+    // The guidance content should mention -n or --line-numbers
+    // We test via the library helper (not the CLI) for simplicity
+    // This is an integration test that the content was updated
+    let output = skim_cmd()
+        .arg("init")
+        .arg("--help")
+        .output()
+        .unwrap();
+    // Just verify the command exists and works — guidance content is tested in unit tests
+    assert!(output.status.success() || !output.stdout.is_empty() || !output.stderr.is_empty());
+}
+
+// ============================================================================
+// AC-17: Edge cases
+// ============================================================================
+
+#[test]
+fn test_line_numbers_empty_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.ts");
+    std::fs::write(&file, "").unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    // Empty file should produce empty output (or just a newline)
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.is_empty() || stdout == "\n",
+        "Empty file should produce empty or just-newline output, got: {:?}",
+        stdout
+    );
+}
+
+#[test]
+fn test_line_numbers_trailing_newline_preserved() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(&file, "type A = string;\n").unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Output should end with newline
+    assert!(
+        stdout.ends_with('\n'),
+        "Output should preserve trailing newline"
+    );
+}
+
+// ============================================================================
+// AC-15: Serde formats — non-full modes skip line numbers
+// ============================================================================
+
+#[test]
+fn test_line_numbers_json_full_mode_applies_identity() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    std::fs::write(&file, r#"{"key": "value"}"#).unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Full mode with JSON: identity line numbers should apply
+    // Output should have line numbers
+    assert!(
+        stdout.contains('\t'),
+        "Full mode JSON should have line number annotations"
+    );
+}
+
+// ============================================================================
+// AC-10: Token cascade interaction — line numbers applied after mode selection
+// ============================================================================
+
+#[test]
+fn test_line_numbers_with_token_cascade() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(
+        &file,
+        "type A = string;\ntype B = number;\nfunction foo(): void { return; }\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--tokens")
+        .arg("100")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should have line numbers on output
+    let lines: Vec<&str> = stdout.lines().collect();
+    // At least some lines should be annotated
+    let has_numbered = lines.iter().any(|l| {
+        let parts: Vec<&str> = l.splitn(2, '\t').collect();
+        parts.len() == 2 && parts[0].parse::<usize>().is_ok()
+    });
+    assert!(has_numbered, "Token cascade output should have line numbers");
+}

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -748,6 +748,87 @@ fn test_line_numbers_pseudo_mode_gaps() {
 }
 
 // ============================================================================
+// Regression: pseudo mode `def` signature lines missing line-number prefix
+//
+// BUG: When pseudo mode strips type annotations from a Python `def` line
+// (e.g. `def f(a: int) -> int:` → `def f(a):`), the output line differs from
+// the source line. The old text-matching approach failed to find it in source
+// and returned source_line=0, which suppresses the line-number prefix.
+//
+// FIX: Use byte-range-based line mapping instead of text matching, so that
+// any modified line still maps to its originating source line number.
+// ============================================================================
+
+#[test]
+fn test_line_numbers_pseudo_python_def_signatures_get_prefix() {
+    // Four-line file: def lines are on source lines 1 and 3.
+    // Pseudo mode strips type annotations so the output `def` lines differ from
+    // source. Before the fix, source_line=0 suppressed their prefix.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.py");
+    // Line 1: def foo(a: int) -> str:   (annotations stripped → `def foo(a):`)
+    // Line 2:     return str(a)
+    // Line 3: def bar(b: str) -> int:   (annotations stripped → `def bar(b):`)
+    // Line 4:     return len(b)
+    std::fs::write(
+        &file,
+        "def foo(a: int) -> str:\n    return str(a)\ndef bar(b: str) -> int:\n    return len(b)\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=pseudo")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Helper: parse `{num}\t{content}` → Some((num, content_string)), or None.
+    let parse_annotated = |s: &str| -> Option<(usize, String)> {
+        let mut parts = s.splitn(2, '\t');
+        let num_str = parts.next()?;
+        let content = parts.next()?;
+        Some((num_str.parse::<usize>().ok()?, content.to_owned()))
+    };
+
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Find the def lines in the output (pseudo output strips type annotations).
+    let foo_line = lines
+        .iter()
+        .find(|&&l| l.contains("def foo(a)"))
+        .copied()
+        .unwrap_or("");
+    let bar_line = lines
+        .iter()
+        .find(|&&l| l.contains("def bar(b)"))
+        .copied()
+        .unwrap_or("");
+
+    let foo_annotated = parse_annotated(foo_line);
+    let bar_annotated = parse_annotated(bar_line);
+
+    assert_eq!(
+        foo_annotated,
+        Some((1, "def foo(a):".to_owned())),
+        "`def foo(a):` must carry source line 1 prefix. \
+         Before fix it had no prefix (source_line=0). Got: {:?}",
+        foo_line
+    );
+    assert_eq!(
+        bar_annotated,
+        Some((3, "def bar(b):".to_owned())),
+        "`def bar(b):` must carry source line 3 prefix. \
+         Before fix it had no prefix (source_line=0). Got: {:?}",
+        bar_line
+    );
+}
+
+// ============================================================================
 // AC-7: Minimal mode — gaps in line numbering for removed comment lines
 // ============================================================================
 

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -157,7 +157,17 @@ fn test_line_numbers_full_mode_identity_mapping() {
 fn test_line_numbers_structure_mode_skips_body_lines() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.ts");
-    // Function body spans lines 3-5, but output replaces with /* ... */
+    // Source layout (6 lines):
+    //   1: "// comment"
+    //   2: "type A = string;"
+    //   3: "function hello(name: string): void {"
+    //   4: "  console.log(name);"
+    //   5: "  return;"
+    //   6: "}"
+    // Structure mode collapses the body (lines 3-6: the "{...}") into
+    // " { /* ... */ }" on the same line as the signature. The output therefore
+    // has 3 lines, annotated with source lines 1, 2, 3 (not 1, 2, 3 sequentially
+    // — the annotation for the signature must be 3, not 4 or 5 or 6).
     std::fs::write(
         &file,
         "// comment\ntype A = string;\nfunction hello(name: string): void {\n  console.log(name);\n  return;\n}\n",
@@ -174,20 +184,172 @@ fn test_line_numbers_structure_mode_skips_body_lines() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    // Structure mode collapses bodies. With -n, the signature line should show
-    // the source line number where the function starts, not consecutive numbering.
-    // We just check that:
-    // 1. All numbered lines have format "{num}\t{content}"
-    // 2. Line numbers are present and 1-indexed
-    for line in stdout.lines() {
-        if line.contains("/* ... */") || line.is_empty() {
-            // The body replacement line should still have a number
-            let parts: Vec<&str> = line.splitn(2, '\t').collect();
-            if parts.len() == 2 {
-                let num: usize = parts[0].parse().expect("Line number should parse as usize");
-                assert!(num >= 1, "Line number should be >= 1");
-            }
-        }
+
+    // Parse all "num\tcontent" pairs
+    let numbered: Vec<(usize, &str)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let num_str = parts.next()?;
+            let content = parts.next()?;
+            let num: usize = num_str.parse().ok()?;
+            Some((num, content))
+        })
+        .collect();
+
+    assert!(
+        !numbered.is_empty(),
+        "Structure mode output should have numbered lines"
+    );
+
+    // AC-2a: Every line number must be >= 1 (basic sanity)
+    for &(num, content) in &numbered {
+        assert!(
+            num >= 1,
+            "All line numbers must be >= 1, got {} for {:?}",
+            num,
+            content
+        );
+    }
+
+    // AC-2b: The first two output lines must carry source line numbers 1 and 2
+    // (they are verbatim copies of the comment and type alias).
+    assert!(
+        numbered.len() >= 2,
+        "Expected at least 2 output lines, got {}",
+        numbered.len()
+    );
+    assert_eq!(
+        numbered[0].0, 1,
+        "First output line (comment) must carry source line 1, got {}",
+        numbered[0].0
+    );
+    assert_eq!(
+        numbered[1].0, 2,
+        "Second output line (type alias) must carry source line 2, got {}",
+        numbered[1].0
+    );
+
+    // AC-2c: The collapsed function signature line must carry source line 3
+    // (the line where the function declaration starts in the source).
+    // A bug that emits sequential 1,2,3 would pass AC-2a but fail here because
+    // the function signature is on source line 3 and the next output line after
+    // the type alias (source line 2) must skip to line 3, not increment by 1.
+    let collapsed_line = numbered
+        .iter()
+        .find(|(_, content)| content.contains("/* ... */"));
+    assert!(
+        collapsed_line.is_some(),
+        "Structure mode output must contain a '/* ... */' collapsed body line"
+    );
+    let (sig_num, _) = collapsed_line.unwrap();
+    assert_eq!(
+        *sig_num, 3,
+        "Collapsed function signature must carry source line 3, got {}. \
+         A bug emitting sequential line numbers (1,2,3) would produce sig_num==3 \
+         here by coincidence; AC-2d below catches that case.",
+        sig_num
+    );
+
+    // AC-2d: The line numbers must NOT be a trivial sequential 1,2,3,...  sequence.
+    // If they are, the implementation is returning output line indices rather than
+    // true source line numbers. Verify this by checking that the source content with
+    // 6 lines collapses to output lines fewer than 6 — the function body lines 4-6
+    // are collapsed, so the output line count must be < 6.
+    assert!(
+        numbered.len() < 6,
+        "Structure mode must collapse the 4-line function body: expected < 6 output lines, got {}",
+        numbered.len()
+    );
+
+    // AC-2e: Confirm the collapsed line's number (3) is NOT equal to its output
+    // position index + 1. The collapsed line is the 3rd output line (index 2),
+    // so output_position = 3.  source_line = 3. They happen to be equal here
+    // because the first two output lines are verbatim. The key assertion is that
+    // the number came from the source (not synthesised), which is proven by
+    // AC-2b + AC-2c together: if the algorithm were just counting output lines it
+    // would still produce 1,2,3 here — so we also add a test with a gap at the start.
+    let line_numbers: Vec<usize> = numbered.iter().map(|&(n, _)| n).collect();
+    // The sequence must be non-decreasing (source lines always advance)
+    for window in line_numbers.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "Line numbers must be non-decreasing, got {:?}",
+            line_numbers
+        );
+    }
+}
+
+/// AC-2 gap test: a function preceded by many blank/comment lines so that the
+/// function signature source line number is much larger than its output position.
+/// This proves the annotation reflects true source lines, not output indices.
+#[test]
+fn test_line_numbers_structure_mode_large_source_gap() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("gap.ts");
+    // Source layout:
+    //   1:  "// line 1"
+    //   2:  "// line 2"
+    //   3:  "// line 3"
+    //   4:  "// line 4"
+    //   5:  "// line 5"
+    //   6:  "function gap(): void {"
+    //   7:  "  return;"
+    //   8:  "}"
+    // Structure output (6 lines: 5 comments + 1 collapsed signature):
+    //   output line 6 must carry source line 6, NOT output line index 6.
+    let mut content = String::new();
+    for i in 1..=5 {
+        content.push_str(&format!("// line {}\n", i));
+    }
+    content.push_str("function gap(): void {\n  return;\n}\n");
+    std::fs::write(&file, &content).unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("--line-numbers")
+        .arg("--mode=structure")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    let numbered: Vec<(usize, &str)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let num_str = parts.next()?;
+            let content = parts.next()?;
+            let num: usize = num_str.parse().ok()?;
+            Some((num, content))
+        })
+        .collect();
+
+    // Find the collapsed signature line
+    let collapsed = numbered
+        .iter()
+        .find(|(_, c)| c.contains("/* ... */"))
+        .expect("Must have a collapsed body line");
+
+    assert_eq!(
+        collapsed.0, 6,
+        "Function on source line 6 must be annotated as line 6, got {}. \
+         If this returns the output position (also 6 here) it still passes — \
+         but the 5 comment lines above have source lines 1-5, which equals \
+         their output positions, so if the algorithm just uses output indices \
+         all these assertions pass trivially. The real proof is in AC-2b/AC-2c.",
+        collapsed.0
+    );
+
+    // Verify none of the body lines (7-8) appear in the output
+    for &(num, _) in &numbered {
+        assert!(
+            num != 7 && num != 8,
+            "Body lines 7 and 8 should not appear in structure output, but got line {}",
+            num
+        );
     }
 }
 

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -364,19 +364,10 @@ fn test_line_numbers_structure_mode_large_source_gap() {
 
     assert_eq!(
         gap_annotation.0, 9,
-        "gap() is on source line 9 but output position {} ({}). \
-         An 'output index + 1' algorithm would return {} here, not 9.",
-        numbered
-            .iter()
-            .position(|(n, c)| *n == gap_annotation.0 && c.contains("/* ... */"))
-            .map(|p| p + 1)
-            .unwrap_or(0),
+        "gap() is on source line 9 but got annotation {} for {:?}. \
+         An 'output index + 1' algorithm would return the output position, not 9.",
+        gap_annotation.0,
         gap_annotation.1,
-        numbered
-            .iter()
-            .position(|(n, c)| *n == gap_annotation.0 && c.contains("/* ... */"))
-            .map(|p| p + 1)
-            .unwrap_or(0),
     );
 
     // The 5 comments must be annotated with source lines 4-8, not 2-6.

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -358,16 +358,13 @@ fn test_line_numbers_structure_mode_large_source_gap() {
     );
 
     // The last collapsed line belongs to gap() at source line 9.
-    let gap_annotation = collapsed_lines
-        .last()
-        .expect("at least one collapsed line");
+    let gap_annotation = collapsed_lines.last().expect("at least one collapsed line");
 
     assert_eq!(
         gap_annotation.0, 9,
         "gap() is on source line 9 but got annotation {} for {:?}. \
          An 'output index + 1' algorithm would return the output position, not 9.",
-        gap_annotation.0,
-        gap_annotation.1,
+        gap_annotation.0, gap_annotation.1,
     );
 
     // The 5 comments must be annotated with source lines 4-8, not 2-6.
@@ -387,7 +384,8 @@ fn test_line_numbers_structure_mode_large_source_gap() {
     for (i, &(src_line, _)) in comment_lines.iter().enumerate() {
         let expected = 4 + i; // source lines 4,5,6,7,8
         assert_eq!(
-            src_line, expected,
+            src_line,
+            expected,
             "comment {} should have source line {}, got {}. \
              Output position {} with source line 4 → an index-only algorithm would give {}.",
             i + 1,

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -968,3 +968,92 @@ fn test_line_numbers_guardrail_identity_map() {
         "Output should have at least one numbered line (guardrail or normal path)"
     );
 }
+
+// ============================================================================
+// Bug fix: --last-lines with duplicate lines (e.g., multiple `}` closings)
+// ============================================================================
+
+#[test]
+fn test_line_numbers_last_lines_full_mode_duplicate_lines() {
+    // Regression test: when a file has duplicate lines (e.g. multiple `}` closings)
+    // and --last-lines is used, content lines in the tail must carry their REAL source
+    // line numbers, not the line number of the first occurrence of that content.
+    //
+    // File layout (6 lines):
+    //   1: function foo() {
+    //   2:     return 1;
+    //   3: }
+    //   4: function bar() {
+    //   5:     return 2;
+    //   6: }
+    //
+    // With --last-lines 3: marker (0 annotation) + lines 5 and 6 as content.
+    // Line 6 is `}`, which also appears at line 3.  The correct annotation is 6, not 3.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.ts");
+    std::fs::write(
+        &file,
+        "function foo() {\n    return 1;\n}\nfunction bar() {\n    return 2;\n}\n",
+    )
+    .unwrap();
+
+    let output = skim_cmd()
+        .arg(file.to_str().unwrap())
+        .arg("-n")
+        .arg("--last-lines")
+        .arg("3")
+        .arg("--mode=full")
+        .arg("--no-cache")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Should have exactly 3 lines: marker + 2 content lines
+    assert_eq!(
+        lines.len(),
+        3,
+        "With --last-lines 3, output should have 3 lines (marker + 2 content). Got:\n{}",
+        stdout
+    );
+
+    // First line is the omission marker — no annotation prefix
+    assert!(
+        !lines[0].starts_with(|c: char| c.is_ascii_digit()),
+        "Marker line should have no numeric prefix, got: {:?}",
+        lines[0]
+    );
+
+    // Helper: extract tab-separated line number from an annotated line
+    let parse_line_num = |s: &str| -> Option<usize> {
+        let parts: Vec<&str> = s.splitn(2, '\t').collect();
+        if parts.len() == 2 {
+            parts[0].parse::<usize>().ok()
+        } else {
+            None
+        }
+    };
+
+    // Second line: source line 5 (`    return 2;`)
+    let num1 = parse_line_num(lines[1]);
+    assert_eq!(
+        num1,
+        Some(5),
+        "Content line 1 should map to source line 5, got: {:?} (full line: {:?})",
+        num1,
+        lines[1]
+    );
+
+    // Third line: source line 6 (`}`) — NOT line 3 which is also `}`
+    let num2 = parse_line_num(lines[2]);
+    assert_eq!(
+        num2,
+        Some(6),
+        "Content line 2 (closing `}}`) should map to source line 6 (its real position), \
+         not line 3 (first `}}` occurrence). Got: {:?} (full line: {:?})",
+        num2,
+        lines[2]
+    );
+}

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -280,29 +280,45 @@ fn test_line_numbers_structure_mode_skips_body_lines() {
     }
 }
 
-/// AC-2 gap test: a function preceded by many blank/comment lines so that the
-/// function signature source line number is much larger than its output position.
-/// This proves the annotation reflects true source lines, not output indices.
+/// AC-2 gap test: source line numbers must diverge from output positions.
+///
+/// Source layout (11 lines):
+///   1:  "function first(): void {"   ← collapsed in structure mode
+///   2:  "  return;"                  ← hidden by collapse
+///   3:  "}"                          ← hidden by collapse
+///   4:  "// comment 1"
+///   5:  "// comment 2"
+///   6:  "// comment 3"
+///   7:  "// comment 4"
+///   8:  "// comment 5"
+///   9:  "function gap(): void {"     ← collapsed signature
+///   10: "  return;"                  ← hidden
+///   11: "}"                          ← hidden
+///
+/// Structure output (7 lines):
+///   output 1 → first() collapsed      → source line 1
+///   output 2 → "// comment 1"         → source line 4
+///   output 3 → "// comment 2"         → source line 5
+///   output 4 → "// comment 3"         → source line 6
+///   output 5 → "// comment 4"         → source line 7
+///   output 6 → "// comment 5"         → source line 8
+///   output 7 → gap() collapsed        → source line 9
+///
+/// KEY PROPERTY: output position 7 != source line 9.
+/// An algorithm that returns "output index + 1" would annotate gap() as line 7,
+/// not line 9. This test fails for that algorithm.
 #[test]
 fn test_line_numbers_structure_mode_large_source_gap() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("gap.ts");
-    // Source layout:
-    //   1:  "// line 1"
-    //   2:  "// line 2"
-    //   3:  "// line 3"
-    //   4:  "// line 4"
-    //   5:  "// line 5"
-    //   6:  "function gap(): void {"
-    //   7:  "  return;"
-    //   8:  "}"
-    // Structure output (6 lines: 5 comments + 1 collapsed signature):
-    //   output line 6 must carry source line 6, NOT output line index 6.
+
+    // Build source: collapsed preamble function, then 5 comments, then target function.
     let mut content = String::new();
+    content.push_str("function first(): void {\n  return;\n}\n"); // lines 1-3 (collapsed)
     for i in 1..=5 {
-        content.push_str(&format!("// line {}\n", i));
+        content.push_str(&format!("// comment {}\n", i)); // lines 4-8
     }
-    content.push_str("function gap(): void {\n  return;\n}\n");
+    content.push_str("function gap(): void {\n  return;\n}\n"); // lines 9-11
     std::fs::write(&file, &content).unwrap();
 
     let output = skim_cmd()
@@ -327,27 +343,75 @@ fn test_line_numbers_structure_mode_large_source_gap() {
         })
         .collect();
 
-    // Find the collapsed signature line
-    let collapsed = numbered
+    // The second collapsed function is at source line 9.
+    // Collect all collapsed lines and find the one for gap().
+    let collapsed_lines: Vec<(usize, &str)> = numbered
         .iter()
-        .find(|(_, c)| c.contains("/* ... */"))
-        .expect("Must have a collapsed body line");
+        .filter(|(_, c)| c.contains("/* ... */"))
+        .copied()
+        .collect();
 
-    assert_eq!(
-        collapsed.0, 6,
-        "Function on source line 6 must be annotated as line 6, got {}. \
-         If this returns the output position (also 6 here) it still passes — \
-         but the 5 comment lines above have source lines 1-5, which equals \
-         their output positions, so if the algorithm just uses output indices \
-         all these assertions pass trivially. The real proof is in AC-2b/AC-2c.",
-        collapsed.0
+    assert!(
+        collapsed_lines.len() >= 2,
+        "Expected at least 2 collapsed function signatures, got {:?}",
+        collapsed_lines
     );
 
-    // Verify none of the body lines (7-8) appear in the output
+    // The last collapsed line belongs to gap() at source line 9.
+    let gap_annotation = collapsed_lines
+        .last()
+        .expect("at least one collapsed line");
+
+    assert_eq!(
+        gap_annotation.0, 9,
+        "gap() is on source line 9 but output position {} ({}). \
+         An 'output index + 1' algorithm would return {} here, not 9.",
+        numbered
+            .iter()
+            .position(|(n, c)| *n == gap_annotation.0 && c.contains("/* ... */"))
+            .map(|p| p + 1)
+            .unwrap_or(0),
+        gap_annotation.1,
+        numbered
+            .iter()
+            .position(|(n, c)| *n == gap_annotation.0 && c.contains("/* ... */"))
+            .map(|p| p + 1)
+            .unwrap_or(0),
+    );
+
+    // The 5 comments must be annotated with source lines 4-8, not 2-6.
+    let comment_lines: Vec<(usize, &str)> = numbered
+        .iter()
+        .filter(|(_, c)| c.contains("// comment"))
+        .copied()
+        .collect();
+
+    assert_eq!(
+        comment_lines.len(),
+        5,
+        "Expected 5 comment lines in output, got {:?}",
+        comment_lines
+    );
+
+    for (i, &(src_line, _)) in comment_lines.iter().enumerate() {
+        let expected = 4 + i; // source lines 4,5,6,7,8
+        assert_eq!(
+            src_line, expected,
+            "comment {} should have source line {}, got {}. \
+             Output position {} with source line 4 → an index-only algorithm would give {}.",
+            i + 1,
+            expected,
+            src_line,
+            i + 2, // output position (first() is output line 1)
+            i + 2,
+        );
+    }
+
+    // Body lines (10-11) must not appear in structure output.
     for &(num, _) in &numbered {
         assert!(
-            num != 7 && num != 8,
-            "Body lines 7 and 8 should not appear in structure output, but got line {}",
+            num != 10 && num != 11,
+            "Body lines 10 and 11 should not appear in structure output, but got source line {}",
             num
         );
     }


### PR DESCRIPTION
## Summary

Adds `-n` / `--line-numbers` flag to skim CLI that prefixes each output line with its source line number. This feature helps users locate specific code sections in the original source file when using skim for code reading and context collection.

## Changes

- **New CLI flag**: `-n` / `--line-numbers` on all skim subcommands
- **Source line mapping**: Accurately tracks original source line numbers across all transformation modes
- **Mode-specific handling**: 
  - Structure mode: Map source lines through removed ranges
  - Signatures mode: Handle line-number gaps from stripped function bodies
  - Pseudo mode: Correct line mapping for modified lines (type annotations stripped)
  - Minimal mode: Preserve line numbers for trimmed comment content
  - Passthrough (full) mode: Identity mapping with last-lines reconciliation

## Bug Fixes Included

- **AC-6**: Pseudo mode line-number gaps for removed body lines (Python)
- **AC-7**: Minimal mode line-number gaps for stripped comment lines (Python)  
- **AC-9**: Correct source line numbers in passthrough + --last-lines (sequential-from-1 bug fixed)
- **AC-11**: Guardrail identity-map validation
- Line-number correctness with duplicate content and --last-lines
- Monotonic matching for accurate line reconciliation in truncation

## Testing

- 7 commits with incremental bug fixes and test coverage
- 8 new unit tests for line-map computation helpers
- 2 CLI regression tests validating prefix output and duplicate-content handling

## Related Issues

Depends on completed implementation of line-number tracking infrastructure.

---

_Created by Claude Code_