### PR TITLE
feat(stats): session tracking, pricing tier, and review fixes (#150)

### DIFF
--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -162,13 +162,23 @@ impl PricingModel {
         input_cost_per_mtok: 3.0,
         tier_name: "Standard",
     };
+    /// Advanced tier at $5/MTok.
+    ///
+    /// AD-AN-3: No model hints are attached — pricing tiers shift frequently
+    /// and model names become stale within months. The $5 rate represents a
+    /// mid-range tier between Standard ($3) and Premium ($15) that covers
+    /// several recently-published model price points.
+    pub(crate) const ADVANCED: Self = Self {
+        input_cost_per_mtok: 5.0,
+        tier_name: "Advanced",
+    };
     pub(crate) const PREMIUM: Self = Self {
         input_cost_per_mtok: 15.0,
         tier_name: "Premium",
     };
 
-    pub(crate) fn all_tiers() -> [Self; 3] {
-        [Self::ECONOMY, Self::STANDARD, Self::PREMIUM]
+    pub(crate) fn all_tiers() -> [Self; 4] {
+        [Self::ECONOMY, Self::STANDARD, Self::ADVANCED, Self::PREMIUM]
     }
 
     pub(crate) fn default_pricing() -> Self {
@@ -1417,13 +1427,15 @@ mod tests {
     #[test]
     fn test_pricing_tiers() {
         let tiers = PricingModel::all_tiers();
-        assert_eq!(tiers.len(), 3);
+        assert_eq!(tiers.len(), 4);
         assert_eq!(tiers[0].tier_name, "Economy");
         assert_eq!(tiers[0].input_cost_per_mtok, 1.0);
         assert_eq!(tiers[1].tier_name, "Standard");
         assert_eq!(tiers[1].input_cost_per_mtok, 3.0);
-        assert_eq!(tiers[2].tier_name, "Premium");
-        assert_eq!(tiers[2].input_cost_per_mtok, 15.0);
+        assert_eq!(tiers[2].tier_name, "Advanced");
+        assert_eq!(tiers[2].input_cost_per_mtok, 5.0);
+        assert_eq!(tiers[3].tier_name, "Premium");
+        assert_eq!(tiers[3].input_cost_per_mtok, 15.0);
     }
 
     #[test]

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -672,31 +672,32 @@ impl AnalyticsDb {
 
     /// Query per-session statistics grouped by session_id.
     ///
-    /// NULL session_id rows are excluded from session grouping but counted in
-    /// `untagged_invocations`. Division by zero is guarded: when
-    /// `distinct_sessions == 0`, `avg_tokens_per_session` is 0.0.
+    /// Uses a single conditional-aggregation query instead of two separate queries
+    /// to avoid a TOCTOU race between the two reads and to reduce round-trips.
+    /// `COUNT(DISTINCT session_id)` naturally ignores NULL rows, so no extra WHERE
+    /// clause is needed for the session count.
+    ///
+    /// Division by zero is guarded: when `distinct_sessions == 0`,
+    /// `avg_tokens_per_session` is 0.0 (computed in Rust after the query).
     pub(crate) fn query_session_stats(&self, since: Option<i64>) -> anyhow::Result<SessionStats> {
-        // Query for sessions (non-NULL session_id rows only)
-        let (where_clause, params) = since_clause_with_extra(since, "session_id IS NOT NULL");
-        let session_sql = format!(
-            "SELECT COUNT(DISTINCT session_id), \
-             COALESCE(SUM(CASE WHEN raw_tokens > compressed_tokens THEN raw_tokens - compressed_tokens ELSE 0 END), 0) \
+        // F2: Single query using conditional aggregation — eliminates the two-query pattern.
+        let (where_clause, params) = since_clause(since);
+        let sql = format!(
+            "SELECT \
+             COUNT(DISTINCT session_id), \
+             COALESCE(SUM(CASE WHEN raw_tokens > compressed_tokens AND session_id IS NOT NULL \
+                              THEN raw_tokens - compressed_tokens ELSE 0 END), 0), \
+             COALESCE(SUM(CASE WHEN session_id IS NULL THEN 1 ELSE 0 END), 0) \
              FROM token_savings {where_clause}"
         );
-        let mut stmt = self.conn.prepare(&session_sql)?;
-        let (distinct_sessions, total_tokens_saved): (u64, i64) = stmt
+        let mut stmt = self.conn.prepare(&sql)?;
+        let (distinct_sessions, total_tokens_saved, untagged_invocations): (u64, i64, u64) = stmt
             .query_row(rusqlite::params_from_iter(params), |row| {
-                Ok((row.get::<_, u64>(0)?, row.get::<_, i64>(1)?))
-            })?;
-
-        // Query for untagged invocations (NULL session_id)
-        let (untagged_clause, untagged_params) =
-            since_clause_with_extra(since, "session_id IS NULL");
-        let untagged_sql = format!("SELECT COUNT(*) FROM token_savings {untagged_clause}");
-        let mut untagged_stmt = self.conn.prepare(&untagged_sql)?;
-        let untagged_invocations: u64 = untagged_stmt
-            .query_row(rusqlite::params_from_iter(untagged_params), |row| {
-                row.get(0)
+                Ok((
+                    row.get::<_, u64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, u64>(2)?,
+                ))
             })?;
 
         let total_tokens_saved = total_tokens_saved.max(0) as u64;

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -684,8 +684,8 @@ impl AnalyticsDb {
              FROM token_savings {where_clause}"
         );
         let mut stmt = self.conn.prepare(&session_sql)?;
-        let (distinct_sessions, total_tokens_saved): (u64, i64) =
-            stmt.query_row(rusqlite::params_from_iter(params), |row| {
+        let (distinct_sessions, total_tokens_saved): (u64, i64) = stmt
+            .query_row(rusqlite::params_from_iter(params), |row| {
                 Ok((row.get::<_, u64>(0)?, row.get::<_, i64>(1)?))
             })?;
 
@@ -1723,10 +1723,7 @@ mod tests {
     fn test_schema_v3_session_id_column_exists() {
         let (db, _tmp) = test_db();
         // PRAGMA table_info lists all columns; confirm session_id is present.
-        let mut stmt = db
-            .conn
-            .prepare("PRAGMA table_info(token_savings)")
-            .unwrap();
+        let mut stmt = db.conn.prepare("PRAGMA table_info(token_savings)").unwrap();
         let col_names: Vec<String> = stmt
             .query_map([], |row| row.get::<_, String>(1))
             .unwrap()
@@ -1764,7 +1761,10 @@ mod tests {
             .conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 3, "schema version should be 3 after all migrations");
+        assert_eq!(
+            version, 3,
+            "schema version should be 3 after all migrations"
+        );
     }
 
     // ========================================================================

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -879,6 +879,7 @@ fn persist_record(record: &TokenSavingsRecord) {
 /// Callers must check `enabled` before calling; this function always records.
 /// The single external caller (`try_record_command`) already guards on `enabled`,
 /// so removing the redundant parameter here keeps the argument count low.
+#[allow(clippy::too_many_arguments)]
 fn record_fire_and_forget(
     raw_text: String,
     compressed_text: String,
@@ -937,6 +938,7 @@ pub(crate) fn record_with_counts(enabled: bool, record: TokenSavingsRecord) {
 ///
 /// Reduces the 12-15 line inline pattern at each subcommand call site to a
 /// single function call. Token counting is deferred to a background thread.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn try_record_command(
     enabled: bool,
     raw_text: String,
@@ -974,6 +976,7 @@ pub(crate) fn try_record_command(
 ///
 /// Delegates to [`record_with_counts`] after resolving cwd and building
 /// the record.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn try_record_command_with_counts(
     enabled: bool,
     raw_tokens: usize,
@@ -1709,5 +1712,208 @@ mod tests {
 
         let results = db.query_by_original_cmd(None).unwrap();
         assert_eq!(results.len(), 15, "should be limited to top 15 results");
+    }
+
+    // ========================================================================
+    // B8: Schema v3 — session_id column
+    // ========================================================================
+
+    /// AD-AN-4: verify the session_id column exists after migration.
+    #[test]
+    fn test_schema_v3_session_id_column_exists() {
+        let (db, _tmp) = test_db();
+        // PRAGMA table_info lists all columns; confirm session_id is present.
+        let mut stmt = db
+            .conn
+            .prepare("PRAGMA table_info(token_savings)")
+            .unwrap();
+        let col_names: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert!(
+            col_names.contains(&"session_id".to_string()),
+            "token_savings must have session_id column after v3 migration; found: {col_names:?}"
+        );
+    }
+
+    /// AD-AN-4: verify the idx_ts_session_id index exists after migration.
+    #[test]
+    fn test_schema_v3_session_id_index_exists() {
+        let (db, _tmp) = test_db();
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_ts_session_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "idx_ts_session_id index should be created by v3 migration"
+        );
+    }
+
+    /// AD-AN-4: verify schema version is 3 after all migrations.
+    #[test]
+    fn test_schema_version_is_3() {
+        let (db, _tmp) = test_db();
+        let version: i64 = db
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, 3, "schema version should be 3 after all migrations");
+    }
+
+    // ========================================================================
+    // B8: query_session_stats — tagged and untagged invocations
+    // ========================================================================
+
+    /// AD-AN-2: session_id is stored and retrievable.
+    #[test]
+    fn test_record_with_session_id_stored() {
+        let (db, _tmp) = test_db();
+        let mut r = sample_record();
+        r.session_id = Some("session-abc-123".to_string());
+        db.record(&r).unwrap();
+
+        let stored: Option<String> = db
+            .conn
+            .query_row("SELECT session_id FROM token_savings", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            stored,
+            Some("session-abc-123".to_string()),
+            "session_id should be stored and retrievable"
+        );
+    }
+
+    /// AD-AN-2: NULL session_id stored for untagged records.
+    #[test]
+    fn test_record_without_session_id_stores_null() {
+        let (db, _tmp) = test_db();
+        let r = sample_record(); // session_id: None
+        db.record(&r).unwrap();
+
+        let stored: Option<String> = db
+            .conn
+            .query_row("SELECT session_id FROM token_savings", [], |row| row.get(0))
+            .unwrap();
+        assert!(
+            stored.is_none(),
+            "session_id should be NULL when not provided"
+        );
+    }
+
+    /// AD-AN-2: query_session_stats returns correct counts for tagged sessions.
+    #[test]
+    fn test_query_session_stats_basic() {
+        let (db, _tmp) = test_db();
+
+        // 3 records tagged to "sess-1", 2 to "sess-2"
+        for _ in 0..3 {
+            let mut r = sample_record();
+            r.session_id = Some("sess-1".to_string());
+            r.raw_tokens = 1000;
+            r.compressed_tokens = 200;
+            db.record(&r).unwrap();
+        }
+        for _ in 0..2 {
+            let mut r = sample_record();
+            r.session_id = Some("sess-2".to_string());
+            r.raw_tokens = 500;
+            r.compressed_tokens = 100;
+            db.record(&r).unwrap();
+        }
+
+        let stats = db.query_session_stats(None).unwrap();
+        assert_eq!(
+            stats.distinct_sessions, 2,
+            "should count 2 distinct sessions"
+        );
+        // sess-1: 3 * (1000 - 200) = 2400; sess-2: 2 * (500 - 100) = 800; total = 3200
+        assert_eq!(
+            stats.total_tokens_saved, 3200,
+            "total tokens saved should be 3200"
+        );
+        // avg per session: 3200 / 2 = 1600
+        assert!(
+            (stats.avg_tokens_per_session - 1600.0).abs() < 1.0,
+            "avg_tokens_per_session should be ~1600.0, got {}",
+            stats.avg_tokens_per_session
+        );
+        assert_eq!(
+            stats.untagged_invocations, 0,
+            "no untagged invocations expected"
+        );
+    }
+
+    /// AD-AN-2: untagged invocations (NULL session_id) are counted separately.
+    #[test]
+    fn test_query_session_stats_untagged() {
+        let (db, _tmp) = test_db();
+
+        // 1 tagged record
+        let mut tagged = sample_record();
+        tagged.session_id = Some("sess-x".to_string());
+        db.record(&tagged).unwrap();
+
+        // 3 untagged records
+        for _ in 0..3 {
+            let r = sample_record(); // session_id: None
+            db.record(&r).unwrap();
+        }
+
+        let stats = db.query_session_stats(None).unwrap();
+        assert_eq!(
+            stats.distinct_sessions, 1,
+            "should count 1 distinct tagged session"
+        );
+        assert_eq!(
+            stats.untagged_invocations, 3,
+            "should count 3 untagged invocations"
+        );
+    }
+
+    /// AD-AN-2: empty DB returns zero-valued SessionStats (no panic).
+    #[test]
+    fn test_query_session_stats_empty_db() {
+        let (db, _tmp) = test_db();
+        let stats = db.query_session_stats(None).unwrap();
+        assert_eq!(stats.distinct_sessions, 0);
+        assert_eq!(stats.total_tokens_saved, 0);
+        assert_eq!(stats.avg_tokens_per_session, 0.0);
+        assert_eq!(stats.untagged_invocations, 0);
+    }
+
+    /// AD-AN-2: since filter applies to session_stats queries.
+    #[test]
+    fn test_query_session_stats_since_filter() {
+        let (db, _tmp) = test_db();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        // Old tagged record (10 days ago)
+        let mut old = sample_record();
+        old.timestamp = now - 86400 * 10;
+        old.session_id = Some("old-session".to_string());
+        db.record(&old).unwrap();
+
+        // Recent tagged record (1 hour ago)
+        let mut recent = sample_record();
+        recent.timestamp = now - 3600;
+        recent.session_id = Some("new-session".to_string());
+        db.record(&recent).unwrap();
+
+        // Filter to last 24h: should see only new-session
+        let stats = db.query_session_stats(Some(now - 86400)).unwrap();
+        assert_eq!(
+            stats.distinct_sessions, 1,
+            "since filter should exclude old session"
+        );
     }
 }

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -75,6 +75,10 @@ pub(crate) struct TokenSavingsRecord {
     pub(crate) mode: Option<String>,
     pub(crate) language: Option<String>,
     pub(crate) parse_tier: Option<String>,
+    /// AD-AN-4: session_id is nullable for backward compatibility — rows
+    /// recorded before schema v3 have NULL and are excluded from per-session
+    /// average calculations.
+    pub(crate) session_id: Option<String>,
 }
 
 // ============================================================================
@@ -141,6 +145,23 @@ pub(crate) struct OriginalCommandStats {
     pub(crate) tokens_saved: u64,
     pub(crate) avg_savings_pct: f64,
     pub(crate) avg_duration_ms: f64,
+}
+
+/// Per-session aggregate statistics derived from the `session_id` column.
+///
+/// AD-AN-2: Only invocations with a non-NULL `session_id` are counted.
+/// Pre-v3 rows (NULL session_id) are excluded so the average reflects
+/// actual observed session throughput rather than inflated all-time totals.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct SessionStats {
+    /// Number of distinct session IDs observed.
+    pub(crate) distinct_sessions: u64,
+    /// Total tokens saved across all tagged invocations.
+    pub(crate) total_tokens_saved: u64,
+    /// Average tokens saved per session (zero-safe, returns 0.0 when no sessions).
+    pub(crate) avg_tokens_per_session: f64,
+    /// Invocations without a session_id (NULL rows, excluded from averages).
+    pub(crate) untagged_invocations: u64,
 }
 
 // ============================================================================
@@ -215,18 +236,27 @@ impl PricingModel {
 /// and per-call `SKIM_DISABLE_ANALYTICS` / `SKIM_INPUT_COST_PER_MTOK` env reads.
 /// Created in `main()` after CLI parsing and threaded to all callers.
 /// Tests construct this struct directly with controlled values — no env mutation.
-#[derive(Debug, Clone, Copy)]
+///
+/// AD-AN-1: `Copy` is intentionally not derived because `session_id: Option<String>`
+/// contains a heap-allocated `String`. `Clone` is derived for explicit duplication
+/// where needed.
+#[derive(Debug, Clone)]
 pub(crate) struct AnalyticsConfig {
     pub enabled: bool,
     pub input_cost_per_mtok: Option<f64>,
+    /// AD-AN-4: Optional session ID injected by the hook rewrite pipeline
+    /// (`--session-id=VALUE`). Propagated to every `TokenSavingsRecord` so
+    /// the per-session dashboard section can group invocations by session.
+    pub session_id: Option<String>,
 }
 
 impl AnalyticsConfig {
     /// Read process env once at the system boundary.
     ///
     /// `cli_disable` is the value of `--disable-analytics` from CLI parsing.
-    /// Call this in main(), then thread the result down to all callers.
-    pub fn from_process(cli_disable: bool) -> Self {
+    /// `session_id` is extracted from `--session-id=VALUE` in `main()` before
+    /// this call. Call this in main(), then thread the result down to all callers.
+    pub fn from_process(cli_disable: bool, session_id: Option<String>) -> Self {
         let env_disabled = std::env::var("SKIM_DISABLE_ANALYTICS")
             .ok()
             .map(|v| Self::parse_disable_value(&v))
@@ -238,6 +268,7 @@ impl AnalyticsConfig {
         Self {
             enabled: !cli_disable && !env_disabled,
             input_cost_per_mtok: cost,
+            session_id,
         }
     }
 
@@ -296,6 +327,14 @@ pub(crate) trait AnalyticsStore {
         _since: Option<i64>,
     ) -> anyhow::Result<Vec<OriginalCommandStats>> {
         Ok(vec![])
+    }
+    fn query_session_stats(&self, _since: Option<i64>) -> anyhow::Result<SessionStats> {
+        Ok(SessionStats {
+            distinct_sessions: 0,
+            total_tokens_saved: 0,
+            avg_tokens_per_session: 0.0,
+            untagged_invocations: 0,
+        })
     }
     fn clear(&self) -> anyhow::Result<()> {
         Ok(())
@@ -367,8 +406,8 @@ impl AnalyticsDb {
             &r.original_cmd
         };
         self.conn.execute(
-            "INSERT INTO token_savings (timestamp, command_type, original_cmd, raw_tokens, compressed_tokens, savings_pct, duration_ms, project_path, mode, language, parse_tier)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            "INSERT INTO token_savings (timestamp, command_type, original_cmd, raw_tokens, compressed_tokens, savings_pct, duration_ms, project_path, mode, language, parse_tier, session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             rusqlite::params![
                 r.timestamp,
                 r.command_type.as_str(),
@@ -381,6 +420,7 @@ impl AnalyticsDb {
                 r.mode,
                 r.language,
                 r.parse_tier,
+                r.session_id,
             ],
         )?;
         Ok(())
@@ -629,6 +669,50 @@ impl AnalyticsDb {
 
         Ok(count)
     }
+
+    /// Query per-session statistics grouped by session_id.
+    ///
+    /// NULL session_id rows are excluded from session grouping but counted in
+    /// `untagged_invocations`. Division by zero is guarded: when
+    /// `distinct_sessions == 0`, `avg_tokens_per_session` is 0.0.
+    pub(crate) fn query_session_stats(&self, since: Option<i64>) -> anyhow::Result<SessionStats> {
+        // Query for sessions (non-NULL session_id rows only)
+        let (where_clause, params) = since_clause_with_extra(since, "session_id IS NOT NULL");
+        let session_sql = format!(
+            "SELECT COUNT(DISTINCT session_id), \
+             COALESCE(SUM(CASE WHEN raw_tokens > compressed_tokens THEN raw_tokens - compressed_tokens ELSE 0 END), 0) \
+             FROM token_savings {where_clause}"
+        );
+        let mut stmt = self.conn.prepare(&session_sql)?;
+        let (distinct_sessions, total_tokens_saved): (u64, i64) =
+            stmt.query_row(rusqlite::params_from_iter(params), |row| {
+                Ok((row.get::<_, u64>(0)?, row.get::<_, i64>(1)?))
+            })?;
+
+        // Query for untagged invocations (NULL session_id)
+        let (untagged_clause, untagged_params) =
+            since_clause_with_extra(since, "session_id IS NULL");
+        let untagged_sql = format!("SELECT COUNT(*) FROM token_savings {untagged_clause}");
+        let mut untagged_stmt = self.conn.prepare(&untagged_sql)?;
+        let untagged_invocations: u64 = untagged_stmt
+            .query_row(rusqlite::params_from_iter(untagged_params), |row| {
+                row.get(0)
+            })?;
+
+        let total_tokens_saved = total_tokens_saved.max(0) as u64;
+        let avg_tokens_per_session = if distinct_sessions > 0 {
+            total_tokens_saved as f64 / distinct_sessions as f64
+        } else {
+            0.0
+        };
+
+        Ok(SessionStats {
+            distinct_sessions,
+            total_tokens_saved,
+            avg_tokens_per_session,
+            untagged_invocations,
+        })
+    }
 }
 
 impl AnalyticsStore for AnalyticsDb {
@@ -655,6 +739,9 @@ impl AnalyticsStore for AnalyticsDb {
         since: Option<i64>,
     ) -> anyhow::Result<Vec<OriginalCommandStats>> {
         self.query_by_original_cmd(since)
+    }
+    fn query_session_stats(&self, since: Option<i64>) -> anyhow::Result<SessionStats> {
+        self.query_session_stats(since)
     }
     fn clear(&self) -> anyhow::Result<()> {
         self.conn.execute("DELETE FROM token_savings", [])?;
@@ -791,7 +878,7 @@ fn persist_record(record: &TokenSavingsRecord) {
 ///
 /// Callers must check `enabled` before calling; this function always records.
 /// The single external caller (`try_record_command`) already guards on `enabled`,
-/// so removing the redundant parameter here keeps the argument count at 7.
+/// so removing the redundant parameter here keeps the argument count low.
 fn record_fire_and_forget(
     raw_text: String,
     compressed_text: String,
@@ -800,6 +887,7 @@ fn record_fire_and_forget(
     duration: Duration,
     project_path: String,
     parse_tier: Option<String>,
+    session_id: Option<String>,
 ) {
     register_thread(std::thread::spawn(move || {
         let Ok(raw_tokens) = tokens::count_tokens(&raw_text) else {
@@ -820,6 +908,7 @@ fn record_fire_and_forget(
             mode: None,
             language: None,
             parse_tier,
+            session_id,
         };
         persist_record(&record);
     }));
@@ -856,6 +945,7 @@ pub(crate) fn try_record_command(
     command_type: CommandType,
     duration: Duration,
     parse_tier: Option<&str>,
+    session_id: Option<&str>,
 ) {
     if !enabled {
         return;
@@ -872,6 +962,7 @@ pub(crate) fn try_record_command(
         duration,
         cwd,
         parse_tier.map(str::to_string),
+        session_id.map(str::to_string),
     );
 }
 
@@ -891,6 +982,7 @@ pub(crate) fn try_record_command_with_counts(
     command_type: CommandType,
     duration: Duration,
     parse_tier: Option<&str>,
+    session_id: Option<&str>,
 ) {
     if !enabled {
         return;
@@ -913,6 +1005,7 @@ pub(crate) fn try_record_command_with_counts(
             mode: None,
             language: None,
             parse_tier: parse_tier.map(str::to_string),
+            session_id: session_id.map(str::to_string),
         },
     );
 }
@@ -951,6 +1044,7 @@ mod tests {
             mode: Some("structure".to_string()),
             language: Some("rust".to_string()),
             parse_tier: None,
+            session_id: None,
         }
     }
 

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -156,7 +156,12 @@ pub(crate) struct OriginalCommandStats {
 pub(crate) struct SessionStats {
     /// Number of distinct session IDs observed.
     pub(crate) distinct_sessions: u64,
-    /// Total tokens saved across all tagged invocations.
+    /// Tokens saved across invocations that carry a non-NULL `session_id`.
+    ///
+    /// Only session-tagged rows contribute to this total.  Rows recorded before
+    /// schema v3 (NULL `session_id`) are excluded so the figure reflects actual
+    /// observed session throughput.  See `untagged_invocations` for the excluded
+    /// row count.
     pub(crate) total_tokens_saved: u64,
     /// Average tokens saved per session (zero-safe, returns 0.0 when no sessions).
     pub(crate) avg_tokens_per_session: f64,
@@ -786,6 +791,16 @@ fn since_clause_with_extra(since: Option<i64>, extra_condition: &str) -> (String
 ///
 /// `Copy` is derived so passing `rec` at a call site never requires `&rec`
 /// (the struct is small: one bool, one enum Copy, one Option<&'a str> ×2).
+///
+/// ## Relationship to `RunContext`
+///
+/// [`crate::cmd::RunContext`] is the dispatch-layer struct that carries all
+/// cross-cutting fields for a subcommand invocation, including UI concerns
+/// (`show_stats`, `json_output`) that are irrelevant to recording.  At recording
+/// call sites, handlers construct a `RecordingContext` from the recording-relevant
+/// subset of `RunContext` plus handler-local fields (`command_type`, `parse_tier`).
+/// `RecordingContext` uses borrowed `&'a str` references (enabling `Copy`) while
+/// `RunContext` owns its strings — the lifetime boundary is intentional.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordingContext<'a> {
     /// Whether analytics recording is enabled for this invocation.
@@ -1973,19 +1988,22 @@ mod tests {
         );
     }
 
-    /// AD-AN-2: untagged invocations (NULL session_id) are counted separately.
+    /// AD-AN-2: untagged invocations (NULL session_id) are counted separately
+    /// and do NOT contribute to `total_tokens_saved`.
     #[test]
     fn test_query_session_stats_untagged() {
         let (db, _tmp) = test_db();
 
-        // 1 tagged record
+        // 1 tagged record: raw=1000, compressed=200 → savings=800
         let mut tagged = sample_record();
         tagged.session_id = Some("sess-x".to_string());
+        tagged.raw_tokens = 1000;
+        tagged.compressed_tokens = 200;
         db.record(&tagged).unwrap();
 
-        // 3 untagged records
+        // 3 untagged records (session_id: None) — must NOT inflate total_tokens_saved
         for _ in 0..3 {
-            let r = sample_record(); // session_id: None
+            let r = sample_record(); // session_id: None, raw=1000, compressed=200
             db.record(&r).unwrap();
         }
 
@@ -1997,6 +2015,12 @@ mod tests {
         assert_eq!(
             stats.untagged_invocations, 3,
             "should count 3 untagged invocations"
+        );
+        // Untagged rows must be excluded from total_tokens_saved.
+        // Only the single tagged record (savings = 800) should count.
+        assert_eq!(
+            stats.total_tokens_saved, 800,
+            "total_tokens_saved must only count tagged rows, not untagged"
         );
     }
 

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -774,6 +774,43 @@ fn since_clause_with_extra(since: Option<i64>, extra_condition: &str) -> (String
 }
 
 // ============================================================================
+// RecordingContext — bundles analytics metadata for subcommand handlers
+// ============================================================================
+
+/// Bundles recording parameters that flow through subcommand handlers.
+///
+/// Introduced in F4 to eliminate the 4-parameter `(analytics_enabled,
+/// command_type, parse_tier, session_id)` tuple that was threaded individually
+/// through every handler function, triggering `clippy::too_many_arguments`
+/// suppressions.
+///
+/// `Copy` is derived so passing `rec` at a call site never requires `&rec`
+/// (the struct is small: one bool, one enum Copy, one Option<&'a str> ×2).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecordingContext<'a> {
+    /// Whether analytics recording is enabled for this invocation.
+    pub enabled: bool,
+    /// The command family tag stored in the analytics DB.
+    pub command_type: CommandType,
+    /// Optional tier label set by the parser (e.g. `"full"`, `"degraded"`).
+    pub parse_tier: Option<&'a str>,
+    /// Hook-injected session identifier (AD-AN-4).
+    pub session_id: Option<&'a str>,
+}
+
+/// Owned recording parameters for the background recording thread.
+///
+/// Bundles the fields that `record_fire_and_forget` previously accepted
+/// individually so the thread spawning function stays under the
+/// `clippy::too_many_arguments` threshold.
+struct FireAndForgetParams {
+    command_type: CommandType,
+    project_path: String,
+    parse_tier: Option<String>,
+    session_id: Option<String>,
+}
+
+// ============================================================================
 // Fire-and-forget recording functions
 // ============================================================================
 
@@ -905,17 +942,19 @@ fn persist_record(record: &TokenSavingsRecord) {
 /// Callers must check `enabled` before calling; this function always records.
 /// The single external caller (`try_record_command`) already guards on `enabled`,
 /// so removing the redundant parameter here keeps the argument count low.
-#[allow(clippy::too_many_arguments)]
 fn record_fire_and_forget(
     raw_text: String,
     compressed_text: String,
     original_cmd: String,
-    command_type: CommandType,
     duration: Duration,
-    project_path: String,
-    parse_tier: Option<String>,
-    session_id: Option<String>,
+    params: FireAndForgetParams,
 ) {
+    let FireAndForgetParams {
+        command_type,
+        project_path,
+        parse_tier,
+        session_id,
+    } = params;
     register_thread(std::thread::spawn(move || {
         let Ok(raw_tokens) = tokens::count_tokens(&raw_text) else {
             return;
@@ -964,18 +1003,18 @@ pub(crate) fn record_with_counts(enabled: bool, record: TokenSavingsRecord) {
 ///
 /// Reduces the 12-15 line inline pattern at each subcommand call site to a
 /// single function call. Token counting is deferred to a background thread.
-#[allow(clippy::too_many_arguments)]
+///
+/// `rec` bundles the recording control fields (enabled, command_type,
+/// parse_tier, session_id) so this function stays under the
+/// `clippy::too_many_arguments` threshold.
 pub(crate) fn try_record_command(
-    enabled: bool,
+    rec: RecordingContext<'_>,
     raw_text: String,
     compressed_text: String,
     original_cmd: String,
-    command_type: CommandType,
     duration: Duration,
-    parse_tier: Option<&str>,
-    session_id: Option<&str>,
 ) {
-    if !enabled {
+    if !rec.enabled {
         return;
     }
     let cwd = std::env::current_dir()
@@ -986,11 +1025,13 @@ pub(crate) fn try_record_command(
         raw_text,
         compressed_text,
         original_cmd,
-        command_type,
         duration,
-        cwd,
-        parse_tier.map(str::to_string),
-        session_id.map(str::to_string),
+        FireAndForgetParams {
+            command_type: rec.command_type,
+            project_path: cwd,
+            parse_tier: rec.parse_tier.map(str::to_string),
+            session_id: rec.session_id.map(str::to_string),
+        },
     );
 }
 
@@ -1002,18 +1043,18 @@ pub(crate) fn try_record_command(
 ///
 /// Delegates to [`record_with_counts`] after resolving cwd and building
 /// the record.
-#[allow(clippy::too_many_arguments)]
+///
+/// `rec` bundles the recording control fields (enabled, command_type,
+/// parse_tier, session_id) so this function stays under the
+/// `clippy::too_many_arguments` threshold.
 pub(crate) fn try_record_command_with_counts(
-    enabled: bool,
+    rec: RecordingContext<'_>,
     raw_tokens: usize,
     compressed_tokens: usize,
     original_cmd: String,
-    command_type: CommandType,
     duration: Duration,
-    parse_tier: Option<&str>,
-    session_id: Option<&str>,
 ) {
-    if !enabled {
+    if !rec.enabled {
         return;
     }
     let cwd = std::env::current_dir()
@@ -1024,7 +1065,7 @@ pub(crate) fn try_record_command_with_counts(
         true,
         TokenSavingsRecord {
             timestamp: now_unix_secs(),
-            command_type,
+            command_type: rec.command_type,
             original_cmd,
             raw_tokens,
             compressed_tokens: compressed_tokens.min(raw_tokens),
@@ -1033,8 +1074,8 @@ pub(crate) fn try_record_command_with_counts(
             project_path: cwd,
             mode: None,
             language: None,
-            parse_tier: parse_tier.map(str::to_string),
-            session_id: session_id.map(str::to_string),
+            parse_tier: rec.parse_tier.map(str::to_string),
+            session_id: rec.session_id.map(str::to_string),
         },
     );
 }

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -813,6 +813,45 @@ pub(crate) struct RecordingContext<'a> {
     pub session_id: Option<&'a str>,
 }
 
+impl<'a> RecordingContext<'a> {
+    /// Return a copy of `self` with `parse_tier` set to `Some(tier)`.
+    ///
+    /// Eliminates the 3-line struct-update boilerplate that appeared at every
+    /// call site where a parser emits a tier annotation:
+    ///
+    /// ```rust
+    /// // Before
+    /// crate::analytics::RecordingContext { parse_tier: Some("full"), ..rec }
+    /// // After
+    /// rec.with_tier("full")
+    /// ```
+    pub(crate) fn with_tier(self, tier: &'a str) -> Self {
+        Self {
+            parse_tier: Some(tier),
+            ..self
+        }
+    }
+
+    /// Return a copy of `self` with `parse_tier` replaced by the supplied
+    /// `Option<&'a str>`.
+    ///
+    /// Used at call sites where the tier is already an `Option` (e.g. derived
+    /// from a local variable or a parser result that may be absent):
+    ///
+    /// ```rust
+    /// // Before
+    /// crate::analytics::RecordingContext { parse_tier: tier_name, ..rec }
+    /// // After
+    /// rec.with_tier_opt(tier_name)
+    /// ```
+    pub(crate) fn with_tier_opt(self, tier: Option<&'a str>) -> Self {
+        Self {
+            parse_tier: tier,
+            ..self
+        }
+    }
+}
+
 /// Owned recording parameters for the background recording thread.
 ///
 /// Bundles the fields that `record_fire_and_forget` previously accepted

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -691,8 +691,8 @@ impl AnalyticsDb {
              FROM token_savings {where_clause}"
         );
         let mut stmt = self.conn.prepare(&sql)?;
-        let (distinct_sessions, total_tokens_saved, untagged_invocations): (u64, i64, u64) = stmt
-            .query_row(rusqlite::params_from_iter(params), |row| {
+        let (distinct_sessions, total_tokens_saved, untagged_invocations): (u64, i64, u64) =
+            stmt.query_row(rusqlite::params_from_iter(params), |row| {
                 Ok((
                     row.get::<_, u64>(0)?,
                     row.get::<_, i64>(1)?,
@@ -1588,7 +1588,10 @@ mod tests {
     /// F1: empty string is rejected.
     #[test]
     fn test_is_safe_session_id_empty() {
-        assert!(!is_safe_session_id(""), "empty session_id should be rejected");
+        assert!(
+            !is_safe_session_id(""),
+            "empty session_id should be rejected"
+        );
     }
 
     /// F1: shell metacharacters are rejected.
@@ -1598,14 +1601,8 @@ mod tests {
             !is_safe_session_id("foo;bar"),
             "semicolon should be rejected"
         );
-        assert!(
-            !is_safe_session_id("foo|bar"),
-            "pipe should be rejected"
-        );
-        assert!(
-            !is_safe_session_id("foo bar"),
-            "space should be rejected"
-        );
+        assert!(!is_safe_session_id("foo|bar"), "pipe should be rejected");
+        assert!(!is_safe_session_id("foo bar"), "space should be rejected");
         assert!(
             !is_safe_session_id("$HOME"),
             "dollar sign should be rejected"

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -156,12 +156,8 @@ pub(crate) struct OriginalCommandStats {
 pub(crate) struct SessionStats {
     /// Number of distinct session IDs observed.
     pub(crate) distinct_sessions: u64,
-    /// Tokens saved across invocations that carry a non-NULL `session_id`.
-    ///
-    /// Only session-tagged rows contribute to this total.  Rows recorded before
-    /// schema v3 (NULL `session_id`) are excluded so the figure reflects actual
-    /// observed session throughput.  See `untagged_invocations` for the excluded
-    /// row count.
+    /// Tokens saved by session-tagged invocations only (NULL rows excluded).
+    /// See `untagged_invocations` for the excluded count.
     pub(crate) total_tokens_saved: u64,
     /// Average tokens saved per session (zero-safe, returns 0.0 when no sessions).
     pub(crate) avg_tokens_per_session: f64,
@@ -782,25 +778,13 @@ fn since_clause_with_extra(since: Option<i64>, extra_condition: &str) -> (String
 // RecordingContext — bundles analytics metadata for subcommand handlers
 // ============================================================================
 
-/// Bundles recording parameters that flow through subcommand handlers.
+/// Bundles analytics recording parameters threaded through subcommand handlers.
 ///
-/// Introduced in F4 to eliminate the 4-parameter `(analytics_enabled,
-/// command_type, parse_tier, session_id)` tuple that was threaded individually
-/// through every handler function, triggering `clippy::too_many_arguments`
-/// suppressions.
-///
-/// `Copy` is derived so passing `rec` at a call site never requires `&rec`
-/// (the struct is small: one bool, one enum Copy, one Option<&'a str> ×2).
-///
-/// ## Relationship to `RunContext`
-///
-/// [`crate::cmd::RunContext`] is the dispatch-layer struct that carries all
-/// cross-cutting fields for a subcommand invocation, including UI concerns
-/// (`show_stats`, `json_output`) that are irrelevant to recording.  At recording
-/// call sites, handlers construct a `RecordingContext` from the recording-relevant
-/// subset of `RunContext` plus handler-local fields (`command_type`, `parse_tier`).
-/// `RecordingContext` uses borrowed `&'a str` references (enabling `Copy`) while
-/// `RunContext` owns its strings — the lifetime boundary is intentional.
+/// `Copy` keeps call sites clean (no `&rec` or `.clone()`).  See
+/// [`crate::cmd::RunContext`] for the broader dispatch-layer struct that also
+/// carries UI concerns (`show_stats`, `json_output`) irrelevant to recording.
+/// `RunContext` owns its strings; `RecordingContext` borrows them — the lifetime
+/// boundary is intentional.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordingContext<'a> {
     /// Whether analytics recording is enabled for this invocation.
@@ -815,16 +799,6 @@ pub(crate) struct RecordingContext<'a> {
 
 impl<'a> RecordingContext<'a> {
     /// Return a copy of `self` with `parse_tier` set to `Some(tier)`.
-    ///
-    /// Eliminates the 3-line struct-update boilerplate that appeared at every
-    /// call site where a parser emits a tier annotation:
-    ///
-    /// ```rust
-    /// // Before
-    /// crate::analytics::RecordingContext { parse_tier: Some("full"), ..rec }
-    /// // After
-    /// rec.with_tier("full")
-    /// ```
     pub(crate) fn with_tier(self, tier: &'a str) -> Self {
         Self {
             parse_tier: Some(tier),
@@ -832,18 +806,9 @@ impl<'a> RecordingContext<'a> {
         }
     }
 
-    /// Return a copy of `self` with `parse_tier` replaced by the supplied
-    /// `Option<&'a str>`.
+    /// Return a copy of `self` with `parse_tier` set to `tier`.
     ///
-    /// Used at call sites where the tier is already an `Option` (e.g. derived
-    /// from a local variable or a parser result that may be absent):
-    ///
-    /// ```rust
-    /// // Before
-    /// crate::analytics::RecordingContext { parse_tier: tier_name, ..rec }
-    /// // After
-    /// rec.with_tier_opt(tier_name)
-    /// ```
+    /// Use when the tier is already `Option<&'a str>` (e.g. from a parser result).
     pub(crate) fn with_tier_opt(self, tier: Option<&'a str>) -> Self {
         Self {
             parse_tier: tier,

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -777,6 +777,31 @@ fn since_clause_with_extra(since: Option<i64>, extra_condition: &str) -> (String
 // Fire-and-forget recording functions
 // ============================================================================
 
+/// Returns `true` if `sid` is safe for shell command interpolation.
+///
+/// Allows `[a-zA-Z0-9_\-.]`, max 128 chars. Rejects empty, oversized,
+/// and metacharacter-bearing values to prevent command injection.
+///
+/// ## Why 128 chars?
+///
+/// Session IDs are agent-generated opaque identifiers (typically UUIDs or
+/// short descriptive strings). 128 characters is generous for any plausible
+/// legitimate value while bounding the injected flag length in command strings.
+///
+/// ## Rationale for allowed characters
+///
+/// `[a-zA-Z0-9_-.]` covers UUIDs, ISO 8601 timestamps, dot-separated
+/// identifiers, and human-readable session names. All other characters —
+/// including shell metacharacters (`;`, `|`, `$`, spaces, backticks, etc.)
+/// — are rejected.
+pub(crate) fn is_safe_session_id(sid: &str) -> bool {
+    !sid.is_empty()
+        && sid.len() <= 128
+        && sid
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+}
+
 /// Compute token savings as a percentage.
 ///
 /// Returns 0.0 when:
@@ -1497,6 +1522,65 @@ mod tests {
         assert!(
             (savings_percentage(100, 20) - 80.0).abs() < 0.01,
             "expected ~80.0%"
+        );
+    }
+
+    // ========================================================================
+    // is_safe_session_id tests (F1, F6, F10)
+    // ========================================================================
+
+    /// F1: 128-char string is accepted; 129-char string is rejected.
+    #[test]
+    fn test_is_safe_session_id_max_length() {
+        let at_limit = "a".repeat(128);
+        assert!(
+            is_safe_session_id(&at_limit),
+            "128-char session_id should be accepted"
+        );
+        let over_limit = "a".repeat(129);
+        assert!(
+            !is_safe_session_id(&over_limit),
+            "129-char session_id should be rejected"
+        );
+    }
+
+    /// F1: empty string is rejected.
+    #[test]
+    fn test_is_safe_session_id_empty() {
+        assert!(!is_safe_session_id(""), "empty session_id should be rejected");
+    }
+
+    /// F1: shell metacharacters are rejected.
+    #[test]
+    fn test_is_safe_session_id_with_metacharacters() {
+        assert!(
+            !is_safe_session_id("foo;bar"),
+            "semicolon should be rejected"
+        );
+        assert!(
+            !is_safe_session_id("foo|bar"),
+            "pipe should be rejected"
+        );
+        assert!(
+            !is_safe_session_id("foo bar"),
+            "space should be rejected"
+        );
+        assert!(
+            !is_safe_session_id("$HOME"),
+            "dollar sign should be rejected"
+        );
+    }
+
+    /// F1: alphanumeric, hyphens, underscores, dots are accepted.
+    #[test]
+    fn test_is_safe_session_id_valid() {
+        assert!(
+            is_safe_session_id("abc-123_test.v2"),
+            "alphanumeric, hyphen, underscore, dot should be accepted"
+        );
+        assert!(
+            is_safe_session_id("session-2024-01-15_abc123"),
+            "typical session ID format should be accepted"
         );
     }
 

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -2001,4 +2001,29 @@ mod tests {
             "since filter should exclude old session"
         );
     }
+
+    // ========================================================================
+    // AnalyticsConfig::from_process tests (F5 step 3)
+    // ========================================================================
+
+    /// F5: from_process carries session_id when provided.
+    #[test]
+    fn test_from_process_passes_session_id() {
+        let config = AnalyticsConfig::from_process(false, Some("my-session".to_string()));
+        assert_eq!(
+            config.session_id.as_deref(),
+            Some("my-session"),
+            "session_id should propagate through from_process"
+        );
+    }
+
+    /// F5: from_process yields None session_id when not provided.
+    #[test]
+    fn test_from_process_none_session_id() {
+        let config = AnalyticsConfig::from_process(false, None);
+        assert!(
+            config.session_id.is_none(),
+            "session_id should be None when not provided"
+        );
+    }
 }

--- a/crates/rskim/src/analytics/schema.rs
+++ b/crates/rskim/src/analytics/schema.rs
@@ -38,5 +38,16 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
         )?;
     }
 
+    if version < 3 {
+        // AD-AN-4: session_id is nullable for backward compatibility — rows
+        // recorded before this migration have NULL session_id and are excluded
+        // from per-session average calculations.
+        conn.execute_batch(
+            "ALTER TABLE token_savings ADD COLUMN session_id TEXT;
+            CREATE INDEX IF NOT EXISTS idx_ts_session_id ON token_savings(session_id);
+            PRAGMA user_version = 3;",
+        )?;
+    }
+
     Ok(())
 }

--- a/crates/rskim/src/cmd/agents/mod.rs
+++ b/crates/rskim/src/cmd/agents/mod.rs
@@ -59,6 +59,7 @@ mod tests {
     const TEST_ANALYTICS: crate::analytics::AnalyticsConfig = crate::analytics::AnalyticsConfig {
         enabled: false,
         input_cost_per_mtok: None,
+        session_id: None,
     };
 
     #[test]

--- a/crates/rskim/src/cmd/build/cargo.rs
+++ b/crates/rskim/src/cmd/build/cargo.rs
@@ -47,8 +47,7 @@ static CARGO_ERROR_LINE_RE: LazyLock<Regex> =
 pub(crate) fn run(
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     let mut full_args = vec!["build".to_string()];
     full_args.extend_from_slice(args);
@@ -63,9 +62,8 @@ pub(crate) fn run(
         &[("CARGO_TERM_COLOR", "never")],
         "install Rust from https://rustup.rs",
         show_stats,
-        analytics_enabled,
+        rec,
         parse,
-        session_id,
     )
 }
 
@@ -76,8 +74,7 @@ pub(crate) fn run(
 pub(crate) fn run_clippy(
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     let mut full_args = vec!["clippy".to_string()];
     full_args.extend_from_slice(args);
@@ -92,9 +89,8 @@ pub(crate) fn run_clippy(
         &[("CARGO_TERM_COLOR", "never")],
         "install Rust from https://rustup.rs",
         show_stats,
-        analytics_enabled,
+        rec,
         parse,
-        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/build/cargo.rs
+++ b/crates/rskim/src/cmd/build/cargo.rs
@@ -48,6 +48,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let mut full_args = vec!["build".to_string()];
     full_args.extend_from_slice(args);
@@ -64,6 +65,7 @@ pub(crate) fn run(
         show_stats,
         analytics_enabled,
         parse,
+        session_id,
     )
 }
 
@@ -75,6 +77,7 @@ pub(crate) fn run_clippy(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let mut full_args = vec!["clippy".to_string()];
     full_args.extend_from_slice(args);
@@ -91,6 +94,7 @@ pub(crate) fn run_clippy(
         show_stats,
         analytics_enabled,
         parse,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/build/mod.rs
+++ b/crates/rskim/src/cmd/build/mod.rs
@@ -38,10 +38,11 @@ pub(crate) fn run(
         None => (None, [].as_slice()),
     };
 
+    let session_id = analytics.session_id.as_deref();
     match sub {
-        Some("cargo") => cargo::run(remaining, show_stats, analytics.enabled),
-        Some("clippy") => cargo::run_clippy(remaining, show_stats, analytics.enabled),
-        Some("tsc") => tsc::run(remaining, show_stats, analytics.enabled),
+        Some("cargo") => cargo::run(remaining, show_stats, analytics.enabled, session_id),
+        Some("clippy") => cargo::run_clippy(remaining, show_stats, analytics.enabled, session_id),
+        Some("tsc") => tsc::run(remaining, show_stats, analytics.enabled, session_id),
         Some(unknown) => {
             let safe_unknown = crate::cmd::sanitize_for_display(unknown);
             anyhow::bail!(
@@ -113,6 +114,7 @@ pub(super) fn run_parsed_command(
     show_stats: bool,
     analytics_enabled: bool,
     parser: fn(&CommandOutput) -> ParseResult<BuildResult>,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let runner = CommandRunner::new(Some(Duration::from_secs(600)));
 
@@ -192,6 +194,7 @@ pub(super) fn run_parsed_command(
         crate::analytics::CommandType::Build,
         output.duration,
         Some(result.tier_name()),
+        session_id,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/build/mod.rs
+++ b/crates/rskim/src/cmd/build/mod.rs
@@ -191,10 +191,7 @@ pub(super) fn run_parsed_command(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        crate::analytics::RecordingContext {
-            parse_tier: Some(result.tier_name()),
-            ..rec
-        },
+        rec.with_tier(result.tier_name()),
         raw_text,
         result.content().to_string(),
         super::format_analytics_label("build", program, &args.join(" ")),

--- a/crates/rskim/src/cmd/build/mod.rs
+++ b/crates/rskim/src/cmd/build/mod.rs
@@ -106,6 +106,7 @@ fn print_help() {
 /// * `env_vars` - Environment variable overrides for the child process
 /// * `install_hint` - Hint message shown if the program is not found
 /// * `parser` - Function to parse the `CommandOutput` into a `ParseResult<BuildResult>`
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_parsed_command(
     program: &str,
     args: &[String],

--- a/crates/rskim/src/cmd/build/mod.rs
+++ b/crates/rskim/src/cmd/build/mod.rs
@@ -38,11 +38,16 @@ pub(crate) fn run(
         None => (None, [].as_slice()),
     };
 
-    let session_id = analytics.session_id.as_deref();
+    let rec = crate::analytics::RecordingContext {
+        enabled: analytics.enabled,
+        command_type: crate::analytics::CommandType::Build,
+        parse_tier: None,
+        session_id: analytics.session_id.as_deref(),
+    };
     match sub {
-        Some("cargo") => cargo::run(remaining, show_stats, analytics.enabled, session_id),
-        Some("clippy") => cargo::run_clippy(remaining, show_stats, analytics.enabled, session_id),
-        Some("tsc") => tsc::run(remaining, show_stats, analytics.enabled, session_id),
+        Some("cargo") => cargo::run(remaining, show_stats, rec),
+        Some("clippy") => cargo::run_clippy(remaining, show_stats, rec),
+        Some("tsc") => tsc::run(remaining, show_stats, rec),
         Some(unknown) => {
             let safe_unknown = crate::cmd::sanitize_for_display(unknown);
             anyhow::bail!(
@@ -106,16 +111,14 @@ fn print_help() {
 /// * `env_vars` - Environment variable overrides for the child process
 /// * `install_hint` - Hint message shown if the program is not found
 /// * `parser` - Function to parse the `CommandOutput` into a `ParseResult<BuildResult>`
-#[allow(clippy::too_many_arguments)]
 pub(super) fn run_parsed_command(
     program: &str,
     args: &[String],
     env_vars: &[(&str, &str)],
     install_hint: &str,
     show_stats: bool,
-    analytics_enabled: bool,
+    rec: crate::analytics::RecordingContext<'_>,
     parser: fn(&CommandOutput) -> ParseResult<BuildResult>,
-    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let runner = CommandRunner::new(Some(Duration::from_secs(600)));
 
@@ -188,14 +191,14 @@ pub(super) fn run_parsed_command(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        analytics_enabled,
+        crate::analytics::RecordingContext {
+            parse_tier: Some(result.tier_name()),
+            ..rec
+        },
         raw_text,
         result.content().to_string(),
         super::format_analytics_label("build", program, &args.join(" ")),
-        crate::analytics::CommandType::Build,
         output.duration,
-        Some(result.tier_name()),
-        session_id,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/build/tsc.rs
+++ b/crates/rskim/src/cmd/build/tsc.rs
@@ -31,8 +31,7 @@ use crate::runner::CommandOutput;
 pub(crate) fn run(
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     run_parsed_command(
         "tsc",
@@ -40,9 +39,8 @@ pub(crate) fn run(
         &[],
         "npm install -g typescript",
         show_stats,
-        analytics_enabled,
+        rec,
         parse_tsc,
-        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/build/tsc.rs
+++ b/crates/rskim/src/cmd/build/tsc.rs
@@ -32,6 +32,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     run_parsed_command(
         "tsc",
@@ -41,6 +42,7 @@ pub(crate) fn run(
         show_stats,
         analytics_enabled,
         parse_tsc,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/file/mod.rs
+++ b/crates/rskim/src/cmd/file/mod.rs
@@ -8,7 +8,6 @@ pub(crate) mod grep;
 pub(crate) mod ls;
 pub(crate) mod rg;
 
-use std::io::IsTerminal;
 use std::process::ExitCode;
 
 use std::collections::BTreeMap;
@@ -123,7 +122,7 @@ pub(crate) fn run_file_tool(
     let mut cmd_args = args.to_vec();
     prepare_args(&mut cmd_args);
 
-    let use_stdin = !std::io::stdin().is_terminal() && args.is_empty();
+    let use_stdin = super::should_read_stdin(args);
 
     run_parsed_command_with_mode(
         ParsedCommandConfig {

--- a/crates/rskim/src/cmd/file/mod.rs
+++ b/crates/rskim/src/cmd/file/mod.rs
@@ -133,11 +133,14 @@ pub(crate) fn run_file_tool(
             install_hint: config.install_hint,
             use_stdin,
             show_stats: ctx.show_stats,
-            command_type: crate::analytics::CommandType::FileOps,
             output_format: ctx.output_format(),
-            analytics_enabled: ctx.analytics_enabled,
             family: "file",
-            session_id: ctx.session_id.as_deref(),
+            rec: crate::analytics::RecordingContext {
+                enabled: ctx.analytics_enabled,
+                command_type: crate::analytics::CommandType::FileOps,
+                parse_tier: None,
+                session_id: ctx.session_id.as_deref(),
+            },
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/file/mod.rs
+++ b/crates/rskim/src/cmd/file/mod.rs
@@ -52,6 +52,7 @@ pub(crate) fn run(
         show_stats,
         json_output,
         analytics_enabled: analytics.enabled,
+        session_id: analytics.session_id.clone(),
     };
 
     match tool_name.as_str() {
@@ -136,6 +137,7 @@ pub(crate) fn run_file_tool(
             output_format: ctx.output_format(),
             analytics_enabled: ctx.analytics_enabled,
             family: "file",
+            session_id: ctx.session_id.as_deref(),
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/git/commit.rs
+++ b/crates/rskim/src/cmd/git/commit.rs
@@ -49,9 +49,10 @@ pub(super) fn run_commit(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--help"]) {
-        return run_passthrough(global_flags, "commit", args, show_stats, analytics_enabled);
+        return run_passthrough(global_flags, "commit", args, show_stats, analytics_enabled, session_id);
     }
 
     let (filtered_args, output_format) = extract_output_format(args);
@@ -70,6 +71,7 @@ pub(super) fn run_commit(
         true, // combine_stderr: hook output and "nothing to commit" come from stderr
         label,
         parse_commit,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/commit.rs
+++ b/crates/rskim/src/cmd/git/commit.rs
@@ -52,7 +52,14 @@ pub(super) fn run_commit(
     session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--help"]) {
-        return run_passthrough(global_flags, "commit", args, show_stats, analytics_enabled, session_id);
+        return run_passthrough(
+            global_flags,
+            "commit",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        );
     }
 
     let (filtered_args, output_format) = extract_output_format(args);

--- a/crates/rskim/src/cmd/git/commit.rs
+++ b/crates/rskim/src/cmd/git/commit.rs
@@ -48,18 +48,10 @@ pub(super) fn run_commit(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--help"]) {
-        return run_passthrough(
-            global_flags,
-            "commit",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        );
+        return run_passthrough(global_flags, "commit", args, show_stats, rec);
     }
 
     let (filtered_args, output_format) = extract_output_format(args);
@@ -68,17 +60,16 @@ pub(super) fn run_commit(
     full_args.push("commit".to_string());
     full_args.extend_from_slice(&filtered_args);
 
-    let label = super::build_analytics_label("commit", args, show_stats, analytics_enabled);
+    let label = super::build_analytics_label("commit", args, show_stats, rec.enabled);
 
     run_parsed_command(
         &full_args,
         show_stats,
-        analytics_enabled,
+        rec,
         output_format,
         true, // combine_stderr: hook output and "nothing to commit" come from stderr
         label,
         parse_commit,
-        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/diff/mod.rs
+++ b/crates/rskim/src/cmd/git/diff/mod.rs
@@ -145,6 +145,7 @@ fn print_diff_help() {
 /// and return the mapped exit code.
 ///
 /// Extracted from `run_diff` to keep the happy path readable.
+#[allow(clippy::too_many_arguments)]
 fn handle_error_exit(
     stdout: String,
     stderr: String,

--- a/crates/rskim/src/cmd/git/diff/mod.rs
+++ b/crates/rskim/src/cmd/git/diff/mod.rs
@@ -153,6 +153,7 @@ fn handle_error_exit(
     show_stats: bool,
     analytics_enabled: bool,
     duration: std::time::Duration,
+    session_id: Option<&str>,
 ) -> ExitCode {
     if !stderr.is_empty() {
         eprint!("{stderr}");
@@ -170,6 +171,7 @@ fn handle_error_exit(
         crate::analytics::CommandType::Git,
         duration,
         Some("passthrough"),
+        session_id,
     );
     map_exit_code(exit_code)
 }
@@ -259,6 +261,7 @@ pub(super) fn run_diff(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_diff_help();
@@ -276,7 +279,7 @@ pub(super) fn run_diff(
             "--check",
         ],
     ) {
-        return run_passthrough(global_flags, "diff", args, show_stats, analytics_enabled);
+        return run_passthrough(global_flags, "diff", args, show_stats, analytics_enabled, session_id);
     }
 
     // Extract skim-specific flags before passing args to git
@@ -302,6 +305,7 @@ pub(super) fn run_diff(
             show_stats,
             analytics_enabled,
             output.duration,
+            session_id,
         ));
     }
 
@@ -330,6 +334,7 @@ pub(super) fn run_diff(
             crate::analytics::CommandType::Git,
             duration,
             Some("full"),
+            session_id,
         );
         return Ok(ExitCode::SUCCESS);
     }
@@ -356,6 +361,7 @@ pub(super) fn run_diff(
                 crate::analytics::CommandType::Git,
                 duration,
                 Some("degraded"),
+                session_id,
             );
             return Ok(ExitCode::SUCCESS);
         }
@@ -380,6 +386,7 @@ pub(super) fn run_diff(
         crate::analytics::CommandType::Git,
         duration,
         Some("full"),
+        session_id,
     );
 
     Ok(ExitCode::SUCCESS)

--- a/crates/rskim/src/cmd/git/diff/mod.rs
+++ b/crates/rskim/src/cmd/git/diff/mod.rs
@@ -145,16 +145,14 @@ fn print_diff_help() {
 /// and return the mapped exit code.
 ///
 /// Extracted from `run_diff` to keep the happy path readable.
-#[allow(clippy::too_many_arguments)]
 fn handle_error_exit(
     stdout: String,
     stderr: String,
     exit_code: Option<i32>,
     label: String,
     show_stats: bool,
-    analytics_enabled: bool,
+    rec: crate::analytics::RecordingContext<'_>,
     duration: std::time::Duration,
-    session_id: Option<&str>,
 ) -> ExitCode {
     if !stderr.is_empty() {
         eprint!("{stderr}");
@@ -168,11 +166,11 @@ fn handle_error_exit(
         stdout,
         label,
         show_stats,
-        analytics_enabled,
-        crate::analytics::CommandType::Git,
+        crate::analytics::RecordingContext {
+            parse_tier: Some("passthrough"),
+            ..rec
+        },
         duration,
-        Some("passthrough"),
-        session_id,
     );
     map_exit_code(exit_code)
 }
@@ -261,8 +259,7 @@ pub(super) fn run_diff(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_diff_help();
@@ -280,14 +277,7 @@ pub(super) fn run_diff(
             "--check",
         ],
     ) {
-        return run_passthrough(
-            global_flags,
-            "diff",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        );
+        return run_passthrough(global_flags, "diff", args, show_stats, rec);
     }
 
     // Extract skim-specific flags before passing args to git
@@ -304,16 +294,15 @@ pub(super) fn run_diff(
     let output = runner.run("git", &arg_refs)?;
 
     if output.exit_code != Some(0) {
-        let label = super::build_analytics_label("diff", args, show_stats, analytics_enabled);
+        let label = super::build_analytics_label("diff", args, show_stats, rec.enabled);
         return Ok(handle_error_exit(
             output.stdout,
             output.stderr,
             output.exit_code,
             label,
             show_stats,
-            analytics_enabled,
+            rec,
             output.duration,
-            session_id,
         ));
     }
 
@@ -326,7 +315,7 @@ pub(super) fn run_diff(
 
     let duration = output.duration;
     let raw_diff = output.stdout;
-    let label = super::build_analytics_label("diff", args, show_stats, analytics_enabled);
+    let label = super::build_analytics_label("diff", args, show_stats, rec.enabled);
 
     // Handle empty diff — record zero-compression analytics so the DB stays
     // consistent with run_passthrough (which always records, even for no-op passes).
@@ -338,11 +327,11 @@ pub(super) fn run_diff(
             raw_diff,
             label,
             show_stats,
-            analytics_enabled,
-            crate::analytics::CommandType::Git,
+            crate::analytics::RecordingContext {
+                parse_tier: Some("full"),
+                ..rec
+            },
             duration,
-            Some("full"),
-            session_id,
         );
         return Ok(ExitCode::SUCCESS);
     }
@@ -365,11 +354,11 @@ pub(super) fn run_diff(
                 raw_diff,
                 label,
                 show_stats,
-                analytics_enabled,
-                crate::analytics::CommandType::Git,
+                crate::analytics::RecordingContext {
+                    parse_tier: Some("degraded"),
+                    ..rec
+                },
                 duration,
-                Some("degraded"),
-                session_id,
             );
             return Ok(ExitCode::SUCCESS);
         }
@@ -390,11 +379,11 @@ pub(super) fn run_diff(
         result_str,
         label,
         show_stats,
-        analytics_enabled,
-        crate::analytics::CommandType::Git,
+        crate::analytics::RecordingContext {
+            parse_tier: Some("full"),
+            ..rec
+        },
         duration,
-        Some("full"),
-        session_id,
     );
 
     Ok(ExitCode::SUCCESS)

--- a/crates/rskim/src/cmd/git/diff/mod.rs
+++ b/crates/rskim/src/cmd/git/diff/mod.rs
@@ -280,7 +280,14 @@ pub(super) fn run_diff(
             "--check",
         ],
     ) {
-        return run_passthrough(global_flags, "diff", args, show_stats, analytics_enabled, session_id);
+        return run_passthrough(
+            global_flags,
+            "diff",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        );
     }
 
     // Extract skim-specific flags before passing args to git

--- a/crates/rskim/src/cmd/git/diff/mod.rs
+++ b/crates/rskim/src/cmd/git/diff/mod.rs
@@ -166,10 +166,7 @@ fn handle_error_exit(
         stdout,
         label,
         show_stats,
-        crate::analytics::RecordingContext {
-            parse_tier: Some("passthrough"),
-            ..rec
-        },
+        rec.with_tier("passthrough"),
         duration,
     );
     map_exit_code(exit_code)
@@ -327,10 +324,7 @@ pub(super) fn run_diff(
             raw_diff,
             label,
             show_stats,
-            crate::analytics::RecordingContext {
-                parse_tier: Some("full"),
-                ..rec
-            },
+            rec.with_tier("full"),
             duration,
         );
         return Ok(ExitCode::SUCCESS);
@@ -354,10 +348,7 @@ pub(super) fn run_diff(
                 raw_diff,
                 label,
                 show_stats,
-                crate::analytics::RecordingContext {
-                    parse_tier: Some("degraded"),
-                    ..rec
-                },
+                rec.with_tier("degraded"),
                 duration,
             );
             return Ok(ExitCode::SUCCESS);
@@ -379,10 +370,7 @@ pub(super) fn run_diff(
         result_str,
         label,
         show_stats,
-        crate::analytics::RecordingContext {
-            parse_tier: Some("full"),
-            ..rec
-        },
+        rec.with_tier("full"),
         duration,
     );
 

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -23,18 +23,10 @@ pub(super) fn run_fetch(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--dry-run", "-q", "--quiet"]) {
-        return run_passthrough(
-            global_flags,
-            "fetch",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        );
+        return run_passthrough(global_flags, "fetch", args, show_stats, rec);
     }
 
     let (filtered_args, output_format) = extract_output_format(args);
@@ -43,18 +35,9 @@ pub(super) fn run_fetch(
     full_args.push("fetch".to_string());
     full_args.extend_from_slice(&filtered_args);
 
-    let label = super::build_analytics_label("fetch", args, show_stats, analytics_enabled);
+    let label = super::build_analytics_label("fetch", args, show_stats, rec.enabled);
 
-    run_parsed_command(
-        &full_args,
-        show_stats,
-        analytics_enabled,
-        output_format,
-        true,
-        label,
-        parse_fetch,
-        session_id,
-    )
+    run_parsed_command(&full_args, show_stats, rec, output_format, true, label, parse_fetch)
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -24,9 +24,10 @@ pub(super) fn run_fetch(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--dry-run", "-q", "--quiet"]) {
-        return run_passthrough(global_flags, "fetch", args, show_stats, analytics_enabled);
+        return run_passthrough(global_flags, "fetch", args, show_stats, analytics_enabled, session_id);
     }
 
     let (filtered_args, output_format) = extract_output_format(args);
@@ -45,6 +46,7 @@ pub(super) fn run_fetch(
         true,
         label,
         parse_fetch,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -37,7 +37,15 @@ pub(super) fn run_fetch(
 
     let label = super::build_analytics_label("fetch", args, show_stats, rec.enabled);
 
-    run_parsed_command(&full_args, show_stats, rec, output_format, true, label, parse_fetch)
+    run_parsed_command(
+        &full_args,
+        show_stats,
+        rec,
+        output_format,
+        true,
+        label,
+        parse_fetch,
+    )
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/git/fetch.rs
+++ b/crates/rskim/src/cmd/git/fetch.rs
@@ -27,7 +27,14 @@ pub(super) fn run_fetch(
     session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--dry-run", "-q", "--quiet"]) {
-        return run_passthrough(global_flags, "fetch", args, show_stats, analytics_enabled, session_id);
+        return run_passthrough(
+            global_flags,
+            "fetch",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        );
     }
 
     let (filtered_args, output_format) = extract_output_format(args);

--- a/crates/rskim/src/cmd/git/log.rs
+++ b/crates/rskim/src/cmd/git/log.rs
@@ -18,9 +18,10 @@ pub(super) fn run_log(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--format", "--pretty"]) {
-        return run_passthrough(global_flags, "log", args, show_stats, analytics_enabled);
+        return run_passthrough(global_flags, "log", args, show_stats, analytics_enabled, session_id);
     }
 
     // Strip --oneline — handler injects its own --format flag.
@@ -51,6 +52,7 @@ pub(super) fn run_log(
         false,
         label,
         parse_log,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/log.rs
+++ b/crates/rskim/src/cmd/git/log.rs
@@ -17,18 +17,10 @@ pub(super) fn run_log(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--format", "--pretty"]) {
-        return run_passthrough(
-            global_flags,
-            "log",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        );
+        return run_passthrough(global_flags, "log", args, show_stats, rec);
     }
 
     // Strip --oneline — handler injects its own --format flag.
@@ -49,18 +41,9 @@ pub(super) fn run_log(
 
     full_args.extend_from_slice(&filtered_args);
 
-    let label = super::build_analytics_label("log", args, show_stats, analytics_enabled);
+    let label = super::build_analytics_label("log", args, show_stats, rec.enabled);
 
-    run_parsed_command(
-        &full_args,
-        show_stats,
-        analytics_enabled,
-        output_format,
-        false,
-        label,
-        parse_log,
-        session_id,
-    )
+    run_parsed_command(&full_args, show_stats, rec, output_format, false, label, parse_log)
 }
 
 /// Parse formatted `git log` output into a compressed GitResult.

--- a/crates/rskim/src/cmd/git/log.rs
+++ b/crates/rskim/src/cmd/git/log.rs
@@ -43,7 +43,15 @@ pub(super) fn run_log(
 
     let label = super::build_analytics_label("log", args, show_stats, rec.enabled);
 
-    run_parsed_command(&full_args, show_stats, rec, output_format, false, label, parse_log)
+    run_parsed_command(
+        &full_args,
+        show_stats,
+        rec,
+        output_format,
+        false,
+        label,
+        parse_log,
+    )
 }
 
 /// Parse formatted `git log` output into a compressed GitResult.

--- a/crates/rskim/src/cmd/git/log.rs
+++ b/crates/rskim/src/cmd/git/log.rs
@@ -21,7 +21,14 @@ pub(super) fn run_log(
     session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--format", "--pretty"]) {
-        return run_passthrough(global_flags, "log", args, show_stats, analytics_enabled, session_id);
+        return run_passthrough(
+            global_flags,
+            "log",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        );
     }
 
     // Strip --oneline — handler injects its own --format flag.

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -337,10 +337,7 @@ pub(super) fn run_passthrough(
         output.stdout,
         build_analytics_label(subcmd, args, show_stats, rec.enabled),
         show_stats,
-        crate::analytics::RecordingContext {
-            parse_tier: Some("passthrough"),
-            ..rec
-        },
+        rec.with_tier("passthrough"),
         output.duration,
     );
 
@@ -407,10 +404,7 @@ where
             scrubbed_stdout,
             label,
             show_stats,
-            crate::analytics::RecordingContext {
-                parse_tier: Some("passthrough"),
-                ..rec
-            },
+            rec.with_tier("passthrough"),
             output.duration,
         );
         return Ok(map_exit_code(exit_code));
@@ -454,7 +448,7 @@ where
         result_str,
         label,
         show_stats,
-        crate::analytics::RecordingContext { parse_tier, ..rec },
+        rec.with_tier_opt(parse_tier),
         output.duration,
     );
 

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -59,59 +59,21 @@ pub(crate) fn run(
     };
 
     let subcmd_args = &rest[1..];
-    let analytics_enabled = analytics.enabled;
-    let session_id = analytics.session_id.as_deref();
+    let rec = crate::analytics::RecordingContext {
+        enabled: analytics.enabled,
+        command_type: crate::analytics::CommandType::Git,
+        parse_tier: None,
+        session_id: analytics.session_id.as_deref(),
+    };
 
     match subcmd.as_str() {
-        "status" => status::run_status(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        "diff" => diff::run_diff(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        "fetch" => fetch::run_fetch(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        "log" => log::run_log(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        "show" => show::run_show(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        "commit" => commit::run_commit(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        "push" => push::run_push(
-            &global_flags,
-            subcmd_args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
+        "status" => status::run_status(&global_flags, subcmd_args, show_stats, rec),
+        "diff" => diff::run_diff(&global_flags, subcmd_args, show_stats, rec),
+        "fetch" => fetch::run_fetch(&global_flags, subcmd_args, show_stats, rec),
+        "log" => log::run_log(&global_flags, subcmd_args, show_stats, rec),
+        "show" => show::run_show(&global_flags, subcmd_args, show_stats, rec),
+        "commit" => commit::run_commit(&global_flags, subcmd_args, show_stats, rec),
+        "push" => push::run_push(&global_flags, subcmd_args, show_stats, rec),
         other => {
             let safe_other = crate::cmd::sanitize_for_display(other);
             anyhow::bail!(
@@ -277,13 +239,12 @@ pub(super) fn build_analytics_label(
 /// A borrowed variant exists in `#[cfg(test)]` only.
 ///
 /// # Parameters (shared by all variants)
-/// - `raw`          — Original git output before any compression.
-/// - `output`       — Compressed output (may equal `raw` for passthrough).
-/// - `label`        — Command label stored in the analytics DB.
-/// - `show_stats`   — Whether to print token-savings stats to stderr.
-/// - `command_type` — Analytics command-type tag (e.g., `CommandType::Git`).
-/// - `duration`     — Wall-clock duration of the underlying git command.
-/// - `parse_tier`   — Optional tier label set by the parser (AD-GIT-12).
+/// - `raw`       — Original git output before any compression.
+/// - `output`    — Compressed output (may equal `raw` for passthrough).
+/// - `label`     — Command label stored in the analytics DB.
+/// - `show_stats`— Whether to print token-savings stats to stderr.
+/// - `rec`       — Recording context (enabled, command_type, parse_tier, session_id).
+/// - `duration`  — Wall-clock duration of the underlying git command.
 ///
 /// Takes ownership of `raw` and `output`, moving them directly into the
 /// analytics call when analytics are enabled — zero extra allocations on
@@ -291,44 +252,22 @@ pub(super) fn build_analytics_label(
 ///
 /// Use this variant in handlers that already own their output strings
 /// (i.e. the string would be dropped immediately after the call anyway).
-/// `parse_tier` is forwarded to the analytics record (AD-GIT-12).
-///
-/// # Note on argument count
-/// The 8 parameters are all semantically distinct: `raw`/`output` are the text
-/// payload, `label`/`show_stats` control reporting, and
-/// `analytics_enabled`/`command_type`/`duration`/`parse_tier` are analytics
-/// metadata injected from the caller for dependency-injection testability.
-/// Collapsing them into an intermediate struct would not reduce call-site
-/// complexity for the 5 callers that supply all values individually.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn finalize_git_output_owned(
     raw: String,
     output: String,
     label: String,
     show_stats: bool,
-    analytics_enabled: bool,
-    command_type: crate::analytics::CommandType,
+    rec: crate::analytics::RecordingContext<'_>,
     duration: std::time::Duration,
-    parse_tier: Option<&'static str>,
-    session_id: Option<&str>,
 ) {
     if show_stats {
         let (orig, comp) = crate::process::count_token_pair(&raw, &output);
         crate::process::report_token_stats(orig, comp, "");
     }
-    crate::analytics::try_record_command(
-        analytics_enabled,
-        raw,
-        output,
-        label,
-        command_type,
-        duration,
-        parse_tier,
-        session_id,
-    );
+    crate::analytics::try_record_command(rec, raw, output, label, duration);
 }
 
-/// Passthrough variant of [`finalize_git_output`].
+/// Passthrough variant of [`finalize_git_output_owned`].
 ///
 /// Use this when `raw` and `output` are **the same string** (passthrough
 /// semantics: no compression occurred).  Takes ownership of `raw` so that
@@ -340,35 +279,22 @@ pub(super) fn finalize_git_output_owned(
 /// Call sites: `run_passthrough`, `run_parsed_command` non-zero exit,
 /// `run_diff` non-zero exit / empty diff / empty-after-parse, and the
 /// equivalent failure paths in `show.rs`.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn finalize_git_output_passthrough(
     raw: String,
     label: String,
     show_stats: bool,
-    analytics_enabled: bool,
-    command_type: crate::analytics::CommandType,
+    rec: crate::analytics::RecordingContext<'_>,
     duration: std::time::Duration,
-    parse_tier: Option<&'static str>,
-    session_id: Option<&str>,
 ) {
     if show_stats {
         // ALLOC NOTE: count_token_pair borrows; no allocation here.
         let (orig, comp) = crate::process::count_token_pair(&raw, &raw);
         crate::process::report_token_stats(orig, comp, "");
     }
-    if analytics_enabled {
+    if rec.enabled {
         // 1 allocation: raw.clone() produces raw_text; raw is moved as
         // compressed_text.  Zero allocations when analytics are disabled.
-        crate::analytics::try_record_command(
-            true,
-            raw.clone(),
-            raw,
-            label,
-            command_type,
-            duration,
-            parse_tier,
-            session_id,
-        );
+        crate::analytics::try_record_command(rec, raw.clone(), raw, label, duration);
     }
 }
 
@@ -386,8 +312,7 @@ pub(super) fn run_passthrough(
     subcmd: &str,
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     let mut full_args: Vec<String> = global_flags.to_vec();
     full_args.push(subcmd.to_string());
@@ -410,13 +335,13 @@ pub(super) fn run_passthrough(
     // and analytics are disabled (PF-021).
     finalize_git_output_passthrough(
         output.stdout,
-        build_analytics_label(subcmd, args, show_stats, analytics_enabled),
+        build_analytics_label(subcmd, args, show_stats, rec.enabled),
         show_stats,
-        analytics_enabled,
-        crate::analytics::CommandType::Git,
+        crate::analytics::RecordingContext {
+            parse_tier: Some("passthrough"),
+            ..rec
+        },
         output.duration,
-        Some("passthrough"),
-        session_id,
     );
 
     Ok(map_exit_code(exit_code))
@@ -442,16 +367,14 @@ pub(super) fn run_passthrough(
 /// the empty stdout buffer, keeping analytics consistent with the passing path.
 /// `raw == compressed` on failure, so the single-clone passthrough variant is
 /// used (PF-018).  The same pattern applies to `run_diff` non-zero exits.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn run_parsed_command<F>(
     subcmd_args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
+    rec: crate::analytics::RecordingContext<'_>,
     output_format: OutputFormat,
     combine_stderr: bool,
     label: String,
     parser: F,
-    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode>
 where
     F: FnOnce(&str) -> GitResult,
@@ -484,11 +407,11 @@ where
             scrubbed_stdout,
             label,
             show_stats,
-            analytics_enabled,
-            crate::analytics::CommandType::Git,
+            crate::analytics::RecordingContext {
+                parse_tier: Some("passthrough"),
+                ..rec
+            },
             output.duration,
-            Some("passthrough"),
-            session_id,
         );
         return Ok(map_exit_code(exit_code));
     }
@@ -531,11 +454,11 @@ where
         result_str,
         label,
         show_stats,
-        analytics_enabled,
-        crate::analytics::CommandType::Git,
+        crate::analytics::RecordingContext {
+            parse_tier,
+            ..rec
+        },
         output.duration,
-        parse_tier,
-        session_id,
     );
 
     Ok(ExitCode::SUCCESS)
@@ -788,31 +711,19 @@ mod tests {
     /// Takes `&str` references and clones them only when analytics are enabled.
     /// No production call site uses this; prefer `finalize_git_output_owned` or
     /// `finalize_git_output_passthrough` in handlers.
-    #[allow(clippy::too_many_arguments)]
     fn finalize_git_output(
         raw: &str,
         output: &str,
         label: String,
         show_stats: bool,
-        analytics_enabled: bool,
-        command_type: crate::analytics::CommandType,
+        rec: crate::analytics::RecordingContext<'_>,
         duration: std::time::Duration,
-        parse_tier: Option<&'static str>,
     ) {
         if show_stats {
             let (orig, comp) = crate::process::count_token_pair(raw, output);
             crate::process::report_token_stats(orig, comp, "");
         }
-        crate::analytics::try_record_command(
-            analytics_enabled,
-            raw.to_string(),
-            output.to_string(),
-            label,
-            command_type,
-            duration,
-            parse_tier,
-            None,
-        );
+        crate::analytics::try_record_command(rec, raw.to_string(), output.to_string(), label, duration);
     }
 
     /// Documents that `run_parsed_command` records analytics on non-zero exit.
@@ -832,10 +743,13 @@ mod tests {
             "",
             "skim git log".to_string(),
             false,
-            false,
-            crate::analytics::CommandType::Git,
+            crate::analytics::RecordingContext {
+                enabled: false,
+                command_type: crate::analytics::CommandType::Git,
+                parse_tier: None,
+                session_id: None,
+            },
             std::time::Duration::ZERO,
-            None,
         );
     }
 

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -298,6 +298,7 @@ pub(super) fn finalize_git_output_owned(
 /// Call sites: `run_passthrough`, `run_parsed_command` non-zero exit,
 /// `run_diff` non-zero exit / empty diff / empty-after-parse, and the
 /// equivalent failure paths in `show.rs`.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn finalize_git_output_passthrough(
     raw: String,
     label: String,
@@ -399,6 +400,7 @@ pub(super) fn run_passthrough(
 /// the empty stdout buffer, keeping analytics consistent with the passing path.
 /// `raw == compressed` on failure, so the single-clone passthrough variant is
 /// used (PF-018).  The same pattern applies to `run_diff` non-zero exits.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn run_parsed_command<F>(
     subcmd_args: &[String],
     show_stats: bool,

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -63,13 +63,55 @@ pub(crate) fn run(
     let session_id = analytics.session_id.as_deref();
 
     match subcmd.as_str() {
-        "status" => status::run_status(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
-        "diff" => diff::run_diff(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
-        "fetch" => fetch::run_fetch(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
-        "log" => log::run_log(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
-        "show" => show::run_show(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
-        "commit" => commit::run_commit(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
-        "push" => push::run_push(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "status" => status::run_status(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        "diff" => diff::run_diff(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        "fetch" => fetch::run_fetch(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        "log" => log::run_log(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        "show" => show::run_show(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        "commit" => commit::run_commit(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        "push" => push::run_push(
+            &global_flags,
+            subcmd_args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
         other => {
             let safe_other = crate::cmd::sanitize_for_display(other);
             anyhow::bail!(

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -60,15 +60,16 @@ pub(crate) fn run(
 
     let subcmd_args = &rest[1..];
     let analytics_enabled = analytics.enabled;
+    let session_id = analytics.session_id.as_deref();
 
     match subcmd.as_str() {
-        "status" => status::run_status(&global_flags, subcmd_args, show_stats, analytics_enabled),
-        "diff" => diff::run_diff(&global_flags, subcmd_args, show_stats, analytics_enabled),
-        "fetch" => fetch::run_fetch(&global_flags, subcmd_args, show_stats, analytics_enabled),
-        "log" => log::run_log(&global_flags, subcmd_args, show_stats, analytics_enabled),
-        "show" => show::run_show(&global_flags, subcmd_args, show_stats, analytics_enabled),
-        "commit" => commit::run_commit(&global_flags, subcmd_args, show_stats, analytics_enabled),
-        "push" => push::run_push(&global_flags, subcmd_args, show_stats, analytics_enabled),
+        "status" => status::run_status(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "diff" => diff::run_diff(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "fetch" => fetch::run_fetch(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "log" => log::run_log(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "show" => show::run_show(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "commit" => commit::run_commit(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
+        "push" => push::run_push(&global_flags, subcmd_args, show_stats, analytics_enabled, session_id),
         other => {
             let safe_other = crate::cmd::sanitize_for_display(other);
             anyhow::bail!(
@@ -267,6 +268,7 @@ pub(super) fn finalize_git_output_owned(
     command_type: crate::analytics::CommandType,
     duration: std::time::Duration,
     parse_tier: Option<&'static str>,
+    session_id: Option<&str>,
 ) {
     if show_stats {
         let (orig, comp) = crate::process::count_token_pair(&raw, &output);
@@ -280,6 +282,7 @@ pub(super) fn finalize_git_output_owned(
         command_type,
         duration,
         parse_tier,
+        session_id,
     );
 }
 
@@ -303,6 +306,7 @@ pub(super) fn finalize_git_output_passthrough(
     command_type: crate::analytics::CommandType,
     duration: std::time::Duration,
     parse_tier: Option<&'static str>,
+    session_id: Option<&str>,
 ) {
     if show_stats {
         // ALLOC NOTE: count_token_pair borrows; no allocation here.
@@ -320,6 +324,7 @@ pub(super) fn finalize_git_output_passthrough(
             command_type,
             duration,
             parse_tier,
+            session_id,
         );
     }
 }
@@ -339,6 +344,7 @@ pub(super) fn run_passthrough(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let mut full_args: Vec<String> = global_flags.to_vec();
     full_args.push(subcmd.to_string());
@@ -367,6 +373,7 @@ pub(super) fn run_passthrough(
         crate::analytics::CommandType::Git,
         output.duration,
         Some("passthrough"),
+        session_id,
     );
 
     Ok(map_exit_code(exit_code))
@@ -400,6 +407,7 @@ pub(super) fn run_parsed_command<F>(
     combine_stderr: bool,
     label: String,
     parser: F,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode>
 where
     F: FnOnce(&str) -> GitResult,
@@ -436,6 +444,7 @@ where
             crate::analytics::CommandType::Git,
             output.duration,
             Some("passthrough"),
+            session_id,
         );
         return Ok(map_exit_code(exit_code));
     }
@@ -482,6 +491,7 @@ where
         crate::analytics::CommandType::Git,
         output.duration,
         parse_tier,
+        session_id,
     );
 
     Ok(ExitCode::SUCCESS)
@@ -757,6 +767,7 @@ mod tests {
             command_type,
             duration,
             parse_tier,
+            None,
         );
     }
 

--- a/crates/rskim/src/cmd/git/mod.rs
+++ b/crates/rskim/src/cmd/git/mod.rs
@@ -454,10 +454,7 @@ where
         result_str,
         label,
         show_stats,
-        crate::analytics::RecordingContext {
-            parse_tier,
-            ..rec
-        },
+        crate::analytics::RecordingContext { parse_tier, ..rec },
         output.duration,
     );
 
@@ -723,7 +720,13 @@ mod tests {
             let (orig, comp) = crate::process::count_token_pair(raw, output);
             crate::process::report_token_stats(orig, comp, "");
         }
-        crate::analytics::try_record_command(rec, raw.to_string(), output.to_string(), label, duration);
+        crate::analytics::try_record_command(
+            rec,
+            raw.to_string(),
+            output.to_string(),
+            label,
+            duration,
+        );
     }
 
     /// Documents that `run_parsed_command` records analytics on non-zero exit.

--- a/crates/rskim/src/cmd/git/push.rs
+++ b/crates/rskim/src/cmd/git/push.rs
@@ -59,7 +59,14 @@ pub(super) fn run_push(
     session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--help"]) {
-        return run_passthrough(global_flags, "push", args, show_stats, analytics_enabled, session_id);
+        return run_passthrough(
+            global_flags,
+            "push",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        );
     }
 
     let (mut effective_args, output_format) = extract_output_format(args);

--- a/crates/rskim/src/cmd/git/push.rs
+++ b/crates/rskim/src/cmd/git/push.rs
@@ -56,9 +56,10 @@ pub(super) fn run_push(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--help"]) {
-        return run_passthrough(global_flags, "push", args, show_stats, analytics_enabled);
+        return run_passthrough(global_flags, "push", args, show_stats, analytics_enabled, session_id);
     }
 
     let (mut effective_args, output_format) = extract_output_format(args);
@@ -88,6 +89,7 @@ pub(super) fn run_push(
         true, // combine_stderr: push writes to stderr
         label,
         parse_push,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/push.rs
+++ b/crates/rskim/src/cmd/git/push.rs
@@ -55,18 +55,10 @@ pub(super) fn run_push(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if user_has_flag(args, &["--help"]) {
-        return run_passthrough(
-            global_flags,
-            "push",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        );
+        return run_passthrough(global_flags, "push", args, show_stats, rec);
     }
 
     let (mut effective_args, output_format) = extract_output_format(args);
@@ -86,17 +78,16 @@ pub(super) fn run_push(
     full_args.push("push".to_string());
     full_args.extend_from_slice(&effective_args);
 
-    let label = super::build_analytics_label("push", args, show_stats, analytics_enabled);
+    let label = super::build_analytics_label("push", args, show_stats, rec.enabled);
 
     run_parsed_command(
         &full_args,
         show_stats,
-        analytics_enabled,
+        rec,
         output_format,
         true, // combine_stderr: push writes to stderr
         label,
         parse_push,
-        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -184,8 +184,7 @@ pub(super) fn run_show(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_show_help();
@@ -194,44 +193,17 @@ pub(super) fn run_show(
 
     // Passthrough for stat-family and format flags.
     if user_has_flag(args, PASSTHROUGH_FLAGS) {
-        return run_passthrough(
-            global_flags,
-            "show",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        );
+        return run_passthrough(global_flags, "show", args, show_stats, rec);
     }
 
     match detect_show_mode(args) {
-        ShowMode::MultiRef => run_passthrough(
-            global_flags,
-            "show",
-            args,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
-        ShowMode::FileContent { refpath } => run_show_file_content(
-            global_flags,
-            args,
-            &refpath,
-            show_stats,
-            analytics_enabled,
-            session_id,
-        ),
+        ShowMode::MultiRef => run_passthrough(global_flags, "show", args, show_stats, rec),
+        ShowMode::FileContent { refpath } => {
+            run_show_file_content(global_flags, args, &refpath, show_stats, rec)
+        }
         ShowMode::Commit => {
             let (git_args, output_format) = extract_output_format(args);
-            run_show_commit(
-                global_flags,
-                &git_args,
-                args,
-                output_format,
-                show_stats,
-                analytics_enabled,
-                session_id,
-            )
+            run_show_commit(global_flags, &git_args, args, output_format, show_stats, rec)
         }
     }
 }
@@ -538,17 +510,19 @@ fn render_show_diff(
 /// directly into the analytics call — eliminating the conditional `Option`
 /// clone dance that previously required a TOCTOU double-check of
 /// an analytics-enabled global (MEDIUM-11, MEDIUM-22).
-#[allow(clippy::too_many_arguments)]
 fn emit_show_commit(
     result: ShowCommitResult,
     raw: String,
     label: String,
     output_format: OutputFormat,
     show_stats: bool,
-    analytics_enabled: bool,
+    rec: crate::analytics::RecordingContext<'_>,
     duration: std::time::Duration,
-    session_id: Option<&str>,
 ) -> anyhow::Result<()> {
+    let rec_full = crate::analytics::RecordingContext {
+        parse_tier: Some("full"),
+        ..rec
+    };
     match output_format {
         OutputFormat::Json => {
             // JSON: serialise result directly; guardrail is irrelevant here
@@ -558,17 +532,7 @@ fn emit_show_commit(
             let json = serde_json::to_string_pretty(&result)
                 .map_err(|e| anyhow::anyhow!("failed to serialize show result: {e}"))?;
             println!("{json}");
-            finalize_git_output_owned(
-                raw,
-                json,
-                label,
-                show_stats,
-                analytics_enabled,
-                crate::analytics::CommandType::Git,
-                duration,
-                Some("full"),
-                session_id,
-            );
+            finalize_git_output_owned(raw, json, label, show_stats, rec_full, duration);
         }
         OutputFormat::Text => {
             // Apply guardrail: if compressed output is larger than raw, emit raw.
@@ -580,7 +544,7 @@ fn emit_show_commit(
             // Guarding here avoids a full memcpy (~100-500 KB) on the no-telemetry
             // hot path (HIGH-1).  The owned variant then moves both strings into
             // `finalize_git_output_owned` without further cloning (MEDIUM-22).
-            let raw_for_record = if show_stats || analytics_enabled {
+            let raw_for_record = if show_stats || rec.enabled {
                 raw.clone()
             } else {
                 String::new()
@@ -593,11 +557,8 @@ fn emit_show_commit(
                 final_output,
                 label,
                 show_stats,
-                analytics_enabled,
-                crate::analytics::CommandType::Git,
+                rec_full,
                 duration,
-                Some("full"),
-                session_id,
             );
         }
     }
@@ -616,8 +577,7 @@ fn run_show_commit(
     original_args: &[String],
     output_format: OutputFormat,
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     let (raw, duration) = match run_git_show_raw(global_flags, git_args)? {
         ShowRawOutcome::Success { stdout, duration } => (stdout, duration),
@@ -633,13 +593,13 @@ fn run_show_commit(
             // (clone) on the analytics path, 0 when disabled (PF-018).
             super::finalize_git_output_passthrough(
                 stdout,
-                build_analytics_label("show", original_args, show_stats, analytics_enabled),
+                build_analytics_label("show", original_args, show_stats, rec.enabled),
                 show_stats,
-                analytics_enabled,
-                crate::analytics::CommandType::Git,
+                crate::analytics::RecordingContext {
+                    parse_tier: Some("passthrough"),
+                    ..rec
+                },
                 duration,
-                Some("passthrough"),
-                session_id,
             );
             return Ok(exit_code);
         }
@@ -648,7 +608,7 @@ fn run_show_commit(
     // Built before the `render_show_diff` check so both the passthrough and
     // the normal path share the same label (HIGH-3).  Derived from *original*
     // args (before `--json` extraction) so the DB records the full invocation.
-    let label = build_analytics_label("show", original_args, show_stats, analytics_enabled);
+    let label = build_analytics_label("show", original_args, show_stats, rec.enabled);
 
     let Some(result) = render_show_diff(&raw, global_flags, git_args) else {
         // Not a regular commit (annotated tag, blob, tree, etc.) — passthrough.
@@ -661,25 +621,16 @@ fn run_show_commit(
             raw,
             label,
             show_stats,
-            analytics_enabled,
-            crate::analytics::CommandType::Git,
+            crate::analytics::RecordingContext {
+                parse_tier: Some("passthrough"),
+                ..rec
+            },
             duration,
-            Some("passthrough"),
-            session_id,
         );
         return Ok(ExitCode::SUCCESS);
     };
 
-    emit_show_commit(
-        result,
-        raw,
-        label,
-        output_format,
-        show_stats,
-        analytics_enabled,
-        duration,
-        session_id,
-    )?;
+    emit_show_commit(result, raw, label, output_format, show_stats, rec, duration)?;
     Ok(ExitCode::SUCCESS)
 }
 
@@ -710,10 +661,9 @@ fn passthrough_file_content(
     raw: String,
     label: String,
     show_stats: bool,
-    analytics_enabled: bool,
+    rec: crate::analytics::RecordingContext<'_>,
     duration: std::time::Duration,
     tier: u8,
-    session_id: Option<&str>,
 ) {
     eprintln!("[skim] git show: falling back to raw (tier {tier})");
     print!("{raw}");
@@ -731,11 +681,11 @@ fn passthrough_file_content(
         raw,
         label,
         show_stats,
-        analytics_enabled,
-        crate::analytics::CommandType::Git,
+        crate::analytics::RecordingContext {
+            parse_tier: tier_name,
+            ..rec
+        },
         duration,
-        tier_name,
-        session_id,
     );
 }
 
@@ -754,8 +704,7 @@ fn run_show_file_content(
     args: &[String],
     refpath: &str,
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     // --json is not meaningful for file-content mode.
     if user_has_flag(args, &["--json"]) {
@@ -794,13 +743,13 @@ fn run_show_file_content(
         // allocation (clone) on the analytics path, 0 when disabled (PF-018).
         super::finalize_git_output_passthrough(
             output.stdout,
-            build_analytics_label("show", args, show_stats, analytics_enabled),
+            build_analytics_label("show", args, show_stats, rec.enabled),
             show_stats,
-            analytics_enabled,
-            crate::analytics::CommandType::Git,
+            crate::analytics::RecordingContext {
+                parse_tier: Some("passthrough"),
+                ..rec
+            },
             output.duration,
-            Some("passthrough"),
-            session_id,
         );
         return Ok(map_exit_code(exit_code));
     }
@@ -808,7 +757,7 @@ fn run_show_file_content(
     let raw = output.stdout;
     let duration = output.duration;
 
-    let label = build_analytics_label("show", args, show_stats, analytics_enabled);
+    let label = build_analytics_label("show", args, show_stats, rec.enabled);
 
     // Detect language from path extension.
     let lang = Language::from_path(Path::new(path_str)).filter(|l| !l.is_serde_based());
@@ -817,15 +766,7 @@ fn run_show_file_content(
         // Tier 2: unsupported or serde-based language — passthrough.
         // Move raw: the else branch always returns, so Rust knows raw is
         // available after the let-else for the Tier 1 path.
-        passthrough_file_content(
-            raw,
-            label,
-            show_stats,
-            analytics_enabled,
-            duration,
-            2,
-            session_id,
-        );
+        passthrough_file_content(raw, label, show_stats, rec, duration, 2);
         return Ok(ExitCode::SUCCESS);
     };
 
@@ -844,15 +785,7 @@ fn run_show_file_content(
                     "[skim:debug] git show file-content transform failed for {path_str}: {e}"
                 );
             }
-            passthrough_file_content(
-                raw,
-                label,
-                show_stats,
-                analytics_enabled,
-                duration,
-                3,
-                session_id,
-            );
+            passthrough_file_content(raw, label, show_stats, rec, duration, 3);
             return Ok(ExitCode::SUCCESS);
         }
     };
@@ -861,7 +794,7 @@ fn run_show_file_content(
     // Clone raw only here (Tier 1 success path), not on every branch (MEDIUM-18).
     // `apply_to_stderr` takes ownership of raw; clone it first so we can pass
     // the original into `finalize_git_output_owned` without a second allocation.
-    let raw_for_record = if show_stats || analytics_enabled {
+    let raw_for_record = if show_stats || rec.enabled {
         raw.clone()
     } else {
         String::new()
@@ -878,11 +811,11 @@ fn run_show_file_content(
         final_output,
         label,
         show_stats,
-        analytics_enabled,
-        crate::analytics::CommandType::Git,
+        crate::analytics::RecordingContext {
+            parse_tier: Some("full"),
+            ..rec
+        },
         duration,
-        Some("full"),
-        session_id,
     );
 
     Ok(ExitCode::SUCCESS)
@@ -1211,8 +1144,14 @@ mod tests {
     fn test_file_content_mode_json_rejected() {
         let global_flags: Vec<String> = vec![];
         let args: Vec<String> = vec!["HEAD:src/main.rs".into(), "--json".into()];
+        let rec = crate::analytics::RecordingContext {
+            enabled: false,
+            command_type: crate::analytics::CommandType::Git,
+            parse_tier: None,
+            session_id: None,
+        };
         let result =
-            run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, false, None)
+            run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, rec)
                 .expect(
                     "run_show_file_content must not return an anyhow error for --json rejection",
                 );

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -185,6 +185,7 @@ pub(super) fn run_show(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_show_help();
@@ -193,15 +194,15 @@ pub(super) fn run_show(
 
     // Passthrough for stat-family and format flags.
     if user_has_flag(args, PASSTHROUGH_FLAGS) {
-        return run_passthrough(global_flags, "show", args, show_stats, analytics_enabled);
+        return run_passthrough(global_flags, "show", args, show_stats, analytics_enabled, session_id);
     }
 
     match detect_show_mode(args) {
         ShowMode::MultiRef => {
-            run_passthrough(global_flags, "show", args, show_stats, analytics_enabled)
+            run_passthrough(global_flags, "show", args, show_stats, analytics_enabled, session_id)
         }
         ShowMode::FileContent { refpath } => {
-            run_show_file_content(global_flags, args, &refpath, show_stats, analytics_enabled)
+            run_show_file_content(global_flags, args, &refpath, show_stats, analytics_enabled, session_id)
         }
         ShowMode::Commit => {
             let (git_args, output_format) = extract_output_format(args);
@@ -212,6 +213,7 @@ pub(super) fn run_show(
                 output_format,
                 show_stats,
                 analytics_enabled,
+                session_id,
             )
         }
     }
@@ -527,6 +529,7 @@ fn emit_show_commit(
     show_stats: bool,
     analytics_enabled: bool,
     duration: std::time::Duration,
+    session_id: Option<&str>,
 ) -> anyhow::Result<()> {
     match output_format {
         OutputFormat::Json => {
@@ -546,6 +549,7 @@ fn emit_show_commit(
                 crate::analytics::CommandType::Git,
                 duration,
                 Some("full"),
+                session_id,
             );
         }
         OutputFormat::Text => {
@@ -575,6 +579,7 @@ fn emit_show_commit(
                 crate::analytics::CommandType::Git,
                 duration,
                 Some("full"),
+                session_id,
             );
         }
     }
@@ -594,6 +599,7 @@ fn run_show_commit(
     output_format: OutputFormat,
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let (raw, duration) = match run_git_show_raw(global_flags, git_args)? {
         ShowRawOutcome::Success { stdout, duration } => (stdout, duration),
@@ -615,6 +621,7 @@ fn run_show_commit(
                 crate::analytics::CommandType::Git,
                 duration,
                 Some("passthrough"),
+                session_id,
             );
             return Ok(exit_code);
         }
@@ -640,6 +647,7 @@ fn run_show_commit(
             crate::analytics::CommandType::Git,
             duration,
             Some("passthrough"),
+            session_id,
         );
         return Ok(ExitCode::SUCCESS);
     };
@@ -652,6 +660,7 @@ fn run_show_commit(
         show_stats,
         analytics_enabled,
         duration,
+        session_id,
     )?;
     Ok(ExitCode::SUCCESS)
 }
@@ -686,6 +695,7 @@ fn passthrough_file_content(
     analytics_enabled: bool,
     duration: std::time::Duration,
     tier: u8,
+    session_id: Option<&str>,
 ) {
     eprintln!("[skim] git show: falling back to raw (tier {tier})");
     print!("{raw}");
@@ -707,6 +717,7 @@ fn passthrough_file_content(
         crate::analytics::CommandType::Git,
         duration,
         tier_name,
+        session_id,
     );
 }
 
@@ -726,6 +737,7 @@ fn run_show_file_content(
     refpath: &str,
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     // --json is not meaningful for file-content mode.
     if user_has_flag(args, &["--json"]) {
@@ -770,6 +782,7 @@ fn run_show_file_content(
             crate::analytics::CommandType::Git,
             output.duration,
             Some("passthrough"),
+            session_id,
         );
         return Ok(map_exit_code(exit_code));
     }
@@ -786,7 +799,7 @@ fn run_show_file_content(
         // Tier 2: unsupported or serde-based language — passthrough.
         // Move raw: the else branch always returns, so Rust knows raw is
         // available after the let-else for the Tier 1 path.
-        passthrough_file_content(raw, label, show_stats, analytics_enabled, duration, 2);
+        passthrough_file_content(raw, label, show_stats, analytics_enabled, duration, 2, session_id);
         return Ok(ExitCode::SUCCESS);
     };
 
@@ -805,7 +818,7 @@ fn run_show_file_content(
                     "[skim:debug] git show file-content transform failed for {path_str}: {e}"
                 );
             }
-            passthrough_file_content(raw, label, show_stats, analytics_enabled, duration, 3);
+            passthrough_file_content(raw, label, show_stats, analytics_enabled, duration, 3, session_id);
             return Ok(ExitCode::SUCCESS);
         }
     };
@@ -835,6 +848,7 @@ fn run_show_file_content(
         crate::analytics::CommandType::Git,
         duration,
         Some("full"),
+        session_id,
     );
 
     Ok(ExitCode::SUCCESS)
@@ -1163,7 +1177,7 @@ mod tests {
     fn test_file_content_mode_json_rejected() {
         let global_flags: Vec<String> = vec![];
         let args: Vec<String> = vec!["HEAD:src/main.rs".into(), "--json".into()];
-        let result = run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, false)
+        let result = run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, false, None)
             .expect("run_show_file_content must not return an anyhow error for --json rejection");
         assert_eq!(
             result,

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -521,6 +521,7 @@ fn render_show_diff(
 /// directly into the analytics call — eliminating the conditional `Option`
 /// clone dance that previously required a TOCTOU double-check of
 /// an analytics-enabled global (MEDIUM-11, MEDIUM-22).
+#[allow(clippy::too_many_arguments)]
 fn emit_show_commit(
     result: ShowCommitResult,
     raw: String,

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -203,7 +203,14 @@ pub(super) fn run_show(
         }
         ShowMode::Commit => {
             let (git_args, output_format) = extract_output_format(args);
-            run_show_commit(global_flags, &git_args, args, output_format, show_stats, rec)
+            run_show_commit(
+                global_flags,
+                &git_args,
+                args,
+                output_format,
+                show_stats,
+                rec,
+            )
         }
     }
 }
@@ -1150,11 +1157,8 @@ mod tests {
             parse_tier: None,
             session_id: None,
         };
-        let result =
-            run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, rec)
-                .expect(
-                    "run_show_file_content must not return an anyhow error for --json rejection",
-                );
+        let result = run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, rec)
+            .expect("run_show_file_content must not return an anyhow error for --json rejection");
         assert_eq!(
             result,
             ExitCode::from(2),

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -526,10 +526,7 @@ fn emit_show_commit(
     rec: crate::analytics::RecordingContext<'_>,
     duration: std::time::Duration,
 ) -> anyhow::Result<()> {
-    let rec_full = crate::analytics::RecordingContext {
-        parse_tier: Some("full"),
-        ..rec
-    };
+    let rec_full = rec.with_tier("full");
     match output_format {
         OutputFormat::Json => {
             // JSON: serialise result directly; guardrail is irrelevant here
@@ -602,10 +599,7 @@ fn run_show_commit(
                 stdout,
                 build_analytics_label("show", original_args, show_stats, rec.enabled),
                 show_stats,
-                crate::analytics::RecordingContext {
-                    parse_tier: Some("passthrough"),
-                    ..rec
-                },
+                rec.with_tier("passthrough"),
                 duration,
             );
             return Ok(exit_code);
@@ -628,10 +622,7 @@ fn run_show_commit(
             raw,
             label,
             show_stats,
-            crate::analytics::RecordingContext {
-                parse_tier: Some("passthrough"),
-                ..rec
-            },
+            rec.with_tier("passthrough"),
             duration,
         );
         return Ok(ExitCode::SUCCESS);
@@ -688,10 +679,7 @@ fn passthrough_file_content(
         raw,
         label,
         show_stats,
-        crate::analytics::RecordingContext {
-            parse_tier: tier_name,
-            ..rec
-        },
+        rec.with_tier_opt(tier_name),
         duration,
     );
 }
@@ -752,10 +740,7 @@ fn run_show_file_content(
             output.stdout,
             build_analytics_label("show", args, show_stats, rec.enabled),
             show_stats,
-            crate::analytics::RecordingContext {
-                parse_tier: Some("passthrough"),
-                ..rec
-            },
+            rec.with_tier("passthrough"),
             output.duration,
         );
         return Ok(map_exit_code(exit_code));
@@ -818,10 +803,7 @@ fn run_show_file_content(
         final_output,
         label,
         show_stats,
-        crate::analytics::RecordingContext {
-            parse_tier: Some("full"),
-            ..rec
-        },
+        rec.with_tier("full"),
         duration,
     );
 

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -194,16 +194,33 @@ pub(super) fn run_show(
 
     // Passthrough for stat-family and format flags.
     if user_has_flag(args, PASSTHROUGH_FLAGS) {
-        return run_passthrough(global_flags, "show", args, show_stats, analytics_enabled, session_id);
+        return run_passthrough(
+            global_flags,
+            "show",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        );
     }
 
     match detect_show_mode(args) {
-        ShowMode::MultiRef => {
-            run_passthrough(global_flags, "show", args, show_stats, analytics_enabled, session_id)
-        }
-        ShowMode::FileContent { refpath } => {
-            run_show_file_content(global_flags, args, &refpath, show_stats, analytics_enabled, session_id)
-        }
+        ShowMode::MultiRef => run_passthrough(
+            global_flags,
+            "show",
+            args,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
+        ShowMode::FileContent { refpath } => run_show_file_content(
+            global_flags,
+            args,
+            &refpath,
+            show_stats,
+            analytics_enabled,
+            session_id,
+        ),
         ShowMode::Commit => {
             let (git_args, output_format) = extract_output_format(args);
             run_show_commit(
@@ -800,7 +817,15 @@ fn run_show_file_content(
         // Tier 2: unsupported or serde-based language — passthrough.
         // Move raw: the else branch always returns, so Rust knows raw is
         // available after the let-else for the Tier 1 path.
-        passthrough_file_content(raw, label, show_stats, analytics_enabled, duration, 2, session_id);
+        passthrough_file_content(
+            raw,
+            label,
+            show_stats,
+            analytics_enabled,
+            duration,
+            2,
+            session_id,
+        );
         return Ok(ExitCode::SUCCESS);
     };
 
@@ -819,7 +844,15 @@ fn run_show_file_content(
                     "[skim:debug] git show file-content transform failed for {path_str}: {e}"
                 );
             }
-            passthrough_file_content(raw, label, show_stats, analytics_enabled, duration, 3, session_id);
+            passthrough_file_content(
+                raw,
+                label,
+                show_stats,
+                analytics_enabled,
+                duration,
+                3,
+                session_id,
+            );
             return Ok(ExitCode::SUCCESS);
         }
     };
@@ -1178,8 +1211,11 @@ mod tests {
     fn test_file_content_mode_json_rejected() {
         let global_flags: Vec<String> = vec![];
         let args: Vec<String> = vec!["HEAD:src/main.rs".into(), "--json".into()];
-        let result = run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, false, None)
-            .expect("run_show_file_content must not return an anyhow error for --json rejection");
+        let result =
+            run_show_file_content(&global_flags, &args, "HEAD:src/main.rs", false, false, None)
+                .expect(
+                    "run_show_file_content must not return an anyhow error for --json rejection",
+                );
         assert_eq!(
             result,
             ExitCode::from(2),

--- a/crates/rskim/src/cmd/git/status.rs
+++ b/crates/rskim/src/cmd/git/status.rs
@@ -23,8 +23,7 @@ pub(super) fn run_status(
     global_flags: &[String],
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     // Strip conflicting format flags — handler injects --porcelain=v2 itself.
     let stripped_args: Vec<String> = args
@@ -43,18 +42,9 @@ pub(super) fn run_status(
     ]);
     full_args.extend_from_slice(&filtered_args);
 
-    let label = super::build_analytics_label("status", args, show_stats, analytics_enabled);
+    let label = super::build_analytics_label("status", args, show_stats, rec.enabled);
 
-    run_parsed_command(
-        &full_args,
-        show_stats,
-        analytics_enabled,
-        output_format,
-        false,
-        label,
-        parse_status,
-        session_id,
-    )
+    run_parsed_command(&full_args, show_stats, rec, output_format, false, label, parse_status)
 }
 
 /// Accumulated per-category file lists from a porcelain v2 status parse.

--- a/crates/rskim/src/cmd/git/status.rs
+++ b/crates/rskim/src/cmd/git/status.rs
@@ -24,6 +24,7 @@ pub(super) fn run_status(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     // Strip conflicting format flags — handler injects --porcelain=v2 itself.
     let stripped_args: Vec<String> = args
@@ -52,6 +53,7 @@ pub(super) fn run_status(
         false,
         label,
         parse_status,
+        session_id,
     )
 }
 

--- a/crates/rskim/src/cmd/git/status.rs
+++ b/crates/rskim/src/cmd/git/status.rs
@@ -44,7 +44,15 @@ pub(super) fn run_status(
 
     let label = super::build_analytics_label("status", args, show_stats, rec.enabled);
 
-    run_parsed_command(&full_args, show_stats, rec, output_format, false, label, parse_status)
+    run_parsed_command(
+        &full_args,
+        show_stats,
+        rec,
+        output_format,
+        false,
+        label,
+        parse_status,
+    )
 }
 
 /// Accumulated per-category file lists from a porcelain v2 status parse.

--- a/crates/rskim/src/cmd/hooks/cursor.rs
+++ b/crates/rskim/src/cmd/hooks/cursor.rs
@@ -24,9 +24,11 @@ impl HookProtocol for CursorHook {
         // Cursor puts command at top level, not nested under tool_input
         let command = json.get("command").and_then(|c| c.as_str())?.to_string();
         // AD-HK-1: Extract session_id from top-level JSON field if present.
+        // F8: Filter empty strings at the parse boundary so callers never see Some("").
         let session_id = json
             .get("session_id")
             .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
             .map(str::to_string);
         Some(HookInput {
             command,
@@ -195,6 +197,21 @@ mod tests {
         let result = hook().parse_input(&json).unwrap();
         assert_eq!(result.command, "cargo test");
         assert_eq!(result.session_id, Some("cursor-session-xyz".to_string()));
+    }
+
+    /// F8: empty session_id is treated as None at the parse boundary.
+    #[test]
+    fn test_cursor_parse_input_empty_session_id_is_none() {
+        let json = serde_json::json!({
+            "session_id": "",
+            "command": "cargo test"
+        });
+        let result = hook().parse_input(&json).unwrap();
+        assert_eq!(result.command, "cargo test");
+        assert!(
+            result.session_id.is_none(),
+            "empty session_id should yield None at parse boundary"
+        );
     }
 
     /// AD-HK-1: session_id is None when absent from Cursor hook JSON.

--- a/crates/rskim/src/cmd/hooks/cursor.rs
+++ b/crates/rskim/src/cmd/hooks/cursor.rs
@@ -23,7 +23,12 @@ impl HookProtocol for CursorHook {
     fn parse_input(&self, json: &serde_json::Value) -> Option<HookInput> {
         // Cursor puts command at top level, not nested under tool_input
         let command = json.get("command").and_then(|c| c.as_str())?.to_string();
-        Some(HookInput { command })
+        // AD-HK-1: Extract session_id from top-level JSON field if present.
+        let session_id = json
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        Some(HookInput { command, session_id })
     }
 
     fn format_response(&self, rewritten_command: &str) -> serde_json::Value {
@@ -171,5 +176,35 @@ mod tests {
             force: false,
         };
         assert!(hook().uninstall(&opts).is_ok());
+    }
+
+    // ========================================================================
+    // B8: AD-HK-1 — Cursor session_id extraction
+    // ========================================================================
+
+    /// AD-HK-1: Cursor parse_input extracts session_id from top-level JSON.
+    #[test]
+    fn test_cursor_parse_input_extracts_session_id() {
+        let json = serde_json::json!({
+            "session_id": "cursor-session-xyz",
+            "command": "cargo test"
+        });
+        let result = hook().parse_input(&json).unwrap();
+        assert_eq!(result.command, "cargo test");
+        assert_eq!(result.session_id, Some("cursor-session-xyz".to_string()));
+    }
+
+    /// AD-HK-1: session_id is None when absent from Cursor hook JSON.
+    #[test]
+    fn test_cursor_parse_input_no_session_id() {
+        let json = serde_json::json!({
+            "command": "cargo build --release"
+        });
+        let result = hook().parse_input(&json).unwrap();
+        assert_eq!(result.command, "cargo build --release");
+        assert!(
+            result.session_id.is_none(),
+            "session_id should be None when absent"
+        );
     }
 }

--- a/crates/rskim/src/cmd/hooks/cursor.rs
+++ b/crates/rskim/src/cmd/hooks/cursor.rs
@@ -28,7 +28,10 @@ impl HookProtocol for CursorHook {
             .get("session_id")
             .and_then(|v| v.as_str())
             .map(str::to_string);
-        Some(HookInput { command, session_id })
+        Some(HookInput {
+            command,
+            session_id,
+        })
     }
 
     fn format_response(&self, rewritten_command: &str) -> serde_json::Value {

--- a/crates/rskim/src/cmd/hooks/mod.rs
+++ b/crates/rskim/src/cmd/hooks/mod.rs
@@ -22,9 +22,15 @@ pub(crate) enum HookSupport {
 }
 
 /// Input extracted from agent's hook event JSON.
+///
+/// AD-HK-1: session_id is extracted from the hook JSON event so that every
+/// skim command rewritten in hook mode is tagged with the originating agent
+/// session. This enables per-session analytics grouping in the stats dashboard.
 #[derive(Debug, Clone)]
 pub(crate) struct HookInput {
     pub(crate) command: String,
+    /// AD-HK-1: Originating agent session ID, if present in the hook JSON.
+    pub(crate) session_id: Option<String>,
 }
 
 /// Result of a hook installation.
@@ -91,13 +97,21 @@ pub(crate) trait HookProtocol {
 ///
 /// Used by Claude Code, Copilot CLI, and Gemini CLI. Cursor differs (top-level `command`).
 /// Codex and OpenCode are awareness-only and return `None` from `parse_input` directly.
+///
+/// AD-HK-1: Also extracts `session_id` from the top-level JSON field when present.
+/// Claude Code emits `{ "session_id": "...", "tool_input": { "command": "..." } }`.
 pub(crate) fn parse_tool_input_command(json: &serde_json::Value) -> Option<HookInput> {
     let command = json
         .get("tool_input")
         .and_then(|ti| ti.get("command"))
         .and_then(|c| c.as_str())?
         .to_string();
-    Some(HookInput { command })
+    // AD-HK-1: Extract session_id from top-level JSON field (Claude Code / Copilot / Gemini).
+    let session_id = json
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Some(HookInput { command, session_id })
 }
 
 /// Generate a standard hook script for an agent.
@@ -213,5 +227,55 @@ mod tests {
     #[should_panic(expected = "agent_cli_name contains unsafe characters")]
     fn test_generate_hook_script_rejects_unsafe_agent_name() {
         generate_hook_script("1.0.0", "agent;rm -rf /");
+    }
+
+    // ========================================================================
+    // B8: AD-HK-1 — session_id extraction in parse_tool_input_command
+    // ========================================================================
+
+    /// AD-HK-1: session_id is extracted from the top-level JSON field.
+    #[test]
+    fn test_parse_tool_input_command_extracts_session_id() {
+        let json = serde_json::json!({
+            "session_id": "my-session-abc",
+            "tool_input": {
+                "command": "cargo build"
+            }
+        });
+        let result = parse_tool_input_command(&json).unwrap();
+        assert_eq!(result.command, "cargo build");
+        assert_eq!(result.session_id, Some("my-session-abc".to_string()));
+    }
+
+    /// AD-HK-1: session_id is None when the field is absent.
+    #[test]
+    fn test_parse_tool_input_command_no_session_id() {
+        let json = serde_json::json!({
+            "tool_input": {
+                "command": "cargo test"
+            }
+        });
+        let result = parse_tool_input_command(&json).unwrap();
+        assert_eq!(result.command, "cargo test");
+        assert!(
+            result.session_id.is_none(),
+            "session_id should be None when not in JSON"
+        );
+    }
+
+    /// AD-HK-1: non-string session_id is treated as None (no panic).
+    #[test]
+    fn test_parse_tool_input_command_non_string_session_id_is_none() {
+        let json = serde_json::json!({
+            "session_id": 12345,
+            "tool_input": {
+                "command": "go test ./..."
+            }
+        });
+        let result = parse_tool_input_command(&json).unwrap();
+        assert!(
+            result.session_id.is_none(),
+            "non-string session_id should yield None"
+        );
     }
 }

--- a/crates/rskim/src/cmd/hooks/mod.rs
+++ b/crates/rskim/src/cmd/hooks/mod.rs
@@ -111,7 +111,10 @@ pub(crate) fn parse_tool_input_command(json: &serde_json::Value) -> Option<HookI
         .get("session_id")
         .and_then(|v| v.as_str())
         .map(str::to_string);
-    Some(HookInput { command, session_id })
+    Some(HookInput {
+        command,
+        session_id,
+    })
 }
 
 /// Generate a standard hook script for an agent.

--- a/crates/rskim/src/cmd/hooks/mod.rs
+++ b/crates/rskim/src/cmd/hooks/mod.rs
@@ -107,9 +107,11 @@ pub(crate) fn parse_tool_input_command(json: &serde_json::Value) -> Option<HookI
         .and_then(|c| c.as_str())?
         .to_string();
     // AD-HK-1: Extract session_id from top-level JSON field (Claude Code / Copilot / Gemini).
+    // F8: Filter empty strings at the parse boundary so callers never see Some("").
     let session_id = json
         .get("session_id")
         .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
         .map(str::to_string);
     Some(HookInput {
         command,
@@ -263,6 +265,23 @@ mod tests {
         assert!(
             result.session_id.is_none(),
             "session_id should be None when not in JSON"
+        );
+    }
+
+    /// F8: empty string session_id is treated as None at the parse boundary.
+    #[test]
+    fn test_parse_tool_input_command_empty_session_id_is_none() {
+        let json = serde_json::json!({
+            "session_id": "",
+            "tool_input": {
+                "command": "cargo build"
+            }
+        });
+        let result = parse_tool_input_command(&json).unwrap();
+        assert_eq!(result.command, "cargo build");
+        assert!(
+            result.session_id.is_none(),
+            "empty session_id should yield None at parse boundary"
         );
     }
 

--- a/crates/rskim/src/cmd/infra/gh/run_watch.rs
+++ b/crates/rskim/src/cmd/infra/gh/run_watch.rs
@@ -77,6 +77,7 @@ pub(super) fn run_watch(args: &[String], ctx: &crate::cmd::RunContext) -> anyhow
     let cfg = StreamConfig {
         analytics_enabled: ctx.analytics_enabled,
         label,
+        session_id: ctx.session_id.clone(),
     };
 
     // Pipe mode: stdin is piped and no run-ID args were given (AD-STR-2).

--- a/crates/rskim/src/cmd/infra/gh/streaming.rs
+++ b/crates/rskim/src/cmd/infra/gh/streaming.rs
@@ -244,14 +244,16 @@ impl DropGuard {
         let raw_tokens = self.raw_bytes / 4;
         let compressed_tokens = self.compressed_bytes / 4;
         crate::analytics::try_record_command_with_counts(
-            self.analytics_enabled,
+            crate::analytics::RecordingContext {
+                enabled: self.analytics_enabled,
+                command_type: crate::analytics::CommandType::Infra,
+                parse_tier: Some("streaming"),
+                session_id: self.session_id.as_deref(),
+            },
             raw_tokens,
             compressed_tokens,
             self.label.clone(),
-            crate::analytics::CommandType::Infra,
             self.start.elapsed(),
-            Some("streaming"),
-            self.session_id.as_deref(),
         );
     }
 }

--- a/crates/rskim/src/cmd/infra/gh/streaming.rs
+++ b/crates/rskim/src/cmd/infra/gh/streaming.rs
@@ -153,6 +153,8 @@ pub(super) struct StreamConfig {
     pub analytics_enabled: bool,
     /// Command label for analytics recording.
     pub label: String,
+    /// AD-AN-1: session_id for per-session analytics grouping.
+    pub session_id: Option<String>,
 }
 
 /// A streaming line-by-line output parser.
@@ -202,10 +204,11 @@ struct DropGuard {
     compressed_bytes: usize,
     analytics_enabled: bool,
     recorded: bool,
+    session_id: Option<String>,
 }
 
 impl DropGuard {
-    fn new(label: String, analytics_enabled: bool) -> Self {
+    fn new(label: String, analytics_enabled: bool, session_id: Option<String>) -> Self {
         Self {
             label,
             start: Instant::now(),
@@ -213,6 +216,7 @@ impl DropGuard {
             compressed_bytes: 0,
             analytics_enabled,
             recorded: false,
+            session_id,
         }
     }
 
@@ -247,6 +251,7 @@ impl DropGuard {
             crate::analytics::CommandType::Infra,
             self.start.elapsed(),
             Some("streaming"),
+            self.session_id.as_deref(),
         );
     }
 }
@@ -311,7 +316,7 @@ pub(super) fn run_streamed_stdin(
     let stdin = io::stdin();
     let stdin_lock = stdin.lock();
     let mut reader = io::BufReader::new(stdin_lock);
-    let mut guard = DropGuard::new(cfg.label, cfg.analytics_enabled);
+    let mut guard = DropGuard::new(cfg.label, cfg.analytics_enabled, cfg.session_id);
     let mut buf: Vec<u8> = Vec::with_capacity(256);
 
     while let Some(raw_line) = read_line_lossy(&mut reader, &mut buf) {
@@ -410,7 +415,7 @@ pub(super) fn run_streamed_spawned(
     let mut child = ChildGuard(child_proc);
 
     let mut stdout = BufWriter::new(io::stdout());
-    let mut guard = DropGuard::new(cfg.label, cfg.analytics_enabled);
+    let mut guard = DropGuard::new(cfg.label, cfg.analytics_enabled, cfg.session_id);
 
     // Spawn a background thread to drain stderr concurrently (AD-STR-8, PF-023).
     // The thread collects all stderr lines into a Vec so we can feed them through
@@ -572,7 +577,7 @@ mod tests {
 
     #[test]
     fn test_drop_guard_records_once() {
-        let mut guard = DropGuard::new("test".to_string(), false);
+        let mut guard = DropGuard::new("test".to_string(), false, None);
         guard.update(100, 50);
         guard.record();
         assert!(guard.recorded);
@@ -581,7 +586,7 @@ mod tests {
 
     #[test]
     fn test_drop_guard_update_accumulates() {
-        let mut guard = DropGuard::new("test".to_string(), false);
+        let mut guard = DropGuard::new("test".to_string(), false, None);
         guard.update(100, 50);
         guard.update(200, 100);
         assert_eq!(guard.raw_bytes, 300);
@@ -618,6 +623,7 @@ mod tests {
         let cfg = StreamConfig {
             analytics_enabled: false,
             label: "test".to_string(),
+            session_id: None,
         };
         // Use a non-existent binary name to trigger "not found on PATH".
         let code = run_streamed_spawned(parser, "skim_nonexistent_binary_xyz", &[], cfg);
@@ -630,6 +636,7 @@ mod tests {
         let cfg = StreamConfig {
             analytics_enabled: false,
             label: "test".to_string(),
+            session_id: None,
         };
         // /bin/sh -c 'exit 3' exits with code 3.
         let args: Vec<String> = vec!["-c".to_string(), "exit 3".to_string()];
@@ -644,6 +651,7 @@ mod tests {
         let cfg = StreamConfig {
             analytics_enabled: false,
             label: "test".to_string(),
+            session_id: None,
         };
         let args: Vec<String> = vec!["-c".to_string(), "echo hello".to_string()];
         let code = run_streamed_spawned(parser, "/bin/sh", &args, cfg);
@@ -750,6 +758,7 @@ mod tests {
         let cfg = StreamConfig {
             analytics_enabled: false,
             label: "test".to_string(),
+            session_id: None,
         };
         let script = r#"for i in $(seq 1 500); do
     echo "stdout line $i"

--- a/crates/rskim/src/cmd/infra/gh/streaming.rs
+++ b/crates/rskim/src/cmd/infra/gh/streaming.rs
@@ -197,6 +197,16 @@ pub(super) trait StreamingParser: Send {
 ///
 /// Holds running totals and a `recorded` flag.  When `Drop` fires, records
 /// only if the success path (`record()`) has not already done so.
+///
+/// ## Owned vs borrowed fields
+///
+/// `DropGuard` stores `analytics_enabled: bool` and `session_id: Option<String>`
+/// as owned values rather than wrapping a `RecordingContext<'a>`.
+/// `RecordingContext` uses borrowed `Option<&'a str>` fields so it can be
+/// `Copy` and passed cheaply across call sites.  A `DropGuard` must outlive
+/// every stack frame up to its `drop`, so it cannot hold borrowed references —
+/// owned values are the correct representation here.  `do_record` reconstructs
+/// a short-lived `RecordingContext` from those owned values at call time.
 struct DropGuard {
     label: String,
     start: Instant,

--- a/crates/rskim/src/cmd/infra/gh/streaming.rs
+++ b/crates/rskim/src/cmd/infra/gh/streaming.rs
@@ -195,18 +195,13 @@ pub(super) trait StreamingParser: Send {
 
 /// Drop guard that records partial analytics on SIGINT/SIGPIPE.
 ///
-/// Holds running totals and a `recorded` flag.  When `Drop` fires, records
+/// Holds running totals and a `recorded` flag; when `Drop` fires, records
 /// only if the success path (`record()`) has not already done so.
 ///
-/// ## Owned vs borrowed fields
-///
-/// `DropGuard` stores `analytics_enabled: bool` and `session_id: Option<String>`
-/// as owned values rather than wrapping a `RecordingContext<'a>`.
-/// `RecordingContext` uses borrowed `Option<&'a str>` fields so it can be
-/// `Copy` and passed cheaply across call sites.  A `DropGuard` must outlive
-/// every stack frame up to its `drop`, so it cannot hold borrowed references —
-/// owned values are the correct representation here.  `do_record` reconstructs
-/// a short-lived `RecordingContext` from those owned values at call time.
+/// Stores `session_id` as an owned `Option<String>` rather than borrowing from
+/// a `RecordingContext<'a>` — a `DropGuard` must outlive every stack frame up
+/// to its `drop`, so borrowed references are not viable here.  `do_record`
+/// reconstructs a short-lived `RecordingContext` from those owned values.
 struct DropGuard {
     label: String,
     start: Instant,

--- a/crates/rskim/src/cmd/infra/mod.rs
+++ b/crates/rskim/src/cmd/infra/mod.rs
@@ -46,6 +46,7 @@ pub(crate) fn run(
         show_stats,
         json_output,
         analytics_enabled: analytics.enabled,
+        session_id: analytics.session_id.clone(),
     };
 
     match tool_name.as_str() {
@@ -177,6 +178,7 @@ pub(crate) fn run_infra_tool(
             output_format: ctx.output_format(),
             analytics_enabled: ctx.analytics_enabled,
             family: "infra",
+            session_id: ctx.session_id.as_deref(),
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/infra/mod.rs
+++ b/crates/rskim/src/cmd/infra/mod.rs
@@ -174,11 +174,14 @@ pub(crate) fn run_infra_tool(
             install_hint: config.install_hint,
             use_stdin,
             show_stats: ctx.show_stats,
-            command_type: crate::analytics::CommandType::Infra,
             output_format: ctx.output_format(),
-            analytics_enabled: ctx.analytics_enabled,
             family: "infra",
-            session_id: ctx.session_id.as_deref(),
+            rec: crate::analytics::RecordingContext {
+                enabled: ctx.analytics_enabled,
+                command_type: crate::analytics::CommandType::Infra,
+                parse_tier: None,
+                session_id: ctx.session_id.as_deref(),
+            },
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/lint/mod.rs
+++ b/crates/rskim/src/cmd/lint/mod.rs
@@ -57,6 +57,7 @@ pub(crate) fn run(
         show_stats,
         json_output,
         analytics_enabled: analytics.enabled,
+        session_id: analytics.session_id.clone(),
     };
 
     match linter_name.as_str() {
@@ -164,6 +165,7 @@ pub(crate) fn run_linter(
             output_format: ctx.output_format(),
             analytics_enabled: ctx.analytics_enabled,
             family: "lint",
+            session_id: ctx.session_id.as_deref(),
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/lint/mod.rs
+++ b/crates/rskim/src/cmd/lint/mod.rs
@@ -17,7 +17,6 @@ pub(crate) mod ruff;
 pub(crate) mod rustfmt;
 
 use std::collections::BTreeMap;
-use std::io::IsTerminal;
 use std::process::ExitCode;
 
 use super::{extract_show_stats, run_parsed_command_with_mode, ParsedCommandConfig};
@@ -151,7 +150,7 @@ pub(crate) fn run_linter(
     let mut cmd_args = args.to_vec();
     prepare_args(&mut cmd_args);
 
-    let use_stdin = !std::io::stdin().is_terminal() && args.is_empty();
+    let use_stdin = super::should_read_stdin(args);
 
     run_parsed_command_with_mode(
         ParsedCommandConfig {

--- a/crates/rskim/src/cmd/lint/mod.rs
+++ b/crates/rskim/src/cmd/lint/mod.rs
@@ -161,11 +161,14 @@ pub(crate) fn run_linter(
             install_hint: config.install_hint,
             use_stdin,
             show_stats: ctx.show_stats,
-            command_type: crate::analytics::CommandType::Lint,
             output_format: ctx.output_format(),
-            analytics_enabled: ctx.analytics_enabled,
             family: "lint",
-            session_id: ctx.session_id.as_deref(),
+            rec: crate::analytics::RecordingContext {
+                enabled: ctx.analytics_enabled,
+                command_type: crate::analytics::CommandType::Lint,
+                parse_tier: None,
+                session_id: ctx.session_id.as_deref(),
+            },
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -140,6 +140,7 @@ pub(crate) fn run(
         compressed_tokens,
         duration,
         result.tier_name(),
+        analytics.session_id.as_deref(),
     );
     Ok(ExitCode::SUCCESS)
 }
@@ -151,6 +152,7 @@ fn record_analytics(
     compressed_tokens: Option<usize>,
     duration: std::time::Duration,
     tier: &str,
+    session_id: Option<&str>,
 ) {
     crate::analytics::try_record_command_with_counts(
         enabled,
@@ -160,6 +162,7 @@ fn record_analytics(
         crate::analytics::CommandType::Log,
         duration,
         Some(tier),
+        session_id,
     );
 }
 

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -155,14 +155,16 @@ fn record_analytics(
     session_id: Option<&str>,
 ) {
     crate::analytics::try_record_command_with_counts(
-        enabled,
+        crate::analytics::RecordingContext {
+            enabled,
+            command_type: crate::analytics::CommandType::Log,
+            parse_tier: Some(tier),
+            session_id,
+        },
         raw_tokens.unwrap_or(0),
         compressed_tokens.unwrap_or(0),
         "skim log".to_string(),
-        crate::analytics::CommandType::Log,
         duration,
-        Some(tier),
-        session_id,
     );
 }
 

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -252,33 +252,23 @@ pub(crate) enum OutputFormat {
 
 /// Cross-cutting configuration for subcommand execution.
 ///
-/// Bundles the four fields that every family dispatcher receives identically,
-/// reducing the positional parameter list to `(args, ctx)` at every call boundary.
-///
-/// ## Fields
-///
-/// - `show_stats` — emit token-reduction statistics to stderr after compression.
-/// - `json_output` — serialize results as JSON instead of human-readable text.
-/// - `analytics_enabled` — persist token savings to the analytics database.
-/// - `session_id` — hook-injected session identifier threaded to every recording
-///   so the stats dashboard can group invocations by originating agent session.
+/// Bundles the fields every family dispatcher receives identically, reducing
+/// the positional parameter list to `(args, ctx)` at every call boundary.
 ///
 /// ## Relationship to `RecordingContext`
 ///
-/// `RunContext` is the UI/dispatch layer struct — it carries all cross-cutting
-/// fields needed by subcommand handlers, including UI concerns (`show_stats`,
-/// `json_output`) that are irrelevant to recording.  At recording call sites,
-/// handlers construct a [`crate::analytics::RecordingContext`] from the relevant
-/// subset (`analytics_enabled`, `session_id`) plus the handler-local fields
-/// (`command_type`, `parse_tier`).  The two structs are intentionally separate:
-/// `RunContext` owns its strings (no lifetime parameter), while `RecordingContext`
-/// borrows them (`Copy`, zero-allocation threading through call chains).
+/// Each family dispatcher constructs a [`crate::analytics::RecordingContext`]
+/// from `analytics_enabled`, `session_id`, and the handler-local `command_type`,
+/// then threads it directly through to [`ParsedCommandConfig::rec`].  The two
+/// structs are intentionally separate: `RunContext` owns its strings while
+/// `RecordingContext` borrows them (`Copy`, zero-allocation threading through
+/// call chains).
 pub(crate) struct RunContext {
     pub show_stats: bool,
     pub json_output: bool,
     pub analytics_enabled: bool,
     /// Optional session ID from `AnalyticsConfig::session_id`.
-    /// Threaded through to `ParsedCommandConfig::session_id` at construction.
+    /// Used by family dispatchers when constructing `RecordingContext`.
     pub session_id: Option<String>,
 }
 
@@ -297,6 +287,13 @@ impl RunContext {
 ///
 /// Groups the cross-cutting parameters for [`run_parsed_command_with_mode`]
 /// to reduce its positional parameter count.
+///
+/// ## Analytics threading
+///
+/// `rec` carries the full [`crate::analytics::RecordingContext`] constructed
+/// once by each family dispatcher.  `run_parsed_command_with_mode` calls
+/// `rec.with_tier(result.tier_name())` at the recording site — no
+/// decompose-then-reconstruct at the call site.
 pub(crate) struct ParsedCommandConfig<'a> {
     pub program: &'a str,
     pub args: &'a [String],
@@ -304,9 +301,7 @@ pub(crate) struct ParsedCommandConfig<'a> {
     pub install_hint: &'a str,
     pub use_stdin: bool,
     pub show_stats: bool,
-    pub command_type: crate::analytics::CommandType,
     pub output_format: OutputFormat,
-    pub analytics_enabled: bool,
     /// Family name used to build analytics labels (e.g. `"lint"`, `"infra"`, `"file"`).
     ///
     /// Analytics labels are recorded as `"skim {family} {program} {args}"`. Without
@@ -314,10 +309,10 @@ pub(crate) struct ParsedCommandConfig<'a> {
     /// name and made the analytics dashboard ambiguous when multiple families share
     /// tool names (e.g., `cargo` appears in both `build` and `pkg`). (PF-022)
     pub family: &'a str,
-    /// Optional session ID propagated from `AnalyticsConfig::session_id`.
-    /// Passed through to `try_record_command` so every recording carries the
-    /// hook-injected session context when available.
-    pub session_id: Option<&'a str>,
+    /// Recording context constructed once by the family dispatcher.
+    /// `run_parsed_command_with_mode` annotates `parse_tier` via
+    /// `rec.with_tier(result.tier_name())` before passing to `try_record_command`.
+    pub rec: crate::analytics::RecordingContext<'a>,
 }
 
 /// Obtain command output from stdin or by spawning the command.
@@ -412,11 +407,9 @@ where
         install_hint,
         use_stdin,
         show_stats,
-        command_type,
         output_format,
-        analytics_enabled,
         family,
-        session_id,
+        rec,
     } = config;
 
     let Some(output) = obtain_output(program, args, env_overrides, install_hint, use_stdin)? else {
@@ -467,12 +460,7 @@ where
     }
 
     crate::analytics::try_record_command(
-        crate::analytics::RecordingContext {
-            enabled: analytics_enabled,
-            command_type,
-            parse_tier: Some(result.tier_name()),
-            session_id,
-        },
+        rec.with_tier(result.tier_name()),
         output.stdout,
         compressed,
         format_analytics_label(family, program, &args.join(" ")),

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -262,6 +262,17 @@ pub(crate) enum OutputFormat {
 /// - `analytics_enabled` — persist token savings to the analytics database.
 /// - `session_id` — hook-injected session identifier threaded to every recording
 ///   so the stats dashboard can group invocations by originating agent session.
+///
+/// ## Relationship to `RecordingContext`
+///
+/// `RunContext` is the UI/dispatch layer struct — it carries all cross-cutting
+/// fields needed by subcommand handlers, including UI concerns (`show_stats`,
+/// `json_output`) that are irrelevant to recording.  At recording call sites,
+/// handlers construct a [`crate::analytics::RecordingContext`] from the relevant
+/// subset (`analytics_enabled`, `session_id`) plus the handler-local fields
+/// (`command_type`, `parse_tier`).  The two structs are intentionally separate:
+/// `RunContext` owns its strings (no lifetime parameter), while `RecordingContext`
+/// borrows them (`Copy`, zero-allocation threading through call chains).
 pub(crate) struct RunContext {
     pub show_stats: bool,
     pub json_output: bool,

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -252,9 +252,16 @@ pub(crate) enum OutputFormat {
 
 /// Cross-cutting configuration for subcommand execution.
 ///
-/// Bundles the three boolean flags that every family dispatcher receives
-/// identically, reducing the 4-parameter `(args, show_stats, json_output,
-/// analytics_enabled)` signature to `(args, ctx)` at every call boundary.
+/// Bundles the four fields that every family dispatcher receives identically,
+/// reducing the positional parameter list to `(args, ctx)` at every call boundary.
+///
+/// ## Fields
+///
+/// - `show_stats` — emit token-reduction statistics to stderr after compression.
+/// - `json_output` — serialize results as JSON instead of human-readable text.
+/// - `analytics_enabled` — persist token savings to the analytics database.
+/// - `session_id` — hook-injected session identifier threaded to every recording
+///   so the stats dashboard can group invocations by originating agent session.
 pub(crate) struct RunContext {
     pub show_stats: bool,
     pub json_output: bool,

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -259,6 +259,9 @@ pub(crate) struct RunContext {
     pub show_stats: bool,
     pub json_output: bool,
     pub analytics_enabled: bool,
+    /// Optional session ID from `AnalyticsConfig::session_id`.
+    /// Threaded through to `ParsedCommandConfig::session_id` at construction.
+    pub session_id: Option<String>,
 }
 
 impl RunContext {
@@ -293,6 +296,10 @@ pub(crate) struct ParsedCommandConfig<'a> {
     /// name and made the analytics dashboard ambiguous when multiple families share
     /// tool names (e.g., `cargo` appears in both `build` and `pkg`). (PF-022)
     pub family: &'a str,
+    /// Optional session ID propagated from `AnalyticsConfig::session_id`.
+    /// Passed through to `try_record_command` so every recording carries the
+    /// hook-injected session context when available.
+    pub session_id: Option<&'a str>,
 }
 
 /// Obtain command output from stdin or by spawning the command.
@@ -391,6 +398,7 @@ where
         output_format,
         analytics_enabled,
         family,
+        session_id,
     } = config;
 
     let Some(output) = obtain_output(program, args, env_overrides, install_hint, use_stdin)? else {
@@ -448,6 +456,7 @@ where
         command_type,
         output.duration,
         Some(result.tier_name()),
+        session_id,
     );
 
     Ok(ExitCode::from(code.clamp(0, 255) as u8))

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -456,14 +456,16 @@ where
     }
 
     crate::analytics::try_record_command(
-        analytics_enabled,
+        crate::analytics::RecordingContext {
+            enabled: analytics_enabled,
+            command_type,
+            parse_tier: Some(result.tier_name()),
+            session_id,
+        },
         output.stdout,
         compressed,
         format_analytics_label(family, program, &args.join(" ")),
-        command_type,
         output.duration,
-        Some(result.tier_name()),
-        session_id,
     );
 
     Ok(ExitCode::from(code.clamp(0, 255) as u8))

--- a/crates/rskim/src/cmd/pkg/cargo.rs
+++ b/crates/rskim/src/cmd/pkg/cargo.rs
@@ -25,6 +25,7 @@ pub(crate) fn run(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -35,7 +36,13 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "audit" => run_audit(subcmd_args, show_stats, json_output, analytics_enabled),
+        "audit" => run_audit(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(
@@ -70,6 +77,7 @@ fn run_audit(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -81,6 +89,7 @@ fn run_audit(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/cargo.rs
+++ b/crates/rskim/src/cmd/pkg/cargo.rs
@@ -24,8 +24,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -36,13 +35,7 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "audit" => run_audit(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
+        "audit" => run_audit(subcmd_args, show_stats, json_output, rec),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(
@@ -76,8 +69,7 @@ fn run_audit(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -88,8 +80,7 @@ fn run_audit(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/mod.rs
+++ b/crates/rskim/src/cmd/pkg/mod.rs
@@ -107,6 +107,7 @@ where
             output_format: crate::cmd::OutputFormat::default(),
             analytics_enabled,
             family: "pkg",
+            session_id: None,
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/pkg/mod.rs
+++ b/crates/rskim/src/cmd/pkg/mod.rs
@@ -8,7 +8,6 @@ mod npm;
 mod pip;
 mod pnpm;
 
-use std::io::IsTerminal;
 use std::process::ExitCode;
 
 use crate::output::ParseResult;
@@ -98,7 +97,7 @@ where
     cmd_args.extend(user_args.iter().cloned());
     inject_flags(&mut cmd_args);
 
-    let use_stdin = !std::io::stdin().is_terminal() && user_args.is_empty();
+    let use_stdin = crate::cmd::should_read_stdin(user_args);
 
     crate::cmd::run_parsed_command_with_mode(
         crate::cmd::ParsedCommandConfig {

--- a/crates/rskim/src/cmd/pkg/mod.rs
+++ b/crates/rskim/src/cmd/pkg/mod.rs
@@ -39,12 +39,37 @@ pub(crate) fn run(
     };
 
     let analytics_enabled = analytics.enabled;
+    let session_id = analytics.session_id.as_deref();
 
     match tool_name.as_str() {
-        "npm" => npm::run(tool_args, show_stats, json_output, analytics_enabled),
-        "pnpm" => pnpm::run(tool_args, show_stats, json_output, analytics_enabled),
-        "pip" => pip::run(tool_args, show_stats, json_output, analytics_enabled),
-        "cargo" => cargo::run(tool_args, show_stats, json_output, analytics_enabled),
+        "npm" => npm::run(
+            tool_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "pnpm" => pnpm::run(
+            tool_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "pip" => pip::run(
+            tool_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "cargo" => cargo::run(
+            tool_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
         tool => {
             let safe_tool = crate::cmd::sanitize_for_display(tool);
             eprintln!(
@@ -83,6 +108,7 @@ pub(super) fn run_pkg_subcommand<T>(
     user_args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
     inject_flags: impl FnOnce(&mut Vec<String>),
     parse_fn: impl FnOnce(&CommandOutput) -> ParseResult<T>,
 ) -> anyhow::Result<ExitCode>
@@ -107,7 +133,7 @@ where
             output_format: crate::cmd::OutputFormat::default(),
             analytics_enabled,
             family: "pkg",
-            session_id: None,
+            session_id,
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/pkg/mod.rs
+++ b/crates/rskim/src/cmd/pkg/mod.rs
@@ -38,38 +38,18 @@ pub(crate) fn run(
         return Ok(ExitCode::SUCCESS);
     };
 
-    let analytics_enabled = analytics.enabled;
-    let session_id = analytics.session_id.as_deref();
+    let rec = crate::analytics::RecordingContext {
+        enabled: analytics.enabled,
+        command_type: crate::analytics::CommandType::Pkg,
+        parse_tier: None,
+        session_id: analytics.session_id.as_deref(),
+    };
 
     match tool_name.as_str() {
-        "npm" => npm::run(
-            tool_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "pnpm" => pnpm::run(
-            tool_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "pip" => pip::run(
-            tool_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "cargo" => cargo::run(
-            tool_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
+        "npm" => npm::run(tool_args, show_stats, json_output, rec),
+        "pnpm" => pnpm::run(tool_args, show_stats, json_output, rec),
+        "pip" => pip::run(tool_args, show_stats, json_output, rec),
+        "cargo" => cargo::run(tool_args, show_stats, json_output, rec),
         tool => {
             let safe_tool = crate::cmd::sanitize_for_display(tool);
             eprintln!(
@@ -107,8 +87,7 @@ pub(super) fn run_pkg_subcommand<T>(
     config: PkgSubcommandConfig<'_>,
     user_args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
     inject_flags: impl FnOnce(&mut Vec<String>),
     parse_fn: impl FnOnce(&CommandOutput) -> ParseResult<T>,
 ) -> anyhow::Result<ExitCode>
@@ -129,11 +108,9 @@ where
             install_hint: config.install_hint,
             use_stdin,
             show_stats,
-            command_type: crate::analytics::CommandType::Pkg,
             output_format: crate::cmd::OutputFormat::default(),
-            analytics_enabled,
             family: "pkg",
-            session_id,
+            rec,
         },
         |output, _args| parse_fn(output),
     )

--- a/crates/rskim/src/cmd/pkg/npm/audit.rs
+++ b/crates/rskim/src/cmd/pkg/npm/audit.rs
@@ -42,8 +42,7 @@ pub(super) fn run_audit(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -54,8 +53,7 @@ pub(super) fn run_audit(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/npm/audit.rs
+++ b/crates/rskim/src/cmd/pkg/npm/audit.rs
@@ -43,6 +43,7 @@ pub(super) fn run_audit(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -54,6 +55,7 @@ pub(super) fn run_audit(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/npm/install.rs
+++ b/crates/rskim/src/cmd/pkg/npm/install.rs
@@ -27,8 +27,7 @@ pub(super) fn run_install(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -39,8 +38,7 @@ pub(super) fn run_install(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/npm/install.rs
+++ b/crates/rskim/src/cmd/pkg/npm/install.rs
@@ -28,6 +28,7 @@ pub(super) fn run_install(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -39,6 +40,7 @@ pub(super) fn run_install(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/npm/ls.rs
+++ b/crates/rskim/src/cmd/pkg/npm/ls.rs
@@ -12,6 +12,7 @@ pub(super) fn run_ls(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -23,6 +24,7 @@ pub(super) fn run_ls(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output {
                 if !user_has_flag(cmd_args, &["--json"]) {

--- a/crates/rskim/src/cmd/pkg/npm/ls.rs
+++ b/crates/rskim/src/cmd/pkg/npm/ls.rs
@@ -11,8 +11,7 @@ pub(super) fn run_ls(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -23,8 +22,7 @@ pub(super) fn run_ls(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output {
                 if !user_has_flag(cmd_args, &["--json"]) {

--- a/crates/rskim/src/cmd/pkg/npm/mod.rs
+++ b/crates/rskim/src/cmd/pkg/npm/mod.rs
@@ -23,8 +23,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -35,34 +34,10 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "install" | "i" | "ci" => install::run_install(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "audit" => audit::run_audit(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "outdated" => outdated::run_outdated(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "ls" | "list" => ls::run_ls(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
+        "install" | "i" | "ci" => install::run_install(subcmd_args, show_stats, json_output, rec),
+        "audit" => audit::run_audit(subcmd_args, show_stats, json_output, rec),
+        "outdated" => outdated::run_outdated(subcmd_args, show_stats, json_output, rec),
+        "ls" | "list" => ls::run_ls(subcmd_args, show_stats, json_output, rec),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(

--- a/crates/rskim/src/cmd/pkg/npm/mod.rs
+++ b/crates/rskim/src/cmd/pkg/npm/mod.rs
@@ -24,6 +24,7 @@ pub(crate) fn run(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -34,14 +35,34 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "install" | "i" | "ci" => {
-            install::run_install(subcmd_args, show_stats, json_output, analytics_enabled)
-        }
-        "audit" => audit::run_audit(subcmd_args, show_stats, json_output, analytics_enabled),
-        "outdated" => {
-            outdated::run_outdated(subcmd_args, show_stats, json_output, analytics_enabled)
-        }
-        "ls" | "list" => ls::run_ls(subcmd_args, show_stats, json_output, analytics_enabled),
+        "install" | "i" | "ci" => install::run_install(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "audit" => audit::run_audit(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "outdated" => outdated::run_outdated(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "ls" | "list" => ls::run_ls(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(

--- a/crates/rskim/src/cmd/pkg/npm/outdated.rs
+++ b/crates/rskim/src/cmd/pkg/npm/outdated.rs
@@ -11,8 +11,7 @@ pub(super) fn run_outdated(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -23,8 +22,7 @@ pub(super) fn run_outdated(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/npm/outdated.rs
+++ b/crates/rskim/src/cmd/pkg/npm/outdated.rs
@@ -12,6 +12,7 @@ pub(super) fn run_outdated(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -23,6 +24,7 @@ pub(super) fn run_outdated(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());

--- a/crates/rskim/src/cmd/pkg/pip.rs
+++ b/crates/rskim/src/cmd/pkg/pip.rs
@@ -34,6 +34,7 @@ pub(crate) fn run(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -44,9 +45,27 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "install" => run_install(subcmd_args, show_stats, json_output, analytics_enabled),
-        "check" => run_check(subcmd_args, show_stats, json_output, analytics_enabled),
-        "list" => run_list(subcmd_args, show_stats, json_output, analytics_enabled),
+        "install" => run_install(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "check" => run_check(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "list" => run_list(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(
@@ -85,6 +104,7 @@ fn run_install(
     show_stats: bool,
     _json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -96,6 +116,7 @@ fn run_install(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |_cmd_args| {},
         parse_install,
     )
@@ -147,6 +168,7 @@ fn run_check(
     show_stats: bool,
     _json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -158,6 +180,7 @@ fn run_check(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |_cmd_args| {},
         parse_check,
     )
@@ -224,6 +247,7 @@ fn run_list(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -235,6 +259,7 @@ fn run_list(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output {
                 if !user_has_flag(cmd_args, &["--outdated"]) {

--- a/crates/rskim/src/cmd/pkg/pip.rs
+++ b/crates/rskim/src/cmd/pkg/pip.rs
@@ -33,8 +33,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -45,27 +44,9 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "install" => run_install(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "check" => run_check(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "list" => run_list(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
+        "install" => run_install(subcmd_args, show_stats, json_output, rec),
+        "check" => run_check(subcmd_args, show_stats, json_output, rec),
+        "list" => run_list(subcmd_args, show_stats, json_output, rec),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(
@@ -103,8 +84,7 @@ fn run_install(
     args: &[String],
     show_stats: bool,
     _json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -115,8 +95,7 @@ fn run_install(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |_cmd_args| {},
         parse_install,
     )
@@ -167,8 +146,7 @@ fn run_check(
     args: &[String],
     show_stats: bool,
     _json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -179,8 +157,7 @@ fn run_check(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |_cmd_args| {},
         parse_check,
     )
@@ -246,8 +223,7 @@ fn run_list(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -258,8 +234,7 @@ fn run_list(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output {
                 if !user_has_flag(cmd_args, &["--outdated"]) {

--- a/crates/rskim/src/cmd/pkg/pnpm.rs
+++ b/crates/rskim/src/cmd/pkg/pnpm.rs
@@ -31,6 +31,7 @@ pub(crate) fn run(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -41,9 +42,27 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "install" | "i" => run_install(subcmd_args, show_stats, json_output, analytics_enabled),
-        "audit" => run_audit(subcmd_args, show_stats, json_output, analytics_enabled),
-        "outdated" => run_outdated(subcmd_args, show_stats, json_output, analytics_enabled),
+        "install" | "i" => run_install(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "audit" => run_audit(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
+        "outdated" => run_outdated(
+            subcmd_args,
+            show_stats,
+            json_output,
+            analytics_enabled,
+            session_id,
+        ),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(
@@ -82,6 +101,7 @@ fn run_install(
     show_stats: bool,
     _json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -93,6 +113,7 @@ fn run_install(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |_cmd_args| {},
         parse_install,
     )
@@ -159,6 +180,7 @@ fn run_audit(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -170,6 +192,7 @@ fn run_audit(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());
@@ -259,6 +282,7 @@ fn run_outdated(
     show_stats: bool,
     json_output: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -270,6 +294,7 @@ fn run_outdated(
         args,
         show_stats,
         analytics_enabled,
+        session_id,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--format"]) {
                 cmd_args.push("--format".to_string());

--- a/crates/rskim/src/cmd/pkg/pnpm.rs
+++ b/crates/rskim/src/cmd/pkg/pnpm.rs
@@ -30,8 +30,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     if args.is_empty() || args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
         print_help();
@@ -42,27 +41,9 @@ pub(crate) fn run(
     let (subcmd, subcmd_args) = args.split_first().expect("already verified non-empty");
 
     match subcmd.as_str() {
-        "install" | "i" => run_install(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "audit" => run_audit(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
-        "outdated" => run_outdated(
-            subcmd_args,
-            show_stats,
-            json_output,
-            analytics_enabled,
-            session_id,
-        ),
+        "install" | "i" => run_install(subcmd_args, show_stats, json_output, rec),
+        "audit" => run_audit(subcmd_args, show_stats, json_output, rec),
+        "outdated" => run_outdated(subcmd_args, show_stats, json_output, rec),
         other => {
             let safe = crate::cmd::sanitize_for_display(other);
             eprintln!(
@@ -100,8 +81,7 @@ fn run_install(
     args: &[String],
     show_stats: bool,
     _json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -112,8 +92,7 @@ fn run_install(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |_cmd_args| {},
         parse_install,
     )
@@ -179,8 +158,7 @@ fn run_audit(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -191,8 +169,7 @@ fn run_audit(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--json"]) {
                 cmd_args.push("--json".to_string());
@@ -281,8 +258,7 @@ fn run_outdated(
     args: &[String],
     show_stats: bool,
     json_output: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     super::run_pkg_subcommand(
         super::PkgSubcommandConfig {
@@ -293,8 +269,7 @@ fn run_outdated(
         },
         args,
         show_stats,
-        analytics_enabled,
-        session_id,
+        rec,
         |cmd_args| {
             if json_output && !user_has_flag(cmd_args, &["--format"]) {
                 cmd_args.push("--format".to_string());

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -508,7 +508,10 @@ mod tests {
     #[test]
     fn test_session_id_injection_preserves_subcommand_and_flags() {
         let result = inject_session_id("skim build cargo --show-stats", Some("sess-xyz"));
-        assert_eq!(result, "skim --session-id=sess-xyz build cargo --show-stats");
+        assert_eq!(
+            result,
+            "skim --session-id=sess-xyz build cargo --show-stats"
+        );
     }
 
     /// AD-HK-2: no injection when session_id is None.

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -50,6 +50,45 @@ pub(super) const HOOK_MAX_STDIN_BYTES: u64 = 64 * 1024;
 /// passthrough, not an error. Logs a warning to hook.log for debugging.
 pub(super) const HOOK_TIMEOUT_SECS: u64 = 5;
 
+/// Inject `--session-id=VALUE` into every `skim ` segment of a (possibly compound) command.
+///
+/// Handles compound operators (` && ` and ` || `) by splitting, injecting into each
+/// segment that starts with `skim `, then rejoining with the original operator.
+///
+/// Assumes `sid` has already passed the safety check (alphanumeric, `-`, `_`, `.` only).
+///
+/// # Examples
+/// - `"skim git status"` → `"skim --session-id=abc git status"`
+/// - `"skim git status && skim build cargo"` → `"skim --session-id=abc git status && skim --session-id=abc build cargo"`
+fn inject_session_id_into_compound(cmd: &str, sid: &str) -> String {
+    // Detect compound operator: try ` && ` first, then ` || `.
+    // Only one type is supported per compound command (mixing is unusual for rewritten cmds).
+    let (separator, parts): (&str, Vec<&str>) = if cmd.contains(" && ") {
+        (" && ", cmd.split(" && ").collect())
+    } else if cmd.contains(" || ") {
+        (" || ", cmd.split(" || ").collect())
+    } else {
+        // Simple (non-compound) command — single inject.
+        if let Some(rest) = cmd.strip_prefix("skim ") {
+            return format!("skim --session-id={sid} {rest}");
+        }
+        return cmd.to_string();
+    };
+
+    let injected: Vec<String> = parts
+        .iter()
+        .map(|segment| {
+            if let Some(rest) = segment.strip_prefix("skim ") {
+                format!("skim --session-id={sid} {rest}")
+            } else {
+                (*segment).to_string()
+            }
+        })
+        .collect();
+
+    injected.join(separator)
+}
+
 /// Run as an agent PreToolUse hook.
 ///
 /// Protocol:
@@ -191,13 +230,7 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
                         .bytes()
                         .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
                 if is_safe {
-                    if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
-                        // Insert --session-id=VALUE after "skim " (the first word).
-                        // e.g. "skim git status" -> "skim --session-id=abc git status"
-                        format!("skim --session-id={sid} {rest}")
-                    } else {
-                        rewritten_cmd.clone()
-                    }
+                    inject_session_id_into_compound(rewritten_cmd, sid)
                 } else {
                     rewritten_cmd.clone()
                 }
@@ -495,12 +528,14 @@ mod tests {
     // ========================================================================
     // B8: AD-HK-2 — session_id injection into rewritten commands
     //
-    // The injection logic is inlined in run_hook_mode (not a separate fn),
-    // so tests reproduce the same logic to verify the format contract.
+    // The injection logic now lives in inject_session_id_into_compound (module level).
+    // This test helper wraps it with the same security validation used in run_hook_mode.
     // ========================================================================
 
-    /// Helper: reproduce the AD-HK-2 injection format used in run_hook_mode,
+    /// Helper: apply the AD-HK-2 injection format used in run_hook_mode,
     /// including the security validation that rejects unsafe characters.
+    /// Delegates to the module-level inject_session_id_into_compound for the
+    /// actual substitution logic so tests cover the production code path.
     fn inject_session_id(rewritten_cmd: &str, session_id: Option<&str>) -> String {
         if let Some(sid) = session_id {
             let is_safe = !sid.is_empty()
@@ -508,9 +543,7 @@ mod tests {
                     .bytes()
                     .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
             if is_safe {
-                if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
-                    return format!("skim --session-id={sid} {rest}");
-                }
+                return inject_session_id_into_compound(rewritten_cmd, sid);
             }
         }
         rewritten_cmd.to_string()
@@ -621,5 +654,41 @@ mod tests {
     fn test_session_id_safe_chars_accepted() {
         let result = inject_session_id("skim git status", Some("sess_123-abc.def"));
         assert_eq!(result, "skim --session-id=sess_123-abc.def git status");
+    }
+
+    // ========================================================================
+    // B-AC5: compound command injection — all skim segments must be tagged
+    // ========================================================================
+
+    /// B-AC5: compound `&&` command injects session_id into every skim segment.
+    #[test]
+    fn test_session_id_injected_into_compound_and_command() {
+        let result = inject_session_id("skim git status && skim build cargo", Some("sess-abc"));
+        assert_eq!(
+            result,
+            "skim --session-id=sess-abc git status && skim --session-id=sess-abc build cargo",
+            "both skim segments in a && compound must receive --session-id injection"
+        );
+    }
+
+    /// B-AC5: compound `||` command injects session_id into every skim segment.
+    #[test]
+    fn test_session_id_injected_into_compound_or_command() {
+        let result = inject_session_id("skim git status || skim build cargo", Some("sess-abc"));
+        assert_eq!(
+            result,
+            "skim --session-id=sess-abc git status || skim --session-id=sess-abc build cargo",
+            "both skim segments in a || compound must receive --session-id injection"
+        );
+    }
+
+    /// B-AC5: non-skim segments in a compound command are left untouched.
+    #[test]
+    fn test_session_id_compound_non_skim_segment_unchanged() {
+        let result = inject_session_id("skim git status && cargo build 2>&1", Some("sess-abc"));
+        assert_eq!(
+            result, "skim --session-id=sess-abc git status && cargo build 2>&1",
+            "non-skim segment in compound must not be modified"
+        );
     }
 }

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -216,7 +216,7 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
     };
 
     match rewritten {
-        Some(ref rewritten_cmd) => {
+        Some(rewritten_cmd) => {
             // AD-HK-2: Inject --session-id=VALUE into the rewritten command so every
             // skim invocation in this session is tagged for per-session analytics.
             // Only inject when session_id is present and command starts with "skim ".
@@ -224,9 +224,10 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
             // hyphens, underscores, dots, max 128 chars) before interpolation into
             // the command string. Malicious session IDs with shell metacharacters
             // (;, |, $, spaces, etc.) are silently dropped to prevent command injection.
+            // F5: match by value so the None arm moves rewritten_cmd instead of cloning.
             let final_cmd = match session_id.as_deref().filter(|sid| crate::analytics::is_safe_session_id(sid)) {
-                Some(sid) => inject_session_id_into_compound(rewritten_cmd, sid),
-                None => rewritten_cmd.clone(),
+                Some(sid) => inject_session_id_into_compound(&rewritten_cmd, sid),
+                None => rewritten_cmd,
             };
             audit_hook(&command, true, &final_cmd);
             // Use agent-specific response format

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -129,9 +129,9 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
         }
     };
 
-    // Extract command using the agent-specific protocol
-    let command = match protocol.parse_input(&json) {
-        Some(input) => input.command,
+    // Extract command (and session_id) using the agent-specific protocol
+    let (command, session_id) = match protocol.parse_input(&json) {
+        Some(input) => (input.command, input.session_id),
         None => {
             audit_hook("", false, "");
             return Ok(ExitCode::SUCCESS); // passthrough on missing/unparseable field
@@ -178,9 +178,23 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
 
     match rewritten {
         Some(ref rewritten_cmd) => {
-            audit_hook(&command, true, rewritten_cmd);
+            // AD-HK-2: Inject --session-id=VALUE into the rewritten command so every
+            // skim invocation in this session is tagged for per-session analytics.
+            // Only inject when session_id is present and command starts with "skim ".
+            let final_cmd = if let Some(ref sid) = session_id {
+                if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
+                    // Insert --session-id=VALUE after "skim " (the first word).
+                    // e.g. "skim git status" -> "skim --session-id=abc git status"
+                    format!("skim --session-id={sid} {rest}")
+                } else {
+                    rewritten_cmd.clone()
+                }
+            } else {
+                rewritten_cmd.clone()
+            };
+            audit_hook(&command, true, &final_cmd);
             // Use agent-specific response format
-            let response = protocol.format_response(rewritten_cmd);
+            let response = protocol.format_response(&final_cmd);
             let json_out = serde_json::to_string(&response)?;
             println!("{json_out}");
         }
@@ -463,6 +477,66 @@ mod tests {
         assert!(
             !should_warn_today(&stamp),
             "second call same day should not warn"
+        );
+    }
+
+    // ========================================================================
+    // B8: AD-HK-2 — session_id injection into rewritten commands
+    //
+    // The injection logic is inlined in run_hook_mode (not a separate fn),
+    // so tests reproduce the same logic to verify the format contract.
+    // ========================================================================
+
+    /// Helper: reproduce the AD-HK-2 injection format used in run_hook_mode.
+    fn inject_session_id(rewritten_cmd: &str, session_id: Option<&str>) -> String {
+        if let Some(sid) = session_id {
+            if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
+                return format!("skim --session-id={sid} {rest}");
+            }
+        }
+        rewritten_cmd.to_string()
+    }
+
+    /// AD-HK-2: session_id is injected after "skim " when present.
+    #[test]
+    fn test_session_id_injected_into_skim_command() {
+        let result = inject_session_id("skim git status", Some("abc-123"));
+        assert_eq!(result, "skim --session-id=abc-123 git status");
+    }
+
+    /// AD-HK-2: subcommand and flags are preserved after injection.
+    #[test]
+    fn test_session_id_injection_preserves_subcommand_and_flags() {
+        let result = inject_session_id("skim build cargo --show-stats", Some("sess-xyz"));
+        assert_eq!(result, "skim --session-id=sess-xyz build cargo --show-stats");
+    }
+
+    /// AD-HK-2: no injection when session_id is None.
+    #[test]
+    fn test_session_id_not_injected_when_none() {
+        let result = inject_session_id("skim git log", None);
+        assert_eq!(result, "skim git log");
+    }
+
+    /// AD-HK-2: non-skim commands are not modified even when session_id is present.
+    #[test]
+    fn test_session_id_not_injected_into_non_skim_command() {
+        // A rewritten compound or partial result that doesn't start with "skim " is passthrough
+        let result = inject_session_id("cargo build 2>&1", Some("sess-x"));
+        assert_eq!(result, "cargo build 2>&1");
+    }
+
+    /// AD-HK-2: injection flag format is --session-id=VALUE (equals form, no space).
+    #[test]
+    fn test_session_id_injection_uses_equals_form() {
+        let result = inject_session_id("skim lint eslint", Some("my-session"));
+        assert!(
+            result.contains("--session-id=my-session"),
+            "injection must use --session-id=VALUE equals form, got: {result}"
+        );
+        assert!(
+            !result.contains("--session-id my-session"),
+            "injection must not use space-separated form"
         );
     }
 }

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -225,7 +225,10 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
             // the command string. Malicious session IDs with shell metacharacters
             // (;, |, $, spaces, etc.) are silently dropped to prevent command injection.
             // F5: match by value so the None arm moves rewritten_cmd instead of cloning.
-            let final_cmd = match session_id.as_deref().filter(|sid| crate::analytics::is_safe_session_id(sid)) {
+            let final_cmd = match session_id
+                .as_deref()
+                .filter(|sid| crate::analytics::is_safe_session_id(sid))
+            {
                 Some(sid) => inject_session_id_into_compound(&rewritten_cmd, sid),
                 None => rewritten_cmd,
             };

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -220,22 +220,13 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
             // AD-HK-2: Inject --session-id=VALUE into the rewritten command so every
             // skim invocation in this session is tagged for per-session analytics.
             // Only inject when session_id is present and command starts with "skim ".
-            // SECURITY: session_id is validated to contain only safe characters
-            // (alphanumeric, hyphens, underscores, dots) before interpolation into
+            // SECURITY: session_id is validated via is_safe_session_id (alphanumeric,
+            // hyphens, underscores, dots, max 128 chars) before interpolation into
             // the command string. Malicious session IDs with shell metacharacters
             // (;, |, $, spaces, etc.) are silently dropped to prevent command injection.
-            let final_cmd = if let Some(ref sid) = session_id {
-                let is_safe = !sid.is_empty()
-                    && sid
-                        .bytes()
-                        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
-                if is_safe {
-                    inject_session_id_into_compound(rewritten_cmd, sid)
-                } else {
-                    rewritten_cmd.clone()
-                }
-            } else {
-                rewritten_cmd.clone()
+            let final_cmd = match session_id.as_deref().filter(|sid| crate::analytics::is_safe_session_id(sid)) {
+                Some(sid) => inject_session_id_into_compound(rewritten_cmd, sid),
+                None => rewritten_cmd.clone(),
             };
             audit_hook(&command, true, &final_cmd);
             // Use agent-specific response format
@@ -537,16 +528,10 @@ mod tests {
     /// Delegates to the module-level inject_session_id_into_compound for the
     /// actual substitution logic so tests cover the production code path.
     fn inject_session_id(rewritten_cmd: &str, session_id: Option<&str>) -> String {
-        if let Some(sid) = session_id {
-            let is_safe = !sid.is_empty()
-                && sid
-                    .bytes()
-                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
-            if is_safe {
-                return inject_session_id_into_compound(rewritten_cmd, sid);
-            }
+        match session_id.filter(|sid| crate::analytics::is_safe_session_id(sid)) {
+            Some(sid) => inject_session_id_into_compound(rewritten_cmd, sid),
+            None => rewritten_cmd.to_string(),
         }
-        rewritten_cmd.to_string()
     }
 
     /// AD-HK-2: session_id is injected after "skim " when present.

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -181,11 +181,23 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
             // AD-HK-2: Inject --session-id=VALUE into the rewritten command so every
             // skim invocation in this session is tagged for per-session analytics.
             // Only inject when session_id is present and command starts with "skim ".
+            // SECURITY: session_id is validated to contain only safe characters
+            // (alphanumeric, hyphens, underscores, dots) before interpolation into
+            // the command string. Malicious session IDs with shell metacharacters
+            // (;, |, $, spaces, etc.) are silently dropped to prevent command injection.
             let final_cmd = if let Some(ref sid) = session_id {
-                if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
-                    // Insert --session-id=VALUE after "skim " (the first word).
-                    // e.g. "skim git status" -> "skim --session-id=abc git status"
-                    format!("skim --session-id={sid} {rest}")
+                let is_safe = !sid.is_empty()
+                    && sid
+                        .bytes()
+                        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
+                if is_safe {
+                    if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
+                        // Insert --session-id=VALUE after "skim " (the first word).
+                        // e.g. "skim git status" -> "skim --session-id=abc git status"
+                        format!("skim --session-id={sid} {rest}")
+                    } else {
+                        rewritten_cmd.clone()
+                    }
                 } else {
                     rewritten_cmd.clone()
                 }
@@ -487,11 +499,18 @@ mod tests {
     // so tests reproduce the same logic to verify the format contract.
     // ========================================================================
 
-    /// Helper: reproduce the AD-HK-2 injection format used in run_hook_mode.
+    /// Helper: reproduce the AD-HK-2 injection format used in run_hook_mode,
+    /// including the security validation that rejects unsafe characters.
     fn inject_session_id(rewritten_cmd: &str, session_id: Option<&str>) -> String {
         if let Some(sid) = session_id {
-            if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
-                return format!("skim --session-id={sid} {rest}");
+            let is_safe = !sid.is_empty()
+                && sid
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
+            if is_safe {
+                if let Some(rest) = rewritten_cmd.strip_prefix("skim ") {
+                    return format!("skim --session-id={sid} {rest}");
+                }
             }
         }
         rewritten_cmd.to_string()
@@ -541,5 +560,66 @@ mod tests {
             !result.contains("--session-id my-session"),
             "injection must not use space-separated form"
         );
+    }
+
+    // ========================================================================
+    // SECURITY: session_id validation — reject shell metacharacters
+    // ========================================================================
+
+    /// SECURITY: session_id with shell metacharacters is silently dropped.
+    #[test]
+    fn test_session_id_with_semicolon_rejected() {
+        let result = inject_session_id("skim git status", Some("foo; rm -rf /"));
+        assert_eq!(
+            result, "skim git status",
+            "session_id with semicolons must not be injected"
+        );
+    }
+
+    /// SECURITY: session_id with pipe character is rejected.
+    #[test]
+    fn test_session_id_with_pipe_rejected() {
+        let result = inject_session_id("skim git status", Some("foo|bar"));
+        assert_eq!(
+            result, "skim git status",
+            "session_id with pipe must not be injected"
+        );
+    }
+
+    /// SECURITY: session_id with spaces is rejected.
+    #[test]
+    fn test_session_id_with_spaces_rejected() {
+        let result = inject_session_id("skim git status", Some("foo bar"));
+        assert_eq!(
+            result, "skim git status",
+            "session_id with spaces must not be injected"
+        );
+    }
+
+    /// SECURITY: session_id with dollar sign (variable expansion) is rejected.
+    #[test]
+    fn test_session_id_with_dollar_rejected() {
+        let result = inject_session_id("skim git status", Some("$HOME"));
+        assert_eq!(
+            result, "skim git status",
+            "session_id with $ must not be injected"
+        );
+    }
+
+    /// SECURITY: empty session_id is not injected.
+    #[test]
+    fn test_session_id_empty_not_injected() {
+        let result = inject_session_id("skim git status", Some(""));
+        assert_eq!(
+            result, "skim git status",
+            "empty session_id must not be injected"
+        );
+    }
+
+    /// Safe session_id characters: alphanumeric, hyphens, underscores, dots.
+    #[test]
+    fn test_session_id_safe_chars_accepted() {
+        let result = inject_session_id("skim git status", Some("sess_123-abc.def"));
+        assert_eq!(result, "skim --session-id=sess_123-abc.def git status");
     }
 }

--- a/crates/rskim/src/cmd/stats.rs
+++ b/crates/rskim/src/cmd/stats.rs
@@ -14,7 +14,9 @@ use std::time::UNIX_EPOCH;
 // arbitrary value coloring is intentionally not centralised.
 use colored::{ColoredString, Colorize};
 
-use crate::analytics::{AnalyticsDb, AnalyticsStore, OriginalCommandStats, PricingModel, SessionStats};
+use crate::analytics::{
+    AnalyticsDb, AnalyticsStore, OriginalCommandStats, PricingModel, SessionStats,
+};
 use crate::cmd::session::types::parse_duration_ago;
 use crate::tokens;
 

--- a/crates/rskim/src/cmd/stats.rs
+++ b/crates/rskim/src/cmd/stats.rs
@@ -14,7 +14,7 @@ use std::time::UNIX_EPOCH;
 // arbitrary value coloring is intentionally not centralised.
 use colored::{ColoredString, Colorize};
 
-use crate::analytics::{AnalyticsDb, AnalyticsStore, OriginalCommandStats, PricingModel};
+use crate::analytics::{AnalyticsDb, AnalyticsStore, OriginalCommandStats, PricingModel, SessionStats};
 use crate::cmd::session::types::parse_duration_ago;
 use crate::tokens;
 
@@ -155,6 +155,7 @@ fn run_json(
     let by_mode = db.query_by_mode(since)?;
     let tier_dist = db.query_tier_distribution(since)?;
     let by_original_cmd = db.query_by_original_cmd(since)?;
+    let session_stats = db.query_session_stats(since)?;
 
     let weighted_pct = weighted_savings_pct(&summary);
 
@@ -185,6 +186,12 @@ fn run_json(
         "by_mode": by_mode,
         "tier_distribution": tier_dist,
         "by_original_cmd": by_original_cmd,
+        "session_stats": {
+            "distinct_sessions": session_stats.distinct_sessions,
+            "total_tokens_saved": session_stats.total_tokens_saved,
+            "avg_tokens_per_session": session_stats.avg_tokens_per_session,
+            "untagged_invocations": session_stats.untagged_invocations,
+        },
         "cost_estimate": cost_estimate,
     });
 
@@ -508,6 +515,47 @@ fn render_parse_quality(
     Ok(())
 }
 
+/// Render per-session analytics summary.
+///
+/// AD-AN-2: Displays distinct session count, total tokens saved across sessions,
+/// average tokens saved per session, and untagged invocation count.
+/// Skipped when no session data is present (distinct_sessions == 0 and
+/// untagged_invocations == 0) to avoid cluttering the dashboard for users
+/// who have not installed the hook or enabled session tracking.
+fn render_session_stats(w: &mut dyn Write, stats: &SessionStats) -> anyhow::Result<()> {
+    if stats.distinct_sessions == 0 && stats.untagged_invocations == 0 {
+        return Ok(());
+    }
+    writeln!(w, "{}", section_header("Per Session"))?;
+    writeln!(w)?;
+    if stats.distinct_sessions > 0 {
+        writeln!(
+            w,
+            "  Sessions tracked:   {}",
+            tokens::format_number(stats.distinct_sessions as usize)
+        )?;
+        writeln!(
+            w,
+            "  Total tokens saved: {}",
+            tokens::format_number(stats.total_tokens_saved as usize).green()
+        )?;
+        writeln!(
+            w,
+            "  Avg per session:    {}",
+            tokens::format_number(stats.avg_tokens_per_session.round() as usize).green()
+        )?;
+    }
+    if stats.untagged_invocations > 0 {
+        writeln!(
+            w,
+            "  Untagged calls:     {}",
+            tokens::format_number(stats.untagged_invocations as usize)
+        )?;
+    }
+    writeln!(w)?;
+    Ok(())
+}
+
 fn render_cost_section(
     w: &mut dyn Write,
     tokens_saved: u64,
@@ -575,6 +623,7 @@ fn run_dashboard(
     if verbose {
         render_parse_quality(w, &db.query_tier_distribution(since)?)?;
     }
+    render_session_stats(w, &db.query_session_stats(since)?)?;
     render_cost_section(w, summary.tokens_saved, cost_override)?;
 
     Ok(ExitCode::SUCCESS)
@@ -649,6 +698,7 @@ mod tests {
         by_mode: Vec<ModeStats>,
         tier_dist: TierDistribution,
         by_original_cmd: Vec<OriginalCommandStats>,
+        session_stats: SessionStats,
     }
 
     impl MockStore {
@@ -671,6 +721,12 @@ mod tests {
                     passthrough_pct: 0.0,
                 },
                 by_original_cmd: vec![],
+                session_stats: SessionStats {
+                    distinct_sessions: 0,
+                    total_tokens_saved: 0,
+                    avg_tokens_per_session: 0.0,
+                    untagged_invocations: 0,
+                },
             }
         }
 
@@ -746,7 +802,25 @@ mod tests {
                     avg_savings_pct: 72.0,
                     avg_duration_ms: 891.0,
                 }],
+                session_stats: SessionStats {
+                    distinct_sessions: 0,
+                    total_tokens_saved: 0,
+                    avg_tokens_per_session: 0.0,
+                    untagged_invocations: 0,
+                },
             }
+        }
+
+        /// Construct a MockStore variant that has session data for testing the Per Session section.
+        fn with_sessions() -> Self {
+            let mut s = Self::with_data();
+            s.session_stats = SessionStats {
+                distinct_sessions: 5,
+                total_tokens_saved: 50_000,
+                avg_tokens_per_session: 10_000.0,
+                untagged_invocations: 12,
+            };
+            s
         }
     }
 
@@ -774,6 +848,9 @@ mod tests {
             _since: Option<i64>,
         ) -> anyhow::Result<Vec<OriginalCommandStats>> {
             Ok(self.by_original_cmd.clone())
+        }
+        fn query_session_stats(&self, _since: Option<i64>) -> anyhow::Result<SessionStats> {
+            Ok(self.session_stats.clone())
         }
         fn clear(&self) -> anyhow::Result<()> {
             Ok(())
@@ -1363,5 +1440,172 @@ mod tests {
             output.contains("125ms") || output.contains("AVG TIME"),
             "By Category section should display average duration"
         );
+    }
+
+    // ========================================================================
+    // B8: AD-AN-2 — render_session_stats and JSON session_stats field
+    // ========================================================================
+
+    /// AD-AN-2: "Per Session" section is hidden when both counts are zero.
+    #[test]
+    fn test_render_session_stats_hidden_when_empty() {
+        let stats = SessionStats {
+            distinct_sessions: 0,
+            total_tokens_saved: 0,
+            avg_tokens_per_session: 0.0,
+            untagged_invocations: 0,
+        };
+        let mut buf = Vec::new();
+        render_session_stats(&mut buf, &stats).expect("should not fail");
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.is_empty(),
+            "Per Session section should produce no output when all counts are zero"
+        );
+    }
+
+    /// AD-AN-2: "Per Session" section is shown when distinct_sessions > 0.
+    #[test]
+    fn test_render_session_stats_shown_with_sessions() {
+        let stats = SessionStats {
+            distinct_sessions: 5,
+            total_tokens_saved: 50_000,
+            avg_tokens_per_session: 10_000.0,
+            untagged_invocations: 0,
+        };
+        let mut buf = Vec::new();
+        render_session_stats(&mut buf, &stats).expect("should not fail");
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("Per Session"),
+            "Per Session header should appear when distinct_sessions > 0"
+        );
+        assert!(
+            output.contains("Sessions tracked"),
+            "should show 'Sessions tracked' label"
+        );
+        assert!(
+            output.contains("50,000") || output.contains("50K"),
+            "should show total tokens saved"
+        );
+    }
+
+    /// AD-AN-2: "Per Session" section is shown when only untagged_invocations > 0.
+    #[test]
+    fn test_render_session_stats_shown_with_untagged_only() {
+        let stats = SessionStats {
+            distinct_sessions: 0,
+            total_tokens_saved: 0,
+            avg_tokens_per_session: 0.0,
+            untagged_invocations: 7,
+        };
+        let mut buf = Vec::new();
+        render_session_stats(&mut buf, &stats).expect("should not fail");
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("Per Session"),
+            "Per Session header should appear when untagged_invocations > 0"
+        );
+        assert!(
+            output.contains("Untagged calls"),
+            "should show 'Untagged calls' label"
+        );
+    }
+
+    /// AD-AN-2: "Untagged calls" line is hidden when untagged_invocations == 0.
+    #[test]
+    fn test_render_session_stats_untagged_hidden_when_zero() {
+        let stats = SessionStats {
+            distinct_sessions: 3,
+            total_tokens_saved: 1000,
+            avg_tokens_per_session: 333.0,
+            untagged_invocations: 0,
+        };
+        let mut buf = Vec::new();
+        render_session_stats(&mut buf, &stats).expect("should not fail");
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            !output.contains("Untagged calls"),
+            "Untagged calls line should be hidden when untagged_invocations == 0"
+        );
+    }
+
+    /// AD-AN-2: dashboard renders "Per Session" section when session data is present.
+    #[test]
+    fn test_dashboard_shows_per_session_section_with_data() {
+        let store = MockStore::with_sessions();
+        let output = capture(|w| run_dashboard(w, &store, None, false, None, None));
+        assert!(
+            output.contains("Per Session"),
+            "dashboard should show Per Session section when session data is present"
+        );
+        assert!(
+            output.contains("Sessions tracked"),
+            "dashboard Per Session section should show tracked sessions count"
+        );
+        assert!(
+            output.contains("Untagged calls"),
+            "dashboard Per Session section should show untagged calls"
+        );
+    }
+
+    /// AD-AN-2: dashboard hides "Per Session" section when no session data.
+    #[test]
+    fn test_dashboard_hides_per_session_section_when_empty() {
+        let store = MockStore::with_data(); // session_stats all zeros
+        let output = capture(|w| run_dashboard(w, &store, None, false, None, None));
+        assert!(
+            !output.contains("Per Session"),
+            "dashboard should NOT show Per Session section when session data is all zeros"
+        );
+    }
+
+    /// AD-AN-2: JSON output includes session_stats object with correct fields.
+    #[test]
+    fn test_run_json_includes_session_stats_field() {
+        let store = MockStore::with_sessions();
+        let output = capture(|w| run_json(w, &store, None, None));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).expect("output should be valid JSON");
+        let ss = &parsed["session_stats"];
+        assert!(
+            ss.is_object(),
+            "JSON output must include 'session_stats' object"
+        );
+        assert_eq!(
+            ss["distinct_sessions"].as_u64().unwrap(),
+            5,
+            "distinct_sessions should be 5"
+        );
+        assert_eq!(
+            ss["total_tokens_saved"].as_u64().unwrap(),
+            50_000,
+            "total_tokens_saved should be 50000"
+        );
+        assert!(
+            (ss["avg_tokens_per_session"].as_f64().unwrap() - 10_000.0).abs() < 1.0,
+            "avg_tokens_per_session should be ~10000"
+        );
+        assert_eq!(
+            ss["untagged_invocations"].as_u64().unwrap(),
+            12,
+            "untagged_invocations should be 12"
+        );
+    }
+
+    /// AD-AN-2: JSON session_stats field is always present (even when zero).
+    #[test]
+    fn test_run_json_session_stats_present_when_empty() {
+        let store = MockStore::with_data(); // session_stats all zeros
+        let output = capture(|w| run_json(w, &store, None, None));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).expect("output should be valid JSON");
+        let ss = &parsed["session_stats"];
+        assert!(
+            ss.is_object(),
+            "session_stats must always be present in JSON output, even when zero"
+        );
+        assert_eq!(ss["distinct_sessions"].as_u64().unwrap(), 0);
+        assert_eq!(ss["untagged_invocations"].as_u64().unwrap(), 0);
     }
 }

--- a/crates/rskim/src/cmd/stats.rs
+++ b/crates/rskim/src/cmd/stats.rs
@@ -1136,6 +1136,10 @@ mod tests {
             "cost section should show Standard tier"
         );
         assert!(
+            output.contains("Advanced"),
+            "cost section should show Advanced tier"
+        );
+        assert!(
             output.contains("Premium"),
             "cost section should show Premium tier"
         );

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -47,8 +47,7 @@ static RE_CARGO_SUMMARY: LazyLock<Regex> = LazyLock::new(|| {
 pub(crate) fn run(
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     let is_nextest = args.iter().any(|a| a == "nextest");
 
@@ -78,9 +77,9 @@ pub(crate) fn run(
             show_stats,
             command_type: crate::analytics::CommandType::Test,
             output_format: OutputFormat::default(),
-            analytics_enabled,
+            analytics_enabled: rec.enabled,
             family: "test",
-            session_id,
+            session_id: rec.session_id,
         },
         move |output, _args| parse_impl(output, is_nextest),
     )

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -79,6 +79,7 @@ pub(crate) fn run(
             output_format: OutputFormat::default(),
             analytics_enabled,
             family: "test",
+            session_id: None,
         },
         move |output, _args| parse_impl(output, is_nextest),
     )

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -48,6 +48,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     let is_nextest = args.iter().any(|a| a == "nextest");
 
@@ -79,7 +80,7 @@ pub(crate) fn run(
             output_format: OutputFormat::default(),
             analytics_enabled,
             family: "test",
-            session_id: None,
+            session_id,
         },
         move |output, _args| parse_impl(output, is_nextest),
     )

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -75,11 +75,9 @@ pub(crate) fn run(
             install_hint: "Install Rust via https://rustup.rs",
             use_stdin,
             show_stats,
-            command_type: crate::analytics::CommandType::Test,
             output_format: OutputFormat::default(),
-            analytics_enabled: rec.enabled,
             family: "test",
-            session_id: rec.session_id,
+            rec,
         },
         move |output, _args| parse_impl(output, is_nextest),
     )

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -116,6 +116,7 @@ pub(crate) fn run(
         crate::analytics::CommandType::Test,
         output.duration,
         Some(parsed.tier_name()),
+        None,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -31,6 +31,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: run `go test` without flag injections and forward raw output.
     if crate::cmd::is_passthrough_mode() {
@@ -116,7 +117,7 @@ pub(crate) fn run(
         crate::analytics::CommandType::Test,
         output.duration,
         Some(parsed.tier_name()),
-        None,
+        session_id,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -30,8 +30,7 @@ use super::shared::{self, try_read_stdin};
 pub(crate) fn run(
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: run `go test` without flag injections and forward raw output.
     if crate::cmd::is_passthrough_mode() {
@@ -111,10 +110,8 @@ pub(crate) fn run(
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
         crate::analytics::RecordingContext {
-            enabled: analytics_enabled,
-            command_type: crate::analytics::CommandType::Test,
             parse_tier: Some(parsed.tier_name()),
-            session_id,
+            ..rec
         },
         combined,
         parsed.content().to_string(),

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -109,10 +109,7 @@ pub(crate) fn run(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        crate::analytics::RecordingContext {
-            parse_tier: Some(parsed.tier_name()),
-            ..rec
-        },
+        rec.with_tier(parsed.tier_name()),
         combined,
         parsed.content().to_string(),
         crate::cmd::format_analytics_label("test", "go", &args.join(" ")),

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -110,14 +110,16 @@ pub(crate) fn run(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        analytics_enabled,
+        crate::analytics::RecordingContext {
+            enabled: analytics_enabled,
+            command_type: crate::analytics::CommandType::Test,
+            parse_tier: Some(parsed.tier_name()),
+            session_id,
+        },
         combined,
         parsed.content().to_string(),
         crate::cmd::format_analytics_label("test", "go", &args.join(" ")),
-        crate::analytics::CommandType::Test,
         output.duration,
-        Some(parsed.tier_name()),
-        session_id,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/test/mod.rs
+++ b/crates/rskim/src/cmd/test/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn run(
     };
 
     match runner {
-        "cargo" => cargo::run(runner_args, show_stats, analytics.enabled, rec.session_id),
+        "cargo" => cargo::run(runner_args, show_stats, rec),
         "go" => go::run(runner_args, show_stats, rec),
         "vitest" | "jest" => vitest::run(runner, runner_args, show_stats, rec),
         "pytest" => pytest::run(runner_args, show_stats, rec),

--- a/crates/rskim/src/cmd/test/mod.rs
+++ b/crates/rskim/src/cmd/test/mod.rs
@@ -35,19 +35,18 @@ pub(crate) fn run(
     };
 
     let runner = runner_name.as_str();
-    let session_id = analytics.session_id.as_deref();
+    let rec = crate::analytics::RecordingContext {
+        enabled: analytics.enabled,
+        command_type: crate::analytics::CommandType::Test,
+        parse_tier: None,
+        session_id: analytics.session_id.as_deref(),
+    };
 
     match runner {
-        "cargo" => cargo::run(runner_args, show_stats, analytics.enabled, session_id),
-        "go" => go::run(runner_args, show_stats, analytics.enabled, session_id),
-        "vitest" | "jest" => vitest::run(
-            runner,
-            runner_args,
-            show_stats,
-            analytics.enabled,
-            session_id,
-        ),
-        "pytest" => pytest::run(runner_args, show_stats, analytics.enabled, session_id),
+        "cargo" => cargo::run(runner_args, show_stats, analytics.enabled, rec.session_id),
+        "go" => go::run(runner_args, show_stats, rec),
+        "vitest" | "jest" => vitest::run(runner, runner_args, show_stats, rec),
+        "pytest" => pytest::run(runner_args, show_stats, rec),
         _ => {
             let safe_runner = crate::cmd::sanitize_for_display(runner);
             eprintln!(

--- a/crates/rskim/src/cmd/test/mod.rs
+++ b/crates/rskim/src/cmd/test/mod.rs
@@ -35,12 +35,19 @@ pub(crate) fn run(
     };
 
     let runner = runner_name.as_str();
+    let session_id = analytics.session_id.as_deref();
 
     match runner {
-        "cargo" => cargo::run(runner_args, show_stats, analytics.enabled),
-        "go" => go::run(runner_args, show_stats, analytics.enabled),
-        "vitest" | "jest" => vitest::run(runner, runner_args, show_stats, analytics.enabled),
-        "pytest" => pytest::run(runner_args, show_stats, analytics.enabled),
+        "cargo" => cargo::run(runner_args, show_stats, analytics.enabled, session_id),
+        "go" => go::run(runner_args, show_stats, analytics.enabled, session_id),
+        "vitest" | "jest" => vitest::run(
+            runner,
+            runner_args,
+            show_stats,
+            analytics.enabled,
+            session_id,
+        ),
+        "pytest" => pytest::run(runner_args, show_stats, analytics.enabled, session_id),
         _ => {
             let safe_runner = crate::cmd::sanitize_for_display(runner);
             eprintln!(

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -96,6 +96,7 @@ pub(crate) fn run(
         crate::analytics::CommandType::Test,
         output.duration,
         Some(result.tier_name()),
+        None,
     );
 
     // Exit code: mirror pytest's exit code if we ran it, or infer from parse

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -46,6 +46,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: bypass compression and forward raw output unchanged.
     if crate::cmd::is_passthrough_mode() {
@@ -96,7 +97,7 @@ pub(crate) fn run(
         crate::analytics::CommandType::Test,
         output.duration,
         Some(result.tier_name()),
-        None,
+        session_id,
     );
 
     // Exit code: mirror pytest's exit code if we ran it, or infer from parse

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -45,8 +45,7 @@ use super::shared::{self, try_read_stdin};
 pub(crate) fn run(
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: bypass compression and forward raw output unchanged.
     if crate::cmd::is_passthrough_mode() {
@@ -91,10 +90,8 @@ pub(crate) fn run(
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
         crate::analytics::RecordingContext {
-            enabled: analytics_enabled,
-            command_type: crate::analytics::CommandType::Test,
             parse_tier: Some(result.tier_name()),
-            session_id,
+            ..rec
         },
         cleaned,
         result.content().to_string(),

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -90,14 +90,16 @@ pub(crate) fn run(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        analytics_enabled,
+        crate::analytics::RecordingContext {
+            enabled: analytics_enabled,
+            command_type: crate::analytics::CommandType::Test,
+            parse_tier: Some(result.tier_name()),
+            session_id,
+        },
         cleaned,
         result.content().to_string(),
         crate::cmd::format_analytics_label("test", "pytest", &args.join(" ")),
-        crate::analytics::CommandType::Test,
         output.duration,
-        Some(result.tier_name()),
-        session_id,
     );
 
     // Exit code: mirror pytest's exit code if we ran it, or infer from parse

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -89,10 +89,7 @@ pub(crate) fn run(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        crate::analytics::RecordingContext {
-            parse_tier: Some(result.tier_name()),
-            ..rec
-        },
+        rec.with_tier(result.tier_name()),
         cleaned,
         result.content().to_string(),
         crate::cmd::format_analytics_label("test", "pytest", &args.join(" ")),

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -92,10 +92,7 @@ pub(crate) fn run(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        crate::analytics::RecordingContext {
-            parse_tier: Some(result.tier_name()),
-            ..rec
-        },
+        rec.with_tier(result.tier_name()),
         raw_output,
         result.content().to_string(),
         crate::cmd::format_analytics_label("test", program, &args.join(" ")),

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -34,8 +34,7 @@ pub(crate) fn run(
     program: &str,
     args: &[String],
     show_stats: bool,
-    analytics_enabled: bool,
-    session_id: Option<&str>,
+    rec: crate::analytics::RecordingContext<'_>,
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: bypass compression, run the raw command and forward output.
     if crate::cmd::is_passthrough_mode() {
@@ -94,10 +93,8 @@ pub(crate) fn run(
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
         crate::analytics::RecordingContext {
-            enabled: analytics_enabled,
-            command_type: crate::analytics::CommandType::Test,
             parse_tier: Some(result.tier_name()),
-            session_id,
+            ..rec
         },
         raw_output,
         result.content().to_string(),

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -35,6 +35,7 @@ pub(crate) fn run(
     args: &[String],
     show_stats: bool,
     analytics_enabled: bool,
+    session_id: Option<&str>,
 ) -> anyhow::Result<ExitCode> {
     // Passthrough mode: bypass compression, run the raw command and forward output.
     if crate::cmd::is_passthrough_mode() {
@@ -99,7 +100,7 @@ pub(crate) fn run(
         crate::analytics::CommandType::Test,
         start.elapsed(),
         Some(result.tier_name()),
-        None,
+        session_id,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -93,14 +93,16 @@ pub(crate) fn run(
 
     // Record analytics (fire-and-forget, non-blocking).
     crate::analytics::try_record_command(
-        analytics_enabled,
+        crate::analytics::RecordingContext {
+            enabled: analytics_enabled,
+            command_type: crate::analytics::CommandType::Test,
+            parse_tier: Some(result.tier_name()),
+            session_id,
+        },
         raw_output,
         result.content().to_string(),
         crate::cmd::format_analytics_label("test", program, &args.join(" ")),
-        crate::analytics::CommandType::Test,
         start.elapsed(),
-        Some(result.tier_name()),
-        session_id,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/cmd/test/vitest.rs
+++ b/crates/rskim/src/cmd/test/vitest.rs
@@ -99,6 +99,7 @@ pub(crate) fn run(
         crate::analytics::CommandType::Test,
         start.elapsed(),
         Some(result.tier_name()),
+        None,
     );
 
     Ok(exit_code)

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -496,9 +496,14 @@ fn main() -> ExitCode {
     // Read analytics config from env + CLI flag once at the system boundary.
     // Thread the struct down to all callers — no per-call env reads.
     let cli_disable_analytics = std::env::args().any(|a| a == "--disable-analytics");
-    // B6: session_id will be extracted from --session-id=VALUE in a later step;
-    // for now pass None so the rest of the pipeline compiles.
-    let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, None);
+    // AD-HK-3: Extract --session-id=VALUE injected by the hook (B5/B6).
+    // The flag is a global flag parsed here before subcommand routing so that
+    // every subcommand automatically inherits the session context without
+    // requiring per-subcommand parsing. The value is passed to AnalyticsConfig
+    // and threaded through all recording call sites.
+    let session_id: Option<String> = std::env::args()
+        .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string));
+    let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, session_id);
 
     let result: anyhow::Result<ExitCode> = match resolve_invocation() {
         Invocation::FileOperation => run_file_operation(&analytics).map(|()| ExitCode::SUCCESS),

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -501,8 +501,9 @@ fn main() -> ExitCode {
     // every subcommand automatically inherits the session context without
     // requiring per-subcommand parsing. The value is passed to AnalyticsConfig
     // and threaded through all recording call sites.
-    let session_id: Option<String> =
-        std::env::args().find_map(|a| a.strip_prefix("--session-id=").map(str::to_string));
+    let session_id: Option<String> = std::env::args()
+        .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string))
+        .filter(|s| !s.is_empty());
     let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, session_id);
 
     let result: anyhow::Result<ExitCode> = match resolve_invocation() {
@@ -560,7 +561,13 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
     if file == "-" {
         let result = process::process_stdin(process_options, args.filename.as_deref())?;
         process::write_result_and_stats(&result, args.show_stats)?;
-        record_file_analytics(analytics.enabled, &result, "skim -", &args);
+        record_file_analytics(
+            analytics.enabled,
+            &result,
+            "skim -",
+            &args,
+            analytics.session_id.as_deref(),
+        );
         return Ok(());
     }
 
@@ -585,12 +592,24 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
 
     let result = process::process_file(&path, process_options)?;
     process::write_result_and_stats(&result, args.show_stats)?;
-    record_file_analytics(analytics.enabled, &result, &format!("skim {file}"), &args);
+    record_file_analytics(
+        analytics.enabled,
+        &result,
+        &format!("skim {file}"),
+        &args,
+        analytics.session_id.as_deref(),
+    );
     Ok(())
 }
 
 /// Record token analytics for file operations (single file or stdin).
-fn record_file_analytics(enabled: bool, result: &process::ProcessResult, cmd: &str, args: &Args) {
+fn record_file_analytics(
+    enabled: bool,
+    result: &process::ProcessResult,
+    cmd: &str,
+    args: &Args,
+    session_id: Option<&str>,
+) {
     if !enabled {
         return;
     }
@@ -617,7 +636,7 @@ fn record_file_analytics(enabled: bool, result: &process::ProcessResult, cmd: &s
                 mode: Some(mode),
                 language: lang,
                 parse_tier: result.parse_tier.map(str::to_string),
-                session_id: None,
+                session_id: session_id.map(str::to_string),
             },
         );
     }
@@ -786,5 +805,44 @@ mod tests {
                  incorrectly route to the 'test' subcommand."
             );
         }
+    }
+
+    // ========================================================================
+    // B-AC14: empty --session-id= normalisation
+    // ========================================================================
+
+    /// B-AC14: the session_id extraction logic normalises empty values to None.
+    ///
+    /// `std::env::args()` cannot be injected in tests, so we verify the filter
+    /// step directly using the same `find_map(...).filter(|s| !s.is_empty())`
+    /// expression applied to a synthetic arg list.
+    #[test]
+    fn test_empty_session_id_arg_normalised_to_none() {
+        // Simulate `--session-id=` (value is empty string)
+        let args = vec!["skim".to_string(), "--session-id=".to_string()];
+        let session_id: Option<String> = args
+            .iter()
+            .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string))
+            .filter(|s| !s.is_empty());
+        assert!(
+            session_id.is_none(),
+            "--session-id= (empty value) must normalise to None, got {:?}",
+            session_id
+        );
+    }
+
+    /// B-AC14: non-empty --session-id= is preserved as Some.
+    #[test]
+    fn test_non_empty_session_id_arg_preserved() {
+        let args = vec!["skim".to_string(), "--session-id=abc-123".to_string()];
+        let session_id: Option<String> = args
+            .iter()
+            .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string))
+            .filter(|s| !s.is_empty());
+        assert_eq!(
+            session_id.as_deref(),
+            Some("abc-123"),
+            "--session-id=abc-123 must produce Some(\"abc-123\")"
+        );
     }
 }

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -520,11 +520,8 @@ fn main() -> ExitCode {
     // Read analytics config from env + CLI flag once at the system boundary.
     // Thread the struct down to all callers — no per-call env reads.
     let cli_disable_analytics = std::env::args().any(|a| a == "--disable-analytics");
-    // AD-HK-3: Extract --session-id=VALUE injected by the hook (B5/B6).
-    // The flag is a global flag parsed here before subcommand routing so that
-    // every subcommand automatically inherits the session context without
-    // requiring per-subcommand parsing. The value is passed to AnalyticsConfig
-    // and threaded through all recording call sites.
+    // Parse --session-id=VALUE before subcommand routing so every subcommand
+    // inherits session context without per-subcommand parsing.
     let session_id = parse_session_id(std::env::args());
     let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, session_id);
 
@@ -883,24 +880,6 @@ mod tests {
         assert!(
             result.is_none(),
             "--session-id <space> VALUE must not be recognised (only equals form supported)"
-        );
-    }
-
-    // ========================================================================
-    // B-AC14: backward-compatible empty normalisation (now via parse_session_id)
-    // ========================================================================
-
-    // NOTE: test_parse_session_id_empty (above, tagged F7) already covers empty
-    // value normalisation — no separate test needed here.
-
-    /// B-AC14: non-empty --session-id= is preserved as Some.
-    #[test]
-    fn test_non_empty_session_id_arg_preserved() {
-        let result = parse_session_id(["skim", "--session-id=abc-123"]);
-        assert_eq!(
-            result.as_deref(),
-            Some("abc-123"),
-            "--session-id=abc-123 must produce Some(\"abc-123\")"
         );
     }
 }

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -496,7 +496,9 @@ fn main() -> ExitCode {
     // Read analytics config from env + CLI flag once at the system boundary.
     // Thread the struct down to all callers — no per-call env reads.
     let cli_disable_analytics = std::env::args().any(|a| a == "--disable-analytics");
-    let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics);
+    // B6: session_id will be extracted from --session-id=VALUE in a later step;
+    // for now pass None so the rest of the pipeline compiles.
+    let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, None);
 
     let result: anyhow::Result<ExitCode> = match resolve_invocation() {
         Invocation::FileOperation => run_file_operation(&analytics).map(|()| ExitCode::SUCCESS),
@@ -609,6 +611,7 @@ fn record_file_analytics(enabled: bool, result: &process::ProcessResult, cmd: &s
                 mode: Some(mode),
                 language: lang,
                 parse_tier: result.parse_tier.map(str::to_string),
+                session_id: None,
             },
         );
     }

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -572,6 +572,7 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         jobs: args.jobs,
         no_ignore: args.no_ignore,
         analytics_enabled: analytics.enabled,
+        session_id: analytics.session_id.clone(),
     };
 
     if path.is_dir() {

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -501,8 +501,8 @@ fn main() -> ExitCode {
     // every subcommand automatically inherits the session context without
     // requiring per-subcommand parsing. The value is passed to AnalyticsConfig
     // and threaded through all recording call sites.
-    let session_id: Option<String> = std::env::args()
-        .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string));
+    let session_id: Option<String> =
+        std::env::args().find_map(|a| a.strip_prefix("--session-id=").map(str::to_string));
     let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, session_id);
 
     let result: anyhow::Result<ExitCode> = match resolve_invocation() {

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -503,11 +503,7 @@ where
     S: AsRef<str>,
 {
     args.into_iter()
-        .find_map(|a| {
-            a.as_ref()
-                .strip_prefix("--session-id=")
-                .map(str::to_string)
-        })
+        .find_map(|a| a.as_ref().strip_prefix("--session-id=").map(str::to_string))
         .filter(|s| analytics::is_safe_session_id(s))
 }
 
@@ -876,10 +872,7 @@ mod tests {
     fn test_parse_session_id_too_long() {
         let long_value = format!("--session-id={}", "a".repeat(129));
         let result = parse_session_id(["skim", long_value.as_str()]);
-        assert!(
-            result.is_none(),
-            "129-char session_id must be rejected"
-        );
+        assert!(result.is_none(), "129-char session_id must be rejected");
     }
 
     /// F9: space-separated form --session-id VALUE is not recognised.

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -483,6 +483,34 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Extract and validate `--session-id=VALUE` from a command-line argument iterator.
+///
+/// Returns `Some(value)` when exactly one `--session-id=VALUE` argument is present
+/// and `value` passes [`analytics::is_safe_session_id`]. Returns `None` when the
+/// flag is absent, the value is empty, the value is unsafe, or the value exceeds
+/// 128 characters.
+///
+/// Only the equals form (`--session-id=VALUE`) is recognised. The space-separated
+/// form (`--session-id VALUE`) is not supported — the hook always injects the flag
+/// in equals form, and accepting the space form would complicate the pre-parse
+/// routing logic.
+///
+/// This is a pure function over an iterator so it can be unit-tested without
+/// mutating `std::env::args()`.
+fn parse_session_id<I, S>(args: I) -> Option<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .find_map(|a| {
+            a.as_ref()
+                .strip_prefix("--session-id=")
+                .map(str::to_string)
+        })
+        .filter(|s| analytics::is_safe_session_id(s))
+}
+
 fn main() -> ExitCode {
     // Initialise debug flag from SKIM_DEBUG env var once, before any threads
     // are spawned. After this call, is_debug_enabled() is a pure atomic load.
@@ -501,9 +529,7 @@ fn main() -> ExitCode {
     // every subcommand automatically inherits the session context without
     // requiring per-subcommand parsing. The value is passed to AnalyticsConfig
     // and threaded through all recording call sites.
-    let session_id: Option<String> = std::env::args()
-        .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string))
-        .filter(|s| !s.is_empty());
+    let session_id = parse_session_id(std::env::args());
     let analytics = analytics::AnalyticsConfig::from_process(cli_disable_analytics, session_id);
 
     let result: anyhow::Result<ExitCode> = match resolve_invocation() {
@@ -808,39 +834,86 @@ mod tests {
     }
 
     // ========================================================================
-    // B-AC14: empty --session-id= normalisation
+    // parse_session_id tests (F7, F9, F10)
+    // ========================================================================
+
+    /// F7: --session-id=VALUE is extracted as Some(VALUE).
+    #[test]
+    fn test_parse_session_id_present() {
+        let result = parse_session_id(["skim", "--session-id=abc-123"]);
+        assert_eq!(result.as_deref(), Some("abc-123"));
+    }
+
+    /// F7: absent flag returns None.
+    #[test]
+    fn test_parse_session_id_absent() {
+        let result = parse_session_id(["skim", "test", "cargo"]);
+        assert!(result.is_none(), "no --session-id should yield None");
+    }
+
+    /// F7: empty value --session-id= returns None (rejects empty at validation).
+    #[test]
+    fn test_parse_session_id_empty() {
+        let result = parse_session_id(["skim", "--session-id="]);
+        assert!(
+            result.is_none(),
+            "--session-id= (empty value) must yield None"
+        );
+    }
+
+    /// F7: unsafe value with shell metacharacters returns None.
+    #[test]
+    fn test_parse_session_id_unsafe() {
+        let result = parse_session_id(["skim", "--session-id=a;b"]);
+        assert!(
+            result.is_none(),
+            "--session-id=a;b (metacharacter) must yield None"
+        );
+    }
+
+    /// F1: value exceeding 128 chars returns None.
+    #[test]
+    fn test_parse_session_id_too_long() {
+        let long_value = format!("--session-id={}", "a".repeat(129));
+        let result = parse_session_id(["skim", long_value.as_str()]);
+        assert!(
+            result.is_none(),
+            "129-char session_id must be rejected"
+        );
+    }
+
+    /// F9: space-separated form --session-id VALUE is not recognised.
+    #[test]
+    fn test_parse_session_id_space_form() {
+        // Space form: the hook always injects in equals form; space form is intentionally unsupported.
+        let result = parse_session_id(["skim", "--session-id", "abc-123"]);
+        assert!(
+            result.is_none(),
+            "--session-id <space> VALUE must not be recognised (only equals form supported)"
+        );
+    }
+
+    // ========================================================================
+    // B-AC14: backward-compatible empty normalisation (now via parse_session_id)
     // ========================================================================
 
     /// B-AC14: the session_id extraction logic normalises empty values to None.
-    ///
-    /// `std::env::args()` cannot be injected in tests, so we verify the filter
-    /// step directly using the same `find_map(...).filter(|s| !s.is_empty())`
-    /// expression applied to a synthetic arg list.
     #[test]
     fn test_empty_session_id_arg_normalised_to_none() {
-        // Simulate `--session-id=` (value is empty string)
-        let args = vec!["skim".to_string(), "--session-id=".to_string()];
-        let session_id: Option<String> = args
-            .iter()
-            .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string))
-            .filter(|s| !s.is_empty());
+        let result = parse_session_id(["skim", "--session-id="]);
         assert!(
-            session_id.is_none(),
+            result.is_none(),
             "--session-id= (empty value) must normalise to None, got {:?}",
-            session_id
+            result
         );
     }
 
     /// B-AC14: non-empty --session-id= is preserved as Some.
     #[test]
     fn test_non_empty_session_id_arg_preserved() {
-        let args = vec!["skim".to_string(), "--session-id=abc-123".to_string()];
-        let session_id: Option<String> = args
-            .iter()
-            .find_map(|a| a.strip_prefix("--session-id=").map(str::to_string))
-            .filter(|s| !s.is_empty());
+        let result = parse_session_id(["skim", "--session-id=abc-123"]);
         assert_eq!(
-            session_id.as_deref(),
+            result.as_deref(),
             Some("abc-123"),
             "--session-id=abc-123 must produce Some(\"abc-123\")"
         );

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -890,16 +890,8 @@ mod tests {
     // B-AC14: backward-compatible empty normalisation (now via parse_session_id)
     // ========================================================================
 
-    /// B-AC14: the session_id extraction logic normalises empty values to None.
-    #[test]
-    fn test_empty_session_id_arg_normalised_to_none() {
-        let result = parse_session_id(["skim", "--session-id="]);
-        assert!(
-            result.is_none(),
-            "--session-id= (empty value) must normalise to None, got {:?}",
-            result
-        );
-    }
+    // NOTE: test_parse_session_id_empty (above, tagged F7) already covers empty
+    // value normalisation — no separate test needed here.
 
     /// B-AC14: non-empty --session-id= is preserved as Some.
     #[test]

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -294,6 +294,7 @@ fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Resu
                 mode: Some(mode),
                 language: None, // mixed languages
                 parse_tier: None,
+                session_id: None,
             },
         );
     }

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -15,13 +15,14 @@ use rskim_core::Language;
 use crate::process::{process_file, report_token_stats, ProcessOptions};
 
 /// Options for multi-file processing
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct MultiFileOptions {
     pub(crate) process: ProcessOptions,
     pub(crate) no_header: bool,
     pub(crate) jobs: Option<usize>,
     pub(crate) no_ignore: bool,
     pub(crate) analytics_enabled: bool,
+    pub(crate) session_id: Option<String>,
 }
 
 /// Glob metacharacters recognised by skim.
@@ -294,7 +295,7 @@ fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Resu
                 mode: Some(mode),
                 language: None, // mixed languages
                 parse_tier: None,
-                session_id: None,
+                session_id: options.session_id.clone(),
             },
         );
     }


### PR DESCRIPTION
## Summary

- **Session tracking pipeline**: Extract `session_id` from agent hooks (Claude, Cursor, Copilot, Gemini), inject into rewritten skim commands, thread through analytics recording, and display Per Session stats on the dashboard
- **Advanced pricing tier**: Add $5/MTok tier between Standard ($3) and Premium ($15)
- **Review findings resolved (F1–F10)**: Centralized `is_safe_session_id` validation with 128-char limit, consolidated `query_session_stats` into single SQL query, introduced `RecordingContext` struct to eliminate parameter threading (removed all `#[allow(clippy::too_many_arguments)]` from recording pipeline), extracted `parse_session_id` as testable pure function, filtered empty session_id at hook parse boundary, eliminated unnecessary `.clone()` in hook injection path

## Changes

**Features:**
- `session_id` extraction from hook JSON (AD-HK-1)
- `--session-id=VALUE` injection into rewritten commands (AD-HK-2)
- CLI `--session-id=` parsing threaded into analytics (AD-HK-3)
- Per Session section in `skim stats` dashboard (AD-AN-2)
- Schema v3 migration: nullable `session_id` column with index
- $5/MTok Advanced pricing tier (AD-AN-3)

**Review fixes:**
- `is_safe_session_id()`: centralized validation, 128-char max, rejects metacharacters (F1, F6, F10)
- Single SQL query for session stats via conditional aggregation (F2)
- Updated `RunContext` docstring (F3)
- `RecordingContext<'a>` + `FireAndForgetParams` structs replace parameter threading (F4)
- Move semantics eliminate `rewritten_cmd.clone()` (F5)
- `parse_session_id` pure function with 6 unit tests (F7, F9)
- Empty session_id filtered at hook parse boundary (F8)
- Defense-in-depth: CLI-side validation via `is_safe_session_id` (F10)

## Test plan

- [x] 3,004 tests pass (`cargo test --all-features`)
- [x] 0 clippy warnings (`cargo clippy -- -D warnings`)
- [x] Formatting clean (`cargo fmt -- --check`)
- [x] Only `canonical.rs` retains `#[allow(clippy::too_many_arguments)]`
- [x] `is_safe_session_id`: boundary tests (128/129 chars, empty, metacharacters)
- [x] `parse_session_id`: 6 tests (present/absent/empty/unsafe/too-long/space-form)
- [x] `from_process` passthrough tests
- [x] Session stats SQL: basic, untagged, empty DB, since filter
- [x] Empty session_id hook parse boundary tests (Claude + Cursor)
- [x] No `rewritten_cmd.clone()` in hook.rs
- [x] No inline `is_ascii_alphanumeric` in hook.rs (all delegated)