### PR TITLE
fix(clippy): allow unwrap/expect/panic in rskim-core inline test modules

### DIFF
--- a/crates/rskim-core/src/lib.rs
+++ b/crates/rskim-core/src/lib.rs
@@ -441,6 +441,7 @@ pub fn supported_languages() -> &'static [Language] {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/lib.rs
+++ b/crates/rskim-core/src/lib.rs
@@ -441,7 +441,7 @@ pub fn supported_languages() -> &'static [Language] {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
+#[allow(clippy::expect_used)] // Allow expect in tests - it's acceptable for test code to panic on unexpected errors
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/transform/minimal.rs
+++ b/crates/rskim-core/src/transform/minimal.rs
@@ -403,6 +403,7 @@ pub(crate) fn trim_and_normalize(source: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/transform/minimal.rs
+++ b/crates/rskim-core/src/transform/minimal.rs
@@ -403,7 +403,7 @@ pub(crate) fn trim_and_normalize(source: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Unwrapping is acceptable in tests
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -400,6 +400,7 @@ pub(crate) fn reconcile_line_map_after_truncation(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -400,7 +400,7 @@ pub(crate) fn reconcile_line_map_after_truncation(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Unwrapping is acceptable in tests
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/transform/pseudo.rs
+++ b/crates/rskim-core/src/transform/pseudo.rs
@@ -624,6 +624,7 @@ fn strip_rust_return_type(function_node: Node, ranges: &mut Vec<(usize, usize)>)
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::{Mode, Parser, TransformConfig};

--- a/crates/rskim-core/src/transform/pseudo.rs
+++ b/crates/rskim-core/src/transform/pseudo.rs
@@ -624,7 +624,7 @@ fn strip_rust_return_type(function_node: Node, ranges: &mut Vec<(usize, usize)>)
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Unwrapping is acceptable in tests
 mod tests {
     use super::*;
     use crate::{Mode, Parser, TransformConfig};

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -620,7 +620,7 @@ pub(crate) fn extract_markdown_headers_with_spans(
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Unwrapping is acceptable in tests
 mod offset_map_tests {
     use super::compute_source_line_map_from_offset_map;
 
@@ -917,7 +917,7 @@ mod offset_map_tests {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Unwrapping is acceptable in tests
 mod markdown_line_map_tests {
     use super::extract_markdown_headers_with_spans;
     use crate::{Language, Parser};

--- a/crates/rskim-core/src/transform/structure.rs
+++ b/crates/rskim-core/src/transform/structure.rs
@@ -620,6 +620,7 @@ pub(crate) fn extract_markdown_headers_with_spans(
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod offset_map_tests {
     use super::compute_source_line_map_from_offset_map;
 
@@ -916,6 +917,7 @@ mod offset_map_tests {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod markdown_line_map_tests {
     use super::extract_markdown_headers_with_spans;
     use crate::{Language, Parser};

--- a/crates/rskim-core/src/transform/truncate.rs
+++ b/crates/rskim-core/src/transform/truncate.rs
@@ -467,6 +467,7 @@ where
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/transform/truncate.rs
+++ b/crates/rskim-core/src/transform/truncate.rs
@@ -467,7 +467,7 @@ where
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
+#[allow(clippy::unwrap_used, clippy::panic)] // Unwrapping and panics are acceptable in tests
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -862,6 +862,7 @@ impl Parser {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rskim-core/src/types.rs
+++ b/crates/rskim-core/src/types.rs
@@ -862,7 +862,7 @@ impl Parser {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used)] // Unwrapping is acceptable in tests
 mod tests {
     use super::*;
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `#[allow(clippy::...)]` attributes to 8 `#[cfg(test)]` modules across 7 files in rskim-core
- Each attribute is scoped to only the lints that file actually violates (`unwrap_used`, `expect_used`, `panic`)
- Matches the established pattern already present in `parser/mod.rs`, `json.rs`, `toml.rs`, `yaml.rs`

Closes #142

## Test plan

- [x] `cargo clippy -p rskim-core --all-targets --all-features -- -D warnings` → 0 errors
- [x] `cargo test --all-features` → 3,103 tests pass, 0 failures
- [x] `cargo fmt -- --check` → clean
- [x] No production code affected (attributes scoped to `#[cfg(test)]` modules only)
EOF
)