### PR TITLE
feat(cli): support multiple file args and absolute glob paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ curl -L https://github.com/dean0x/skim/releases/latest/download/rskim-x86_64-unk
 
 ## Commands
 
+**Local dev binary:** `target/release/skim` is on PATH for local testing. After every merge to main, run `cargo build --release` to keep it current.
+
 ### Build & Test
 ```bash
 cargo build --release          # Production build
@@ -244,6 +246,7 @@ git push origin main --tags
 
 ### Post-Release Cleanup
 - Delete release branch: `git branch -d release/vX.Y.Z`
+- Rebuild local dev binary: `cargo build --release` (keeps `target/release/skim` current with main)
 
 ## Design Constraints
 

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -477,14 +477,11 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
     }
 
     // --filename is only valid when the single argument is '-' (stdin)
-    if args.filename.is_some() {
-        let is_stdin = args.files.len() == 1 && args.files[0] == "-";
-        if !is_stdin {
-            anyhow::bail!(
-                "--filename is only valid when reading from stdin (file argument is '-')\n\
-                 For files on disk, language is auto-detected from the file extension."
-            );
-        }
+    if args.filename.is_some() && !(args.files.len() == 1 && args.files[0] == "-") {
+        anyhow::bail!(
+            "--filename is only valid when reading from stdin (file argument is '-')\n\
+             For files on disk, language is auto-detected from the file extension."
+        );
     }
 
     Ok(())
@@ -593,6 +590,15 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         line_numbers: args.line_numbers,
     };
 
+    let multi_options = multi::MultiFileOptions {
+        process: process_options,
+        no_header: args.no_header,
+        jobs: args.jobs,
+        no_ignore: args.no_ignore,
+        analytics_enabled: analytics.enabled,
+        session_id: analytics.session_id.clone(),
+    };
+
     // === Single-argument path (existing behaviour, unchanged) ===
     if args.files.len() == 1 {
         let file = &args.files[0];
@@ -611,15 +617,6 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         }
 
         let path = PathBuf::from(file);
-
-        let multi_options = multi::MultiFileOptions {
-            process: process_options,
-            no_header: args.no_header,
-            jobs: args.jobs,
-            no_ignore: args.no_ignore,
-            analytics_enabled: analytics.enabled,
-            session_id: analytics.session_id.clone(),
-        };
 
         if path.is_dir() {
             return multi::process_directory(&path, multi_options);
@@ -655,17 +652,7 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
     // Expand each argument: glob pattern → expand, directory → collect,
     // plain file → add directly.  All results are gathered into a single Vec
     // and processed together via process_files.
-    let multi_options = multi::MultiFileOptions {
-        process: process_options,
-        no_header: args.no_header,
-        jobs: args.jobs,
-        no_ignore: args.no_ignore,
-        analytics_enabled: analytics.enabled,
-        session_id: analytics.session_id.clone(),
-    };
-
-    let cmd_str = format!("skim {}", args.files.join(" "));
-    multi::process_explicit_files(&args.files, multi_options, &cmd_str)
+    multi::process_explicit_files(&args.files, multi_options)
 }
 
 /// Record token analytics for file operations (single file or stdin).

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -556,9 +556,11 @@ fn main() -> ExitCode {
 
 /// File/directory/glob/stdin processing pipeline.
 ///
-/// Parses CLI args via clap, validates constraints, then delegates to
-/// the appropriate processor (stdin, directory, glob, single file, or
-/// explicit multi-file list).
+/// Parses CLI args via clap, validates constraints, then routes to
+/// the appropriate processor based on argument count:
+/// - 0 args → usage error
+/// - 1 arg  → `process_single_arg` (stdin, directory, glob, or single file)
+/// - N args → explicit multi-file list (no stdin mixing allowed)
 fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<()> {
     let args = Args::parse();
     validate_args(&args)?;
@@ -599,43 +601,14 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         session_id: analytics.session_id.clone(),
     };
 
-    // === Single-argument path (existing behaviour, unchanged) ===
     if args.files.len() == 1 {
-        let file = &args.files[0];
-
-        if file == "-" {
-            let result = process::process_stdin(process_options, args.filename.as_deref())?;
-            process::write_result_and_stats(&result, args.show_stats)?;
-            record_file_analytics(
-                analytics.enabled,
-                &result,
-                "skim -",
-                &args,
-                analytics.session_id.as_deref(),
-            );
-            return Ok(());
-        }
-
-        let path = PathBuf::from(file);
-
-        if path.is_dir() {
-            return multi::process_directory(&path, multi_options);
-        }
-
-        if multi::has_glob_pattern(file) {
-            return multi::process_glob(file, multi_options);
-        }
-
-        let result = process::process_file(&path, process_options)?;
-        process::write_result_and_stats(&result, args.show_stats)?;
-        record_file_analytics(
-            analytics.enabled,
-            &result,
-            &format!("skim {file}"),
+        return process_single_arg(
+            &args.files[0],
             &args,
-            analytics.session_id.as_deref(),
+            analytics,
+            process_options,
+            multi_options,
         );
-        return Ok(());
     }
 
     // === Multiple arguments: `skim file1.ts file2.ts` ===
@@ -653,6 +626,55 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
     // plain file → add directly.  All results are gathered into a single Vec
     // and processed together via process_files.
     multi::process_explicit_files(&args.files, multi_options)
+}
+
+/// Dispatch a single argument to the appropriate processor.
+///
+/// Handles four cases in priority order:
+/// 1. `-`       → read from stdin
+/// 2. directory → recursive directory walk
+/// 3. glob      → glob pattern expansion
+/// 4. file path → single file processing
+fn process_single_arg(
+    file: &str,
+    args: &Args,
+    analytics: &analytics::AnalyticsConfig,
+    process_options: process::ProcessOptions,
+    multi_options: multi::MultiFileOptions,
+) -> anyhow::Result<()> {
+    if file == "-" {
+        let result = process::process_stdin(process_options, args.filename.as_deref())?;
+        process::write_result_and_stats(&result, args.show_stats)?;
+        record_file_analytics(
+            analytics.enabled,
+            &result,
+            "skim -",
+            args,
+            analytics.session_id.as_deref(),
+        );
+        return Ok(());
+    }
+
+    let path = PathBuf::from(file);
+
+    if path.is_dir() {
+        return multi::process_directory(&path, multi_options);
+    }
+
+    if multi::has_glob_pattern(file) {
+        return multi::process_glob(file, multi_options);
+    }
+
+    let result = process::process_file(&path, process_options)?;
+    process::write_result_and_stats(&result, args.show_stats)?;
+    record_file_analytics(
+        analytics.enabled,
+        &result,
+        &format!("skim {file}"),
+        args,
+        analytics.session_id.as_deref(),
+    );
+    Ok(())
 }
 
 /// Record token analytics for file operations (single file or stdin).

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -204,9 +204,10 @@ SUBCOMMANDS:\n  \
     stats [--since N] [--format json]        Token analytics dashboard\n\n\
 For more info: https://github.com/dean0x/skim")]
 struct Args {
-    /// File, directory, or glob pattern to process (use '-' for stdin)
-    #[arg(value_name = "FILE", required_unless_present = "clear_cache")]
-    file: Option<String>,
+    /// Files, directories, or glob patterns to process (use '-' for stdin).
+    /// Multiple arguments are accepted: `skim file1.ts file2.ts` or `skim 'src/**/*.ts' file.py`.
+    #[arg(value_name = "FILE")]
+    files: Vec<String>,
 
     /// Transformation mode
     #[arg(short, long, value_enum, default_value = "structure")]
@@ -475,11 +476,15 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
         );
     }
 
-    if args.filename.is_some() && args.file.as_deref() != Some("-") {
-        anyhow::bail!(
-            "--filename is only valid when reading from stdin (file argument is '-')\n\
-             For files on disk, language is auto-detected from the file extension."
-        );
+    // --filename is only valid when the single argument is '-' (stdin)
+    if args.filename.is_some() {
+        let is_stdin = args.files.len() == 1 && args.files[0] == "-";
+        if !is_stdin {
+            anyhow::bail!(
+                "--filename is only valid when reading from stdin (file argument is '-')\n\
+                 For files on disk, language is auto-detected from the file extension."
+            );
+        }
     }
 
     Ok(())
@@ -555,7 +560,8 @@ fn main() -> ExitCode {
 /// File/directory/glob/stdin processing pipeline.
 ///
 /// Parses CLI args via clap, validates constraints, then delegates to
-/// the appropriate processor (stdin, directory, glob, or single file).
+/// the appropriate processor (stdin, directory, glob, single file, or
+/// explicit multi-file list).
 fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<()> {
     let args = Args::parse();
     validate_args(&args)?;
@@ -566,10 +572,13 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         return Ok(());
     }
 
-    let file = args
-        .file
-        .clone()
-        .ok_or_else(|| anyhow::anyhow!("FILE argument is required"))?;
+    if args.files.is_empty() {
+        anyhow::bail!(
+            "FILE argument is required\n\
+             Usage: skim <FILE|DIR|GLOB> [--mode structure|signatures|types|full]\n\
+             Use 'skim --help' for more information."
+        );
+    }
 
     let process_options = process::ProcessOptions {
         mode: Mode::from(args.mode),
@@ -584,21 +593,68 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         line_numbers: args.line_numbers,
     };
 
-    if file == "-" {
-        let result = process::process_stdin(process_options, args.filename.as_deref())?;
+    // === Single-argument path (existing behaviour, unchanged) ===
+    if args.files.len() == 1 {
+        let file = &args.files[0];
+
+        if file == "-" {
+            let result = process::process_stdin(process_options, args.filename.as_deref())?;
+            process::write_result_and_stats(&result, args.show_stats)?;
+            record_file_analytics(
+                analytics.enabled,
+                &result,
+                "skim -",
+                &args,
+                analytics.session_id.as_deref(),
+            );
+            return Ok(());
+        }
+
+        let path = PathBuf::from(file);
+
+        let multi_options = multi::MultiFileOptions {
+            process: process_options,
+            no_header: args.no_header,
+            jobs: args.jobs,
+            no_ignore: args.no_ignore,
+            analytics_enabled: analytics.enabled,
+            session_id: analytics.session_id.clone(),
+        };
+
+        if path.is_dir() {
+            return multi::process_directory(&path, multi_options);
+        }
+
+        if multi::has_glob_pattern(file) {
+            return multi::process_glob(file, multi_options);
+        }
+
+        let result = process::process_file(&path, process_options)?;
         process::write_result_and_stats(&result, args.show_stats)?;
         record_file_analytics(
             analytics.enabled,
             &result,
-            "skim -",
+            &format!("skim {file}"),
             &args,
             analytics.session_id.as_deref(),
         );
         return Ok(());
     }
 
-    let path = PathBuf::from(&file);
+    // === Multiple arguments: `skim file1.ts file2.ts` ===
+    //
+    // Stdin (`-`) cannot be mixed with other files: the single stdin stream
+    // cannot be read once per file argument.
+    if args.files.iter().any(|f| f == "-") {
+        anyhow::bail!(
+            "stdin ('-') cannot be combined with other file arguments\n\
+             Use 'skim -' alone to read from stdin, or specify file paths directly."
+        );
+    }
 
+    // Expand each argument: glob pattern → expand, directory → collect,
+    // plain file → add directly.  All results are gathered into a single Vec
+    // and processed together via process_files.
     let multi_options = multi::MultiFileOptions {
         process: process_options,
         no_header: args.no_header,
@@ -608,24 +664,8 @@ fn run_file_operation(analytics: &analytics::AnalyticsConfig) -> anyhow::Result<
         session_id: analytics.session_id.clone(),
     };
 
-    if path.is_dir() {
-        return multi::process_directory(&path, multi_options);
-    }
-
-    if multi::has_glob_pattern(&file) {
-        return multi::process_glob(&file, multi_options);
-    }
-
-    let result = process::process_file(&path, process_options)?;
-    process::write_result_and_stats(&result, args.show_stats)?;
-    record_file_analytics(
-        analytics.enabled,
-        &result,
-        &format!("skim {file}"),
-        &args,
-        analytics.session_id.as_deref(),
-    );
-    Ok(())
+    let cmd_str = format!("skim {}", args.files.join(" "));
+    multi::process_explicit_files(&args.files, multi_options, &cmd_str)
 }
 
 /// Record token analytics for file operations (single file or stdin).

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -182,7 +182,7 @@ fn no_ignore_hint(no_ignore: bool) -> &'static str {
 ///
 /// Precondition: `paths` must be non-empty. Callers should validate and
 /// produce a descriptive error (with `--no-ignore` hint) before calling.
-pub(crate) fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Result<()> {
+fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Result<()> {
     debug_assert!(
         !paths.is_empty(),
         "BUG: process_files called with empty paths"
@@ -385,6 +385,11 @@ pub(crate) fn process_explicit_files(
         );
     }
 
+    // Deduplicate: a plain file arg and a glob arg may both resolve to the
+    // same path (e.g. `skim explicit.ts '*.ts'`). Sort first so dedup is O(n).
+    paths.sort();
+    paths.dedup();
+
     process_files(paths, options)
 }
 
@@ -440,45 +445,7 @@ fn expand_glob_to_paths(pattern: &str, no_ignore: bool) -> anyhow::Result<Vec<Pa
 /// gitignore rules are applied *before* glob matching, so gitignored files
 /// are excluded even when the glob would otherwise match them.
 pub(crate) fn process_glob(pattern: &str, options: MultiFileOptions) -> anyhow::Result<()> {
-    validate_glob_pattern(pattern)?;
-
-    let (walk_root, glob_pattern) = glob_walk_root(pattern);
-
-    let glob = GlobBuilder::new(glob_pattern)
-        .literal_separator(false)
-        .build()
-        .map_err(|e| anyhow::anyhow!("Invalid glob pattern '{}': {}", pattern, e))?;
-    let matcher = glob.compile_matcher();
-
-    let mut builder = WalkBuilder::new(walk_root);
-    configure_walker(&mut builder, options.no_ignore);
-
-    // SECURITY: Symlink traversal is prevented by `follow_links(false)` on the
-    // walker (configured in `configure_walker`). Path traversal via `..` is
-    // rejected by `validate_glob_pattern`. Together these make `canonicalize()`
-    // unnecessary here, avoiding a syscall per file in the hot path.
-    let paths: Vec<PathBuf> = builder
-        .build()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
-        .filter(|entry| {
-            entry
-                .path()
-                .strip_prefix(walk_root)
-                .ok()
-                .is_some_and(|rel| matcher.is_match(rel))
-        })
-        .map(|entry| entry.into_path())
-        .collect();
-
-    if paths.is_empty() {
-        anyhow::bail!(
-            "No files found: pattern '{}'{}",
-            pattern,
-            no_ignore_hint(options.no_ignore)
-        );
-    }
-
+    let paths = expand_glob_to_paths(pattern, options.no_ignore)?;
     process_files(paths, options)
 }
 

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -136,14 +136,12 @@ fn glob_walk_root(pattern: &str) -> (&str, &str) {
         // For absolute paths like "/Users/foo/src/**/*.ts":
         //   segments = ["", "Users", "foo", "src", "**", "*.ts"]
         //   static_count = 4  (segments 0..4 have no glob chars)
-        //   lengths = [0, 5, 3, 3], separators = 3
-        //   root_end = 11 + 3 = 14 (but - 1 for sep before glob) -> 13
-        //   Wait: we want root = "/Users/foo/src" (len=14).
+        //   root = "/Users/foo/src" (len=14)
         //
         // The formula: sum of static segment lengths + (static_count - 1) separators
-        // gives us the end index of the last static segment in the original string.
+        // gives the end index of the last static segment in the original string.
         // For absolute paths the leading "" segment has len=0, so the leading "/" is
-        // naturally captured as the separator counted between segment 0 and segment 1.
+        // captured as the separator between segment 0 and segment 1.
         let root_end: usize = segments[..static_count]
             .iter()
             .map(|s| s.len())
@@ -323,14 +321,14 @@ pub(crate) fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> a
 /// All resolved paths are collected into a single `Vec<PathBuf>` and processed
 /// together. This enables `skim file1.ts file2.ts` and mixed forms like
 /// `skim 'src/**/*.ts' extra.py`.
-///
-/// `cmd_str` is used only for analytics attribution (e.g. `"skim file1.ts file2.ts"`).
 pub(crate) fn process_explicit_files(
     args: &[String],
     options: MultiFileOptions,
-    cmd_str: &str,
 ) -> anyhow::Result<()> {
-    debug_assert!(!args.is_empty(), "BUG: process_explicit_files called with empty args");
+    debug_assert!(
+        !args.is_empty(),
+        "BUG: process_explicit_files called with empty args"
+    );
 
     let no_ignore = options.no_ignore;
     let mut paths: Vec<PathBuf> = Vec::new();
@@ -387,7 +385,6 @@ pub(crate) fn process_explicit_files(
         );
     }
 
-    let _ = cmd_str; // used for analytics attribution by caller
     process_files(paths, options)
 }
 

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -37,40 +37,21 @@ pub(crate) fn has_glob_pattern(path: &str) -> bool {
     path.contains(GLOB_METACHARACTERS)
 }
 
-/// Validate glob pattern to prevent path traversal attacks
+/// Validate glob pattern to prevent path traversal attacks.
+///
+/// Absolute Unix paths (`/Users/…`) and Windows drive paths (`C:/…`) are
+/// intentionally **allowed** — AI agents and shell users routinely pass fully
+/// qualified paths. Only genuinely dangerous patterns are rejected:
+///
+/// - `..` traversal (escapes the intended subtree)
+/// - Windows UNC network paths (`\\server\share`) — not local paths
 fn validate_glob_pattern(pattern: &str) -> anyhow::Result<()> {
-    // Reject absolute paths
-    if pattern.starts_with('/') {
-        anyhow::bail!(
-            "Glob pattern must be relative (cannot start with '/')\n\
-             Pattern: {}\n\
-             Use relative paths like 'src/**/*.ts' instead of '/src/**/*.ts'",
-            pattern
-        );
-    }
-
-    // Reject Windows drive letter paths (e.g., "C:\..." or "D:/...")
-    if pattern.len() >= 3 {
-        let bytes = pattern.as_bytes();
-        if bytes[0].is_ascii_alphabetic()
-            && bytes[1] == b':'
-            && (bytes[2] == b'\\' || bytes[2] == b'/')
-        {
-            anyhow::bail!(
-                "Glob pattern must be relative (absolute Windows path not allowed)\n\
-                 Pattern: {}\n\
-                 Use relative paths like 'src/**/*.ts' instead",
-                pattern
-            );
-        }
-    }
-
-    // Reject Windows UNC paths (e.g., "\\server\share")
+    // Reject Windows UNC paths (e.g., "\\server\share") — network paths, not local
     if pattern.starts_with("\\\\") {
         anyhow::bail!(
-            "Glob pattern must be relative (UNC path not allowed)\n\
+            "Glob pattern cannot use UNC network paths\n\
              Pattern: {}\n\
-             Use relative paths like 'src/**/*.ts' instead",
+             Use a local path like '/Users/foo/src/**/*.ts' instead",
             pattern
         );
     }
@@ -80,7 +61,7 @@ fn validate_glob_pattern(pattern: &str) -> anyhow::Result<()> {
         anyhow::bail!(
             "Glob pattern cannot contain '..' (parent directory traversal)\n\
              Pattern: {}\n\
-             This prevents accessing files outside the current directory",
+             This prevents accessing files outside the intended directory",
             pattern
         );
     }
@@ -115,14 +96,20 @@ fn configure_walker(builder: &mut WalkBuilder, no_ignore: bool) {
 /// glob metacharacters ([`GLOB_METACHARACTERS`]), and join them as the root.
 /// The remainder becomes the override pattern.
 ///
+/// Absolute Unix paths are handled correctly: the leading empty segment from
+/// `"/Users/foo/src/**/*.ts".split('/')` is treated as a static segment, so
+/// the computed root includes the leading `/`.
+///
 /// # Examples
 ///
 /// ```text
-/// "src/**/*.ts"       -> ("src",       "**/*.ts")
-/// "*.ts"              -> (".",         "*.ts")
-/// "src/utils/**/*.ts" -> ("src/utils", "**/*.ts")
-/// "**/*.ts"           -> (".",         "**/*.ts")
-/// "src/*.rs"          -> ("src",       "*.rs")
+/// "src/**/*.ts"             -> ("src",            "**/*.ts")
+/// "*.ts"                    -> (".",               "*.ts")
+/// "src/utils/**/*.ts"       -> ("src/utils",       "**/*.ts")
+/// "**/*.ts"                 -> (".",               "**/*.ts")
+/// "src/*.rs"                -> ("src",             "*.rs")
+/// "/Users/foo/src/**/*.ts"  -> ("/Users/foo/src",  "**/*.ts")
+/// "/**/*.ts"                -> ("/",               "**/*.ts")
 /// ```
 fn glob_walk_root(pattern: &str) -> (&str, &str) {
     let segments: Vec<&str> = pattern.split('/').collect();
@@ -136,6 +123,7 @@ fn glob_walk_root(pattern: &str) -> (&str, &str) {
     }
 
     if static_count == 0 {
+        // First segment itself contains glob chars (e.g. "**/*.ts", "*.ts")
         (".", pattern)
     } else if static_count == segments.len() {
         // All segments are static (no glob metacharacters). Treat the
@@ -144,7 +132,18 @@ fn glob_walk_root(pattern: &str) -> (&str, &str) {
         // before calling, but we must not panic on unexpected input.
         (pattern, "**")
     } else {
-        // Find the byte offset where the glob portion starts
+        // Find the byte offset where the glob portion starts.
+        // For absolute paths like "/Users/foo/src/**/*.ts":
+        //   segments = ["", "Users", "foo", "src", "**", "*.ts"]
+        //   static_count = 4  (segments 0..4 have no glob chars)
+        //   lengths = [0, 5, 3, 3], separators = 3
+        //   root_end = 11 + 3 = 14 (but - 1 for sep before glob) -> 13
+        //   Wait: we want root = "/Users/foo/src" (len=14).
+        //
+        // The formula: sum of static segment lengths + (static_count - 1) separators
+        // gives us the end index of the last static segment in the original string.
+        // For absolute paths the leading "" segment has len=0, so the leading "/" is
+        // naturally captured as the separator counted between segment 0 and segment 1.
         let root_end: usize = segments[..static_count]
             .iter()
             .map(|s| s.len())
@@ -152,7 +151,18 @@ fn glob_walk_root(pattern: &str) -> (&str, &str) {
             + static_count
             - 1; // account for the '/' separators between segments
 
-        let root = &pattern[..root_end];
+        // Edge case: absolute path whose first glob char appears right after the
+        // leading slash (e.g. "/**/*.ts").
+        //   segments = ["", "**", "*.ts"], static_count = 1
+        //   root_end = 0 + 1 - 1 = 0  =>  pattern[..0] = ""  (wrong — should be "/")
+        // Handle by checking if root_end would produce an empty slice for an absolute
+        // path: in that case return "/" as the root.
+        let root = if root_end == 0 && pattern.starts_with('/') {
+            "/"
+        } else {
+            &pattern[..root_end]
+        };
+
         let rest = &pattern[root_end + 1..]; // skip the '/' separator
         (root, rest)
     }
@@ -169,12 +179,12 @@ fn no_ignore_hint(no_ignore: bool) -> &'static str {
 
 /// Process multiple files with parallel processing via rayon.
 ///
-/// Used by both glob and directory inputs. Handles parallel execution,
-/// error aggregation, and accumulated token statistics.
+/// Used by glob, directory, and explicit multi-file inputs. Handles parallel
+/// execution, error aggregation, and accumulated token statistics.
 ///
 /// Precondition: `paths` must be non-empty. Callers should validate and
 /// produce a descriptive error (with `--no-ignore` hint) before calling.
-fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Result<()> {
+pub(crate) fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Result<()> {
     debug_assert!(
         !paths.is_empty(),
         "BUG: process_files called with empty paths"
@@ -303,6 +313,128 @@ fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Resu
     Ok(())
 }
 
+/// Process a list of explicitly specified file arguments.
+///
+/// Each argument may be:
+/// - A glob pattern (contains `*`, `?`, `[`, or `{`) — expanded via [`process_glob`] logic
+/// - A directory path — files are collected recursively via [`collect_files_from_directory`]
+/// - A plain file path — added directly
+///
+/// All resolved paths are collected into a single `Vec<PathBuf>` and processed
+/// together. This enables `skim file1.ts file2.ts` and mixed forms like
+/// `skim 'src/**/*.ts' extra.py`.
+///
+/// `cmd_str` is used only for analytics attribution (e.g. `"skim file1.ts file2.ts"`).
+pub(crate) fn process_explicit_files(
+    args: &[String],
+    options: MultiFileOptions,
+    cmd_str: &str,
+) -> anyhow::Result<()> {
+    debug_assert!(!args.is_empty(), "BUG: process_explicit_files called with empty args");
+
+    let no_ignore = options.no_ignore;
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for arg in args {
+        if has_glob_pattern(arg) {
+            // Glob expansion — validate then walk
+            match expand_glob_to_paths(arg, no_ignore) {
+                Ok(mut matched) => paths.append(&mut matched),
+                Err(e) => errors.push(format!("{arg}: {e}")),
+            }
+        } else {
+            let path = PathBuf::from(arg);
+            if path.is_dir() {
+                let mut dir_files = collect_files_from_directory(&path, no_ignore);
+                if dir_files.is_empty() {
+                    errors.push(format!(
+                        "No files found in directory '{}'{}",
+                        path.display(),
+                        no_ignore_hint(no_ignore)
+                    ));
+                } else {
+                    paths.append(&mut dir_files);
+                }
+            } else if path.exists() {
+                paths.push(path);
+            } else {
+                errors.push(format!("File not found: '{}'", path.display()));
+            }
+        }
+    }
+
+    if !errors.is_empty() && paths.is_empty() {
+        // All arguments failed — report the first error as the primary message,
+        // then list the rest.
+        let mut msg = errors.remove(0);
+        for e in errors {
+            msg.push('\n');
+            msg.push_str(&e);
+        }
+        anyhow::bail!("{}", msg);
+    }
+
+    // Partial failures: warn on stderr but continue with resolved paths.
+    for e in &errors {
+        eprintln!("Warning: {e}");
+    }
+
+    if paths.is_empty() {
+        anyhow::bail!(
+            "No files found for the given arguments{}",
+            no_ignore_hint(no_ignore)
+        );
+    }
+
+    let _ = cmd_str; // used for analytics attribution by caller
+    process_files(paths, options)
+}
+
+/// Expand a glob pattern to a list of matching paths.
+///
+/// Separated from [`process_glob`] so it can be used within
+/// [`process_explicit_files`] without going through the full single-glob
+/// pipeline (which calls `process_files` directly).
+fn expand_glob_to_paths(pattern: &str, no_ignore: bool) -> anyhow::Result<Vec<PathBuf>> {
+    validate_glob_pattern(pattern)?;
+
+    let (walk_root, glob_pattern) = glob_walk_root(pattern);
+
+    let glob = GlobBuilder::new(glob_pattern)
+        .literal_separator(false)
+        .build()
+        .map_err(|e| anyhow::anyhow!("Invalid glob pattern '{}': {}", pattern, e))?;
+    let matcher = glob.compile_matcher();
+
+    let mut builder = WalkBuilder::new(walk_root);
+    configure_walker(&mut builder, no_ignore);
+
+    let paths: Vec<PathBuf> = builder
+        .build()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+        .filter(|entry| {
+            entry
+                .path()
+                .strip_prefix(walk_root)
+                .ok()
+                .is_some_and(|rel| matcher.is_match(rel))
+        })
+        .map(|entry| entry.into_path())
+        .collect();
+
+    if paths.is_empty() {
+        anyhow::bail!(
+            "No files found: pattern '{}'{}",
+            pattern,
+            no_ignore_hint(no_ignore)
+        );
+    }
+
+    Ok(paths)
+}
+
 /// Process multiple files matched by glob pattern.
 ///
 /// Uses `ignore::WalkBuilder` for directory walking (respects `.gitignore`
@@ -408,19 +540,20 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_glob_pattern_rejects_absolute_unix_paths() {
-        let result = validate_glob_pattern("/etc/passwd");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("cannot start with '/'"), "got: {msg}");
+    fn test_validate_glob_pattern_accepts_absolute_unix_paths() {
+        // Absolute paths are legitimate in AI agent workflows where the full
+        // path is known. They must NOT be rejected.
+        assert!(validate_glob_pattern("/etc/passwd").is_ok());
+        assert!(validate_glob_pattern("/Users/foo/src/**/*.ts").is_ok());
+        assert!(validate_glob_pattern("/src/**/*.ts").is_ok());
     }
 
     #[test]
-    fn test_validate_glob_pattern_rejects_absolute_path_with_glob() {
-        let result = validate_glob_pattern("/src/**/*.ts");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("cannot start with '/'"), "got: {msg}");
+    fn test_validate_glob_pattern_accepts_windows_drive_paths() {
+        // Windows drive-letter paths are absolute local paths, not network
+        // paths. Allow them so Windows users can pass absolute paths.
+        assert!(validate_glob_pattern("C:\\Users\\*.ts").is_ok());
+        assert!(validate_glob_pattern("D:/projects/**/*.rs").is_ok());
     }
 
     #[test]
@@ -440,19 +573,11 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_glob_pattern_rejects_windows_drive_paths() {
-        let result = validate_glob_pattern("C:\\Users\\*.ts");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("absolute Windows path"), "got: {msg}");
-    }
-
-    #[test]
     fn test_validate_glob_pattern_rejects_windows_unc_paths() {
         let result = validate_glob_pattern("\\\\server\\share\\*.ts");
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("UNC path"), "got: {msg}");
+        assert!(msg.contains("UNC network paths"), "got: {msg}");
     }
 
     #[test]
@@ -523,5 +648,32 @@ mod tests {
         // with a match-everything glob. This should not happen in practice
         // (callers check has_glob_pattern first), but must not panic.
         assert_eq!(glob_walk_root("src/file.ts"), ("src/file.ts", "**"));
+    }
+
+    // ========================================================================
+    // glob_walk_root: absolute path tests
+    // ========================================================================
+
+    #[test]
+    fn test_glob_walk_root_absolute_path() {
+        // /Users/foo/src/**/*.ts should split to root=/Users/foo/src, glob=**/*.ts
+        assert_eq!(
+            glob_walk_root("/Users/foo/src/**/*.ts"),
+            ("/Users/foo/src", "**/*.ts")
+        );
+    }
+
+    #[test]
+    fn test_glob_walk_root_absolute_root_glob() {
+        // "/**/*.ts" — glob char immediately after leading slash
+        // segments = ["", "**", "*.ts"], static_count = 1 (just "")
+        // root_end = 0 + 1 - 1 = 0, but pattern starts with '/', so root = "/"
+        assert_eq!(glob_walk_root("/**/*.ts"), ("/", "**/*.ts"));
+    }
+
+    #[test]
+    fn test_glob_walk_root_absolute_single_dir() {
+        // "/src/*.rs" -> ("/src", "*.rs")
+        assert_eq!(glob_walk_root("/src/*.rs"), ("/src", "*.rs"));
     }
 }

--- a/crates/rskim/tests/cli_glob.rs
+++ b/crates/rskim/tests/cli_glob.rs
@@ -113,14 +113,18 @@ fn test_glob_no_matches() {
 }
 
 #[test]
-fn test_glob_absolute_path_rejected() {
+fn test_glob_absolute_path_accepted() {
+    // Absolute paths are legitimate and must NOT be rejected — AI agents and
+    // shell users commonly pass fully-qualified paths.  /etc/*.conf is unlikely
+    // to return results in a test environment, so we just verify the error is
+    // "No files found" (pattern evaluated, no match) rather than a validation
+    // rejection.
     Command::cargo_bin("skim")
         .unwrap()
-        .arg("/etc/*.conf")
+        .arg("/nonexistent_skim_test_dir/*.conf")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("must be relative"))
-        .stderr(predicate::str::contains("cannot start with '/'"));
+        .stderr(predicate::str::contains("No files found"));
 }
 
 #[test]

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -102,14 +102,16 @@ fn test_multi_file_shows_headers() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    // Each file should appear as a "// {path}" header comment
+    // Headers are emitted as "// {full path}" — check the exact prefix+path.
+    let header_a = format!("// {}", temp.path().join("a.ts").display());
+    let header_b = format!("// {}", temp.path().join("b.ts").display());
     assert!(
-        stdout.contains("// ") && stdout.contains("a.ts"),
-        "Expected '// ...a.ts' header, got:\n{stdout}"
+        stdout.contains(&header_a),
+        "Expected header '{header_a}', got:\n{stdout}"
     );
     assert!(
-        stdout.contains("// ") && stdout.contains("b.ts"),
-        "Expected '// ...b.ts' header, got:\n{stdout}"
+        stdout.contains(&header_b),
+        "Expected header '{header_b}', got:\n{stdout}"
     );
 }
 
@@ -229,10 +231,7 @@ fn test_multi_file_filename_flag_rejected() {
         .arg(temp.path().join("file2.ts"))
         .assert()
         .failure()
-        .stderr(
-            predicate::str::contains("--filename")
-                .or(predicate::str::contains("stdin")),
-        );
+        .stderr(predicate::str::contains("--filename").or(predicate::str::contains("stdin")));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -1,0 +1,268 @@
+//! Integration tests for multiple file arguments.
+//!
+//! Covers `skim file1.ts file2.ts file3.ts` — the ability to pass multiple
+//! positional arguments just like `cat file1 file2 file3`.  This is separate
+//! from glob patterns (tested in `cli_glob.rs`) even though the underlying
+//! dispatch overlaps.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+// ============================================================================
+// Happy path — multiple plain file arguments
+// ============================================================================
+
+#[test]
+fn test_multi_file_two_args_both_processed() {
+    let temp = TempDir::new().unwrap();
+
+    fs::write(
+        temp.path().join("alpha.ts"),
+        "function alpha() { return 1; }",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("beta.ts"),
+        "function beta() { return 2; }",
+    )
+    .unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("alpha.ts"))
+        .arg(temp.path().join("beta.ts"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("function alpha"))
+        .stdout(predicate::str::contains("function beta"));
+}
+
+#[test]
+fn test_multi_file_three_args() {
+    let temp = TempDir::new().unwrap();
+
+    fs::write(
+        temp.path().join("one.ts"),
+        "function one() { return 1; }",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("two.ts"),
+        "function two() { return 2; }",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("three.ts"),
+        "function three() { return 3; }",
+    )
+    .unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("one.ts"))
+        .arg(temp.path().join("two.ts"))
+        .arg(temp.path().join("three.ts"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("function one"))
+        .stdout(predicate::str::contains("function two"))
+        .stdout(predicate::str::contains("function three"));
+}
+
+#[test]
+fn test_multi_file_mixed_languages() {
+    let temp = TempDir::new().unwrap();
+
+    fs::write(
+        temp.path().join("main.rs"),
+        "fn main() { println!(\"hello\"); }",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("script.py"),
+        "def run():\n    pass\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("main.rs"))
+        .arg(temp.path().join("script.py"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fn main"))
+        .stdout(predicate::str::contains("def run"));
+}
+
+// ============================================================================
+// Headers in multi-file output
+// ============================================================================
+
+#[test]
+fn test_multi_file_shows_headers() {
+    let temp = TempDir::new().unwrap();
+
+    fs::write(temp.path().join("a.ts"), "function a() {}").unwrap();
+    fs::write(temp.path().join("b.ts"), "function b() {}").unwrap();
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("a.ts"))
+        .arg(temp.path().join("b.ts"))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8_lossy(&output);
+    // Each file should have its path in a header comment
+    assert!(
+        stdout.contains("a.ts"),
+        "Expected header for a.ts, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("b.ts"),
+        "Expected header for b.ts, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_multi_file_no_header_flag() {
+    let temp = TempDir::new().unwrap();
+
+    fs::write(temp.path().join("a.ts"), "function a() {}").unwrap();
+    fs::write(temp.path().join("b.ts"), "function b() {}").unwrap();
+
+    // "// ===" is the multi-file separator marker in the output
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("a.ts"))
+        .arg(temp.path().join("b.ts"))
+        .arg("--no-header")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("// ").not());
+}
+
+// ============================================================================
+// Mode flag propagates to all files
+// ============================================================================
+
+#[test]
+fn test_multi_file_signatures_mode_applied_to_all() {
+    let temp = TempDir::new().unwrap();
+
+    // Signatures mode strips bodies — `return 1` must not appear
+    fs::write(
+        temp.path().join("a.ts"),
+        "function a(): number { return 1; }",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("b.ts"),
+        "function b(): number { return 2; }",
+    )
+    .unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("a.ts"))
+        .arg(temp.path().join("b.ts"))
+        .arg("--mode=signatures")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("function a"))
+        .stdout(predicate::str::contains("function b"))
+        .stdout(predicate::str::contains("return").not());
+}
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+#[test]
+fn test_multi_file_nonexistent_file_warns_but_succeeds() {
+    // When some files exist and some don't, skim processes the valid ones and
+    // warns about the missing ones on stderr (like `cat` behaviour).
+    let temp = TempDir::new().unwrap();
+
+    fs::write(temp.path().join("real.ts"), "function real() {}").unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("real.ts"))
+        .arg(temp.path().join("ghost.ts")) // does not exist
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("function real"))
+        .stderr(predicate::str::contains("ghost.ts").or(predicate::str::contains("not found")));
+}
+
+#[test]
+fn test_multi_file_all_nonexistent_fails() {
+    // When ALL specified files are missing, the command fails.
+    let temp = TempDir::new().unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("ghost1.ts"))
+        .arg(temp.path().join("ghost2.ts"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ghost1.ts").or(predicate::str::contains("not found")));
+}
+
+#[test]
+fn test_multi_file_stdin_mixed_fails() {
+    // Stdin ('-') cannot be combined with file arguments.
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("file.ts"), "function f() {}").unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg("-")
+        .arg(temp.path().join("file.ts"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("stdin").or(predicate::str::contains("cannot")));
+}
+
+// ============================================================================
+// Mixing plain files and glob patterns in multiple args
+// ============================================================================
+
+#[test]
+fn test_multi_file_mix_plain_and_glob() {
+    let temp = TempDir::new().unwrap();
+
+    fs::write(
+        temp.path().join("explicit.ts"),
+        "function explicit() {}",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("glob1.ts"),
+        "function glob1() {}",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("glob2.ts"),
+        "function glob2() {}",
+    )
+    .unwrap();
+
+    // Pass explicit.ts as a plain arg and use a glob to match glob*.ts
+    let glob_pattern = format!("{}/*.ts", temp.path().display());
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(temp.path().join("explicit.ts"))
+        .arg(&glob_pattern)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("function explicit"))
+        .stdout(predicate::str::contains("function glob1").or(predicate::str::contains("function glob2")));
+}

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -102,14 +102,14 @@ fn test_multi_file_shows_headers() {
         .clone();
 
     let stdout = String::from_utf8_lossy(&output);
-    // Each file should have its path in a header comment
+    // Each file should appear as a "// {path}" header comment
     assert!(
-        stdout.contains("a.ts"),
-        "Expected header for a.ts, got:\n{stdout}"
+        stdout.contains("// ") && stdout.contains("a.ts"),
+        "Expected '// ...a.ts' header, got:\n{stdout}"
     );
     assert!(
-        stdout.contains("b.ts"),
-        "Expected header for b.ts, got:\n{stdout}"
+        stdout.contains("// ") && stdout.contains("b.ts"),
+        "Expected '// ...b.ts' header, got:\n{stdout}"
     );
 }
 
@@ -212,6 +212,27 @@ fn test_multi_file_stdin_mixed_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("stdin").or(predicate::str::contains("cannot")));
+}
+
+#[test]
+fn test_multi_file_filename_flag_rejected() {
+    // --filename is only meaningful for stdin ('-'). When multiple file
+    // arguments are given, the flag must be rejected with a clear error.
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("file1.ts"), "function f1() {}").unwrap();
+    fs::write(temp.path().join("file2.ts"), "function f2() {}").unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg("--filename=main.rs")
+        .arg(temp.path().join("file1.ts"))
+        .arg(temp.path().join("file2.ts"))
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("--filename")
+                .or(predicate::str::contains("stdin")),
+        );
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -136,7 +136,7 @@ fn test_multi_file_no_header_flag() {
     fs::write(temp.path().join("a.ts"), "function a() {}").unwrap();
     fs::write(temp.path().join("b.ts"), "function b() {}").unwrap();
 
-    // "// ===" is the multi-file separator marker in the output
+    // Headers use the format "// {path}" — assert none appear with --no-header
     Command::cargo_bin("skim")
         .unwrap()
         .arg(temp.path().join("a.ts"))

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -23,11 +23,7 @@ fn test_multi_file_two_args_both_processed() {
         "function alpha() { return 1; }",
     )
     .unwrap();
-    fs::write(
-        temp.path().join("beta.ts"),
-        "function beta() { return 2; }",
-    )
-    .unwrap();
+    fs::write(temp.path().join("beta.ts"), "function beta() { return 2; }").unwrap();
 
     Command::cargo_bin("skim")
         .unwrap()
@@ -43,16 +39,8 @@ fn test_multi_file_two_args_both_processed() {
 fn test_multi_file_three_args() {
     let temp = TempDir::new().unwrap();
 
-    fs::write(
-        temp.path().join("one.ts"),
-        "function one() { return 1; }",
-    )
-    .unwrap();
-    fs::write(
-        temp.path().join("two.ts"),
-        "function two() { return 2; }",
-    )
-    .unwrap();
+    fs::write(temp.path().join("one.ts"), "function one() { return 1; }").unwrap();
+    fs::write(temp.path().join("two.ts"), "function two() { return 2; }").unwrap();
     fs::write(
         temp.path().join("three.ts"),
         "function three() { return 3; }",
@@ -80,11 +68,7 @@ fn test_multi_file_mixed_languages() {
         "fn main() { println!(\"hello\"); }",
     )
     .unwrap();
-    fs::write(
-        temp.path().join("script.py"),
-        "def run():\n    pass\n",
-    )
-    .unwrap();
+    fs::write(temp.path().join("script.py"), "def run():\n    pass\n").unwrap();
 
     Command::cargo_bin("skim")
         .unwrap()
@@ -238,21 +222,9 @@ fn test_multi_file_stdin_mixed_fails() {
 fn test_multi_file_mix_plain_and_glob() {
     let temp = TempDir::new().unwrap();
 
-    fs::write(
-        temp.path().join("explicit.ts"),
-        "function explicit() {}",
-    )
-    .unwrap();
-    fs::write(
-        temp.path().join("glob1.ts"),
-        "function glob1() {}",
-    )
-    .unwrap();
-    fs::write(
-        temp.path().join("glob2.ts"),
-        "function glob2() {}",
-    )
-    .unwrap();
+    fs::write(temp.path().join("explicit.ts"), "function explicit() {}").unwrap();
+    fs::write(temp.path().join("glob1.ts"), "function glob1() {}").unwrap();
+    fs::write(temp.path().join("glob2.ts"), "function glob2() {}").unwrap();
 
     // Pass explicit.ts as a plain arg and use a glob to match glob*.ts
     let glob_pattern = format!("{}/*.ts", temp.path().display());
@@ -264,5 +236,8 @@ fn test_multi_file_mix_plain_and_glob() {
         .assert()
         .success()
         .stdout(predicate::str::contains("function explicit"))
-        .stdout(predicate::str::contains("function glob1").or(predicate::str::contains("function glob2")));
+        .stdout(
+            predicate::str::contains("function glob1")
+                .or(predicate::str::contains("function glob2")),
+        );
 }


### PR DESCRIPTION
## Summary

- **Multiple file arguments**: `skim file1.ts file2.ts file3.ts` now processes all files (previously only one positional arg was accepted)
- **Absolute glob paths**: `skim '/Users/.../src/**/*.ts'` now works (previously rejected with "must be relative")
- Partial failures warn on stderr and continue processing valid files (cat semantics)

Fixes the two issues reported by users where AI agents couldn't pass multiple files or use absolute paths.

## Changes

- `Args.file: Option<String>` → `Args.files: Vec<String>` with multi-file dispatch
- Removed absolute path rejection from `validate_glob_pattern` (keeps `..` traversal + UNC rejection)
- Fixed `glob_walk_root` edge case for `/**/*.ts` patterns
- Added `process_explicit_files` for multi-arg path (handles mix of plain files, globs, directories)

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 3,102 tests pass
- [x] 10 new integration tests in `cli_multi_file.rs`
- [x] Manual smoke tests: multi-file, absolute glob, partial failure, stdin rejection, single-file regression