### PR TITLE
feat: skim heatmap -- git history risk/coupling analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`skim heatmap` subcommand** — Git history risk and coupling analysis. Mines git log to produce 6 metrics: file churn, co-change coupling (blast radius), stability scores, author concentration (bus factor), fix-after-touch risk, and module encapsulation health. Supports adaptive dual windowing (max of 90 days / 200 commits), auto-exclusion of lock files and build artifacts, JSON and text output, and path scoping. 87 new tests.
+
 ### Changed
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (3,103 tests passing)
+- ✅ Full Rust project with comprehensive test suite (3,190 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -159,6 +159,7 @@ cargo fmt -- --check           # Format check
 - `learn` — Detect CLI error-retry patterns in agent sessions and generate correction rules (`--generate`, `--agent`, `--dry-run`, `--no-truncate`)
 - `rewrite` — Rewrite developer commands into skim equivalents (`--hook` for agent integration)
 - `stats` — Token analytics dashboard with per-session tracking (`--since`, `--format json`, `--verbose`, `--clear`)
+- `heatmap` — Git history risk/coupling analysis: churn, co-change coupling, stability scores, author concentration, fix-after-touch, module encapsulation (`--json`, `--since`, `--last`, `--window`, `--path`, `--top`)
 
 **Multi-category dispatchers:**
 - `cargo` — Rust toolchain compression: test, build, clippy, audit, nextest
@@ -568,7 +569,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,103 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,190 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ cargo fmt -- --check           # Format check
 - `learn` — Detect CLI error-retry patterns in agent sessions and generate correction rules (`--generate`, `--agent`, `--dry-run`, `--no-truncate`)
 - `rewrite` — Rewrite developer commands into skim equivalents (`--hook` for agent integration)
 - `stats` — Token analytics dashboard with per-session tracking (`--since`, `--format json`, `--verbose`, `--clear`)
+
+**Analysis:**
 - `heatmap` — Git history risk/coupling analysis: churn, co-change coupling, stability scores, author concentration, fix-after-touch, module encapsulation (`--json`, `--since`, `--last`, `--window`, `--path`, `--top`)
 
 **Multi-category dispatchers:**

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -44,6 +44,7 @@ pub(crate) enum CommandType {
     Infra,
     FileOps,
     Log,
+    Heatmap,
 }
 
 impl CommandType {
@@ -58,6 +59,7 @@ impl CommandType {
             CommandType::Infra => "infra",
             CommandType::FileOps => "fileops",
             CommandType::Log => "log",
+            CommandType::Heatmap => "heatmap",
         }
     }
 }

--- a/crates/rskim/src/cmd/heatmap/excludes.rs
+++ b/crates/rskim/src/cmd/heatmap/excludes.rs
@@ -1,0 +1,160 @@
+//! Default exclusion patterns and GlobSet construction for `skim heatmap`.
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+
+// ============================================================================
+// Default exclusion patterns
+// ============================================================================
+
+/// Hardcoded patterns for files that should be excluded from heatmap analysis
+/// by default (lock files, build artifacts, minified bundles, logs, etc.).
+pub(crate) const DEFAULT_EXCLUDES: &[&str] = &[
+    // Lock files
+    "Cargo.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Pipfile.lock",
+    "composer.lock",
+    "Gemfile.lock",
+    "go.sum",
+    "*.lock",
+    // Build / dist artifacts
+    "dist/**",
+    "build/**",
+    "target/**",
+    "out/**",
+    ".next/**",
+    ".nuxt/**",
+    "__pycache__/**",
+    "*.egg-info/**",
+    // Minified / generated bundles
+    "*.min.js",
+    "*.min.css",
+    "*.bundle.js",
+    "*.chunk.js",
+    // Log files
+    "*.log",
+    "logs/**",
+    // Vendored dependencies
+    "vendor/**",
+    "node_modules/**",
+    // IDE / OS metadata
+    ".idea/**",
+    ".vscode/**",
+    ".DS_Store",
+    // Coverage / test artifacts
+    "coverage/**",
+    ".nyc_output/**",
+    // Migration generated files
+    "migrations/**/*.sql",
+];
+
+// ============================================================================
+// GlobSet construction
+// ============================================================================
+
+/// Build a [`GlobSet`] from the default excludes plus any extra patterns.
+///
+/// Returns an empty set when `no_exclude` is `true` so that no files are
+/// filtered out.
+pub(crate) fn build_exclude_set(no_exclude: bool, extra: &[String]) -> GlobSet {
+    if no_exclude {
+        return GlobSet::empty();
+    }
+
+    let mut builder = GlobSetBuilder::new();
+
+    for pattern in DEFAULT_EXCLUDES {
+        if let Ok(glob) = Glob::new(pattern) {
+            builder.add(glob);
+        }
+    }
+
+    for pattern in extra {
+        if let Ok(glob) = Glob::new(pattern) {
+            builder.add(glob);
+        }
+    }
+
+    builder.build().unwrap_or_else(|_| GlobSet::empty())
+}
+
+/// Return `true` when `path` matches any pattern in `set`.
+pub(crate) fn should_exclude(path: &str, set: &GlobSet) -> bool {
+    set.is_match(path)
+}
+
+/// Return `true` when a numstat line represents a binary file.
+///
+/// git numstat uses `-` for both additions and deletions when the file is binary.
+#[allow(dead_code)]
+pub(crate) fn is_binary_marker(additions: &str, deletions: &str) -> bool {
+    additions == "-" && deletions == "-"
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lock_file_excluded_by_default() {
+        let set = build_exclude_set(false, &[]);
+        assert!(should_exclude("Cargo.lock", &set));
+        assert!(should_exclude("package-lock.json", &set));
+        assert!(should_exclude("yarn.lock", &set));
+    }
+
+    #[test]
+    fn test_build_dir_excluded_by_default() {
+        let set = build_exclude_set(false, &[]);
+        assert!(should_exclude("dist/main.js", &set));
+        assert!(should_exclude("target/debug/foo", &set));
+    }
+
+    #[test]
+    fn test_minified_excluded() {
+        let set = build_exclude_set(false, &[]);
+        assert!(should_exclude("app.min.js", &set));
+        assert!(should_exclude("styles.min.css", &set));
+    }
+
+    #[test]
+    fn test_source_file_not_excluded() {
+        let set = build_exclude_set(false, &[]);
+        assert!(!should_exclude("src/main.rs", &set));
+        assert!(!should_exclude("lib/utils.ts", &set));
+    }
+
+    #[test]
+    fn test_no_exclude_skips_all_patterns() {
+        let set = build_exclude_set(true, &[]);
+        assert!(!should_exclude("Cargo.lock", &set));
+        assert!(!should_exclude("dist/main.js", &set));
+    }
+
+    #[test]
+    fn test_extra_excludes_applied() {
+        let extra = vec!["*.generated.ts".to_string()];
+        let set = build_exclude_set(false, &extra);
+        assert!(should_exclude("foo.generated.ts", &set));
+        assert!(!should_exclude("foo.ts", &set));
+    }
+
+    #[test]
+    fn test_is_binary_marker_true() {
+        assert!(is_binary_marker("-", "-"));
+    }
+
+    #[test]
+    fn test_is_binary_marker_false() {
+        assert!(!is_binary_marker("0", "0"));
+        assert!(!is_binary_marker("-", "0"));
+        assert!(!is_binary_marker("10", "-"));
+    }
+}

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -9,6 +9,15 @@ use crate::runner::{is_spawn_error, CommandRunner};
 
 use super::types::{CommitRecord, FileChange, HeatmapConfig};
 
+/// Map a `CommandRunner` error to a friendly "git not installed" message when appropriate.
+fn git_not_found(e: anyhow::Error) -> anyhow::Error {
+    if is_spawn_error(&e) {
+        anyhow::anyhow!("git is not installed or not in PATH")
+    } else {
+        e
+    }
+}
+
 // ============================================================================
 // Trait — for testability
 // ============================================================================
@@ -53,13 +62,7 @@ impl CliGitSource {
         let out = self
             .runner
             .run("git", &["rev-parse", "--show-toplevel"])
-            .map_err(|e| {
-                if is_spawn_error(&e) {
-                    anyhow::anyhow!("git is not installed or not in PATH")
-                } else {
-                    e
-                }
-            })?;
+            .map_err(git_not_found)?;
         Ok(out.stdout.trim().to_string())
     }
 
@@ -81,8 +84,8 @@ impl CliGitSource {
         if n == 0 {
             return Ok(None);
         }
-        let skip = format!("{}", n.saturating_sub(1));
-        let n_str = format!("{n}");
+        let skip = n.saturating_sub(1).to_string();
+        let n_str = n.to_string();
         let out = self.runner.run(
             "git",
             &[
@@ -99,18 +102,9 @@ impl CliGitSource {
         if trimmed.is_empty() {
             return Ok(None);
         }
-        let ts: u64 = trimmed
-            .lines()
-            .next()
-            .unwrap_or("")
-            .trim()
-            .parse()
-            .unwrap_or(0);
-        if ts == 0 {
-            Ok(None)
-        } else {
-            Ok(Some(ts))
-        }
+        // trimmed is non-empty; first line is the timestamp
+        let ts: u64 = trimmed.lines().next().unwrap_or("").parse().unwrap_or(0);
+        Ok((ts > 0).then_some(ts))
     }
 
     /// Build the git log arg list from a config.
@@ -145,13 +139,7 @@ impl GitDataSource for CliGitSource {
         let mut owned_args: Vec<String> = Vec::new();
         let args = self.build_git_log_args(config, &mut owned_args);
 
-        let output = self.runner.run("git", &args).map_err(|e| {
-            if is_spawn_error(&e) {
-                anyhow::anyhow!("git is not installed or not in PATH")
-            } else {
-                e
-            }
-        })?;
+        let output = self.runner.run("git", &args).map_err(git_not_found)?;
 
         parse_git_log_output(&output.stdout)
     }
@@ -258,9 +246,7 @@ fn resolve_rename(raw: &str) -> String {
             // inner is "old => new"
             if let Some(arrow_pos) = inner.find(" => ") {
                 let new_part = &inner[arrow_pos + 4..];
-                // Reconstruct: prefix + new_part + suffix
-                let resolved = format!("{prefix}{new_part}{suffix}");
-                return resolved;
+                return format!("{prefix}{new_part}{suffix}");
             }
         }
     }

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -153,27 +153,25 @@ impl CliGitSource {
 
 impl GitDataSource for CliGitSource {
     fn is_git_repo(&self) -> bool {
-        CliGitSource::is_git_repo(self)
+        self.is_git_repo()
     }
 
     fn get_repo_root(&self) -> anyhow::Result<String> {
-        CliGitSource::get_repo_root(self)
+        self.get_repo_root()
     }
 
     fn detect_shallow_clone(&self) -> bool {
-        CliGitSource::detect_shallow_clone(self)
+        self.detect_shallow_clone()
     }
 
     fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>> {
-        CliGitSource::fetch_commit_count_since(self, n)
+        self.fetch_commit_count_since(n)
     }
 
     fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>> {
         let owned_args = self.build_git_log_args(config);
         let args: Vec<&str> = owned_args.iter().map(String::as_str).collect();
-
         let output = self.runner.run("git", &args).map_err(git_not_found)?;
-
         parse_git_log_output(&output.stdout)
     }
 }

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -1,0 +1,389 @@
+//! Git data source for `skim heatmap` — the ONLY I/O file in this module.
+//!
+//! Uses `CommandRunner` to execute git commands and parses their output into
+//! `CommitRecord` values via a simple state machine.
+
+use std::time::Duration;
+
+use crate::runner::{is_spawn_error, CommandRunner};
+
+use super::types::{CommitRecord, FileChange, HeatmapConfig};
+
+// ============================================================================
+// Trait — for testability
+// ============================================================================
+
+/// Abstraction over git data sources.
+///
+/// The only implementation is [`CliGitSource`]; the trait enables unit-testing
+/// the orchestration logic in `mod.rs` without spawning a real git process.
+pub(crate) trait GitDataSource {
+    fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>>;
+}
+
+// ============================================================================
+// CLI implementation
+// ============================================================================
+
+/// Concrete git data source that delegates to the `git` binary.
+pub(crate) struct CliGitSource {
+    runner: CommandRunner,
+}
+
+impl CliGitSource {
+    pub(crate) fn new() -> Self {
+        Self {
+            runner: CommandRunner::new(Some(Duration::from_secs(120))),
+        }
+    }
+
+    /// Return `true` when the cwd is inside a git repository.
+    pub(crate) fn is_git_repo(&self) -> bool {
+        match self
+            .runner
+            .run("git", &["rev-parse", "--is-inside-work-tree"])
+        {
+            Ok(out) => out.exit_code == Some(0),
+            Err(_) => false,
+        }
+    }
+
+    /// Return the repository root path.
+    pub(crate) fn get_repo_root(&self) -> anyhow::Result<String> {
+        let out = self
+            .runner
+            .run("git", &["rev-parse", "--show-toplevel"])
+            .map_err(|e| {
+                if is_spawn_error(&e) {
+                    anyhow::anyhow!("git is not installed or not in PATH")
+                } else {
+                    e
+                }
+            })?;
+        Ok(out.stdout.trim().to_string())
+    }
+
+    /// Return `true` when the repo is a shallow clone.
+    pub(crate) fn detect_shallow_clone(&self) -> bool {
+        match self
+            .runner
+            .run("git", &["rev-parse", "--is-shallow-repository"])
+        {
+            Ok(out) => out.stdout.trim() == "true",
+            Err(_) => false,
+        }
+    }
+
+    /// Fetch the Unix timestamp of the Nth-oldest commit within the last `n` commits.
+    ///
+    /// Returns `None` when the repo has fewer than `n` commits.
+    pub(crate) fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>> {
+        if n == 0 {
+            return Ok(None);
+        }
+        let skip = format!("{}", n.saturating_sub(1));
+        let n_str = format!("{n}");
+        let out = self.runner.run(
+            "git",
+            &[
+                "log",
+                "--format=%ad",
+                "--date=unix",
+                "-n",
+                &n_str,
+                "--skip",
+                &skip,
+            ],
+        )?;
+        let trimmed = out.stdout.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        let ts: u64 = trimmed
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .parse()
+            .unwrap_or(0);
+        if ts == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(ts))
+        }
+    }
+
+    /// Build the git log arg list from a config.
+    fn build_git_log_args<'a>(
+        &self,
+        config: &HeatmapConfig,
+        extra: &'a mut Vec<String>,
+    ) -> Vec<&'a str> {
+        // The base args that don't vary.
+        extra.push("log".to_string());
+        extra.push("--format=COMMIT:%H|%aN|%ad|%s".to_string());
+        extra.push("--numstat".to_string());
+        extra.push("--no-merges".to_string());
+        extra.push("--date=unix".to_string());
+        extra.push("-M".to_string());
+
+        if let Some(since) = config.since {
+            extra.push(format!("--since={since}"));
+        }
+
+        if let Some(ref path) = config.path {
+            extra.push("--".to_string());
+            extra.push(path.clone());
+        }
+
+        extra.iter().map(String::as_str).collect()
+    }
+}
+
+impl GitDataSource for CliGitSource {
+    fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>> {
+        let mut owned_args: Vec<String> = Vec::new();
+        let args = self.build_git_log_args(config, &mut owned_args);
+
+        let output = self.runner.run("git", &args).map_err(|e| {
+            if is_spawn_error(&e) {
+                anyhow::anyhow!("git is not installed or not in PATH")
+            } else {
+                e
+            }
+        })?;
+
+        parse_git_log_output(&output.stdout)
+    }
+}
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+/// Parse the output of `git log --format=COMMIT:%H|%aN|%ad|%s --numstat`.
+///
+/// Exposed as `pub(crate)` so unit tests can exercise the parser on hardcoded
+/// strings without spawning a real git process.
+pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord>> {
+    let mut commits: Vec<CommitRecord> = Vec::new();
+    let mut current: Option<CommitRecord> = None;
+
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("COMMIT:") {
+            // Flush the previous commit
+            if let Some(c) = current.take() {
+                commits.push(c);
+            }
+            // Parse: hash|author|timestamp|subject
+            let parts: Vec<&str> = rest.splitn(4, '|').collect();
+            if parts.len() < 4 {
+                continue;
+            }
+            let hash = parts[0].trim().to_string();
+            let author = parts[1].trim().to_string();
+            let timestamp: u64 = parts[2].trim().parse().unwrap_or(0);
+            let subject = parts[3].trim().to_string();
+
+            current = Some(CommitRecord {
+                hash,
+                author,
+                timestamp,
+                subject,
+                files: Vec::new(),
+            });
+        } else if line.trim().is_empty() {
+            // Blank lines separate commits — skip
+            continue;
+        } else {
+            // Numstat line: additions\tdeletions\tpath
+            // Binary files: - - path
+            if let Some(record) = current.as_mut() {
+                if let Some(file_change) = parse_numstat_line(line) {
+                    record.files.push(file_change);
+                }
+            }
+        }
+    }
+
+    // Flush the last commit
+    if let Some(c) = current {
+        commits.push(c);
+    }
+
+    Ok(commits)
+}
+
+/// Parse a single git numstat line into a `FileChange`.
+///
+/// Returns `None` for binary files (marked with `-` in both columns) or
+/// malformed lines.
+fn parse_numstat_line(line: &str) -> Option<FileChange> {
+    let parts: Vec<&str> = line.splitn(3, '\t').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    let additions_str = parts[0].trim();
+    let deletions_str = parts[1].trim();
+    let raw_path = parts[2].trim();
+
+    // Skip binary files
+    if additions_str == "-" && deletions_str == "-" {
+        return None;
+    }
+
+    let additions: u64 = additions_str.parse().unwrap_or(0);
+    let deletions: u64 = deletions_str.parse().unwrap_or(0);
+
+    // Resolve renames: `{old => new}` or `dir/{old => new}/rest`
+    let path = resolve_rename(raw_path);
+
+    Some(FileChange {
+        path,
+        additions,
+        deletions,
+    })
+}
+
+/// Resolve a git rename path like `{old => new}` or `dir/{old => new}/file`.
+fn resolve_rename(raw: &str) -> String {
+    // Find `{...}` brace pair
+    if let (Some(open), Some(close)) = (raw.find('{'), raw.rfind('}')) {
+        if open < close {
+            let prefix = &raw[..open];
+            let suffix = &raw[close + 1..];
+            let inner = &raw[open + 1..close];
+
+            // inner is "old => new"
+            if let Some(arrow_pos) = inner.find(" => ") {
+                let new_part = &inner[arrow_pos + 4..];
+                // Reconstruct: prefix + new_part + suffix
+                let resolved = format!("{prefix}{new_part}{suffix}");
+                return resolved;
+            }
+        }
+    }
+    raw.to_string()
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_log(entries: &[(&str, &str, u64, &str, &[(&str, &str, &str)])]) -> String {
+        let mut out = String::new();
+        for (hash, author, ts, subject, files) in entries {
+            out.push_str(&format!("COMMIT:{hash}|{author}|{ts}|{subject}\n"));
+            for (add, del, path) in *files {
+                out.push_str(&format!("{add}\t{del}\t{path}\n"));
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn test_parse_empty_input() {
+        let result = parse_git_log_output("").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_single_commit_no_files() {
+        let input = "COMMIT:abc123|Alice|1700000000|fix: something\n\n";
+        let result = parse_git_log_output(input).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].hash, "abc123");
+        assert_eq!(result[0].author, "Alice");
+        assert_eq!(result[0].timestamp, 1_700_000_000);
+        assert_eq!(result[0].subject, "fix: something");
+        assert!(result[0].files.is_empty());
+    }
+
+    #[test]
+    fn test_parse_single_commit_with_files() {
+        let input = "COMMIT:abc123|Alice|1700000000|chore: update\n5\t2\tsrc/main.rs\n3\t1\tlib/utils.rs\n\n";
+        let result = parse_git_log_output(input).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].files.len(), 2);
+        assert_eq!(result[0].files[0].path, "src/main.rs");
+        assert_eq!(result[0].files[0].additions, 5);
+        assert_eq!(result[0].files[0].deletions, 2);
+    }
+
+    #[test]
+    fn test_parse_multiple_commits() {
+        let input = make_log(&[
+            (
+                "hash1",
+                "Alice",
+                1_000,
+                "first commit",
+                &[("10", "0", "a.rs")],
+            ),
+            (
+                "hash2",
+                "Bob",
+                2_000,
+                "second commit",
+                &[("5", "3", "b.rs")],
+            ),
+        ]);
+        let result = parse_git_log_output(&input).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].hash, "hash1");
+        assert_eq!(result[1].hash, "hash2");
+    }
+
+    #[test]
+    fn test_binary_files_skipped() {
+        let input = "COMMIT:abc|Alice|1000|msg\n-\t-\tbinary.bin\n5\t2\treal.rs\n\n";
+        let result = parse_git_log_output(input).unwrap();
+        assert_eq!(result[0].files.len(), 1);
+        assert_eq!(result[0].files[0].path, "real.rs");
+    }
+
+    #[test]
+    fn test_rename_resolution_simple() {
+        assert_eq!(resolve_rename("{old.rs => new.rs}"), "new.rs");
+    }
+
+    #[test]
+    fn test_rename_resolution_with_prefix() {
+        assert_eq!(resolve_rename("src/{old.rs => new.rs}"), "src/new.rs");
+    }
+
+    #[test]
+    fn test_rename_resolution_with_suffix() {
+        assert_eq!(
+            resolve_rename("src/{old => new}/main.rs"),
+            "src/new/main.rs"
+        );
+    }
+
+    #[test]
+    fn test_no_rename_passthrough() {
+        assert_eq!(resolve_rename("src/main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn test_parse_commit_subject_with_pipe() {
+        // Subject may contain the separator — splitn(4) protects us
+        let input = "COMMIT:abc|Alice|1000|feat: add foo|bar\n\n";
+        let result = parse_git_log_output(input).unwrap();
+        assert_eq!(result[0].subject, "feat: add foo|bar");
+    }
+
+    #[test]
+    fn test_malformed_numstat_line_ignored() {
+        let input = "COMMIT:abc|Alice|1000|msg\nnot-a-numstat-line\n\n";
+        let result = parse_git_log_output(input).unwrap();
+        // The malformed line should be silently ignored
+        assert_eq!(result[0].files.len(), 0);
+    }
+}

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -26,7 +26,27 @@ fn git_not_found(e: anyhow::Error) -> anyhow::Error {
 ///
 /// The only implementation is [`CliGitSource`]; the trait enables unit-testing
 /// the orchestration logic in `mod.rs` without spawning a real git process.
+///
+/// Infra methods (`is_git_repo`, `get_repo_root`, `detect_shallow_clone`,
+/// `fetch_commit_count_since`) are included so `run_with_source` can accept a
+/// single `&dyn GitDataSource` instead of splitting into a concrete `&CliGitSource`
+/// for infrastructure and a trait object for data fetch.
 pub(crate) trait GitDataSource {
+    /// Return `true` when the cwd is inside a git repository.
+    fn is_git_repo(&self) -> bool;
+
+    /// Return the repository root path.
+    fn get_repo_root(&self) -> anyhow::Result<String>;
+
+    /// Return `true` when the repo is a shallow clone.
+    fn detect_shallow_clone(&self) -> bool;
+
+    /// Fetch the Unix timestamp of the Nth-oldest commit within the last `n` commits.
+    ///
+    /// Returns `None` when the repo has fewer than `n` commits.
+    fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>>;
+
+    /// Fetch commit records according to `config`.
     fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>>;
 }
 
@@ -108,36 +128,49 @@ impl CliGitSource {
     }
 
     /// Build the git log arg list from a config.
-    fn build_git_log_args<'a>(
-        &self,
-        config: &HeatmapConfig,
-        extra: &'a mut Vec<String>,
-    ) -> Vec<&'a str> {
-        // The base args that don't vary.
-        extra.push("log".to_string());
-        extra.push("--format=COMMIT:%H|%aN|%ad|%s".to_string());
-        extra.push("--numstat".to_string());
-        extra.push("--no-merges".to_string());
-        extra.push("--date=unix".to_string());
-        extra.push("-M".to_string());
+    fn build_git_log_args(&self, config: &HeatmapConfig) -> Vec<String> {
+        let mut args = vec![
+            "log".to_string(),
+            "--format=COMMIT:%H|%aN|%ad|%s".to_string(),
+            "--numstat".to_string(),
+            "--no-merges".to_string(),
+            "--date=unix".to_string(),
+            "-M".to_string(),
+        ];
 
         if let Some(since) = config.since {
-            extra.push(format!("--since={since}"));
+            args.push(format!("--since={since}"));
         }
 
         if let Some(ref path) = config.path {
-            extra.push("--".to_string());
-            extra.push(path.clone());
+            args.push("--".to_string());
+            args.push(path.clone());
         }
 
-        extra.iter().map(String::as_str).collect()
+        args
     }
 }
 
 impl GitDataSource for CliGitSource {
+    fn is_git_repo(&self) -> bool {
+        CliGitSource::is_git_repo(self)
+    }
+
+    fn get_repo_root(&self) -> anyhow::Result<String> {
+        CliGitSource::get_repo_root(self)
+    }
+
+    fn detect_shallow_clone(&self) -> bool {
+        CliGitSource::detect_shallow_clone(self)
+    }
+
+    fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>> {
+        CliGitSource::fetch_commit_count_since(self, n)
+    }
+
     fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>> {
-        let mut owned_args: Vec<String> = Vec::new();
-        let args = self.build_git_log_args(config, &mut owned_args);
+        let owned_args = self.build_git_log_args(config);
+        let args: Vec<&str> = owned_args.iter().map(String::as_str).collect();
 
         let output = self.runner.run("git", &args).map_err(git_not_found)?;
 

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -59,10 +59,21 @@ pub(crate) fn compute_churn(commits: &[CommitRecord]) -> HashMap<String, ChurnMe
 // Metric 2: Coupling
 // ============================================================================
 
+/// Maximum number of files in a commit that participates in coupling pair generation.
+///
+/// Commits touching more than this many files (e.g. large reformats) still count
+/// toward `weighted_total` for each file, but are skipped for pair enumeration.
+/// This caps worst-case pair allocations at 50*49 = 2450 per commit instead of
+/// unbounded O(n^2).
+const COUPLING_MAX_FILES: usize = 50;
+
 /// Compute file coupling from commit co-occurrences.
 ///
 /// Weights each pair's contribution by `1.0 / sqrt(files_in_commit)` to
 /// discount large commits (e.g. reformatting all files at once).
+///
+/// Commits with more than [`COUPLING_MAX_FILES`] files are excluded from pair
+/// enumeration (but still contribute to each file's `weighted_total`).
 ///
 /// Returns:
 /// - per-file blast radius map: `HashMap<String, Vec<CouplingEntry>>`
@@ -72,28 +83,24 @@ pub(crate) fn compute_coupling(
     threshold: f64,
     min_support: usize,
 ) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
-    // co_occurrences[(a, b)] = weighted sum of commits where a and b appear together
-    let mut co_occur: HashMap<(String, String), f64> = HashMap::new();
+    // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b)
+    let mut co_occur: HashMap<(String, String), (f64, usize)> = HashMap::new();
     // weighted_total[a] = weighted sum of commits touching a
     let mut weighted_total: HashMap<String, f64> = HashMap::new();
-    // support[(a,b)] = raw commit count (for filtering)
-    let mut support_count: HashMap<(String, String), usize> = HashMap::new();
 
     for commit in commits {
         let files: Vec<&str> = commit.files.iter().map(|f| f.path.as_str()).collect();
         let n = files.len();
-        if n < 2 {
-            // A single-file commit contributes to weighted_total but not coupling
-            for f in &files {
-                let w = 1.0 / (n as f64).sqrt();
-                *weighted_total.entry(f.to_string()).or_insert(0.0) += w;
-            }
-            continue;
-        }
         let weight = 1.0 / (n as f64).sqrt();
 
+        // Every commit contributes to weighted_total for its files
         for f in &files {
             *weighted_total.entry(f.to_string()).or_insert(0.0) += weight;
+        }
+
+        // Skip large commits for pair enumeration to avoid O(n^2) blowup
+        if !(2..=COUPLING_MAX_FILES).contains(&n) {
+            continue;
         }
 
         // All ordered pairs (a, b) where a != b
@@ -102,10 +109,10 @@ pub(crate) fn compute_coupling(
                 if i == j {
                     continue;
                 }
-                let a = files[i].to_string();
-                let b = files[j].to_string();
-                *support_count.entry((a.clone(), b.clone())).or_insert(0) += 1;
-                *co_occur.entry((a, b)).or_insert(0.0) += weight;
+                let key = (files[i].to_string(), files[j].to_string());
+                let entry = co_occur.entry(key).or_insert((0.0, 0));
+                entry.0 += weight;
+                entry.1 += 1;
             }
         }
     }
@@ -114,7 +121,7 @@ pub(crate) fn compute_coupling(
     let mut blast_radius: HashMap<String, Vec<CouplingEntry>> = HashMap::new();
     let mut graph_edges: HashMap<(String, String), (f64, usize)> = HashMap::new();
 
-    for ((a, b), weighted_co) in &co_occur {
+    for ((a, b), (weighted_co, sup)) in &co_occur {
         let total_a = weighted_total.get(a).copied().unwrap_or(0.0);
         if total_a == 0.0 {
             continue;
@@ -123,11 +130,7 @@ pub(crate) fn compute_coupling(
         if confidence < threshold {
             continue;
         }
-        let sup = support_count
-            .get(&(a.clone(), b.clone()))
-            .copied()
-            .unwrap_or(0);
-        if sup < min_support {
+        if *sup < min_support {
             continue;
         }
 
@@ -137,7 +140,7 @@ pub(crate) fn compute_coupling(
             .push(CouplingEntry {
                 path: b.clone(),
                 confidence,
-                support: sup,
+                support: *sup,
             });
 
         // De-duplicate edges: only store canonical (smaller, larger) pair
@@ -146,7 +149,7 @@ pub(crate) fn compute_coupling(
         } else {
             (b.clone(), a.clone())
         };
-        let entry = graph_edges.entry(edge_key).or_insert((0.0, sup));
+        let entry = graph_edges.entry(edge_key).or_insert((0.0, *sup));
         if confidence > entry.0 {
             entry.0 = confidence;
         }
@@ -393,6 +396,24 @@ pub(crate) fn compute_fix_after_touch(
 // Metric 6: Encapsulation
 // ============================================================================
 
+/// Extract the top-level directory component from a file path.
+///
+/// Returns `None` for root-level files (no directory component), e.g. `Makefile`.
+/// Returns `Some("src")` for `src/lib.rs`, `Some("tests")` for `tests/foo.rs`.
+fn extract_top_dir(path: &str) -> Option<String> {
+    let p = std::path::Path::new(path);
+    // Require at least one parent directory (not root-level files)
+    let parent = p.parent()?;
+    let s = parent.to_string_lossy();
+    if s.is_empty() || s == "." {
+        return None;
+    }
+    // Return the first path component as the module name
+    p.components()
+        .next()
+        .and_then(|c| c.as_os_str().to_str().map(String::from))
+}
+
 /// Compute module encapsulation health.
 ///
 /// For each directory, counts commits that touch ONLY that directory vs.
@@ -414,36 +435,16 @@ pub(crate) fn compute_encapsulation(
         let dirs: HashSet<String> = commit
             .files
             .iter()
-            .filter_map(|f| {
-                let p = std::path::Path::new(&f.path);
-                p.parent().and_then(|parent| {
-                    let s = parent.to_string_lossy();
-                    if s.is_empty() || s == "." {
-                        None
-                    } else {
-                        // Use first component only for top-level dir grouping
-                        p.components()
-                            .next()
-                            .and_then(|c| c.as_os_str().to_str().map(String::from))
-                    }
-                })
-            })
+            .filter_map(|f| extract_top_dir(&f.path))
             .collect();
 
         // Track files per module
         for file in &commit.files {
-            if let Some(dir) = std::path::Path::new(&file.path)
-                .components()
-                .next()
-                .and_then(|c| c.as_os_str().to_str().map(String::from))
-            {
-                if dir != file.path {
-                    // Skip root-level files
-                    module_files
-                        .entry(dir.clone())
-                        .or_default()
-                        .insert(file.path.clone());
-                }
+            if let Some(dir) = extract_top_dir(&file.path) {
+                module_files
+                    .entry(dir)
+                    .or_default()
+                    .insert(file.path.clone());
             }
         }
 
@@ -605,6 +606,24 @@ mod tests {
         assert!(!a_entries.is_empty());
         assert_eq!(a_entries[0].path, "b.rs");
         assert!(!graph.is_empty());
+    }
+
+    #[test]
+    fn test_coupling_large_commit_excluded_from_pairs() {
+        // Build a commit with COUPLING_MAX_FILES + 1 files — must not generate pairs,
+        // but the files should still appear in weighted_total (so they are not lost
+        // from the churn perspective).
+        let many_files: Vec<String> = (0..=COUPLING_MAX_FILES)
+            .map(|i| format!("file_{i}.rs"))
+            .collect();
+        let file_refs: Vec<&str> = many_files.iter().map(String::as_str).collect();
+        let commits = vec![make_commit("h1", "A", 1, "m", &file_refs)];
+
+        // With threshold=0.0 and min_support=1, any pair would be included if generated.
+        // The large-commit cap means zero pairs should appear.
+        let (blast, graph) = compute_coupling(&commits, 0.0, 1);
+        assert!(blast.is_empty(), "large commit must not generate coupling pairs");
+        assert!(graph.is_empty(), "large commit must not generate graph edges");
     }
 
     // -----------------------------------------------------------------------
@@ -815,5 +834,21 @@ mod tests {
         for window in result.windows(2) {
             assert!(window[0].encapsulation_pct <= window[1].encapsulation_pct);
         }
+    }
+
+    #[test]
+    fn test_extract_top_dir_root_level_file() {
+        assert_eq!(extract_top_dir("Makefile"), None);
+        assert_eq!(extract_top_dir("README.md"), None);
+    }
+
+    #[test]
+    fn test_extract_top_dir_nested_file() {
+        assert_eq!(extract_top_dir("src/lib.rs"), Some("src".to_string()));
+        assert_eq!(
+            extract_top_dir("src/cmd/heatmap/mod.rs"),
+            Some("src".to_string())
+        );
+        assert_eq!(extract_top_dir("tests/foo.rs"), Some("tests".to_string()));
     }
 }

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -83,10 +83,12 @@ pub(crate) fn compute_coupling(
     threshold: f64,
     min_support: usize,
 ) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
-    // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b)
-    let mut co_occur: HashMap<(String, String), (f64, usize)> = HashMap::new();
+    // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b).
+    // &str keys borrow from CommitRecord.files[].path — valid for entire function
+    // because `commits` (and therefore all CommitRecords) outlive these maps.
+    let mut co_occur: HashMap<(&str, &str), (f64, usize)> = HashMap::new();
     // weighted_total[a] = weighted sum of commits touching a
-    let mut weighted_total: HashMap<String, f64> = HashMap::new();
+    let mut weighted_total: HashMap<&str, f64> = HashMap::new();
 
     for commit in commits {
         let files: Vec<&str> = commit.files.iter().map(|f| f.path.as_str()).collect();
@@ -95,7 +97,7 @@ pub(crate) fn compute_coupling(
 
         // Every commit contributes to weighted_total for its files
         for f in &files {
-            *weighted_total.entry(f.to_string()).or_insert(0.0) += weight;
+            *weighted_total.entry(f).or_insert(0.0) += weight;
         }
 
         // Skip large commits for pair enumeration to avoid O(n^2) blowup
@@ -103,13 +105,13 @@ pub(crate) fn compute_coupling(
             continue;
         }
 
-        // All ordered pairs (a, b) where a != b
+        // All ordered pairs (a, b) where a != b — zero allocations in the hot path
         for i in 0..n {
             for j in 0..n {
                 if i == j {
                     continue;
                 }
-                let key = (files[i].to_string(), files[j].to_string());
+                let key = (files[i], files[j]);
                 let entry = co_occur.entry(key).or_insert((0.0, 0));
                 entry.0 += weight;
                 entry.1 += 1;
@@ -117,11 +119,12 @@ pub(crate) fn compute_coupling(
         }
     }
 
-    // Build blast_radius per file and global graph
+    // Build blast_radius per file and global graph — .to_string() only here,
+    // when building the owned output structures.
     let mut blast_radius: HashMap<String, Vec<CouplingEntry>> = HashMap::new();
     let mut graph_edges: HashMap<(String, String), (f64, usize)> = HashMap::new();
 
-    for ((a, b), (weighted_co, sup)) in &co_occur {
+    for (&(a, b), &(weighted_co, sup)) in &co_occur {
         let total_a = weighted_total.get(a).copied().unwrap_or(0.0);
         if total_a == 0.0 {
             continue;
@@ -130,26 +133,26 @@ pub(crate) fn compute_coupling(
         if confidence < threshold {
             continue;
         }
-        if *sup < min_support {
+        if sup < min_support {
             continue;
         }
 
         blast_radius
-            .entry(a.clone())
+            .entry(a.to_string())
             .or_default()
             .push(CouplingEntry {
-                path: b.clone(),
+                path: b.to_string(),
                 confidence,
-                support: *sup,
+                support: sup,
             });
 
         // De-duplicate edges: only store canonical (smaller, larger) pair
         let edge_key = if a <= b {
-            (a.clone(), b.clone())
+            (a.to_string(), b.to_string())
         } else {
-            (b.clone(), a.clone())
+            (b.to_string(), a.to_string())
         };
-        let entry = graph_edges.entry(edge_key).or_insert((0.0, *sup));
+        let entry = graph_edges.entry(edge_key).or_insert((0.0, sup));
         if confidence > entry.0 {
             entry.0 = confidence;
         }

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -373,10 +373,10 @@ pub(crate) fn compute_fix_after_touch(
                 (proximity_set.len() as f64 / total as f64) * 100.0
             };
 
-            // Union: commits flagged by either signal
-            let keyword_set: HashSet<usize> =
-                indices.iter().copied().filter(|&i| is_fix[i]).collect();
-            let union_count = keyword_set.union(&proximity_set).count();
+            // Union: fix commits (keyword) ∪ non-fix commits followed by a fix (proximity).
+            // The two sets are disjoint by construction (proximity_set only contains non-fix
+            // indices), so union_count = keyword_count + proximity_set.len().
+            let union_count = keyword_count + proximity_set.len();
             let combined_pct = (union_count as f64 / total as f64) * 100.0;
 
             (
@@ -622,8 +622,14 @@ mod tests {
         // With threshold=0.0 and min_support=1, any pair would be included if generated.
         // The large-commit cap means zero pairs should appear.
         let (blast, graph) = compute_coupling(&commits, 0.0, 1);
-        assert!(blast.is_empty(), "large commit must not generate coupling pairs");
-        assert!(graph.is_empty(), "large commit must not generate graph edges");
+        assert!(
+            blast.is_empty(),
+            "large commit must not generate coupling pairs"
+        );
+        assert!(
+            graph.is_empty(),
+            "large commit must not generate graph edges"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -160,11 +160,7 @@ pub(crate) fn compute_coupling(
 
     // Sort each blast radius by confidence descending
     for entries in blast_radius.values_mut() {
-        entries.sort_by(|x, y| {
-            y.confidence
-                .partial_cmp(&x.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        entries.sort_by(|x, y| y.confidence.total_cmp(&x.confidence));
     }
 
     let coupling_graph: Vec<CouplingEdge> = graph_edges
@@ -492,11 +488,7 @@ pub(crate) fn compute_encapsulation(
         .collect();
 
     // Sort by encapsulation_pct ascending (worst first)
-    results.sort_by(|a, b| {
-        a.encapsulation_pct
-            .partial_cmp(&b.encapsulation_pct)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    results.sort_by(|a, b| a.encapsulation_pct.total_cmp(&b.encapsulation_pct));
 
     results
 }

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -123,7 +123,10 @@ pub(crate) fn compute_coupling(
         if confidence < threshold {
             continue;
         }
-        let sup = support_count.get(&(a.clone(), b.clone())).copied().unwrap_or(0);
+        let sup = support_count
+            .get(&(a.clone(), b.clone()))
+            .copied()
+            .unwrap_or(0);
         if sup < min_support {
             continue;
         }
@@ -222,9 +225,8 @@ pub(crate) fn compute_stability(
             } else {
                 0.0
             };
-            // Exponential decay: recent = exp(-days/30). Invert: older = higher component.
-            let recency_component = 1.0 - (-days_since / 30.0_f64).exp();
-            let recency_component = recency_component.clamp(0.0, 1.0);
+            // Recent files are riskier: exp(-days/30) → 1.0 today, ~0 after months.
+            let recency_component = (-days_since / 30.0_f64).exp().clamp(0.0, 1.0);
 
             let fix_count = file_fix_count.get(&path).copied().unwrap_or(0);
             let volatility_component = if commit_count == 0 {
@@ -617,9 +619,9 @@ mod tests {
     }
 
     #[test]
-    fn test_stability_high_for_old_stable_file() {
+    fn test_stability_moderate_for_max_churn_old_file() {
         let fix_re = build_fix_regex();
-        // One commit, old (365 days ago), no fix keywords
+        // One commit, old (365 days ago), no fix keywords, but max churn (1/1)
         let old_ts = 0u64;
         let now = 365 * 86400u64;
         let commits = vec![make_commit(
@@ -631,12 +633,11 @@ mod tests {
         )];
         let result = compute_stability(&commits, &fix_re, 1, now);
         let score = result["stable.rs"];
-        // Old file with 1 commit should have a reasonable score
-        // Churn = 1/1 = 1.0, recency ≈ 1.0 (very old), volatility = 0
-        // penalty = 40 + 35 + 0 = 75, score = 25
+        // Churn = 1/1 = 1.0 → penalty 40, recency ≈ 0 (old), volatility = 0
+        // penalty ≈ 40, score ≈ 60
         assert!(
-            score <= 30,
-            "expected low score for churned+old file, got {score}"
+            score >= 50 && score <= 70,
+            "expected moderate score for max-churn but old file, got {score}"
         );
     }
 

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -104,9 +104,8 @@ pub(crate) fn compute_coupling(
                 }
                 let a = files[i].to_string();
                 let b = files[j].to_string();
-                let key = (a, b);
-                *co_occur.entry(key.clone()).or_insert(0.0) += weight;
-                *support_count.entry(key).or_insert(0) += 1;
+                *support_count.entry((a.clone(), b.clone())).or_insert(0) += 1;
+                *co_occur.entry((a, b)).or_insert(0.0) += weight;
             }
         }
     }
@@ -124,10 +123,7 @@ pub(crate) fn compute_coupling(
         if confidence < threshold {
             continue;
         }
-        let sup = support_count
-            .get(&(a.clone(), b.clone()))
-            .copied()
-            .unwrap_or(0);
+        let sup = support_count.get(&(a.clone(), b.clone())).copied().unwrap_or(0);
         if sup < min_support {
             continue;
         }
@@ -353,27 +349,10 @@ pub(crate) fn compute_fix_after_touch(
             // Proximity: non-fix commit at index i, followed by a fix commit
             // also touching this file within the next `window` commits
             let index_set: HashSet<usize> = indices.iter().copied().collect();
-            let mut proximity_count = 0usize;
             let non_fix_indices: Vec<usize> =
                 indices.iter().copied().filter(|&i| !is_fix[i]).collect();
 
-            for &idx in &non_fix_indices {
-                let upper = (idx + 1 + window).min(commits.len());
-                let found_fix = ((idx + 1)..upper).any(|j| is_fix[j] && index_set.contains(&j));
-                if found_fix {
-                    proximity_count += 1;
-                }
-            }
-
-            let proximity_pct = if non_fix_indices.is_empty() {
-                0.0
-            } else {
-                (proximity_count as f64 / total as f64) * 100.0
-            };
-
-            // Union: commits flagged by either signal
-            let keyword_set: HashSet<usize> =
-                indices.iter().copied().filter(|&i| is_fix[i]).collect();
+            // Build proximity set (non-fix indices followed by a fix within window)
             let proximity_set: HashSet<usize> = non_fix_indices
                 .iter()
                 .copied()
@@ -383,6 +362,15 @@ pub(crate) fn compute_fix_after_touch(
                 })
                 .collect();
 
+            let proximity_pct = if non_fix_indices.is_empty() {
+                0.0
+            } else {
+                (proximity_set.len() as f64 / total as f64) * 100.0
+            };
+
+            // Union: commits flagged by either signal
+            let keyword_set: HashSet<usize> =
+                indices.iter().copied().filter(|&i| is_fix[i]).collect();
             let union_count = keyword_set.union(&proximity_set).count();
             let combined_pct = (union_count as f64 / total as f64) * 100.0;
 

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -796,9 +796,9 @@ mod tests {
         //   proximity_set = {0} (size 1) → proximity_pct = 1/3*100 ≈ 33.33%
         //   union_count   = 2  → combined_pct = 2/3*100 ≈ 66.67%
         let commits = vec![
-            make_commit("h1", "Alice", 1, "feat: add",        &["a.rs"]),
-            make_commit("h2", "Alice", 2, "fix: bug in a",    &["a.rs"]),
-            make_commit("h3", "Alice", 3, "feat: more work",  &["a.rs"]),
+            make_commit("h1", "Alice", 1, "feat: add", &["a.rs"]),
+            make_commit("h2", "Alice", 2, "fix: bug in a", &["a.rs"]),
+            make_commit("h3", "Alice", 3, "feat: more work", &["a.rs"]),
         ];
         let fix_re = build_fix_regex();
         let result = compute_fix_after_touch(&commits, &fix_re, 5);
@@ -806,9 +806,9 @@ mod tests {
 
         assert!(!m.insufficient_data);
 
-        let expected_keyword_pct  = 100.0 / 3.0; // 33.33…
+        let expected_keyword_pct = 100.0 / 3.0; // 33.33…
         let expected_proximity_pct = 100.0 / 3.0; // 33.33…
-        let expected_combined_pct  = 200.0 / 3.0; // 66.67…
+        let expected_combined_pct = 200.0 / 3.0; // 66.67…
 
         assert!(
             (m.keyword_pct - expected_keyword_pct).abs() < 1e-9,

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -357,26 +357,28 @@ pub(crate) fn compute_fix_after_touch(
             let non_fix_indices: Vec<usize> =
                 indices.iter().copied().filter(|&i| !is_fix[i]).collect();
 
-            // Build proximity set (non-fix indices followed by a fix within window)
-            let proximity_set: HashSet<usize> = non_fix_indices
+            // Count non-fix indices followed by a fix within window (no need to
+            // materialise a set — uniqueness is guaranteed because each non-fix
+            // index appears at most once in non_fix_indices).
+            let proximity_count: usize = non_fix_indices
                 .iter()
                 .copied()
                 .filter(|&idx| {
                     let upper = (idx + 1 + window).min(commits.len());
                     ((idx + 1)..upper).any(|j| is_fix[j] && index_set.contains(&j))
                 })
-                .collect();
+                .count();
 
             let proximity_pct = if non_fix_indices.is_empty() {
                 0.0
             } else {
-                (proximity_set.len() as f64 / total as f64) * 100.0
+                (proximity_count as f64 / total as f64) * 100.0
             };
 
             // Union: fix commits (keyword) ∪ non-fix commits followed by a fix (proximity).
-            // The two sets are disjoint by construction (proximity_set only contains non-fix
-            // indices), so union_count = keyword_count + proximity_set.len().
-            let union_count = keyword_count + proximity_set.len();
+            // The two sets are disjoint by construction (proximity_count only counts non-fix
+            // indices), so union_count = keyword_count + proximity_count.
+            let union_count = keyword_count + proximity_count;
             let combined_pct = (union_count as f64 / total as f64) * 100.0;
 
             (

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -1,0 +1,830 @@
+//! Pure computation functions for `skim heatmap` — 6 risk metrics.
+//!
+//! Zero I/O. All functions accept `&[CommitRecord]` and return computed values.
+//! `now_epoch` is a parameter (not `SystemTime::now()`) for deterministic tests.
+
+use std::collections::{HashMap, HashSet};
+
+use regex::Regex;
+
+use super::types::{
+    AuthorMetrics, ChurnMetrics, CommitRecord, CouplingEdge, CouplingEntry, FixRiskMetrics,
+    ModuleHealth,
+};
+
+// ============================================================================
+// Fix keyword regex
+// ============================================================================
+
+/// Build the regex that identifies "fix" commits by subject keywords.
+pub(crate) fn build_fix_regex() -> Regex {
+    Regex::new(r"(?i)\b(fix|bug|hotfix|patch|revert)\b").expect("valid regex")
+}
+
+// ============================================================================
+// Metric 1: Churn
+// ============================================================================
+
+/// Count commits per file and compute rate = file_commits / total_commits.
+pub(crate) fn compute_churn(commits: &[CommitRecord]) -> HashMap<String, ChurnMetrics> {
+    let total = commits.len();
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    for commit in commits {
+        for file in &commit.files {
+            *counts.entry(file.path.clone()).or_insert(0) += 1;
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|(path, file_commits)| {
+            let rate = if total == 0 {
+                0.0
+            } else {
+                file_commits as f64 / total as f64
+            };
+            (
+                path,
+                ChurnMetrics {
+                    commits: file_commits,
+                    rate,
+                },
+            )
+        })
+        .collect()
+}
+
+// ============================================================================
+// Metric 2: Coupling
+// ============================================================================
+
+/// Compute file coupling from commit co-occurrences.
+///
+/// Weights each pair's contribution by `1.0 / sqrt(files_in_commit)` to
+/// discount large commits (e.g. reformatting all files at once).
+///
+/// Returns:
+/// - per-file blast radius map: `HashMap<String, Vec<CouplingEntry>>`
+/// - global coupling graph: `Vec<CouplingEdge>`
+pub(crate) fn compute_coupling(
+    commits: &[CommitRecord],
+    threshold: f64,
+    min_support: usize,
+) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
+    // co_occurrences[(a, b)] = weighted sum of commits where a and b appear together
+    let mut co_occur: HashMap<(String, String), f64> = HashMap::new();
+    // weighted_total[a] = weighted sum of commits touching a
+    let mut weighted_total: HashMap<String, f64> = HashMap::new();
+    // support[(a,b)] = raw commit count (for filtering)
+    let mut support_count: HashMap<(String, String), usize> = HashMap::new();
+
+    for commit in commits {
+        let files: Vec<&str> = commit.files.iter().map(|f| f.path.as_str()).collect();
+        let n = files.len();
+        if n < 2 {
+            // A single-file commit contributes to weighted_total but not coupling
+            for f in &files {
+                let w = 1.0 / (n as f64).sqrt();
+                *weighted_total.entry(f.to_string()).or_insert(0.0) += w;
+            }
+            continue;
+        }
+        let weight = 1.0 / (n as f64).sqrt();
+
+        for f in &files {
+            *weighted_total.entry(f.to_string()).or_insert(0.0) += weight;
+        }
+
+        // All ordered pairs (a, b) where a != b
+        for i in 0..n {
+            for j in 0..n {
+                if i == j {
+                    continue;
+                }
+                let a = files[i].to_string();
+                let b = files[j].to_string();
+                let key = (a, b);
+                *co_occur.entry(key.clone()).or_insert(0.0) += weight;
+                *support_count.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // Build blast_radius per file and global graph
+    let mut blast_radius: HashMap<String, Vec<CouplingEntry>> = HashMap::new();
+    let mut graph_edges: HashMap<(String, String), (f64, usize)> = HashMap::new();
+
+    for ((a, b), weighted_co) in &co_occur {
+        let total_a = weighted_total.get(a).copied().unwrap_or(0.0);
+        if total_a == 0.0 {
+            continue;
+        }
+        let confidence = weighted_co / total_a;
+        if confidence < threshold {
+            continue;
+        }
+        let sup = support_count
+            .get(&(a.clone(), b.clone()))
+            .copied()
+            .unwrap_or(0);
+        if sup < min_support {
+            continue;
+        }
+
+        blast_radius
+            .entry(a.clone())
+            .or_default()
+            .push(CouplingEntry {
+                path: b.clone(),
+                confidence,
+                support: sup,
+            });
+
+        // De-duplicate edges: only store canonical (smaller, larger) pair
+        let edge_key = if a <= b {
+            (a.clone(), b.clone())
+        } else {
+            (b.clone(), a.clone())
+        };
+        let entry = graph_edges.entry(edge_key).or_insert((0.0, sup));
+        if confidence > entry.0 {
+            entry.0 = confidence;
+        }
+    }
+
+    // Sort each blast radius by confidence descending
+    for entries in blast_radius.values_mut() {
+        entries.sort_by(|x, y| {
+            y.confidence
+                .partial_cmp(&x.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+
+    let coupling_graph: Vec<CouplingEdge> = graph_edges
+        .into_iter()
+        .map(|((a, b), (confidence, support))| CouplingEdge {
+            a,
+            b,
+            confidence,
+            support,
+        })
+        .collect();
+
+    (blast_radius, coupling_graph)
+}
+
+// ============================================================================
+// Metric 3: Stability
+// ============================================================================
+
+/// Compute a stability score [0, 100] for each file.
+///
+/// Formula: `100 - (churn_component * 40 + recency_component * 35 + volatility_component * 25)`
+///
+/// - `churn_component` = file_commits / max_churn (0–1)
+/// - `recency_component` = inverted exponential decay based on days since last change
+/// - `volatility_component` = fix_commits / total_commits for the file
+///
+/// `now_epoch` is a parameter so tests are deterministic.
+pub(crate) fn compute_stability(
+    commits: &[CommitRecord],
+    fix_regex: &Regex,
+    max_churn: usize,
+    now_epoch: u64,
+) -> HashMap<String, u8> {
+    // Per-file commit info
+    let mut file_commits: HashMap<String, Vec<u64>> = HashMap::new(); // file -> timestamps
+    let mut file_fix_count: HashMap<String, usize> = HashMap::new();
+
+    for commit in commits {
+        let is_fix = fix_regex.is_match(&commit.subject);
+        for file in &commit.files {
+            file_commits
+                .entry(file.path.clone())
+                .or_default()
+                .push(commit.timestamp);
+            if is_fix {
+                *file_fix_count.entry(file.path.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let effective_max = max_churn.max(1);
+
+    file_commits
+        .into_iter()
+        .map(|(path, timestamps)| {
+            let commit_count = timestamps.len();
+            let churn_component = (commit_count as f64 / effective_max as f64).min(1.0);
+
+            // Recency: days since last commit. Decay half-life ~30 days.
+            let last_ts = timestamps.iter().copied().max().unwrap_or(0);
+            let days_since = if now_epoch >= last_ts {
+                ((now_epoch - last_ts) as f64) / 86400.0
+            } else {
+                0.0
+            };
+            // Exponential decay: recent = exp(-days/30). Invert: older = higher component.
+            let recency_component = 1.0 - (-days_since / 30.0_f64).exp();
+            let recency_component = recency_component.clamp(0.0, 1.0);
+
+            let fix_count = file_fix_count.get(&path).copied().unwrap_or(0);
+            let volatility_component = if commit_count == 0 {
+                0.0
+            } else {
+                (fix_count as f64 / commit_count as f64).min(1.0)
+            };
+
+            let penalty =
+                churn_component * 40.0 + recency_component * 35.0 + volatility_component * 25.0;
+            let score = (100.0 - penalty).round().clamp(0.0, 100.0) as u8;
+
+            (path, score)
+        })
+        .collect()
+}
+
+// ============================================================================
+// Metric 4: Author diversity
+// ============================================================================
+
+/// Compute author diversity metrics per file.
+pub(crate) fn compute_authors(commits: &[CommitRecord]) -> HashMap<String, AuthorMetrics> {
+    // file -> author -> commit_count
+    let mut file_author_counts: HashMap<String, HashMap<String, usize>> = HashMap::new();
+
+    for commit in commits {
+        for file in &commit.files {
+            *file_author_counts
+                .entry(file.path.clone())
+                .or_default()
+                .entry(commit.author.clone())
+                .or_insert(0) += 1;
+        }
+    }
+
+    file_author_counts
+        .into_iter()
+        .map(|(path, author_counts)| {
+            let total: usize = author_counts.values().sum();
+            if total == 0 {
+                return (
+                    path,
+                    AuthorMetrics {
+                        count: 0,
+                        top_author_pct: 0.0,
+                        single_owner_risk: false,
+                    },
+                );
+            }
+
+            let max_count = author_counts.values().copied().max().unwrap_or(0);
+            let top_author_pct = (max_count as f64 / total as f64) * 100.0;
+            let single_owner_risk = top_author_pct > 80.0;
+
+            // Authors with >5% of commits
+            let threshold = (total as f64 * 0.05).ceil() as usize;
+            let count = author_counts.values().filter(|&&c| c >= threshold).count();
+
+            (
+                path,
+                AuthorMetrics {
+                    count,
+                    top_author_pct,
+                    single_owner_risk,
+                },
+            )
+        })
+        .collect()
+}
+
+// ============================================================================
+// Metric 5: Fix-after-touch
+// ============================================================================
+
+/// Compute fix-after-touch risk per file.
+///
+/// - `keyword_pct`: percentage of commits touching the file that are fix commits.
+/// - `proximity_pct`: percentage of non-fix commits after which a fix commit
+///   also touching the file appears within `window` commits.
+/// - `combined_pct`: union (not sum) of the two signals.
+/// - `insufficient_data`: true when the file has <2 commits.
+pub(crate) fn compute_fix_after_touch(
+    commits: &[CommitRecord],
+    fix_regex: &Regex,
+    window: usize,
+) -> HashMap<String, FixRiskMetrics> {
+    // Classify every commit
+    let is_fix: Vec<bool> = commits
+        .iter()
+        .map(|c| fix_regex.is_match(&c.subject))
+        .collect();
+
+    // Per-file: which commit indices touch it?
+    let mut file_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, commit) in commits.iter().enumerate() {
+        for file in &commit.files {
+            file_indices.entry(file.path.clone()).or_default().push(i);
+        }
+    }
+
+    file_indices
+        .into_iter()
+        .map(|(path, indices)| {
+            let total = indices.len();
+            if total < 2 {
+                return (
+                    path,
+                    FixRiskMetrics {
+                        keyword_pct: 0.0,
+                        proximity_pct: 0.0,
+                        combined_pct: 0.0,
+                        insufficient_data: true,
+                    },
+                );
+            }
+
+            // Keyword: fix commits touching this file
+            let keyword_count = indices.iter().filter(|&&i| is_fix[i]).count();
+            let keyword_pct = (keyword_count as f64 / total as f64) * 100.0;
+
+            // Proximity: non-fix commit at index i, followed by a fix commit
+            // also touching this file within the next `window` commits
+            let index_set: HashSet<usize> = indices.iter().copied().collect();
+            let mut proximity_count = 0usize;
+            let non_fix_indices: Vec<usize> =
+                indices.iter().copied().filter(|&i| !is_fix[i]).collect();
+
+            for &idx in &non_fix_indices {
+                let upper = (idx + 1 + window).min(commits.len());
+                let found_fix = ((idx + 1)..upper).any(|j| is_fix[j] && index_set.contains(&j));
+                if found_fix {
+                    proximity_count += 1;
+                }
+            }
+
+            let proximity_pct = if non_fix_indices.is_empty() {
+                0.0
+            } else {
+                (proximity_count as f64 / total as f64) * 100.0
+            };
+
+            // Union: commits flagged by either signal
+            let keyword_set: HashSet<usize> =
+                indices.iter().copied().filter(|&i| is_fix[i]).collect();
+            let proximity_set: HashSet<usize> = non_fix_indices
+                .iter()
+                .copied()
+                .filter(|&idx| {
+                    let upper = (idx + 1 + window).min(commits.len());
+                    ((idx + 1)..upper).any(|j| is_fix[j] && index_set.contains(&j))
+                })
+                .collect();
+
+            let union_count = keyword_set.union(&proximity_set).count();
+            let combined_pct = (union_count as f64 / total as f64) * 100.0;
+
+            (
+                path,
+                FixRiskMetrics {
+                    keyword_pct,
+                    proximity_pct,
+                    combined_pct,
+                    insufficient_data: false,
+                },
+            )
+        })
+        .collect()
+}
+
+// ============================================================================
+// Metric 6: Encapsulation
+// ============================================================================
+
+/// Compute module encapsulation health.
+///
+/// For each directory, counts commits that touch ONLY that directory vs.
+/// commits that also touch other directories (cross-boundary).
+///
+/// Filters modules with fewer than `min_commits` total commits.
+/// Returns results sorted by encapsulation_pct ascending (worst first).
+pub(crate) fn compute_encapsulation(
+    commits: &[CommitRecord],
+    min_commits: usize,
+) -> Vec<ModuleHealth> {
+    // module -> files seen
+    let mut module_files: HashMap<String, HashSet<String>> = HashMap::new();
+    // module -> (total_commits, cross_boundary_commits)
+    let mut module_stats: HashMap<String, (usize, usize)> = HashMap::new();
+
+    for commit in commits {
+        // Collect unique top-level directories for this commit
+        let dirs: HashSet<String> = commit
+            .files
+            .iter()
+            .filter_map(|f| {
+                let p = std::path::Path::new(&f.path);
+                p.parent().and_then(|parent| {
+                    let s = parent.to_string_lossy();
+                    if s.is_empty() || s == "." {
+                        None
+                    } else {
+                        // Use first component only for top-level dir grouping
+                        p.components()
+                            .next()
+                            .and_then(|c| c.as_os_str().to_str().map(String::from))
+                    }
+                })
+            })
+            .collect();
+
+        // Track files per module
+        for file in &commit.files {
+            if let Some(dir) = std::path::Path::new(&file.path)
+                .components()
+                .next()
+                .and_then(|c| c.as_os_str().to_str().map(String::from))
+            {
+                if dir != file.path {
+                    // Skip root-level files
+                    module_files
+                        .entry(dir.clone())
+                        .or_default()
+                        .insert(file.path.clone());
+                }
+            }
+        }
+
+        // Cross-boundary = commit touches >1 module
+        let is_cross = dirs.len() > 1;
+        for dir in &dirs {
+            let entry = module_stats.entry(dir.clone()).or_insert((0, 0));
+            entry.0 += 1;
+            if is_cross {
+                entry.1 += 1;
+            }
+        }
+    }
+
+    let mut results: Vec<ModuleHealth> = module_stats
+        .into_iter()
+        .filter_map(|(path, (total_commits, cross_boundary_commits))| {
+            if total_commits < min_commits {
+                return None;
+            }
+            let encapsulation_pct = if total_commits == 0 {
+                100.0
+            } else {
+                let internal = total_commits.saturating_sub(cross_boundary_commits);
+                (internal as f64 / total_commits as f64) * 100.0
+            };
+            let files_count = module_files.get(&path).map(|s| s.len()).unwrap_or(0);
+            Some(ModuleHealth {
+                path,
+                encapsulation_pct,
+                files_count,
+                total_commits,
+                cross_boundary_commits,
+            })
+        })
+        .collect();
+
+    // Sort by encapsulation_pct ascending (worst first)
+    results.sort_by(|a, b| {
+        a.encapsulation_pct
+            .partial_cmp(&b.encapsulation_pct)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::cmd::heatmap::types::FileChange;
+
+    fn make_commit(
+        hash: &str,
+        author: &str,
+        ts: u64,
+        subject: &str,
+        files: &[&str],
+    ) -> CommitRecord {
+        CommitRecord {
+            hash: hash.to_string(),
+            author: author.to_string(),
+            timestamp: ts,
+            subject: subject.to_string(),
+            files: files
+                .iter()
+                .map(|p| FileChange {
+                    path: p.to_string(),
+                    additions: 1,
+                    deletions: 0,
+                })
+                .collect(),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_churn
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_churn_empty() {
+        let result = compute_churn(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_churn_single_commit() {
+        let commits = vec![make_commit("h1", "Alice", 1000, "msg", &["a.rs"])];
+        let result = compute_churn(&commits);
+        let m = result.get("a.rs").unwrap();
+        assert_eq!(m.commits, 1);
+        assert!((m.rate - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_churn_multiple_commits() {
+        let commits = vec![
+            make_commit("h1", "Alice", 1000, "msg", &["a.rs", "b.rs"]),
+            make_commit("h2", "Bob", 2000, "msg", &["a.rs"]),
+        ];
+        let result = compute_churn(&commits);
+        assert_eq!(result["a.rs"].commits, 2);
+        assert_eq!(result["b.rs"].commits, 1);
+        assert!((result["a.rs"].rate - 1.0).abs() < 1e-9); // 2/2
+        assert!((result["b.rs"].rate - 0.5).abs() < 1e-9); // 1/2
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_coupling
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_coupling_empty() {
+        let (blast, graph) = compute_coupling(&[], 0.5, 1);
+        assert!(blast.is_empty());
+        assert!(graph.is_empty());
+    }
+
+    #[test]
+    fn test_coupling_below_threshold_excluded() {
+        // 3 commits: a.rs and b.rs appear together in 1, a.rs alone in 2 others.
+        // weighted_total[a] = 1/sqrt(2) + 1/sqrt(1) + 1/sqrt(1) ≈ 0.707 + 2 = 2.707
+        // co_occur[(a,b)] = 1/sqrt(2) ≈ 0.707
+        // confidence(a→b) = 0.707 / 2.707 ≈ 0.261
+        // threshold 0.5 should exclude this pair
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "msg", &["a.rs", "b.rs"]),
+            make_commit("h2", "Alice", 2, "msg", &["a.rs"]),
+            make_commit("h3", "Alice", 3, "msg", &["a.rs"]),
+        ];
+        let (blast, _graph) = compute_coupling(&commits, 0.5, 1);
+        // confidence ~0.261 < 0.5, so no coupling entries for a.rs
+        let a_entries = blast.get("a.rs").map(|v| v.len()).unwrap_or(0);
+        assert_eq!(a_entries, 0);
+    }
+
+    #[test]
+    fn test_coupling_below_min_support_excluded() {
+        let commits = vec![make_commit("h1", "Alice", 1000, "msg", &["a.rs", "b.rs"])];
+        let (blast, _graph) = compute_coupling(&commits, 0.0, 5); // min_support=5, only 1 commit
+        assert_eq!(blast.get("a.rs").map(|v| v.len()).unwrap_or(0), 0);
+    }
+
+    #[test]
+    fn test_coupling_strong_pair() {
+        // a.rs and b.rs always appear together
+        let commits = vec![
+            make_commit("h1", "A", 1, "m", &["a.rs", "b.rs"]),
+            make_commit("h2", "A", 2, "m", &["a.rs", "b.rs"]),
+            make_commit("h3", "A", 3, "m", &["a.rs", "b.rs"]),
+        ];
+        let (blast, graph) = compute_coupling(&commits, 0.5, 3);
+        let a_entries = blast.get("a.rs").unwrap();
+        assert!(!a_entries.is_empty());
+        assert_eq!(a_entries[0].path, "b.rs");
+        assert!(!graph.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_stability
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_stability_empty() {
+        let fix_re = build_fix_regex();
+        let result = compute_stability(&[], &fix_re, 0, 0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_stability_high_for_old_stable_file() {
+        let fix_re = build_fix_regex();
+        // One commit, old (365 days ago), no fix keywords
+        let old_ts = 0u64;
+        let now = 365 * 86400u64;
+        let commits = vec![make_commit(
+            "h1",
+            "Alice",
+            old_ts,
+            "feat: initial",
+            &["stable.rs"],
+        )];
+        let result = compute_stability(&commits, &fix_re, 1, now);
+        let score = result["stable.rs"];
+        // Old file with 1 commit should have a reasonable score
+        // Churn = 1/1 = 1.0, recency ≈ 1.0 (very old), volatility = 0
+        // penalty = 40 + 35 + 0 = 75, score = 25
+        assert!(
+            score <= 30,
+            "expected low score for churned+old file, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_stability_recent_fix_lowers_score() {
+        let fix_re = build_fix_regex();
+        let now = 1_000_000u64;
+        let commits = vec![make_commit(
+            "h1",
+            "Alice",
+            now - 100,
+            "fix: critical bug",
+            &["risky.rs"],
+        )];
+        let result = compute_stability(&commits, &fix_re, 1, now);
+        let score = result["risky.rs"];
+        // Recent fix commit → low stability
+        assert!(score < 50, "expected low score for recent fix, got {score}");
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_authors
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_authors_empty() {
+        let result = compute_authors(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_authors_single_owner() {
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "m", &["a.rs"]),
+            make_commit("h2", "Alice", 2, "m", &["a.rs"]),
+            make_commit("h3", "Alice", 3, "m", &["a.rs"]),
+        ];
+        let result = compute_authors(&commits);
+        let m = &result["a.rs"];
+        assert!(m.single_owner_risk);
+        assert!((m.top_author_pct - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_authors_multiple_owners() {
+        let mut commits = Vec::new();
+        for i in 0..5u64 {
+            commits.push(make_commit(&format!("h{i}"), "Alice", i, "m", &["a.rs"]));
+        }
+        commits.push(make_commit("h5", "Bob", 5, "m", &["a.rs"]));
+        let result = compute_authors(&commits);
+        let m = &result["a.rs"];
+        // Alice: 5/6 = 83.3% → single_owner_risk = true
+        assert!(m.single_owner_risk);
+    }
+
+    #[test]
+    fn test_authors_no_single_owner_risk() {
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "m", &["a.rs"]),
+            make_commit("h2", "Bob", 2, "m", &["a.rs"]),
+            make_commit("h3", "Charlie", 3, "m", &["a.rs"]),
+            make_commit("h4", "Dave", 4, "m", &["a.rs"]),
+            make_commit("h5", "Eve", 5, "m", &["a.rs"]),
+        ];
+        let result = compute_authors(&commits);
+        // Each author has 20% → no single owner
+        assert!(!result["a.rs"].single_owner_risk);
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_fix_after_touch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_fix_risk_empty() {
+        let fix_re = build_fix_regex();
+        let result = compute_fix_after_touch(&[], &fix_re, 5);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_fix_risk_single_commit_insufficient_data() {
+        let commits = vec![make_commit("h1", "Alice", 1, "feat: add", &["a.rs"])];
+        let fix_re = build_fix_regex();
+        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        assert!(result["a.rs"].insufficient_data);
+    }
+
+    #[test]
+    fn test_fix_risk_keyword_detection() {
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "feat: add", &["a.rs"]),
+            make_commit("h2", "Alice", 2, "fix: bug in a", &["a.rs"]),
+        ];
+        let fix_re = build_fix_regex();
+        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let m = &result["a.rs"];
+        assert!(!m.insufficient_data);
+        // 1 fix commit out of 2 = 50%
+        assert!((m.keyword_pct - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_fix_risk_proximity_detection() {
+        // commit 0: feat touching a.rs
+        // commit 1: fix touching a.rs (within window of commit 0)
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "feat: add", &["a.rs"]),
+            make_commit("h2", "Alice", 2, "fix: quick patch", &["a.rs"]),
+        ];
+        let fix_re = build_fix_regex();
+        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let m = &result["a.rs"];
+        assert!(!m.insufficient_data);
+        assert!(m.proximity_pct > 0.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_encapsulation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_encapsulation_empty() {
+        let result = compute_encapsulation(&[], 1);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_encapsulation_single_module() {
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "m", &["src/a.rs", "src/b.rs"]),
+            make_commit("h2", "Alice", 2, "m", &["src/c.rs"]),
+            make_commit("h3", "Alice", 3, "m", &["src/d.rs"]),
+        ];
+        let result = compute_encapsulation(&commits, 1);
+        // All commits touch only "src" module → 100% encapsulation
+        let src = result.iter().find(|m| m.path == "src").unwrap();
+        assert!((src.encapsulation_pct - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_encapsulation_cross_boundary() {
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "m", &["src/a.rs", "tests/b.rs"]),
+            make_commit("h2", "Alice", 2, "m", &["src/c.rs"]),
+            make_commit("h3", "Alice", 3, "m", &["src/d.rs"]),
+        ];
+        let result = compute_encapsulation(&commits, 1);
+        let src = result.iter().find(|m| m.path == "src").unwrap();
+        // 1 cross-boundary out of 3 → 66.7% internal → encapsulation = 66.7%
+        assert!(src.encapsulation_pct < 100.0);
+        assert_eq!(src.cross_boundary_commits, 1);
+    }
+
+    #[test]
+    fn test_encapsulation_min_commits_filter() {
+        let commits = vec![make_commit("h1", "Alice", 1, "m", &["src/a.rs"])];
+        let result = compute_encapsulation(&commits, 3); // requires ≥3 commits
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_encapsulation_sorted_ascending() {
+        let commits = vec![
+            // src: 1 cross out of 2 = 50% encapsulation
+            make_commit("h1", "Alice", 1, "m", &["src/a.rs", "lib/b.rs"]),
+            make_commit("h2", "Alice", 2, "m", &["src/c.rs"]),
+            // lib: 1 cross out of 2 = 50% encapsulation — both should be returned
+            make_commit("h3", "Alice", 3, "m", &["lib/d.rs"]),
+            make_commit("h4", "Alice", 4, "m", &["lib/e.rs", "src/f.rs"]),
+        ];
+        let result = compute_encapsulation(&commits, 1);
+        // Sorted ascending by encapsulation_pct
+        for window in result.windows(2) {
+            assert!(window[0].encapsulation_pct <= window[1].encapsulation_pct);
+        }
+    }
+}

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -778,7 +778,53 @@ mod tests {
         let result = compute_fix_after_touch(&commits, &fix_re, 5);
         let m = &result["a.rs"];
         assert!(!m.insufficient_data);
-        assert!(m.proximity_pct > 0.0);
+        // total=2, proximity_set={0}, proximity_pct = 1/2*100 = 50%
+        assert!((m.proximity_pct - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_fix_risk_combined_both_signals() {
+        // Exercises the disjointness optimization: keyword_count + proximity_set.len().
+        //
+        // commit 0 (idx 0): feat touching a.rs → non-fix
+        // commit 1 (idx 1): fix touching a.rs  → keyword hit; also within window of idx 0
+        //                                         so idx 0 enters proximity_set
+        // commit 2 (idx 2): feat touching a.rs → non-fix (outside window trailing edge)
+        //
+        // Expected for a.rs (total=3):
+        //   keyword_count = 1  → keyword_pct  = 1/3*100 ≈ 33.33%
+        //   proximity_set = {0} (size 1) → proximity_pct = 1/3*100 ≈ 33.33%
+        //   union_count   = 2  → combined_pct = 2/3*100 ≈ 66.67%
+        let commits = vec![
+            make_commit("h1", "Alice", 1, "feat: add",        &["a.rs"]),
+            make_commit("h2", "Alice", 2, "fix: bug in a",    &["a.rs"]),
+            make_commit("h3", "Alice", 3, "feat: more work",  &["a.rs"]),
+        ];
+        let fix_re = build_fix_regex();
+        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let m = &result["a.rs"];
+
+        assert!(!m.insufficient_data);
+
+        let expected_keyword_pct  = 100.0 / 3.0; // 33.33…
+        let expected_proximity_pct = 100.0 / 3.0; // 33.33…
+        let expected_combined_pct  = 200.0 / 3.0; // 66.67…
+
+        assert!(
+            (m.keyword_pct - expected_keyword_pct).abs() < 1e-9,
+            "keyword_pct: expected {expected_keyword_pct}, got {}",
+            m.keyword_pct
+        );
+        assert!(
+            (m.proximity_pct - expected_proximity_pct).abs() < 1e-9,
+            "proximity_pct: expected {expected_proximity_pct}, got {}",
+            m.proximity_pct
+        );
+        assert!(
+            (m.combined_pct - expected_combined_pct).abs() < 1e-9,
+            "combined_pct: expected {expected_combined_pct}, got {}",
+            m.combined_pct
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -433,18 +433,22 @@ pub(crate) fn compute_encapsulation(
     let mut module_stats: HashMap<String, (usize, usize)> = HashMap::new();
 
     for commit in commits {
-        // Collect unique top-level directories for this commit
-        let dirs: HashSet<String> = commit
+        // Precompute top-level directory for each file once to avoid calling
+        // extract_top_dir twice per file (once for dirs, once for module_files).
+        let file_dirs: Vec<Option<String>> = commit
             .files
             .iter()
-            .filter_map(|f| extract_top_dir(&f.path))
+            .map(|f| extract_top_dir(&f.path))
             .collect();
 
+        // Collect unique top-level directories for this commit
+        let dirs: HashSet<&str> = file_dirs.iter().filter_map(|d| d.as_deref()).collect();
+
         // Track files per module
-        for file in &commit.files {
-            if let Some(dir) = extract_top_dir(&file.path) {
+        for (file, dir) in commit.files.iter().zip(file_dirs.iter()) {
+            if let Some(ref d) = dir {
                 module_files
-                    .entry(dir)
+                    .entry(d.clone())
                     .or_default()
                     .insert(file.path.clone());
             }
@@ -453,7 +457,7 @@ pub(crate) fn compute_encapsulation(
         // Cross-boundary = commit touches >1 module
         let is_cross = dirs.len() > 1;
         for dir in &dirs {
-            let entry = module_stats.entry(dir.clone()).or_insert((0, 0));
+            let entry = module_stats.entry(dir.to_string()).or_insert((0, 0));
             entry.0 += 1;
             if is_cross {
                 entry.1 += 1;

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -28,7 +28,8 @@ use metrics::{
 };
 use output::{render_json, render_text};
 use types::{
-    AuthorMetrics, FileMetrics, FixRiskMetrics, HeatmapConfig, HeatmapResult, WindowInfo,
+    AuthorMetrics, CommitRecord, FileMetrics, FixRiskMetrics, HeatmapConfig, HeatmapResult,
+    WindowInfo,
 };
 
 // ============================================================================
@@ -184,10 +185,78 @@ fn run_with_source(
         return Ok(ExitCode::FAILURE);
     }
 
-    // Step 5: Compute metrics (now_epoch captured once in Step 2, reused here)
+    // Steps 5-9: Compute metrics and assemble result
     let start_time = std::time::Instant::now();
+    let mut result = compute_heatmap(
+        commits,
+        config,
+        &effective_config,
+        now_epoch,
+        repo_root,
+        warnings,
+        config.debug,
+    );
+
+    // Apply --top N limit to files
+    result.files.truncate(config.top_n);
+
+    // Step 10: Render
+    let elapsed = start_time.elapsed();
+    let mut stdout = io::stdout().lock();
+
+    if config.format_json {
+        let json = render_json(&result)?;
+        writeln!(stdout, "{json}")?;
+    } else {
+        let text = render_text(&result, config.top_n);
+        write!(stdout, "{text}")?;
+    }
+
+    // Step 11: Fire-and-forget analytics
+    let rec = RecordingContext {
+        enabled: analytics.enabled,
+        command_type: CommandType::Heatmap,
+        parse_tier: None,
+        session_id: analytics.session_id.as_deref(),
+    };
+    crate::analytics::try_record_command(
+        rec,
+        String::new(), // no raw text for heatmap
+        String::new(), // no compressed text
+        "skim heatmap".to_string(),
+        elapsed,
+    );
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// ============================================================================
+// Pure metric computation (Steps 5-9)
+// ============================================================================
+
+/// Compute all six risk metrics from commits and assemble a `HeatmapResult`.
+///
+/// This is a pure function — no I/O, no side effects. All git I/O is handled
+/// by the callers (Steps 1-4 in `run_with_source`). Accepting `now_epoch` as a
+/// parameter (instead of calling `SystemTime::now()` here) keeps the function
+/// deterministic and testable.
+///
+/// `debug` controls whether timing is emitted to stderr.
+fn compute_heatmap(
+    commits: Vec<CommitRecord>,
+    config: &HeatmapConfig,
+    effective_config: &HeatmapConfig,
+    now_epoch: u64,
+    repository: String,
+    warnings: Vec<String>,
+    debug: bool,
+) -> HeatmapResult {
+    use std::time::Instant;
+
+    let t0 = Instant::now();
     let fix_regex = build_fix_regex();
 
+    // Step 5: Compute metrics
     let churn_map = compute_churn(&commits);
     let max_churn = churn_map.values().map(|m| m.commits).max().unwrap_or(1);
     let stability_map = compute_stability(&commits, &fix_regex, max_churn, now_epoch);
@@ -197,11 +266,11 @@ fn run_with_source(
         compute_coupling(&commits, config.coupling_threshold, 3);
     let modules = compute_encapsulation(&commits, 3);
 
-    if config.debug {
-        let compute_elapsed = start_time.elapsed();
+    if debug {
+        let elapsed = t0.elapsed();
         eprintln!(
             "[skim:heatmap] metrics computed in {:.1}ms — {} files, {} coupling edges, {} modules",
-            compute_elapsed.as_secs_f64() * 1000.0,
+            elapsed.as_secs_f64() * 1000.0,
             churn_map.len(),
             coupling_graph.len(),
             modules.len(),
@@ -243,7 +312,7 @@ fn run_with_source(
     file_metrics.sort_by(|a, b| a.stability_score.cmp(&b.stability_score));
 
     // Step 7: Build window info
-    let window_info = build_window_info(&effective_config, commits.len(), now_epoch);
+    let window_info = build_window_info(effective_config, commits.len(), now_epoch);
 
     // Step 8: Get excluded patterns for output
     let excluded_patterns: Vec<String> = if config.no_exclude {
@@ -257,49 +326,17 @@ fn run_with_source(
     };
 
     // Step 9: Build result
-    let mut result = HeatmapResult {
+    HeatmapResult {
         version: 1,
         generated_at: format_epoch(now_epoch),
-        repository: repo_root,
+        repository,
         window: window_info,
         files: file_metrics,
         modules,
         coupling_graph,
         excluded_patterns,
         warnings,
-    };
-
-    // Apply --top N limit to files
-    result.files.truncate(config.top_n);
-
-    // Step 10: Render
-    let elapsed = start_time.elapsed();
-    let mut stdout = io::stdout().lock();
-
-    if config.format_json {
-        let json = render_json(&result)?;
-        writeln!(stdout, "{json}")?;
-    } else {
-        let text = render_text(&result, config.top_n);
-        write!(stdout, "{text}")?;
     }
-
-    // Step 11: Fire-and-forget analytics
-    let rec = RecordingContext {
-        enabled: analytics.enabled,
-        command_type: CommandType::Heatmap,
-        parse_tier: None,
-        session_id: analytics.session_id.as_deref(),
-    };
-    crate::analytics::try_record_command(
-        rec,
-        String::new(), // no raw text for heatmap
-        String::new(), // no compressed text
-        "skim heatmap".to_string(),
-        elapsed,
-    );
-
-    Ok(ExitCode::SUCCESS)
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -14,6 +14,7 @@ mod metrics;
 mod output;
 mod types;
 
+use std::collections::HashSet;
 use std::io::{self, Write};
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -28,8 +29,8 @@ use metrics::{
 };
 use output::{render_json, render_text};
 use types::{
-    AuthorMetrics, ChurnMetrics, CouplingEntry, FileMetrics, FixRiskMetrics, HeatmapConfig,
-    HeatmapResult, WindowInfo,
+    AuthorMetrics, ChurnMetrics, FileMetrics, FixRiskMetrics, HeatmapConfig, HeatmapResult,
+    WindowInfo,
 };
 
 // ============================================================================
@@ -74,25 +75,27 @@ pub(crate) fn run(
         }
     };
 
-    let source = CliGitSource::new();
-    run_with_source(&source, &config, analytics)
+    let git_source = CliGitSource::new();
+    run_with_source(&git_source, &git_source, &config, analytics)
 }
 
 /// Orchestration with injected data source (enables testing).
+///
+/// `git` handles infrastructure checks (repo detection, root, shallow clone,
+/// commit count). `source` handles the actual commit fetch and may be a test double.
 fn run_with_source(
+    git: &CliGitSource,
     source: &dyn GitDataSource,
     config: &HeatmapConfig,
     analytics: &crate::analytics::AnalyticsConfig,
 ) -> anyhow::Result<ExitCode> {
-    let git_source = CliGitSource::new();
-
     // Step 1: Validate git environment
-    if !git_source.is_git_repo() {
+    if !git.is_git_repo() {
         eprintln!("skim heatmap: Not a git repository");
         return Ok(ExitCode::FAILURE);
     }
 
-    let repo_root = match git_source.get_repo_root() {
+    let repo_root = match git.get_repo_root() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("skim heatmap: {e}");
@@ -102,7 +105,7 @@ fn run_with_source(
 
     let mut warnings: Vec<String> = Vec::new();
 
-    if git_source.detect_shallow_clone() {
+    if git.detect_shallow_clone() {
         warnings.push(
             "Shallow clone detected — history may be incomplete, metrics may be skewed."
                 .to_string(),
@@ -110,7 +113,7 @@ fn run_with_source(
     }
 
     // Step 2: Resolve effective config (presets and --last)
-    let effective_config = resolve_effective_config(config, &git_source, &mut warnings)?;
+    let effective_config = resolve_effective_config(config, git, &mut warnings)?;
 
     // Step 3: Fetch commits
     let raw_commits = match source.fetch_commits(&effective_config) {
@@ -165,7 +168,7 @@ fn run_with_source(
     let modules = compute_encapsulation(&commits, 3);
 
     // Step 6: Assemble FileMetrics
-    let mut all_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut all_paths: HashSet<String> = HashSet::new();
     for commit in &commits {
         for f in &commit.files {
             all_paths.insert(f.path.clone());
@@ -191,17 +194,7 @@ fn run_with_source(
                 combined_pct: 0.0,
                 insufficient_data: true,
             });
-            let blast_radius = blast_radius_map
-                .get(&path)
-                .cloned()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|e| CouplingEntry {
-                    path: e.path,
-                    confidence: e.confidence,
-                    support: e.support,
-                })
-                .collect();
+            let blast_radius = blast_radius_map.get(&path).cloned().unwrap_or_default();
 
             FileMetrics {
                 path,

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -133,7 +133,10 @@ fn run_with_source(
         };
         eprintln!("[skim:heatmap] window mode: {mode}");
         if let Some(since) = effective_config.since {
-            eprintln!("[skim:heatmap] since epoch: {since} ({})", format_epoch(since));
+            eprintln!(
+                "[skim:heatmap] since epoch: {since} ({})",
+                format_epoch(since)
+            );
         }
     }
 
@@ -194,7 +197,6 @@ fn run_with_source(
         now_epoch,
         repo_root,
         warnings,
-        config.debug,
     );
 
     // Apply --top N limit to files
@@ -240,8 +242,6 @@ fn run_with_source(
 /// by the callers (Steps 1-4 in `run_with_source`). Accepting `now_epoch` as a
 /// parameter (instead of calling `SystemTime::now()` here) keeps the function
 /// deterministic and testable.
-///
-/// `debug` controls whether timing is emitted to stderr.
 fn compute_heatmap(
     commits: Vec<CommitRecord>,
     config: &HeatmapConfig,
@@ -249,7 +249,6 @@ fn compute_heatmap(
     now_epoch: u64,
     repository: String,
     warnings: Vec<String>,
-    debug: bool,
 ) -> HeatmapResult {
     use std::time::Instant;
 
@@ -266,7 +265,7 @@ fn compute_heatmap(
         compute_coupling(&commits, config.coupling_threshold, 3);
     let modules = compute_encapsulation(&commits, 3);
 
-    if debug {
+    if config.debug {
         let elapsed = t0.elapsed();
         eprintln!(
             "[skim:heatmap] metrics computed in {:.1}ms — {} files, {} coupling edges, {} modules",
@@ -442,7 +441,7 @@ fn build_window_info(
         .map(format_epoch)
         .unwrap_or_else(|| "all".to_string());
 
-    let (effective_strategy, time_commits, count_commits) = if config.dual_mode {
+    let effective_strategy = if config.dual_mode {
         let time_since = config.dual_time_since.unwrap_or(0);
         let count_since = config.dual_count_since.unwrap_or(0);
         let strategy = if time_since <= count_since {
@@ -450,9 +449,9 @@ fn build_window_info(
         } else {
             "count"
         };
-        (Some(strategy.to_string()), None, None)
+        Some(strategy.to_string())
     } else {
-        (None, None, None)
+        None
     };
 
     WindowInfo {
@@ -460,8 +459,8 @@ fn build_window_info(
         since: since_str,
         until: format_epoch(now_epoch),
         commits_analyzed,
-        time_commits,
-        count_commits,
+        time_commits: None,
+        count_commits: None,
         effective_strategy,
     }
 }
@@ -627,9 +626,7 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
                 }
                 // Positional (non-flag) argument — `skim heatmap` takes no
                 // positional args; suggest --path if the user meant a directory.
-                anyhow::bail!(
-                    "unexpected argument: '{other}'. Did you mean --path={other}?"
-                );
+                anyhow::bail!("unexpected argument: '{other}'. Did you mean --path={other}?");
             }
         }
 
@@ -871,7 +868,10 @@ mod tests {
         let result = parse_args(&["--fix-window=0".to_string()]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("--fix-window must be at least 1"), "got: {msg}");
+        assert!(
+            msg.contains("--fix-window must be at least 1"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -1,0 +1,740 @@
+//! `skim heatmap` subcommand — git history risk/coupling analysis.
+//!
+//! Computes 6 metrics from git log history:
+//! 1. Churn: commit frequency per file
+//! 2. Coupling: files that change together (blast radius)
+//! 3. Stability: composite score (churn + recency + volatility)
+//! 4. Author diversity: bus-factor risk detection
+//! 5. Fix-after-touch: proximity-based bug-introduction risk
+//! 6. Module encapsulation: cross-boundary coupling health
+
+mod excludes;
+mod git_source;
+mod metrics;
+mod output;
+mod types;
+
+use std::io::{self, Write};
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::analytics::{CommandType, RecordingContext};
+
+use excludes::{build_exclude_set, should_exclude};
+use git_source::{CliGitSource, GitDataSource};
+use metrics::{
+    build_fix_regex, compute_authors, compute_churn, compute_coupling, compute_encapsulation,
+    compute_fix_after_touch, compute_stability,
+};
+use output::{render_json, render_text};
+use types::{
+    AuthorMetrics, ChurnMetrics, CouplingEntry, FileMetrics, FixRiskMetrics, HeatmapConfig,
+    HeatmapResult, WindowInfo,
+};
+
+// ============================================================================
+// Window presets
+// ============================================================================
+
+/// Map a named preset to `--since` epoch seconds offset.
+fn preset_to_since_secs(preset: &str) -> Option<u64> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    match preset {
+        "sprint" => Some(now.saturating_sub(14 * 86400)),
+        "month" => Some(now.saturating_sub(30 * 86400)),
+        "quarter" => Some(now.saturating_sub(90 * 86400)),
+        "year" => Some(now.saturating_sub(365 * 86400)),
+        _ => None,
+    }
+}
+
+// ============================================================================
+// Entry point
+// ============================================================================
+
+/// Run the `skim heatmap` subcommand.
+pub(crate) fn run(
+    args: &[String],
+    analytics: &crate::analytics::AnalyticsConfig,
+) -> anyhow::Result<ExitCode> {
+    if args.iter().any(|a| matches!(a.as_str(), "--help" | "-h")) {
+        print_help();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let config = match parse_args(args) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("skim heatmap: {e}");
+            eprintln!("Run `skim heatmap --help` for usage.");
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    let source = CliGitSource::new();
+    run_with_source(&source, &config, analytics)
+}
+
+/// Orchestration with injected data source (enables testing).
+fn run_with_source(
+    source: &dyn GitDataSource,
+    config: &HeatmapConfig,
+    analytics: &crate::analytics::AnalyticsConfig,
+) -> anyhow::Result<ExitCode> {
+    let git_source = CliGitSource::new();
+
+    // Step 1: Validate git environment
+    if !git_source.is_git_repo() {
+        eprintln!("skim heatmap: Not a git repository");
+        return Ok(ExitCode::FAILURE);
+    }
+
+    let repo_root = match git_source.get_repo_root() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("skim heatmap: {e}");
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    let mut warnings: Vec<String> = Vec::new();
+
+    if git_source.detect_shallow_clone() {
+        warnings.push(
+            "Shallow clone detected — history may be incomplete, metrics may be skewed."
+                .to_string(),
+        );
+    }
+
+    // Step 2: Resolve effective config (presets and --last)
+    let effective_config = resolve_effective_config(config, &git_source, &mut warnings)?;
+
+    // Step 3: Fetch commits
+    let raw_commits = match source.fetch_commits(&effective_config) {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("not installed") || msg.contains("not in PATH") {
+                eprintln!("skim heatmap: {msg}");
+            } else {
+                eprintln!("skim heatmap: failed to fetch git log: {msg}");
+            }
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    if raw_commits.is_empty() {
+        eprintln!("skim heatmap: No commits found in repository");
+        return Ok(ExitCode::FAILURE);
+    }
+
+    // Step 4: Apply exclusions
+    let exclude_set = build_exclude_set(config.no_exclude, &config.extra_excludes);
+    let mut commits = raw_commits;
+    for commit in &mut commits {
+        commit
+            .files
+            .retain(|f| !should_exclude(&f.path, &exclude_set));
+    }
+    // Remove commits that are now file-less after exclusion
+    commits.retain(|c| !c.files.is_empty());
+
+    if commits.is_empty() {
+        eprintln!("skim heatmap: No analyzable files after exclusions");
+        return Ok(ExitCode::FAILURE);
+    }
+
+    // Step 5: Compute metrics
+    let start_time = std::time::Instant::now();
+    let fix_regex = build_fix_regex();
+    let now_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let churn_map = compute_churn(&commits);
+    let max_churn = churn_map.values().map(|m| m.commits).max().unwrap_or(1);
+    let stability_map = compute_stability(&commits, &fix_regex, max_churn, now_epoch);
+    let author_map = compute_authors(&commits);
+    let fix_risk_map = compute_fix_after_touch(&commits, &fix_regex, config.fix_window);
+    let (blast_radius_map, coupling_graph) =
+        compute_coupling(&commits, config.coupling_threshold, 3);
+    let modules = compute_encapsulation(&commits, 3);
+
+    // Step 6: Assemble FileMetrics
+    let mut all_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for commit in &commits {
+        for f in &commit.files {
+            all_paths.insert(f.path.clone());
+        }
+    }
+
+    let mut file_metrics: Vec<FileMetrics> = all_paths
+        .into_iter()
+        .map(|path| {
+            let churn = churn_map.get(&path).cloned().unwrap_or(ChurnMetrics {
+                commits: 0,
+                rate: 0.0,
+            });
+            let stability_score = stability_map.get(&path).copied().unwrap_or(100);
+            let authors = author_map.get(&path).cloned().unwrap_or(AuthorMetrics {
+                count: 0,
+                top_author_pct: 0.0,
+                single_owner_risk: false,
+            });
+            let fix_risk = fix_risk_map.get(&path).cloned().unwrap_or(FixRiskMetrics {
+                keyword_pct: 0.0,
+                proximity_pct: 0.0,
+                combined_pct: 0.0,
+                insufficient_data: true,
+            });
+            let blast_radius = blast_radius_map
+                .get(&path)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|e| CouplingEntry {
+                    path: e.path,
+                    confidence: e.confidence,
+                    support: e.support,
+                })
+                .collect();
+
+            FileMetrics {
+                path,
+                churn,
+                stability_score,
+                authors,
+                fix_risk,
+                blast_radius,
+            }
+        })
+        .collect();
+
+    // Sort by churn descending for consistent output
+    file_metrics.sort_by(|a, b| b.churn.commits.cmp(&a.churn.commits));
+
+    // Step 7: Build window info
+    let window_info = build_window_info(&effective_config, commits.len());
+
+    // Step 8: Get excluded patterns for output
+    let excluded_patterns: Vec<String> = if config.no_exclude {
+        Vec::new()
+    } else {
+        excludes::DEFAULT_EXCLUDES
+            .iter()
+            .map(|s| s.to_string())
+            .chain(config.extra_excludes.iter().cloned())
+            .collect()
+    };
+
+    // Step 9: Build result
+    let result = HeatmapResult {
+        version: 1,
+        generated_at: format_epoch(now_epoch),
+        repository: repo_root,
+        window: window_info,
+        files: file_metrics,
+        modules,
+        coupling_graph,
+        excluded_patterns,
+        warnings,
+    };
+
+    // Step 10: Render
+    let elapsed = start_time.elapsed();
+    let mut stdout = io::stdout().lock();
+
+    if config.format_json {
+        let json = render_json(&result)?;
+        writeln!(stdout, "{json}")?;
+    } else {
+        let text = render_text(&result, config.top_n);
+        write!(stdout, "{text}")?;
+    }
+
+    // Step 11: Fire-and-forget analytics
+    let rec = RecordingContext {
+        enabled: analytics.enabled,
+        command_type: CommandType::Heatmap,
+        parse_tier: None,
+        session_id: analytics.session_id.as_deref(),
+    };
+    crate::analytics::try_record_command(
+        rec,
+        String::new(), // no raw text for heatmap
+        String::new(), // no compressed text
+        "skim heatmap".to_string(),
+        elapsed,
+    );
+
+    Ok(ExitCode::SUCCESS)
+}
+
+// ============================================================================
+// Config resolution
+// ============================================================================
+
+/// Resolve the effective `HeatmapConfig` by applying presets and `--last`.
+///
+/// Precedence: `--since` > `--last` > `--window` preset > dual default.
+fn resolve_effective_config(
+    config: &HeatmapConfig,
+    source: &CliGitSource,
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<HeatmapConfig> {
+    let mut effective = config.clone();
+
+    // Count explicit time-selection flags
+    let explicit_count = [
+        config.since.is_some(),
+        config.last_n.is_some(),
+        config.window_preset.is_some(),
+    ]
+    .iter()
+    .filter(|&&b| b)
+    .count();
+
+    if explicit_count > 1 {
+        warnings.push(
+            "Multiple window flags specified — using first (--since > --last > --window)."
+                .to_string(),
+        );
+    }
+
+    if let Some(since) = config.since {
+        // Already set — highest precedence
+        effective.since = Some(since);
+    } else if let Some(n) = config.last_n {
+        // --last N: find the timestamp of the Nth commit
+        match source.fetch_commit_count_since(n) {
+            Ok(Some(ts)) => {
+                effective.since = Some(ts);
+            }
+            Ok(None) => {
+                warnings.push(format!(
+                    "Repository has fewer than {n} commits — analyzing all history."
+                ));
+            }
+            Err(e) => {
+                warnings.push(format!("Could not resolve --last {n}: {e}"));
+            }
+        }
+    } else if let Some(ref preset) = config.window_preset {
+        if let Some(since) = preset_to_since_secs(preset) {
+            effective.since = Some(since);
+        } else {
+            warnings.push(format!(
+                "Unknown window preset '{preset}' — valid: sprint, month, quarter, year. Analyzing all history."
+            ));
+        }
+    } else {
+        // Dual default: 90 days
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        effective.since = Some(now.saturating_sub(90 * 86400));
+    }
+
+    Ok(effective)
+}
+
+// ============================================================================
+// Window info construction
+// ============================================================================
+
+fn build_window_info(config: &HeatmapConfig, commits_analyzed: usize) -> WindowInfo {
+    let mode = if let Some(ref preset) = config.window_preset {
+        preset.clone()
+    } else if let Some(n) = config.last_n {
+        format!("last-{n}")
+    } else if let Some(since) = config.since {
+        format!("since-{since}")
+    } else {
+        "90d".to_string()
+    };
+
+    let since_str = config
+        .since
+        .map(format_epoch)
+        .unwrap_or_else(|| "all".to_string());
+
+    let now_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    WindowInfo {
+        mode,
+        since: since_str,
+        until: format_epoch(now_epoch),
+        commits_analyzed,
+        time_commits: None,
+        count_commits: None,
+        effective_strategy: None,
+    }
+}
+
+// ============================================================================
+// Formatting helpers
+// ============================================================================
+
+/// Format a Unix epoch as a simple date string (YYYY-MM-DD).
+fn format_epoch(epoch: u64) -> String {
+    // Manual calculation — no chrono dependency
+    // Days since 1970-01-01
+    let days = epoch / 86400;
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+/// Convert days since 1970-01-01 to (year, month, day).
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097; // day of era [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // year of era
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // day of year [0, 365]
+    let mp = (5 * doy + 2) / 153; // month prime
+    let d = doy - (153 * mp + 2) / 5 + 1; // day [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // month [1, 12]
+    let y_adj = if m <= 2 { y + 1 } else { y };
+    (y_adj, m, d)
+}
+
+// ============================================================================
+// Argument parsing
+// ============================================================================
+
+/// Parse CLI args into `HeatmapConfig`.
+///
+/// Follows the manual flag-parsing pattern used by `stats.rs`.
+fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
+    let mut config = HeatmapConfig::default();
+    let mut i = 0;
+
+    while i < args.len() {
+        let arg = args[i].as_str();
+
+        // --since=VALUE or --since VALUE
+        if let Some(val) = extract_value(args, &mut i, "--since") {
+            let ts = parse_since_value(&val)?;
+            config.since = Some(ts);
+            continue;
+        }
+
+        // --path
+        if let Some(val) = extract_value(args, &mut i, "--path") {
+            config.path = Some(val);
+            continue;
+        }
+
+        // --top
+        if let Some(val) = extract_value(args, &mut i, "--top") {
+            config.top_n = val
+                .parse()
+                .map_err(|_| anyhow::anyhow!("--top requires a positive integer"))?;
+            continue;
+        }
+
+        // --window
+        if let Some(val) = extract_value(args, &mut i, "--window") {
+            config.window_preset = Some(val);
+            continue;
+        }
+
+        // --last
+        if let Some(val) = extract_value(args, &mut i, "--last") {
+            config.last_n = Some(
+                val.parse()
+                    .map_err(|_| anyhow::anyhow!("--last requires a positive integer"))?,
+            );
+            continue;
+        }
+
+        // --exclude
+        if let Some(val) = extract_value(args, &mut i, "--exclude") {
+            config.extra_excludes.push(val);
+            continue;
+        }
+
+        // --coupling-threshold
+        if let Some(val) = extract_value(args, &mut i, "--coupling-threshold") {
+            config.coupling_threshold = val
+                .parse::<f64>()
+                .map_err(|_| {
+                    anyhow::anyhow!("--coupling-threshold requires a float between 0 and 1")
+                })?
+                .clamp(0.0, 1.0);
+            continue;
+        }
+
+        // --fix-window
+        if let Some(val) = extract_value(args, &mut i, "--fix-window") {
+            config.fix_window = val
+                .parse()
+                .map_err(|_| anyhow::anyhow!("--fix-window requires a positive integer"))?;
+            continue;
+        }
+
+        // Boolean flags
+        match arg {
+            "--json" | "--format=json" => config.format_json = true,
+            "--no-exclude" => config.no_exclude = true,
+            "--debug" => config.debug = true,
+            other => {
+                if other.starts_with('-') {
+                    anyhow::bail!("unknown flag: {other}");
+                }
+                // Positional argument — currently unused
+            }
+        }
+
+        i += 1;
+    }
+
+    Ok(config)
+}
+
+/// Extract a `--flag VALUE` or `--flag=VALUE` pair, advancing `i`.
+///
+/// Returns `Some(value_string)` on match, `None` otherwise. Advances `i`
+/// past the consumed argument(s).
+fn extract_value(args: &[String], i: &mut usize, flag: &str) -> Option<String> {
+    let arg = args[*i].as_str();
+    let equals_prefix = format!("{flag}=");
+
+    if arg == flag {
+        // --flag VALUE form
+        if *i + 1 < args.len() {
+            *i += 2;
+            Some(args[*i - 1].clone())
+        } else {
+            None
+        }
+    } else if let Some(val) = arg.strip_prefix(&equals_prefix) {
+        // --flag=VALUE form
+        *i += 1;
+        Some(val.to_string())
+    } else {
+        None
+    }
+}
+
+/// Parse a `--since` value: accepts epoch seconds (integer) or duration strings
+/// like "30d", "2w", "24h".
+fn parse_since_value(val: &str) -> anyhow::Result<u64> {
+    // Try plain integer (epoch seconds)
+    if let Ok(epoch) = val.parse::<u64>() {
+        return Ok(epoch);
+    }
+    // Try duration string
+    let sys_time = crate::cmd::session::types::parse_duration_ago(val)?;
+    let epoch = sys_time
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| anyhow::anyhow!("--since: time before Unix epoch"))?
+        .as_secs();
+    Ok(epoch)
+}
+
+// ============================================================================
+// Help
+// ============================================================================
+
+fn print_help() {
+    print!(
+        "\
+skim heatmap — git history risk and coupling analysis
+
+USAGE:
+    skim heatmap [OPTIONS]
+
+OPTIONS:
+    --since <VALUE>               Analyze commits since epoch (seconds) or duration (30d, 2w, 24h)
+    --last <N>                    Analyze last N commits
+    --window <PRESET>             Named window: sprint (14d), month (30d), quarter (90d), year (365d)
+    --path <DIR>                  Scope analysis to files under this path
+    --json                        Output JSON instead of human-readable text
+    --top <N>                     Maximum files to display (default: 20)
+    --no-exclude                  Disable default exclusion patterns (lock files, build dirs, etc.)
+    --exclude <PATTERN>           Add extra glob pattern to exclude (repeatable)
+    --coupling-threshold <FLOAT>  Coupling confidence threshold (default: 0.5)
+    --fix-window <N>              Proximity window for fix-after-touch detection (default: 5)
+    --debug                       Enable debug output
+    -h, --help                    Show this help message
+
+WINDOW PRESETS:
+    sprint     14 days
+    month      30 days
+    quarter    90 days (default when no window specified)
+    year       365 days
+
+EXAMPLES:
+    skim heatmap                           # Analyze last 90 days
+    skim heatmap --last 200                # Analyze last 200 commits
+    skim heatmap --window sprint           # Analyze last sprint
+    skim heatmap --since 30d               # Analyze last 30 days
+    skim heatmap --json                    # JSON output
+    skim heatmap --path src/               # Scope to src/ directory
+    skim heatmap --no-exclude              # Include lock files and build artifacts
+    skim heatmap --coupling-threshold 0.3  # Lower coupling threshold
+
+METRICS:
+    Top Churn          Files changed most frequently
+    Blast Radius       Files that tend to change together (coupling)
+    Fix Risk           Files with high fix-commit density or fix-after-touch
+    Module Health      Directory encapsulation (cross-boundary coupling)
+    Bus Factor Risk    Files with a single dominant author (>80%% of commits)
+"
+    );
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_args_defaults() {
+        let config = parse_args(&[]).unwrap();
+        assert_eq!(config.top_n, 20);
+        assert!((config.coupling_threshold - 0.5).abs() < 1e-9);
+        assert_eq!(config.fix_window, 5);
+        assert!(!config.format_json);
+        assert!(!config.no_exclude);
+    }
+
+    #[test]
+    fn test_parse_args_json_flag() {
+        let config = parse_args(&["--json".to_string()]).unwrap();
+        assert!(config.format_json);
+    }
+
+    #[test]
+    fn test_parse_args_top_n() {
+        let config = parse_args(&["--top".to_string(), "5".to_string()]).unwrap();
+        assert_eq!(config.top_n, 5);
+    }
+
+    #[test]
+    fn test_parse_args_top_n_equals() {
+        let config = parse_args(&["--top=10".to_string()]).unwrap();
+        assert_eq!(config.top_n, 10);
+    }
+
+    #[test]
+    fn test_parse_args_window_preset() {
+        let config = parse_args(&["--window=sprint".to_string()]).unwrap();
+        assert_eq!(config.window_preset.as_deref(), Some("sprint"));
+    }
+
+    #[test]
+    fn test_parse_args_last_n() {
+        let config = parse_args(&["--last=100".to_string()]).unwrap();
+        assert_eq!(config.last_n, Some(100));
+    }
+
+    #[test]
+    fn test_parse_args_no_exclude() {
+        let config = parse_args(&["--no-exclude".to_string()]).unwrap();
+        assert!(config.no_exclude);
+    }
+
+    #[test]
+    fn test_parse_args_coupling_threshold() {
+        let config = parse_args(&["--coupling-threshold=0.3".to_string()]).unwrap();
+        assert!((config.coupling_threshold - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_parse_args_since_epoch() {
+        let config = parse_args(&["--since=1700000000".to_string()]).unwrap();
+        assert_eq!(config.since, Some(1_700_000_000));
+    }
+
+    #[test]
+    fn test_parse_args_since_duration() {
+        let config = parse_args(&["--since=30d".to_string()]).unwrap();
+        // Should be set to some epoch in the past
+        assert!(config.since.is_some());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let since = config.since.unwrap();
+        let diff = now - since;
+        assert!(diff >= 29 * 86400 && diff <= 31 * 86400);
+    }
+
+    #[test]
+    fn test_parse_args_path() {
+        let config = parse_args(&["--path=src/".to_string()]).unwrap();
+        assert_eq!(config.path.as_deref(), Some("src/"));
+    }
+
+    #[test]
+    fn test_parse_args_unknown_flag_errors() {
+        let result = parse_args(&["--unknown-flag".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_epoch_known_date() {
+        // 2024-01-01 = 1704067200
+        assert_eq!(format_epoch(1_704_067_200), "2024-01-01");
+    }
+
+    #[test]
+    fn test_format_epoch_unix_epoch() {
+        assert_eq!(format_epoch(0), "1970-01-01");
+    }
+
+    #[test]
+    fn test_preset_to_since_secs_sprint() {
+        let since = preset_to_since_secs("sprint").unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let diff = now - since;
+        assert!(diff >= 13 * 86400 && diff <= 15 * 86400);
+    }
+
+    #[test]
+    fn test_preset_to_since_secs_unknown() {
+        assert!(preset_to_since_secs("unknown-preset").is_none());
+    }
+
+    #[test]
+    fn test_days_to_ymd_epoch() {
+        assert_eq!(days_to_ymd(0), (1970, 1, 1));
+    }
+
+    #[test]
+    fn test_days_to_ymd_known_date() {
+        // 2024-01-01 = 19723 days since epoch
+        assert_eq!(days_to_ymd(19723), (2024, 1, 1));
+    }
+
+    #[test]
+    fn test_parse_args_extra_exclude() {
+        let config = parse_args(&["--exclude=*.generated.ts".to_string()]).unwrap();
+        assert_eq!(config.extra_excludes, vec!["*.generated.ts"]);
+    }
+
+    #[test]
+    fn test_parse_args_fix_window() {
+        let config = parse_args(&["--fix-window=10".to_string()]).unwrap();
+        assert_eq!(config.fix_window, 10);
+    }
+}

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -214,18 +214,16 @@ fn run_with_source(
     config: &HeatmapConfig,
     analytics: &crate::analytics::AnalyticsConfig,
 ) -> anyhow::Result<ExitCode> {
-    let prepared = match prepare_commits(source, config)? {
-        Some(p) => p,
-        None => return Ok(ExitCode::FAILURE),
-    };
-
     let PreparedCommits {
         commits,
         window,
         now_epoch,
         repo_root,
         warnings,
-    } = prepared;
+    } = match prepare_commits(source, config)? {
+        Some(p) => p,
+        None => return Ok(ExitCode::FAILURE),
+    };
 
     // Steps 5-9: Compute metrics and assemble result
     let start_time = std::time::Instant::now();
@@ -420,8 +418,8 @@ fn resolve_effective_config(
         config.last_n.is_some(),
         config.window_preset.is_some(),
     ]
-    .iter()
-    .filter(|&&b| b)
+    .into_iter()
+    .filter(|b| *b)
     .count();
 
     if explicit_count > 1 {

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -14,7 +14,6 @@ mod metrics;
 mod output;
 mod types;
 
-use std::collections::HashSet;
 use std::io::{self, Write};
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -29,8 +28,7 @@ use metrics::{
 };
 use output::{render_json, render_text};
 use types::{
-    AuthorMetrics, ChurnMetrics, FileMetrics, FixRiskMetrics, HeatmapConfig, HeatmapResult,
-    WindowInfo,
+    AuthorMetrics, FileMetrics, FixRiskMetrics, HeatmapConfig, HeatmapResult, WindowInfo,
 };
 
 // ============================================================================
@@ -38,17 +36,13 @@ use types::{
 // ============================================================================
 
 /// Map a named preset to `--since` epoch seconds offset.
-fn preset_to_since_secs(preset: &str) -> Option<u64> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+fn preset_to_since_secs(preset: &str, now_epoch: u64) -> Option<u64> {
     match preset {
-        "sprint" => Some(now.saturating_sub(14 * 86400)),
-        "month" => Some(now.saturating_sub(30 * 86400)),
-        "quarter" => Some(now.saturating_sub(90 * 86400)),
-        "half" => Some(now.saturating_sub(180 * 86400)),
-        "year" => Some(now.saturating_sub(365 * 86400)),
+        "sprint" => Some(now_epoch.saturating_sub(14 * 86400)),
+        "month" => Some(now_epoch.saturating_sub(30 * 86400)),
+        "quarter" => Some(now_epoch.saturating_sub(90 * 86400)),
+        "half" => Some(now_epoch.saturating_sub(180 * 86400)),
+        "year" => Some(now_epoch.saturating_sub(365 * 86400)),
         "all" => Some(0),
         _ => None,
     }
@@ -78,26 +72,25 @@ pub(crate) fn run(
     };
 
     let git_source = CliGitSource::new();
-    run_with_source(&git_source, &git_source, &config, analytics)
+    run_with_source(&git_source, &config, analytics)
 }
 
 /// Orchestration with injected data source (enables testing).
 ///
-/// `git` handles infrastructure checks (repo detection, root, shallow clone,
-/// commit count). `source` handles the actual commit fetch and may be a test double.
+/// All git I/O is routed through `source` — infra checks (repo detection, root,
+/// shallow clone, commit count) and the commit fetch all use the same trait object.
 fn run_with_source(
-    git: &CliGitSource,
     source: &dyn GitDataSource,
     config: &HeatmapConfig,
     analytics: &crate::analytics::AnalyticsConfig,
 ) -> anyhow::Result<ExitCode> {
     // Step 1: Validate git environment
-    if !git.is_git_repo() {
+    if !source.is_git_repo() {
         eprintln!("skim heatmap: Not a git repository");
         return Ok(ExitCode::FAILURE);
     }
 
-    let repo_root = match git.get_repo_root() {
+    let repo_root = match source.get_repo_root() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("skim heatmap: {e}");
@@ -107,7 +100,7 @@ fn run_with_source(
 
     let mut warnings: Vec<String> = Vec::new();
 
-    if git.detect_shallow_clone() {
+    if source.detect_shallow_clone() {
         warnings.push(
             "Shallow clone detected — history may be incomplete, metrics may be skewed."
                 .to_string(),
@@ -115,11 +108,19 @@ fn run_with_source(
     }
 
     if config.debug {
-        eprintln!("[heatmap] repo root: {repo_root}");
+        eprintln!("[skim:heatmap] repo root: {repo_root}");
     }
 
+    // Capture a single clock snapshot for all window-resolution helpers so that
+    // preset_to_since_secs, resolve_effective_config, and build_window_info all
+    // use the same value (Issue 1: temporal consistency).
+    let now_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
     // Step 2: Resolve effective config (presets and --last)
-    let effective_config = resolve_effective_config(config, git, &mut warnings)?;
+    let effective_config = resolve_effective_config(config, source, &mut warnings, now_epoch)?;
 
     if config.debug {
         let mode = if effective_config.dual_mode {
@@ -129,9 +130,9 @@ fn run_with_source(
         } else {
             "time"
         };
-        eprintln!("[heatmap] window mode: {mode}");
+        eprintln!("[skim:heatmap] window mode: {mode}");
         if let Some(since) = effective_config.since {
-            eprintln!("[heatmap] since epoch: {since} ({})", format_epoch(since));
+            eprintln!("[skim:heatmap] since epoch: {since} ({})", format_epoch(since));
         }
     }
 
@@ -150,7 +151,7 @@ fn run_with_source(
     };
 
     if config.debug {
-        eprintln!("[heatmap] raw commits fetched: {}", raw_commits.len());
+        eprintln!("[skim:heatmap] raw commits fetched: {}", raw_commits.len());
     }
 
     if raw_commits.is_empty() {
@@ -172,7 +173,7 @@ fn run_with_source(
 
     if config.debug {
         eprintln!(
-            "[heatmap] commits after exclusion: {} ({} excluded)",
+            "[skim:heatmap] commits after exclusion: {} ({} excluded)",
             commits.len(),
             raw_commit_count - commits.len()
         );
@@ -183,13 +184,9 @@ fn run_with_source(
         return Ok(ExitCode::FAILURE);
     }
 
-    // Step 5: Compute metrics
+    // Step 5: Compute metrics (now_epoch captured once in Step 2, reused here)
     let start_time = std::time::Instant::now();
     let fix_regex = build_fix_regex();
-    let now_epoch = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
 
     let churn_map = compute_churn(&commits);
     let max_churn = churn_map.values().map(|m| m.commits).max().unwrap_or(1);
@@ -203,7 +200,7 @@ fn run_with_source(
     if config.debug {
         let compute_elapsed = start_time.elapsed();
         eprintln!(
-            "[heatmap] metrics computed in {:.1}ms — {} files, {} coupling edges, {} modules",
+            "[skim:heatmap] metrics computed in {:.1}ms — {} files, {} coupling edges, {} modules",
             compute_elapsed.as_secs_f64() * 1000.0,
             churn_map.len(),
             coupling_graph.len(),
@@ -212,20 +209,11 @@ fn run_with_source(
     }
 
     // Step 6: Assemble FileMetrics
-    let mut all_paths: HashSet<String> = HashSet::new();
-    for commit in &commits {
-        for f in &commit.files {
-            all_paths.insert(f.path.clone());
-        }
-    }
-
-    let mut file_metrics: Vec<FileMetrics> = all_paths
+    // `churn_map` already contains every path seen across all commits; no need
+    // to rebuild a separate HashSet from the commit list.
+    let mut file_metrics: Vec<FileMetrics> = churn_map
         .into_iter()
-        .map(|path| {
-            let churn = churn_map.get(&path).cloned().unwrap_or(ChurnMetrics {
-                commits: 0,
-                rate: 0.0,
-            });
+        .map(|(path, churn)| {
             let stability_score = stability_map.get(&path).copied().unwrap_or(100);
             let authors = author_map.get(&path).cloned().unwrap_or(AuthorMetrics {
                 count: 0,
@@ -255,17 +243,17 @@ fn run_with_source(
     file_metrics.sort_by(|a, b| a.stability_score.cmp(&b.stability_score));
 
     // Step 7: Build window info
-    let window_info = build_window_info(&effective_config, commits.len());
+    let window_info = build_window_info(&effective_config, commits.len(), now_epoch);
 
     // Step 8: Get excluded patterns for output
     let excluded_patterns: Vec<String> = if config.no_exclude {
         Vec::new()
     } else {
-        excludes::DEFAULT_EXCLUDES
-            .iter()
-            .map(|s| s.to_string())
-            .chain(config.extra_excludes.iter().cloned())
-            .collect()
+        let capacity = excludes::DEFAULT_EXCLUDES.len() + config.extra_excludes.len();
+        let mut patterns = Vec::with_capacity(capacity);
+        patterns.extend(excludes::DEFAULT_EXCLUDES.iter().map(|s| s.to_string()));
+        patterns.extend(config.extra_excludes.iter().cloned());
+        patterns
     };
 
     // Step 9: Build result
@@ -323,8 +311,9 @@ fn run_with_source(
 /// Precedence: `--since` > `--last` > `--window` preset > dual default.
 fn resolve_effective_config(
     config: &HeatmapConfig,
-    source: &CliGitSource,
+    source: &dyn GitDataSource,
     warnings: &mut Vec<String>,
+    now_epoch: u64,
 ) -> anyhow::Result<HeatmapConfig> {
     let mut effective = config.clone();
 
@@ -364,7 +353,7 @@ fn resolve_effective_config(
             }
         }
     } else if let Some(ref preset) = config.window_preset {
-        if let Some(since) = preset_to_since_secs(preset) {
+        if let Some(since) = preset_to_since_secs(preset, now_epoch) {
             effective.since = Some(since);
         } else {
             warnings.push(format!(
@@ -373,11 +362,7 @@ fn resolve_effective_config(
         }
     } else {
         // Dual default: max(last 90 days, last 200 commits)
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let time_since = now.saturating_sub(90 * 86400);
+        let time_since = now_epoch.saturating_sub(90 * 86400);
 
         let count_since = match source.fetch_commit_count_since(200) {
             Ok(Some(ts)) => ts,
@@ -398,7 +383,11 @@ fn resolve_effective_config(
 // Window info construction
 // ============================================================================
 
-fn build_window_info(config: &HeatmapConfig, commits_analyzed: usize) -> WindowInfo {
+fn build_window_info(
+    config: &HeatmapConfig,
+    commits_analyzed: usize,
+    now_epoch: u64,
+) -> WindowInfo {
     let mode = if config.dual_mode {
         "dual".to_string()
     } else if let Some(ref preset) = config.window_preset {
@@ -415,11 +404,6 @@ fn build_window_info(config: &HeatmapConfig, commits_analyzed: usize) -> WindowI
         .since
         .map(format_epoch)
         .unwrap_or_else(|| "all".to_string());
-
-    let now_epoch = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
 
     let (effective_strategy, time_commits, count_commits) = if config.dual_mode {
         let time_since = config.dual_time_since.unwrap_or(0);
@@ -480,13 +464,38 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 
 /// Parse CLI args into `HeatmapConfig`.
 ///
-/// Follows the manual flag-parsing pattern used by `stats.rs`.
+/// Follows the manual flag-parsing pattern used by `stats.rs` and `discover.rs`.
+/// Initialises `config.debug` from the process-wide debug flag so that
+/// `SKIM_DEBUG=1` (initialised by `main()` before dispatch) is honoured automatically.
 fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
-    let mut config = HeatmapConfig::default();
+    let mut config = HeatmapConfig {
+        // Inherit SKIM_DEBUG / --debug flag set by main() before subcommand dispatch.
+        debug: crate::debug::is_debug_enabled(),
+        ..HeatmapConfig::default()
+    };
     let mut i = 0;
+
+    // Value-taking flags — used to detect when a flag is passed without a value
+    // (e.g. `skim heatmap --since`) before extract_value calls so the error is
+    // actionable rather than falling through to "unknown flag: --since".
+    const VALUE_FLAGS: &[&str] = &[
+        "--since",
+        "--path",
+        "--top",
+        "--window",
+        "--last",
+        "--exclude",
+        "--coupling-threshold",
+        "--fix-window",
+        "--format",
+    ];
 
     while i < args.len() {
         let arg = args[i].as_str();
+
+        if VALUE_FLAGS.contains(&arg) && i + 1 >= args.len() {
+            anyhow::bail!("{arg} requires a value");
+        }
 
         // --since=VALUE or --since VALUE
         if let Some(val) = extract_value(args, &mut i, "--since") {
@@ -503,9 +512,13 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
 
         // --top
         if let Some(val) = extract_value(args, &mut i, "--top") {
-            config.top_n = val
+            let n: usize = val
                 .parse()
                 .map_err(|_| anyhow::anyhow!("--top requires a positive integer"))?;
+            if n == 0 {
+                anyhow::bail!("--top must be at least 1");
+            }
+            config.top_n = n;
             continue;
         }
 
@@ -543,9 +556,13 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
 
         // --fix-window
         if let Some(val) = extract_value(args, &mut i, "--fix-window") {
-            config.fix_window = val
+            let n: usize = val
                 .parse()
                 .map_err(|_| anyhow::anyhow!("--fix-window requires a positive integer"))?;
+            if n == 0 {
+                anyhow::bail!("--fix-window must be at least 1");
+            }
+            config.fix_window = n;
             continue;
         }
 
@@ -563,11 +580,19 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
         match arg {
             "--json" => config.format_json = true,
             "--no-exclude" => config.no_exclude = true,
-            "--debug" => config.debug = true,
+            "--debug" => {
+                config.debug = true;
+                crate::debug::force_enable_debug();
+            }
             other => {
                 if other.starts_with('-') {
                     anyhow::bail!("unknown flag: {other}");
                 }
+                // Positional (non-flag) argument — `skim heatmap` takes no
+                // positional args; suggest --path if the user meant a directory.
+                anyhow::bail!(
+                    "unexpected argument: '{other}'. Did you mean --path={other}?"
+                );
             }
         }
 
@@ -778,18 +803,55 @@ mod tests {
 
     #[test]
     fn test_preset_to_since_secs_sprint() {
-        let since = preset_to_since_secs("sprint").unwrap();
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
+        let since = preset_to_since_secs("sprint", now).unwrap();
         let diff = now - since;
         assert!(diff >= 13 * 86400 && diff <= 15 * 86400);
     }
 
     #[test]
     fn test_preset_to_since_secs_unknown() {
-        assert!(preset_to_since_secs("unknown-preset").is_none());
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(preset_to_since_secs("unknown-preset", now).is_none());
+    }
+
+    #[test]
+    fn test_parse_args_top_zero_errors() {
+        let result = parse_args(&["--top=0".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("--top must be at least 1"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_args_fix_window_zero_errors() {
+        let result = parse_args(&["--fix-window=0".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("--fix-window must be at least 1"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_args_since_missing_value_errors() {
+        let result = parse_args(&["--since".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("--since requires a value"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_args_unexpected_positional_errors() {
+        let result = parse_args(&["src/".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("unexpected argument"), "got: {msg}");
+        assert!(msg.contains("--path=src/"), "got: {msg}");
     }
 
     #[test]

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -73,26 +73,36 @@ pub(crate) fn run(
     run_with_source(&git_source, &config, analytics)
 }
 
-/// Orchestration with injected data source (enables testing).
+/// Bundled output of [`prepare_commits`] — everything needed to call [`compute_heatmap`].
+struct PreparedCommits {
+    commits: Vec<CommitRecord>,
+    window: ResolvedWindow,
+    now_epoch: u64,
+    repo_root: String,
+    warnings: Vec<String>,
+}
+
+/// Execute Steps 1–4 of the heatmap pipeline (git I/O + exclusions).
 ///
-/// All git I/O is routed through `source` — infra checks (repo detection, root,
-/// shallow clone, commit count) and the commit fetch all use the same trait object.
-fn run_with_source(
+/// Returns `Ok(None)` for all early-exit conditions (not a git repo, no commits,
+/// all commits excluded). Callers treat `None` as a `ExitCode::FAILURE` signal.
+/// Returns `Ok(Some(PreparedCommits))` when the pipeline should proceed to
+/// metric computation.
+fn prepare_commits(
     source: &dyn GitDataSource,
     config: &HeatmapConfig,
-    analytics: &crate::analytics::AnalyticsConfig,
-) -> anyhow::Result<ExitCode> {
+) -> anyhow::Result<Option<PreparedCommits>> {
     // Step 1: Validate git environment
     if !source.is_git_repo() {
         eprintln!("skim heatmap: Not a git repository");
-        return Ok(ExitCode::FAILURE);
+        return Ok(None);
     }
 
     let repo_root = match source.get_repo_root() {
         Ok(r) => r,
         Err(e) => {
             eprintln!("skim heatmap: {e}");
-            return Ok(ExitCode::FAILURE);
+            return Ok(None);
         }
     };
 
@@ -148,7 +158,7 @@ fn run_with_source(
             } else {
                 eprintln!("skim heatmap: failed to fetch git log: {msg}");
             }
-            return Ok(ExitCode::FAILURE);
+            return Ok(None);
         }
     };
 
@@ -158,7 +168,7 @@ fn run_with_source(
 
     if raw_commits.is_empty() {
         eprintln!("skim heatmap: No commits found in repository");
-        return Ok(ExitCode::FAILURE);
+        return Ok(None);
     }
 
     // Step 4: Apply exclusions
@@ -183,8 +193,39 @@ fn run_with_source(
 
     if commits.is_empty() {
         eprintln!("skim heatmap: No analyzable files after exclusions");
-        return Ok(ExitCode::FAILURE);
+        return Ok(None);
     }
+
+    Ok(Some(PreparedCommits {
+        commits,
+        window,
+        now_epoch,
+        repo_root,
+        warnings,
+    }))
+}
+
+/// Orchestration with injected data source (enables testing).
+///
+/// All git I/O is routed through `source` — infra checks (repo detection, root,
+/// shallow clone, commit count) and the commit fetch all use the same trait object.
+fn run_with_source(
+    source: &dyn GitDataSource,
+    config: &HeatmapConfig,
+    analytics: &crate::analytics::AnalyticsConfig,
+) -> anyhow::Result<ExitCode> {
+    let prepared = match prepare_commits(source, config)? {
+        Some(p) => p,
+        None => return Ok(ExitCode::FAILURE),
+    };
+
+    let PreparedCommits {
+        commits,
+        window,
+        now_epoch,
+        repo_root,
+        warnings,
+    } = prepared;
 
     // Steps 5-9: Compute metrics and assemble result
     let start_time = std::time::Instant::now();

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -308,7 +308,7 @@ fn compute_heatmap(
         .collect();
 
     // Sort by stability_score ascending (riskiest first)
-    file_metrics.sort_by(|a, b| a.stability_score.cmp(&b.stability_score));
+    file_metrics.sort_by_key(|f| f.stability_score);
 
     // Step 7: Build window info
     let window_info = build_window_info(effective_config, commits.len(), now_epoch);

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -233,6 +233,10 @@ fn run_with_source(
 // Pure metric computation (Steps 5-9)
 // ============================================================================
 
+/// Minimum number of co-occurrences required before a coupling pair or module
+/// is included in results. Prevents noise from one-off coincidences.
+const MIN_SUPPORT_THRESHOLD: usize = 3;
+
 /// Compute all six risk metrics from commits and assemble a `HeatmapResult`.
 ///
 /// No git I/O — all repository data is pre-fetched by callers (Steps 1-4 in
@@ -260,8 +264,8 @@ fn compute_heatmap(
     let author_map = compute_authors(&commits);
     let fix_risk_map = compute_fix_after_touch(&commits, &fix_regex, config.fix_window);
     let (blast_radius_map, coupling_graph) =
-        compute_coupling(&commits, config.coupling_threshold, 3);
-    let modules = compute_encapsulation(&commits, 3);
+        compute_coupling(&commits, config.coupling_threshold, MIN_SUPPORT_THRESHOLD);
+    let modules = compute_encapsulation(&commits, MIN_SUPPORT_THRESHOLD);
 
     if config.debug {
         let elapsed = t0.elapsed();

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -238,10 +238,11 @@ fn run_with_source(
 
 /// Compute all six risk metrics from commits and assemble a `HeatmapResult`.
 ///
-/// This is a pure function — no I/O, no side effects. All git I/O is handled
-/// by the callers (Steps 1-4 in `run_with_source`). Accepting `now_epoch` as a
-/// parameter (instead of calling `SystemTime::now()` here) keeps the function
-/// deterministic and testable.
+/// No git I/O — all repository data is pre-fetched by callers (Steps 1-4 in
+/// `run_with_source`). Accepting `now_epoch` as a parameter (instead of calling
+/// `SystemTime::now()` here) keeps metric computation deterministic and testable.
+///
+/// Debug timing is emitted to stderr when `config.debug` is enabled.
 fn compute_heatmap(
     commits: Vec<CommitRecord>,
     config: &HeatmapConfig,
@@ -459,8 +460,6 @@ fn build_window_info(
         since: since_str,
         until: format_epoch(now_epoch),
         commits_analyzed,
-        time_commits: None,
-        count_commits: None,
         effective_strategy,
     }
 }
@@ -912,5 +911,112 @@ mod tests {
     fn test_parse_args_fix_window() {
         let config = parse_args(&["--fix-window=10".to_string()]).unwrap();
         assert_eq!(config.fix_window, 10);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_window_info
+    // -----------------------------------------------------------------------
+
+    fn base_config() -> HeatmapConfig {
+        HeatmapConfig::default()
+    }
+
+    const NOW: u64 = 1_704_067_200; // 2024-01-01
+
+    #[test]
+    fn test_build_window_info_dual_mode() {
+        let mut config = base_config();
+        config.dual_mode = true;
+        // time_since <= count_since → effective_strategy = "time"
+        config.dual_time_since = Some(1_000_000);
+        config.dual_count_since = Some(2_000_000);
+
+        let info = build_window_info(&config, 42, NOW);
+
+        assert_eq!(info.mode, "dual");
+        assert_eq!(info.commits_analyzed, 42);
+        assert_eq!(info.effective_strategy.as_deref(), Some("time"));
+    }
+
+    #[test]
+    fn test_build_window_info_dual_mode_count_wins() {
+        let mut config = base_config();
+        config.dual_mode = true;
+        // time_since > count_since → effective_strategy = "count"
+        config.dual_time_since = Some(2_000_000);
+        config.dual_count_since = Some(1_000_000);
+
+        let info = build_window_info(&config, 10, NOW);
+
+        assert_eq!(info.mode, "dual");
+        assert_eq!(info.effective_strategy.as_deref(), Some("count"));
+    }
+
+    #[test]
+    fn test_build_window_info_preset_mode() {
+        let mut config = base_config();
+        config.window_preset = Some("quarter".to_string());
+
+        let info = build_window_info(&config, 50, NOW);
+
+        assert_eq!(info.mode, "quarter");
+        assert!(info.effective_strategy.is_none());
+    }
+
+    #[test]
+    fn test_build_window_info_count_mode() {
+        let mut config = base_config();
+        config.last_n = Some(200);
+
+        let info = build_window_info(&config, 200, NOW);
+
+        assert_eq!(info.mode, "count");
+        assert!(info.effective_strategy.is_none());
+    }
+
+    #[test]
+    fn test_build_window_info_time_mode() {
+        let mut config = base_config();
+        config.since = Some(1_700_000_000);
+
+        let info = build_window_info(&config, 77, NOW);
+
+        assert_eq!(info.mode, "time");
+        assert_eq!(info.since, "2023-11-14"); // epoch 1_700_000_000
+        assert!(info.effective_strategy.is_none());
+    }
+
+    #[test]
+    fn test_build_window_info_default_falls_back_to_dual() {
+        // No flags set → dual fallback branch
+        let config = base_config();
+
+        let info = build_window_info(&config, 0, NOW);
+
+        assert_eq!(info.mode, "dual");
+        // No dual_time_since/dual_count_since configured → effective_strategy still present
+        // (dual_mode=false here hits the else branch which produces None for effective_strategy)
+        // Wait: dual_mode=false, so effective_strategy is None in the non-dual-mode branch.
+        // The mode string comes from the final else → "dual", but effective_strategy is None
+        // because we only set effective_strategy inside `if config.dual_mode`.
+        assert!(info.effective_strategy.is_none());
+    }
+
+    #[test]
+    fn test_build_window_info_no_since_shows_all() {
+        let config = base_config();
+
+        let info = build_window_info(&config, 0, NOW);
+
+        assert_eq!(info.since, "all");
+    }
+
+    #[test]
+    fn test_build_window_info_commits_analyzed_passthrough() {
+        let config = base_config();
+
+        let info = build_window_info(&config, 999, NOW);
+
+        assert_eq!(info.commits_analyzed, 999);
     }
 }

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -27,10 +27,7 @@ use metrics::{
     compute_fix_after_touch, compute_stability,
 };
 use output::{render_json, render_text};
-use types::{
-    AuthorMetrics, CommitRecord, FileMetrics, FixRiskMetrics, HeatmapConfig, HeatmapResult,
-    WindowInfo,
-};
+use types::{CommitRecord, FileMetrics, HeatmapConfig, HeatmapResult, WindowInfo};
 
 // ============================================================================
 // Window presets
@@ -284,17 +281,8 @@ fn compute_heatmap(
         .into_iter()
         .map(|(path, churn)| {
             let stability_score = stability_map.get(&path).copied().unwrap_or(100);
-            let authors = author_map.get(&path).cloned().unwrap_or(AuthorMetrics {
-                count: 0,
-                top_author_pct: 0.0,
-                single_owner_risk: false,
-            });
-            let fix_risk = fix_risk_map.get(&path).cloned().unwrap_or(FixRiskMetrics {
-                keyword_pct: 0.0,
-                proximity_pct: 0.0,
-                combined_pct: 0.0,
-                insufficient_data: true,
-            });
+            let authors = author_map.get(&path).cloned().unwrap_or_default();
+            let fix_risk = fix_risk_map.get(&path).cloned().unwrap_or_default();
             let blast_radius = blast_radius_map.get(&path).cloned().unwrap_or_default();
 
             FileMetrics {

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -27,7 +27,7 @@ use metrics::{
     compute_fix_after_touch, compute_stability,
 };
 use output::{render_json, render_text};
-use types::{CommitRecord, FileMetrics, HeatmapConfig, HeatmapResult, WindowInfo};
+use types::{CommitRecord, FileMetrics, HeatmapConfig, HeatmapResult, ResolvedWindow, WindowInfo};
 
 // ============================================================================
 // Window presets
@@ -118,10 +118,11 @@ fn run_with_source(
         .as_secs();
 
     // Step 2: Resolve effective config (presets and --last)
-    let effective_config = resolve_effective_config(config, source, &mut warnings, now_epoch)?;
+    let (effective_config, window) =
+        resolve_effective_config(config, source, &mut warnings, now_epoch)?;
 
     if config.debug {
-        let mode = if effective_config.dual_mode {
+        let mode = if window.dual_mode {
             "dual"
         } else if config.last_n.is_some() {
             "count"
@@ -129,7 +130,7 @@ fn run_with_source(
             "time"
         };
         eprintln!("[skim:heatmap] window mode: {mode}");
-        if let Some(since) = effective_config.since {
+        if let Some(since) = window.since {
             eprintln!(
                 "[skim:heatmap] since epoch: {since} ({})",
                 format_epoch(since)
@@ -187,14 +188,7 @@ fn run_with_source(
 
     // Steps 5-9: Compute metrics and assemble result
     let start_time = std::time::Instant::now();
-    let mut result = compute_heatmap(
-        commits,
-        config,
-        &effective_config,
-        now_epoch,
-        repo_root,
-        warnings,
-    );
+    let mut result = compute_heatmap(commits, config, &window, now_epoch, repo_root, warnings);
 
     // Apply --top N limit to files
     result.files.truncate(config.top_n);
@@ -247,7 +241,7 @@ const MIN_SUPPORT_THRESHOLD: usize = 3;
 fn compute_heatmap(
     commits: Vec<CommitRecord>,
     config: &HeatmapConfig,
-    effective_config: &HeatmapConfig,
+    window: &ResolvedWindow,
     now_epoch: u64,
     repository: String,
     warnings: Vec<String>,
@@ -304,7 +298,7 @@ fn compute_heatmap(
     file_metrics.sort_by_key(|f| f.stability_score);
 
     // Step 7: Build window info
-    let window_info = build_window_info(effective_config, commits.len(), now_epoch);
+    let window_info = build_window_info(window, commits.len(), now_epoch);
 
     // Step 8: Get excluded patterns for output
     let excluded_patterns: Vec<String> = if config.no_exclude {
@@ -338,13 +332,25 @@ fn compute_heatmap(
 /// Resolve the effective `HeatmapConfig` by applying presets and `--last`.
 ///
 /// Precedence: `--since` > `--last` > `--window` preset > dual default.
+///
+/// Returns a tuple of:
+/// - `HeatmapConfig` with `since` set to the resolved epoch (used by `fetch_commits`)
+/// - `ResolvedWindow` carrying window metadata (mode, dual fields) for `build_window_info`
 fn resolve_effective_config(
     config: &HeatmapConfig,
     source: &dyn GitDataSource,
     warnings: &mut Vec<String>,
     now_epoch: u64,
-) -> anyhow::Result<HeatmapConfig> {
+) -> anyhow::Result<(HeatmapConfig, ResolvedWindow)> {
     let mut effective = config.clone();
+    let mut window = ResolvedWindow {
+        since: None,
+        dual_mode: false,
+        dual_time_since: None,
+        dual_count_since: None,
+        window_preset: config.window_preset.clone(),
+        last_n: config.last_n,
+    };
 
     // Count explicit time-selection flags
     let explicit_count = [
@@ -366,11 +372,13 @@ fn resolve_effective_config(
     if let Some(since) = config.since {
         // Already set — highest precedence
         effective.since = Some(since);
+        window.since = Some(since);
     } else if let Some(n) = config.last_n {
         // --last N: find the timestamp of the Nth commit
         match source.fetch_commit_count_since(n) {
             Ok(Some(ts)) => {
                 effective.since = Some(ts);
+                window.since = Some(ts);
             }
             Ok(None) => {
                 warnings.push(format!(
@@ -384,6 +392,7 @@ fn resolve_effective_config(
     } else if let Some(ref preset) = config.window_preset {
         if let Some(since) = preset_to_since_secs(preset, now_epoch) {
             effective.since = Some(since);
+            window.since = Some(since);
         } else {
             warnings.push(format!(
                 "Unknown window preset '{preset}' — valid: sprint, month, quarter, half, year, all. Analyzing all history."
@@ -399,13 +408,15 @@ fn resolve_effective_config(
         };
 
         // Use whichever captures more history (lower epoch = more history)
-        effective.since = Some(time_since.min(count_since));
-        effective.dual_mode = true;
-        effective.dual_time_since = Some(time_since);
-        effective.dual_count_since = Some(count_since);
+        let resolved_since = time_since.min(count_since);
+        effective.since = Some(resolved_since);
+        window.since = Some(resolved_since);
+        window.dual_mode = true;
+        window.dual_time_since = Some(time_since);
+        window.dual_count_since = Some(count_since);
     }
 
-    Ok(effective)
+    Ok((effective, window))
 }
 
 // ============================================================================
@@ -413,30 +424,30 @@ fn resolve_effective_config(
 // ============================================================================
 
 fn build_window_info(
-    config: &HeatmapConfig,
+    window: &ResolvedWindow,
     commits_analyzed: usize,
     now_epoch: u64,
 ) -> WindowInfo {
-    let mode = if config.dual_mode {
+    let mode = if window.dual_mode {
         "dual".to_string()
-    } else if let Some(ref preset) = config.window_preset {
+    } else if let Some(ref preset) = window.window_preset {
         preset.clone()
-    } else if config.last_n.is_some() {
+    } else if window.last_n.is_some() {
         "count".to_string()
-    } else if config.since.is_some() {
+    } else if window.since.is_some() {
         "time".to_string()
     } else {
         "dual".to_string()
     };
 
-    let since_str = config
+    let since_str = window
         .since
         .map(format_epoch)
         .unwrap_or_else(|| "all".to_string());
 
-    let effective_strategy = if config.dual_mode {
-        let time_since = config.dual_time_since.unwrap_or(0);
-        let count_since = config.dual_count_since.unwrap_or(0);
+    let effective_strategy = if window.dual_mode {
+        let time_since = window.dual_time_since.unwrap_or(0);
+        let count_since = window.dual_count_since.unwrap_or(0);
         let strategy = if time_since <= count_since {
             "time"
         } else {
@@ -909,21 +920,30 @@ mod tests {
     // build_window_info
     // -----------------------------------------------------------------------
 
-    fn base_config() -> HeatmapConfig {
-        HeatmapConfig::default()
+    fn base_window() -> ResolvedWindow {
+        ResolvedWindow {
+            since: None,
+            dual_mode: false,
+            dual_time_since: None,
+            dual_count_since: None,
+            window_preset: None,
+            last_n: None,
+        }
     }
 
     const NOW: u64 = 1_704_067_200; // 2024-01-01
 
     #[test]
     fn test_build_window_info_dual_mode() {
-        let mut config = base_config();
-        config.dual_mode = true;
-        // time_since <= count_since → effective_strategy = "time"
-        config.dual_time_since = Some(1_000_000);
-        config.dual_count_since = Some(2_000_000);
+        let window = ResolvedWindow {
+            dual_mode: true,
+            // time_since <= count_since → effective_strategy = "time"
+            dual_time_since: Some(1_000_000),
+            dual_count_since: Some(2_000_000),
+            ..base_window()
+        };
 
-        let info = build_window_info(&config, 42, NOW);
+        let info = build_window_info(&window, 42, NOW);
 
         assert_eq!(info.mode, "dual");
         assert_eq!(info.commits_analyzed, 42);
@@ -932,13 +952,15 @@ mod tests {
 
     #[test]
     fn test_build_window_info_dual_mode_count_wins() {
-        let mut config = base_config();
-        config.dual_mode = true;
-        // time_since > count_since → effective_strategy = "count"
-        config.dual_time_since = Some(2_000_000);
-        config.dual_count_since = Some(1_000_000);
+        let window = ResolvedWindow {
+            dual_mode: true,
+            // time_since > count_since → effective_strategy = "count"
+            dual_time_since: Some(2_000_000),
+            dual_count_since: Some(1_000_000),
+            ..base_window()
+        };
 
-        let info = build_window_info(&config, 10, NOW);
+        let info = build_window_info(&window, 10, NOW);
 
         assert_eq!(info.mode, "dual");
         assert_eq!(info.effective_strategy.as_deref(), Some("count"));
@@ -946,10 +968,12 @@ mod tests {
 
     #[test]
     fn test_build_window_info_preset_mode() {
-        let mut config = base_config();
-        config.window_preset = Some("quarter".to_string());
+        let window = ResolvedWindow {
+            window_preset: Some("quarter".to_string()),
+            ..base_window()
+        };
 
-        let info = build_window_info(&config, 50, NOW);
+        let info = build_window_info(&window, 50, NOW);
 
         assert_eq!(info.mode, "quarter");
         assert!(info.effective_strategy.is_none());
@@ -957,10 +981,12 @@ mod tests {
 
     #[test]
     fn test_build_window_info_count_mode() {
-        let mut config = base_config();
-        config.last_n = Some(200);
+        let window = ResolvedWindow {
+            last_n: Some(200),
+            ..base_window()
+        };
 
-        let info = build_window_info(&config, 200, NOW);
+        let info = build_window_info(&window, 200, NOW);
 
         assert_eq!(info.mode, "count");
         assert!(info.effective_strategy.is_none());
@@ -968,10 +994,12 @@ mod tests {
 
     #[test]
     fn test_build_window_info_time_mode() {
-        let mut config = base_config();
-        config.since = Some(1_700_000_000);
+        let window = ResolvedWindow {
+            since: Some(1_700_000_000),
+            ..base_window()
+        };
 
-        let info = build_window_info(&config, 77, NOW);
+        let info = build_window_info(&window, 77, NOW);
 
         assert_eq!(info.mode, "time");
         assert_eq!(info.since, "2023-11-14"); // epoch 1_700_000_000
@@ -982,9 +1010,9 @@ mod tests {
     fn test_build_window_info_default_falls_back_to_dual() {
         // No flags set → falls through to the "dual" fallback mode string.
         // dual_mode=false, so effective_strategy is None (only set in the dual_mode branch).
-        let config = base_config();
+        let window = base_window();
 
-        let info = build_window_info(&config, 0, NOW);
+        let info = build_window_info(&window, 0, NOW);
 
         assert_eq!(info.mode, "dual");
         assert!(info.effective_strategy.is_none());
@@ -992,18 +1020,18 @@ mod tests {
 
     #[test]
     fn test_build_window_info_no_since_shows_all() {
-        let config = base_config();
+        let window = base_window();
 
-        let info = build_window_info(&config, 0, NOW);
+        let info = build_window_info(&window, 0, NOW);
 
         assert_eq!(info.since, "all");
     }
 
     #[test]
     fn test_build_window_info_commits_analyzed_passthrough() {
-        let config = base_config();
+        let window = base_window();
 
-        let info = build_window_info(&config, 999, NOW);
+        let info = build_window_info(&window, 999, NOW);
 
         assert_eq!(info.commits_analyzed, 999);
     }

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -47,7 +47,9 @@ fn preset_to_since_secs(preset: &str) -> Option<u64> {
         "sprint" => Some(now.saturating_sub(14 * 86400)),
         "month" => Some(now.saturating_sub(30 * 86400)),
         "quarter" => Some(now.saturating_sub(90 * 86400)),
+        "half" => Some(now.saturating_sub(180 * 86400)),
         "year" => Some(now.saturating_sub(365 * 86400)),
+        "all" => Some(0),
         _ => None,
     }
 }
@@ -112,8 +114,26 @@ fn run_with_source(
         );
     }
 
+    if config.debug {
+        eprintln!("[heatmap] repo root: {repo_root}");
+    }
+
     // Step 2: Resolve effective config (presets and --last)
     let effective_config = resolve_effective_config(config, git, &mut warnings)?;
+
+    if config.debug {
+        let mode = if effective_config.dual_mode {
+            "dual"
+        } else if config.last_n.is_some() {
+            "count"
+        } else {
+            "time"
+        };
+        eprintln!("[heatmap] window mode: {mode}");
+        if let Some(since) = effective_config.since {
+            eprintln!("[heatmap] since epoch: {since} ({})", format_epoch(since));
+        }
+    }
 
     // Step 3: Fetch commits
     let raw_commits = match source.fetch_commits(&effective_config) {
@@ -129,6 +149,10 @@ fn run_with_source(
         }
     };
 
+    if config.debug {
+        eprintln!("[heatmap] raw commits fetched: {}", raw_commits.len());
+    }
+
     if raw_commits.is_empty() {
         eprintln!("skim heatmap: No commits found in repository");
         return Ok(ExitCode::FAILURE);
@@ -136,6 +160,7 @@ fn run_with_source(
 
     // Step 4: Apply exclusions
     let exclude_set = build_exclude_set(config.no_exclude, &config.extra_excludes);
+    let raw_commit_count = raw_commits.len();
     let mut commits = raw_commits;
     for commit in &mut commits {
         commit
@@ -144,6 +169,14 @@ fn run_with_source(
     }
     // Remove commits that are now file-less after exclusion
     commits.retain(|c| !c.files.is_empty());
+
+    if config.debug {
+        eprintln!(
+            "[heatmap] commits after exclusion: {} ({} excluded)",
+            commits.len(),
+            raw_commit_count - commits.len()
+        );
+    }
 
     if commits.is_empty() {
         eprintln!("skim heatmap: No analyzable files after exclusions");
@@ -166,6 +199,17 @@ fn run_with_source(
     let (blast_radius_map, coupling_graph) =
         compute_coupling(&commits, config.coupling_threshold, 3);
     let modules = compute_encapsulation(&commits, 3);
+
+    if config.debug {
+        let compute_elapsed = start_time.elapsed();
+        eprintln!(
+            "[heatmap] metrics computed in {:.1}ms — {} files, {} coupling edges, {} modules",
+            compute_elapsed.as_secs_f64() * 1000.0,
+            churn_map.len(),
+            coupling_graph.len(),
+            modules.len(),
+        );
+    }
 
     // Step 6: Assemble FileMetrics
     let mut all_paths: HashSet<String> = HashSet::new();
@@ -207,8 +251,8 @@ fn run_with_source(
         })
         .collect();
 
-    // Sort by churn descending for consistent output
-    file_metrics.sort_by(|a, b| b.churn.commits.cmp(&a.churn.commits));
+    // Sort by stability_score ascending (riskiest first)
+    file_metrics.sort_by(|a, b| a.stability_score.cmp(&b.stability_score));
 
     // Step 7: Build window info
     let window_info = build_window_info(&effective_config, commits.len());
@@ -321,16 +365,27 @@ fn resolve_effective_config(
             effective.since = Some(since);
         } else {
             warnings.push(format!(
-                "Unknown window preset '{preset}' — valid: sprint, month, quarter, year. Analyzing all history."
+                "Unknown window preset '{preset}' — valid: sprint, month, quarter, half, year, all. Analyzing all history."
             ));
         }
     } else {
-        // Dual default: 90 days
+        // Dual default: max(last 90 days, last 200 commits)
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        effective.since = Some(now.saturating_sub(90 * 86400));
+        let time_since = now.saturating_sub(90 * 86400);
+
+        let count_since = match source.fetch_commit_count_since(200) {
+            Ok(Some(ts)) => ts,
+            _ => time_since, // fallback to time-based if lookup fails
+        };
+
+        // Use whichever captures more history (lower epoch = more history)
+        effective.since = Some(time_since.min(count_since));
+        effective.dual_mode = true;
+        effective.dual_time_since = Some(time_since);
+        effective.dual_count_since = Some(count_since);
     }
 
     Ok(effective)
@@ -341,14 +396,16 @@ fn resolve_effective_config(
 // ============================================================================
 
 fn build_window_info(config: &HeatmapConfig, commits_analyzed: usize) -> WindowInfo {
-    let mode = if let Some(ref preset) = config.window_preset {
+    let mode = if config.dual_mode {
+        "dual".to_string()
+    } else if let Some(ref preset) = config.window_preset {
         preset.clone()
-    } else if let Some(n) = config.last_n {
-        format!("last-{n}")
-    } else if let Some(since) = config.since {
-        format!("since-{since}")
+    } else if config.last_n.is_some() {
+        "count".to_string()
+    } else if config.since.is_some() {
+        "time".to_string()
     } else {
-        "90d".to_string()
+        "dual".to_string()
     };
 
     let since_str = config
@@ -361,14 +418,27 @@ fn build_window_info(config: &HeatmapConfig, commits_analyzed: usize) -> WindowI
         .unwrap_or_default()
         .as_secs();
 
+    let (effective_strategy, time_commits, count_commits) = if config.dual_mode {
+        let time_since = config.dual_time_since.unwrap_or(0);
+        let count_since = config.dual_count_since.unwrap_or(0);
+        let strategy = if time_since <= count_since {
+            "time"
+        } else {
+            "count"
+        };
+        (Some(strategy.to_string()), None, None)
+    } else {
+        (None, None, None)
+    };
+
     WindowInfo {
         mode,
         since: since_str,
         until: format_epoch(now_epoch),
         commits_analyzed,
-        time_commits: None,
-        count_commits: None,
-        effective_strategy: None,
+        time_commits,
+        count_commits,
+        effective_strategy,
     }
 }
 
@@ -476,16 +546,25 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
             continue;
         }
 
+        // --format VALUE
+        if let Some(val) = extract_value(args, &mut i, "--format") {
+            if val == "json" {
+                config.format_json = true;
+            } else {
+                anyhow::bail!("--format only supports 'json', got: {val}");
+            }
+            continue;
+        }
+
         // Boolean flags
         match arg {
-            "--json" | "--format=json" => config.format_json = true,
+            "--json" => config.format_json = true,
             "--no-exclude" => config.no_exclude = true,
             "--debug" => config.debug = true,
             other => {
                 if other.starts_with('-') {
                     anyhow::bail!("unknown flag: {other}");
                 }
-                // Positional argument — currently unused
             }
         }
 
@@ -551,7 +630,7 @@ USAGE:
 OPTIONS:
     --since <VALUE>               Analyze commits since epoch (seconds) or duration (30d, 2w, 24h)
     --last <N>                    Analyze last N commits
-    --window <PRESET>             Named window: sprint (14d), month (30d), quarter (90d), year (365d)
+    --window <PRESET>             Named window: sprint|month|quarter|half|year|all
     --path <DIR>                  Scope analysis to files under this path
     --json                        Output JSON instead of human-readable text
     --top <N>                     Maximum files to display (default: 20)
@@ -565,8 +644,10 @@ OPTIONS:
 WINDOW PRESETS:
     sprint     14 days
     month      30 days
-    quarter    90 days (default when no window specified)
+    quarter    90 days
+    half       180 days
     year       365 days
+    all        No time limit (analyze entire history)
 
 EXAMPLES:
     skim heatmap                           # Analyze last 90 days

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -988,17 +988,13 @@ mod tests {
 
     #[test]
     fn test_build_window_info_default_falls_back_to_dual() {
-        // No flags set → dual fallback branch
+        // No flags set → falls through to the "dual" fallback mode string.
+        // dual_mode=false, so effective_strategy is None (only set in the dual_mode branch).
         let config = base_config();
 
         let info = build_window_info(&config, 0, NOW);
 
         assert_eq!(info.mode, "dual");
-        // No dual_time_since/dual_count_since configured → effective_strategy still present
-        // (dual_mode=false here hits the else branch which produces None for effective_strategy)
-        // Wait: dual_mode=false, so effective_strategy is None in the non-dual-mode branch.
-        // The mode string comes from the final else → "dual", but effective_strategy is None
-        // because we only set effective_strategy inside `if config.dual_mode`.
         assert!(info.effective_strategy.is_none());
     }
 

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -656,27 +656,37 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
         }
 
         // Boolean flags
-        match arg {
-            "--json" => config.format_json = true,
-            "--no-exclude" => config.no_exclude = true,
-            "--debug" => {
-                config.debug = true;
-                crate::debug::force_enable_debug();
-            }
-            other => {
-                if other.starts_with('-') {
-                    anyhow::bail!("unknown flag: {other}");
-                }
-                // Positional (non-flag) argument — `skim heatmap` takes no
-                // positional args; suggest --path if the user meant a directory.
-                anyhow::bail!("unexpected argument: '{other}'. Did you mean --path={other}?");
-            }
+        if apply_boolean_flag(&mut config, arg)? {
+            i += 1;
+            continue;
         }
 
-        i += 1;
+        if arg.starts_with('-') {
+            anyhow::bail!("unknown flag: {arg}");
+        }
+        // Positional (non-flag) argument — `skim heatmap` takes no
+        // positional args; suggest --path if the user meant a directory.
+        anyhow::bail!("unexpected argument: '{arg}'. Did you mean --path={arg}?");
     }
 
     Ok(config)
+}
+
+/// Apply a recognised boolean flag to `config`.
+///
+/// Returns `Ok(true)` if the flag was recognised and applied, `Ok(false)` if
+/// the flag is unknown (caller falls through to the unknown-flag error).
+fn apply_boolean_flag(config: &mut HeatmapConfig, flag: &str) -> anyhow::Result<bool> {
+    match flag {
+        "--json" => config.format_json = true,
+        "--no-exclude" => config.no_exclude = true,
+        "--debug" => {
+            config.debug = true;
+            crate::debug::force_enable_debug();
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
 }
 
 /// Extract a `--flag VALUE` or `--flag=VALUE` pair, advancing `i`.

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -628,10 +628,13 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
 
         // --last
         if let Some(val) = extract_value(args, &mut i, "--last") {
-            config.last_n = Some(
-                val.parse()
-                    .map_err(|_| anyhow::anyhow!("--last requires a positive integer"))?,
-            );
+            let n: usize = val
+                .parse()
+                .map_err(|_| anyhow::anyhow!("--last requires a positive integer"))?;
+            if n == 0 {
+                anyhow::bail!("--last must be at least 1");
+            }
+            config.last_n = Some(n);
             continue;
         }
 
@@ -944,6 +947,14 @@ mod tests {
             msg.contains("--fix-window must be at least 1"),
             "got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_parse_args_last_zero_errors() {
+        let result = parse_args(&["--last=0".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("--last must be at least 1"), "got: {msg}");
     }
 
     #[test]

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -269,7 +269,7 @@ fn run_with_source(
     };
 
     // Step 9: Build result
-    let result = HeatmapResult {
+    let mut result = HeatmapResult {
         version: 1,
         generated_at: format_epoch(now_epoch),
         repository: repo_root,
@@ -280,6 +280,9 @@ fn run_with_source(
         excluded_patterns,
         warnings,
     };
+
+    // Apply --top N limit to files
+    result.files.truncate(config.top_n);
 
     // Step 10: Render
     let elapsed = start_time.elapsed();
@@ -632,7 +635,7 @@ OPTIONS:
     --last <N>                    Analyze last N commits
     --window <PRESET>             Named window: sprint|month|quarter|half|year|all
     --path <DIR>                  Scope analysis to files under this path
-    --json                        Output JSON instead of human-readable text
+    --json, --format json         Output JSON instead of human-readable text
     --top <N>                     Maximum files to display (default: 20)
     --no-exclude                  Disable default exclusion patterns (lock files, build dirs, etc.)
     --exclude <PATTERN>           Add extra glob pattern to exclude (repeatable)

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -293,14 +293,35 @@ fn compute_heatmap(
     let fix_regex = build_fix_regex();
 
     // Step 5: Compute metrics
+    // Phase 1: churn must run first — max_churn feeds into stability.
     let churn_map = compute_churn(&commits);
     let max_churn = churn_map.values().map(|m| m.commits).max().unwrap_or(1);
-    let stability_map = compute_stability(&commits, &fix_regex, max_churn, now_epoch);
-    let author_map = compute_authors(&commits);
-    let fix_risk_map = compute_fix_after_touch(&commits, &fix_regex, config.fix_window);
-    let (blast_radius_map, coupling_graph) =
-        compute_coupling(&commits, config.coupling_threshold, MIN_SUPPORT_THRESHOLD);
-    let modules = compute_encapsulation(&commits, MIN_SUPPORT_THRESHOLD);
+
+    // Phase 2: remaining 5 metrics are independent of each other — run in parallel.
+    let fix_window = config.fix_window;
+    let coupling_threshold = config.coupling_threshold;
+    let (
+        (stability_map, author_map),
+        ((fix_risk_map, (blast_radius_map, coupling_graph)), modules),
+    ) = rayon::join(
+        || {
+            rayon::join(
+                || compute_stability(&commits, &fix_regex, max_churn, now_epoch),
+                || compute_authors(&commits),
+            )
+        },
+        || {
+            rayon::join(
+                || {
+                    rayon::join(
+                        || compute_fix_after_touch(&commits, &fix_regex, fix_window),
+                        || compute_coupling(&commits, coupling_threshold, MIN_SUPPORT_THRESHOLD),
+                    )
+                },
+                || compute_encapsulation(&commits, MIN_SUPPORT_THRESHOLD),
+            )
+        },
+    );
 
     if config.debug {
         let elapsed = t0.elapsed();

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -120,9 +120,7 @@ fn render_fix_risk(out: &mut String, result: &HeatmapResult, top_n: usize) {
         .iter()
         .filter(|f| f.fix_risk.combined_pct > 20.0 && !f.fix_risk.insufficient_data)
         .collect();
-    fix_risk_files.sort_by(|a, b| {
-        b.fix_risk.combined_pct.total_cmp(&a.fix_risk.combined_pct)
-    });
+    fix_risk_files.sort_by(|a, b| b.fix_risk.combined_pct.total_cmp(&a.fix_risk.combined_pct));
 
     if fix_risk_files.is_empty() {
         out.push_str("  (no files above threshold)\n");

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -1,0 +1,424 @@
+//! Rendering layer for `skim heatmap` output.
+//!
+//! Two formats: JSON (via serde_json) and human-readable text (via colored).
+
+use colored::Colorize;
+
+use super::types::HeatmapResult;
+
+// ============================================================================
+// NO_COLOR detection
+// ============================================================================
+
+fn no_color() -> bool {
+    std::env::var("NO_COLOR").is_ok()
+}
+
+// ============================================================================
+// JSON output
+// ============================================================================
+
+/// Render the heatmap result as pretty-printed JSON.
+pub(crate) fn render_json(result: &HeatmapResult) -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(result)?)
+}
+
+// ============================================================================
+// Text output
+// ============================================================================
+
+/// Render the heatmap result as a human-readable text report.
+pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
+    let mut out = String::new();
+    let use_color = !no_color();
+
+    // Header
+    let header = format!(
+        "─── Heatmap: {} ({} commits, {} window) ───",
+        result.repository, result.window.commits_analyzed, result.window.mode
+    );
+    if use_color {
+        out.push_str(&header.bold().to_string());
+    } else {
+        out.push_str(&header);
+    }
+    out.push('\n');
+
+    if !result.warnings.is_empty() {
+        for w in &result.warnings {
+            out.push_str(&format!("  ⚠  {w}\n"));
+        }
+    }
+    out.push('\n');
+
+    // Top Churn
+    section_header(&mut out, "Top Churn:", use_color);
+    let mut files_by_churn: Vec<_> = result.files.iter().collect();
+    files_by_churn.sort_by(|a, b| b.churn.commits.cmp(&a.churn.commits));
+
+    if files_by_churn.is_empty() {
+        out.push_str("  (no files)\n");
+    } else {
+        for fm in files_by_churn.iter().take(top_n) {
+            let rate_pct = fm.churn.rate * 100.0;
+            let stability = fm.stability_score;
+            let line = format!(
+                "  {:4} commits  {:5.1}% rate  stability {:3}  {}",
+                fm.churn.commits, rate_pct, stability, fm.path
+            );
+            if use_color {
+                let churn_str = format!("{:4}", fm.churn.commits).yellow().to_string();
+                let rate_str = format!("{rate_pct:5.1}%").to_string();
+                let stab_str = if stability < 40 {
+                    format!("{stability:3}").red().to_string()
+                } else if stability < 70 {
+                    format!("{stability:3}").yellow().to_string()
+                } else {
+                    format!("{stability:3}").green().to_string()
+                };
+                out.push_str(&format!(
+                    "  {churn_str} commits  {rate_str} rate  stability {stab_str}  {}\n",
+                    fm.path
+                ));
+            } else {
+                out.push_str(&line);
+                out.push('\n');
+            }
+        }
+    }
+    out.push('\n');
+
+    // Blast Radius (coupling)
+    let threshold_pct = 0.0; // We show whatever passed the threshold filter
+    section_header(
+        &mut out,
+        &format!("Blast Radius (coupling > {threshold_pct:.0}%):",),
+        use_color,
+    );
+    let mut files_with_coupling: Vec<_> = result
+        .files
+        .iter()
+        .filter(|f| !f.blast_radius.is_empty())
+        .collect();
+    files_with_coupling.sort_by(|a, b| {
+        let a_conf = a.blast_radius.first().map(|e| e.confidence).unwrap_or(0.0);
+        let b_conf = b.blast_radius.first().map(|e| e.confidence).unwrap_or(0.0);
+        b_conf
+            .partial_cmp(&a_conf)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    if files_with_coupling.is_empty() {
+        out.push_str("  (no coupling above threshold)\n");
+    } else {
+        for fm in files_with_coupling.iter().take(top_n) {
+            out.push_str(&format!("  {}\n", fm.path));
+            for entry in fm.blast_radius.iter().take(5) {
+                let conf_pct = entry.confidence * 100.0;
+                if use_color {
+                    let conf_str = format!("{conf_pct:5.1}%").cyan().to_string();
+                    out.push_str(&format!(
+                        "    → {} ({conf_str} confidence, {} support)\n",
+                        entry.path, entry.support
+                    ));
+                } else {
+                    out.push_str(&format!(
+                        "    → {} ({conf_pct:5.1}% confidence, {} support)\n",
+                        entry.path, entry.support
+                    ));
+                }
+            }
+        }
+    }
+    out.push('\n');
+
+    // Fix Risk
+    section_header(&mut out, "Fix Risk (> 20%):", use_color);
+    let mut fix_risk_files: Vec<_> = result
+        .files
+        .iter()
+        .filter(|f| f.fix_risk.combined_pct > 20.0 && !f.fix_risk.insufficient_data)
+        .collect();
+    fix_risk_files.sort_by(|a, b| {
+        b.fix_risk
+            .combined_pct
+            .partial_cmp(&a.fix_risk.combined_pct)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    if fix_risk_files.is_empty() {
+        out.push_str("  (no files above threshold)\n");
+    } else {
+        for fm in fix_risk_files.iter().take(top_n) {
+            let combined = fm.fix_risk.combined_pct;
+            let kw = fm.fix_risk.keyword_pct;
+            let prox = fm.fix_risk.proximity_pct;
+            if use_color {
+                let combined_str = format!("{combined:5.1}%").red().to_string();
+                out.push_str(&format!(
+                    "  {} combined={combined_str} keyword={kw:5.1}% proximity={prox:5.1}%\n",
+                    fm.path
+                ));
+            } else {
+                out.push_str(&format!(
+                    "  {} combined={combined:5.1}% keyword={kw:5.1}% proximity={prox:5.1}%\n",
+                    fm.path
+                ));
+            }
+        }
+    }
+    out.push('\n');
+
+    // Module Health
+    section_header(&mut out, "Module Health:", use_color);
+    if result.modules.is_empty() {
+        out.push_str("  (no modules with enough data)\n");
+    } else {
+        for module in result.modules.iter().take(top_n) {
+            let pct = module.encapsulation_pct;
+            if use_color {
+                let pct_str = if pct < 50.0 {
+                    format!("{pct:5.1}%").red().to_string()
+                } else if pct < 75.0 {
+                    format!("{pct:5.1}%").yellow().to_string()
+                } else {
+                    format!("{pct:5.1}%").green().to_string()
+                };
+                out.push_str(&format!(
+                    "  {} encapsulation={pct_str} files={} commits={} cross={}\n",
+                    module.path,
+                    module.files_count,
+                    module.total_commits,
+                    module.cross_boundary_commits
+                ));
+            } else {
+                out.push_str(&format!(
+                    "  {} encapsulation={pct:5.1}% files={} commits={} cross={}\n",
+                    module.path,
+                    module.files_count,
+                    module.total_commits,
+                    module.cross_boundary_commits
+                ));
+            }
+        }
+    }
+    out.push('\n');
+
+    // Bus Factor Risk
+    section_header(&mut out, "Bus Factor Risk:", use_color);
+    let bus_factor_files: Vec<_> = result
+        .files
+        .iter()
+        .filter(|f| f.authors.single_owner_risk)
+        .collect();
+
+    if bus_factor_files.is_empty() {
+        out.push_str("  (no single-owner risk detected)\n");
+    } else {
+        for fm in bus_factor_files.iter().take(top_n) {
+            let pct = fm.authors.top_author_pct;
+            if use_color {
+                let pct_str = format!("{pct:5.1}%").red().to_string();
+                out.push_str(&format!(
+                    "  {} top-author={pct_str} authors={}\n",
+                    fm.path, fm.authors.count
+                ));
+            } else {
+                out.push_str(&format!(
+                    "  {} top-author={pct:5.1}% authors={}\n",
+                    fm.path, fm.authors.count
+                ));
+            }
+        }
+    }
+    out.push('\n');
+
+    out
+}
+
+fn section_header(out: &mut String, title: &str, use_color: bool) {
+    if use_color {
+        out.push_str(&title.bold().underline().to_string());
+    } else {
+        out.push_str(title);
+    }
+    out.push('\n');
+}
+
+// ============================================================================
+// Unit tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::cmd::heatmap::types::{
+        AuthorMetrics, ChurnMetrics, CouplingEdge, CouplingEntry, FileMetrics, FixRiskMetrics,
+        ModuleHealth, WindowInfo,
+    };
+
+    fn make_result() -> HeatmapResult {
+        HeatmapResult {
+            version: 1,
+            generated_at: "2025-01-01T00:00:00Z".to_string(),
+            repository: "test-repo".to_string(),
+            window: WindowInfo {
+                mode: "90d".to_string(),
+                since: "2024-10-01".to_string(),
+                until: "2025-01-01".to_string(),
+                commits_analyzed: 10,
+                time_commits: None,
+                count_commits: None,
+                effective_strategy: None,
+            },
+            files: vec![FileMetrics {
+                path: "src/main.rs".to_string(),
+                churn: ChurnMetrics {
+                    commits: 5,
+                    rate: 0.5,
+                },
+                stability_score: 42,
+                authors: AuthorMetrics {
+                    count: 2,
+                    top_author_pct: 85.0,
+                    single_owner_risk: true,
+                },
+                fix_risk: FixRiskMetrics {
+                    keyword_pct: 40.0,
+                    proximity_pct: 20.0,
+                    combined_pct: 50.0,
+                    insufficient_data: false,
+                },
+                blast_radius: vec![CouplingEntry {
+                    path: "src/lib.rs".to_string(),
+                    confidence: 0.75,
+                    support: 4,
+                }],
+            }],
+            modules: vec![ModuleHealth {
+                path: "src".to_string(),
+                encapsulation_pct: 60.0,
+                files_count: 5,
+                total_commits: 10,
+                cross_boundary_commits: 4,
+            }],
+            coupling_graph: vec![CouplingEdge {
+                a: "src/main.rs".to_string(),
+                b: "src/lib.rs".to_string(),
+                confidence: 0.75,
+                support: 4,
+            }],
+            excluded_patterns: vec!["Cargo.lock".to_string()],
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn test_json_roundtrip() {
+        let result = make_result();
+        let json = render_json(&result).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["version"], 1);
+        assert_eq!(parsed["repository"], "test-repo");
+        assert!(parsed["files"].is_array());
+        assert!(parsed["modules"].is_array());
+        assert!(parsed["coupling_graph"].is_array());
+    }
+
+    #[test]
+    fn test_json_has_all_metric_keys() {
+        let result = make_result();
+        let json = render_json(&result).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let file = &parsed["files"][0];
+        assert!(file["churn"].is_object());
+        assert!(file["stability_score"].is_number());
+        assert!(file["authors"].is_object());
+        assert!(file["fix_risk"].is_object());
+        assert!(file["blast_radius"].is_array());
+    }
+
+    #[test]
+    fn test_text_contains_top_churn_section() {
+        let result = make_result();
+        let text = render_text(&result, 20);
+        assert!(text.contains("Top Churn"), "expected Top Churn section");
+    }
+
+    #[test]
+    fn test_text_contains_blast_radius_section() {
+        let result = make_result();
+        let text = render_text(&result, 20);
+        assert!(
+            text.contains("Blast Radius"),
+            "expected Blast Radius section"
+        );
+    }
+
+    #[test]
+    fn test_text_contains_module_health_section() {
+        let result = make_result();
+        let text = render_text(&result, 20);
+        assert!(
+            text.contains("Module Health"),
+            "expected Module Health section"
+        );
+    }
+
+    #[test]
+    fn test_text_contains_bus_factor_section() {
+        let result = make_result();
+        let text = render_text(&result, 20);
+        assert!(text.contains("Bus Factor"), "expected Bus Factor section");
+    }
+
+    #[test]
+    fn test_text_contains_fix_risk_section() {
+        let result = make_result();
+        let text = render_text(&result, 20);
+        assert!(text.contains("Fix Risk"), "expected Fix Risk section");
+    }
+
+    #[test]
+    fn test_text_contains_repo_name() {
+        let result = make_result();
+        let text = render_text(&result, 20);
+        assert!(text.contains("test-repo"));
+    }
+
+    #[test]
+    fn test_text_respects_top_n() {
+        let mut result = make_result();
+        // Add many files
+        for i in 0..30 {
+            result.files.push(FileMetrics {
+                path: format!("file{i}.rs"),
+                churn: ChurnMetrics {
+                    commits: i + 1,
+                    rate: 0.1,
+                },
+                stability_score: 50,
+                authors: AuthorMetrics {
+                    count: 1,
+                    top_author_pct: 100.0,
+                    single_owner_risk: false,
+                },
+                fix_risk: FixRiskMetrics {
+                    keyword_pct: 0.0,
+                    proximity_pct: 0.0,
+                    combined_pct: 0.0,
+                    insufficient_data: true,
+                },
+                blast_radius: vec![],
+            });
+        }
+        let text = render_text(&result, 3);
+        // Should only show 3 entries in Top Churn
+        let churn_count = text.matches("commits  ").count();
+        assert!(
+            churn_count <= 3,
+            "expected at most 3 churn entries, got {churn_count}"
+        );
+    }
+}

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -1,18 +1,13 @@
 //! Rendering layer for `skim heatmap` output.
 //!
 //! Two formats: JSON (via serde_json) and human-readable text (via colored).
+//!
+//! Color handling: the `colored` crate automatically respects `NO_COLOR`,
+//! `TERM=dumb`, and non-TTY output. No manual `NO_COLOR` detection is needed.
 
 use colored::Colorize;
 
 use super::types::HeatmapResult;
-
-// ============================================================================
-// NO_COLOR detection
-// ============================================================================
-
-fn no_color() -> bool {
-    std::env::var("NO_COLOR").is_ok()
-}
 
 // ============================================================================
 // JSON output
@@ -28,20 +23,18 @@ pub(crate) fn render_json(result: &HeatmapResult) -> anyhow::Result<String> {
 // ============================================================================
 
 /// Render the heatmap result as a human-readable text report.
+///
+/// Color application is unconditional: the `colored` crate strips ANSI codes
+/// automatically when `NO_COLOR` is set or stdout is not a TTY.
 pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     let mut out = String::new();
-    let use_color = !no_color();
 
     // Header
     let header = format!(
         "─── Heatmap: {} ({} commits, {} window) ───",
         result.repository, result.window.commits_analyzed, result.window.mode
     );
-    if use_color {
-        out.push_str(&header.bold().to_string());
-    } else {
-        out.push_str(&header);
-    }
+    out.push_str(&header.bold().to_string());
     out.push('\n');
 
     if !result.warnings.is_empty() {
@@ -52,7 +45,7 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     out.push('\n');
 
     // Top Churn
-    section_header(&mut out, "Top Churn:", use_color);
+    section_header(&mut out, "Top Churn:");
     let mut files_by_churn: Vec<_> = result.files.iter().collect();
     files_by_churn.sort_by(|a, b| b.churn.commits.cmp(&a.churn.commits));
 
@@ -62,38 +55,25 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         for fm in files_by_churn.iter().take(top_n) {
             let rate_pct = fm.churn.rate * 100.0;
             let stability = fm.stability_score;
-            let line = format!(
-                "  {:4} commits  {:5.1}% rate  stability {:3}  {}",
-                fm.churn.commits, rate_pct, stability, fm.path
-            );
-            if use_color {
-                let churn_str = format!("{:4}", fm.churn.commits).yellow().to_string();
-                let rate_str = format!("{rate_pct:5.1}%").to_string();
-                let stab_str = if stability < 40 {
-                    format!("{stability:3}").red().to_string()
-                } else if stability < 70 {
-                    format!("{stability:3}").yellow().to_string()
-                } else {
-                    format!("{stability:3}").green().to_string()
-                };
-                out.push_str(&format!(
-                    "  {churn_str} commits  {rate_str} rate  stability {stab_str}  {}\n",
-                    fm.path
-                ));
+            let churn_str = format!("{:4}", fm.churn.commits).yellow().to_string();
+            let rate_str = format!("{rate_pct:5.1}%");
+            let stab_str = if stability < 40 {
+                format!("{stability:3}").red().to_string()
+            } else if stability < 70 {
+                format!("{stability:3}").yellow().to_string()
             } else {
-                out.push_str(&line);
-                out.push('\n');
-            }
+                format!("{stability:3}").green().to_string()
+            };
+            out.push_str(&format!(
+                "  {churn_str} commits  {rate_str} rate  stability {stab_str}  {}\n",
+                fm.path
+            ));
         }
     }
     out.push('\n');
 
     // Blast Radius (coupling)
-    section_header(
-        &mut out,
-        "Blast Radius (coupling above threshold):",
-        use_color,
-    );
+    section_header(&mut out, "Blast Radius (coupling above threshold):");
     let mut files_with_coupling: Vec<_> = result
         .files
         .iter()
@@ -114,25 +94,18 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
             out.push_str(&format!("  {}\n", fm.path));
             for entry in fm.blast_radius.iter().take(5) {
                 let conf_pct = entry.confidence * 100.0;
-                if use_color {
-                    let conf_str = format!("{conf_pct:5.1}%").cyan().to_string();
-                    out.push_str(&format!(
-                        "    → {} ({conf_str} confidence, {} support)\n",
-                        entry.path, entry.support
-                    ));
-                } else {
-                    out.push_str(&format!(
-                        "    → {} ({conf_pct:5.1}% confidence, {} support)\n",
-                        entry.path, entry.support
-                    ));
-                }
+                let conf_str = format!("{conf_pct:5.1}%").cyan().to_string();
+                out.push_str(&format!(
+                    "    → {} ({conf_str} confidence, {} support)\n",
+                    entry.path, entry.support
+                ));
             }
         }
     }
     out.push('\n');
 
     // Fix Risk
-    section_header(&mut out, "Fix Risk (> 20%):", use_color);
+    section_header(&mut out, "Fix Risk (> 20%):");
     let mut fix_risk_files: Vec<_> = result
         .files
         .iter()
@@ -152,59 +125,42 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
             let combined = fm.fix_risk.combined_pct;
             let kw = fm.fix_risk.keyword_pct;
             let prox = fm.fix_risk.proximity_pct;
-            if use_color {
-                let combined_str = format!("{combined:5.1}%").red().to_string();
-                out.push_str(&format!(
-                    "  {} combined={combined_str} keyword={kw:5.1}% proximity={prox:5.1}%\n",
-                    fm.path
-                ));
-            } else {
-                out.push_str(&format!(
-                    "  {} combined={combined:5.1}% keyword={kw:5.1}% proximity={prox:5.1}%\n",
-                    fm.path
-                ));
-            }
+            let combined_str = format!("{combined:5.1}%").red().to_string();
+            out.push_str(&format!(
+                "  {} combined={combined_str} keyword={kw:5.1}% proximity={prox:5.1}%\n",
+                fm.path
+            ));
         }
     }
     out.push('\n');
 
     // Module Health
-    section_header(&mut out, "Module Health:", use_color);
+    section_header(&mut out, "Module Health:");
     if result.modules.is_empty() {
         out.push_str("  (no modules with enough data)\n");
     } else {
         for module in result.modules.iter().take(top_n) {
             let pct = module.encapsulation_pct;
-            if use_color {
-                let pct_str = if pct < 50.0 {
-                    format!("{pct:5.1}%").red().to_string()
-                } else if pct < 75.0 {
-                    format!("{pct:5.1}%").yellow().to_string()
-                } else {
-                    format!("{pct:5.1}%").green().to_string()
-                };
-                out.push_str(&format!(
-                    "  {} encapsulation={pct_str} files={} commits={} cross={}\n",
-                    module.path,
-                    module.files_count,
-                    module.total_commits,
-                    module.cross_boundary_commits
-                ));
+            let pct_str = if pct < 50.0 {
+                format!("{pct:5.1}%").red().to_string()
+            } else if pct < 75.0 {
+                format!("{pct:5.1}%").yellow().to_string()
             } else {
-                out.push_str(&format!(
-                    "  {} encapsulation={pct:5.1}% files={} commits={} cross={}\n",
-                    module.path,
-                    module.files_count,
-                    module.total_commits,
-                    module.cross_boundary_commits
-                ));
-            }
+                format!("{pct:5.1}%").green().to_string()
+            };
+            out.push_str(&format!(
+                "  {} encapsulation={pct_str} files={} commits={} cross={}\n",
+                module.path,
+                module.files_count,
+                module.total_commits,
+                module.cross_boundary_commits
+            ));
         }
     }
     out.push('\n');
 
     // Bus Factor Risk
-    section_header(&mut out, "Bus Factor Risk:", use_color);
+    section_header(&mut out, "Bus Factor Risk:");
     let bus_factor_files: Vec<_> = result
         .files
         .iter()
@@ -216,18 +172,11 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     } else {
         for fm in bus_factor_files.iter().take(top_n) {
             let pct = fm.authors.top_author_pct;
-            if use_color {
-                let pct_str = format!("{pct:5.1}%").red().to_string();
-                out.push_str(&format!(
-                    "  {} top-author={pct_str} authors={}\n",
-                    fm.path, fm.authors.count
-                ));
-            } else {
-                out.push_str(&format!(
-                    "  {} top-author={pct:5.1}% authors={}\n",
-                    fm.path, fm.authors.count
-                ));
-            }
+            let pct_str = format!("{pct:5.1}%").red().to_string();
+            out.push_str(&format!(
+                "  {} top-author={pct_str} authors={}\n",
+                fm.path, fm.authors.count
+            ));
         }
     }
     out.push('\n');
@@ -235,12 +184,8 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     out
 }
 
-fn section_header(out: &mut String, title: &str, use_color: bool) {
-    if use_color {
-        out.push_str(&title.bold().underline().to_string());
-    } else {
-        out.push_str(title);
-    }
+fn section_header(out: &mut String, title: &str) {
+    out.push_str(&title.bold().underline().to_string());
     out.push('\n');
 }
 
@@ -418,6 +363,40 @@ mod tests {
         assert!(
             churn_count <= 3,
             "expected at most 3 churn entries, got {churn_count}"
+        );
+    }
+
+    #[test]
+    fn test_text_empty_files_shows_placeholder() {
+        let mut result = make_result();
+        result.files.clear();
+        let text = render_text(&result, 20);
+        assert!(
+            text.contains("(no files)"),
+            "expected '(no files)' placeholder in Top Churn section"
+        );
+        assert!(
+            text.contains("(no coupling above threshold)"),
+            "expected '(no coupling above threshold)' placeholder in Blast Radius section"
+        );
+        assert!(
+            text.contains("(no files above threshold)"),
+            "expected '(no files above threshold)' placeholder in Fix Risk section"
+        );
+        assert!(
+            text.contains("(no single-owner risk detected)"),
+            "expected '(no single-owner risk detected)' placeholder in Bus Factor section"
+        );
+    }
+
+    #[test]
+    fn test_text_empty_modules_shows_placeholder() {
+        let mut result = make_result();
+        result.modules.clear();
+        let text = render_text(&result, 20);
+        assert!(
+            text.contains("(no modules with enough data)"),
+            "expected '(no modules with enough data)' placeholder in Module Health section"
         );
     }
 }

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -44,8 +44,17 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     }
     out.push('\n');
 
-    // Top Churn
-    section_header(&mut out, "Top Churn:");
+    render_top_churn(&mut out, result, top_n);
+    render_blast_radius(&mut out, result, top_n);
+    render_fix_risk(&mut out, result, top_n);
+    render_module_health(&mut out, result, top_n);
+    render_bus_factor(&mut out, result, top_n);
+
+    out
+}
+
+fn render_top_churn(out: &mut String, result: &HeatmapResult, top_n: usize) {
+    section_header(out, "Top Churn:");
     let mut files_by_churn: Vec<_> = result.files.iter().collect();
     files_by_churn.sort_by_key(|f| std::cmp::Reverse(f.churn.commits));
 
@@ -71,9 +80,10 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         }
     }
     out.push('\n');
+}
 
-    // Blast Radius (coupling)
-    section_header(&mut out, "Blast Radius (coupling above threshold):");
+fn render_blast_radius(out: &mut String, result: &HeatmapResult, top_n: usize) {
+    section_header(out, "Blast Radius (coupling above threshold):");
     let mut files_with_coupling: Vec<_> = result
         .files
         .iter()
@@ -104,9 +114,10 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         }
     }
     out.push('\n');
+}
 
-    // Fix Risk
-    section_header(&mut out, "Fix Risk (> 20%):");
+fn render_fix_risk(out: &mut String, result: &HeatmapResult, top_n: usize) {
+    section_header(out, "Fix Risk (> 20%):");
     let mut fix_risk_files: Vec<_> = result
         .files
         .iter()
@@ -134,9 +145,10 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         }
     }
     out.push('\n');
+}
 
-    // Module Health
-    section_header(&mut out, "Module Health:");
+fn render_module_health(out: &mut String, result: &HeatmapResult, top_n: usize) {
+    section_header(out, "Module Health:");
     if result.modules.is_empty() {
         out.push_str("  (no modules with enough data)\n");
     } else {
@@ -159,9 +171,10 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         }
     }
     out.push('\n');
+}
 
-    // Bus Factor Risk
-    section_header(&mut out, "Bus Factor Risk:");
+fn render_bus_factor(out: &mut String, result: &HeatmapResult, top_n: usize) {
+    section_header(out, "Bus Factor Risk:");
     let bus_factor_files: Vec<_> = result
         .files
         .iter()
@@ -181,8 +194,6 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         }
     }
     out.push('\n');
-
-    out
 }
 
 fn section_header(out: &mut String, title: &str) {

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -47,7 +47,7 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     // Top Churn
     section_header(&mut out, "Top Churn:");
     let mut files_by_churn: Vec<_> = result.files.iter().collect();
-    files_by_churn.sort_by(|a, b| b.churn.commits.cmp(&a.churn.commits));
+    files_by_churn.sort_by_key(|f| std::cmp::Reverse(f.churn.commits));
 
     if files_by_churn.is_empty() {
         out.push_str("  (no files)\n");

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -89,7 +89,11 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     out.push('\n');
 
     // Blast Radius (coupling)
-    section_header(&mut out, "Blast Radius (coupling above threshold):", use_color);
+    section_header(
+        &mut out,
+        "Blast Radius (coupling above threshold):",
+        use_color,
+    );
     let mut files_with_coupling: Vec<_> = result
         .files
         .iter()

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -89,12 +89,7 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     out.push('\n');
 
     // Blast Radius (coupling)
-    let threshold_pct = 0.0; // We show whatever passed the threshold filter
-    section_header(
-        &mut out,
-        &format!("Blast Radius (coupling > {threshold_pct:.0}%):",),
-        use_color,
-    );
+    section_header(&mut out, "Blast Radius (coupling above threshold):", use_color);
     let mut files_with_coupling: Vec<_> = result
         .files
         .iter()

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -79,6 +79,7 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
         .iter()
         .filter(|f| !f.blast_radius.is_empty())
         .collect();
+    // sort_by (not sort_by_key): f64 fields require partial_cmp because f64 does not implement Ord.
     files_with_coupling.sort_by(|a, b| {
         let a_conf = a.blast_radius.first().map(|e| e.confidence).unwrap_or(0.0);
         let b_conf = b.blast_radius.first().map(|e| e.confidence).unwrap_or(0.0);
@@ -212,8 +213,6 @@ mod tests {
                 since: "2024-10-01".to_string(),
                 until: "2025-01-01".to_string(),
                 commits_analyzed: 10,
-                time_commits: None,
-                count_commits: None,
                 effective_strategy: None,
             },
             files: vec![FileMetrics {
@@ -334,7 +333,8 @@ mod tests {
     #[test]
     fn test_text_respects_top_n() {
         let mut result = make_result();
-        // Add many files
+        // Add 30 files with commits 1..=30 so file29.rs (30 commits) is highest-churn,
+        // file28.rs (29) second, file27.rs (28) third, and file0.rs (1 commit) is lowest.
         for i in 0..30 {
             result.files.push(FileMetrics {
                 path: format!("file{i}.rs"),
@@ -358,11 +358,31 @@ mod tests {
             });
         }
         let text = render_text(&result, 3);
-        // Should only show 3 entries in Top Churn
+
+        // Count guard: at most 3 entries rendered in Top Churn section.
         let churn_count = text.matches("commits  ").count();
         assert!(
             churn_count <= 3,
             "expected at most 3 churn entries, got {churn_count}"
+        );
+
+        // Sort-order guard: the three highest-churn files must appear; the lowest must not.
+        // This catches an ascending-vs-descending sort bug that the count check cannot.
+        assert!(
+            text.contains("file29.rs"),
+            "expected highest-churn file (file29.rs, 30 commits) to appear in top-3"
+        );
+        assert!(
+            text.contains("file28.rs"),
+            "expected second-highest-churn file (file28.rs, 29 commits) to appear in top-3"
+        );
+        assert!(
+            text.contains("file27.rs"),
+            "expected third-highest-churn file (file27.rs, 28 commits) to appear in top-3"
+        );
+        assert!(
+            !text.contains("file0.rs"),
+            "expected lowest-churn file (file0.rs, 1 commit) to be excluded from top-3"
         );
     }
 

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -89,13 +89,10 @@ fn render_blast_radius(out: &mut String, result: &HeatmapResult, top_n: usize) {
         .iter()
         .filter(|f| !f.blast_radius.is_empty())
         .collect();
-    // sort_by (not sort_by_key): f64 fields require partial_cmp because f64 does not implement Ord.
     files_with_coupling.sort_by(|a, b| {
         let a_conf = a.blast_radius.first().map(|e| e.confidence).unwrap_or(0.0);
         let b_conf = b.blast_radius.first().map(|e| e.confidence).unwrap_or(0.0);
-        b_conf
-            .partial_cmp(&a_conf)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        b_conf.total_cmp(&a_conf)
     });
 
     if files_with_coupling.is_empty() {
@@ -124,10 +121,7 @@ fn render_fix_risk(out: &mut String, result: &HeatmapResult, top_n: usize) {
         .filter(|f| f.fix_risk.combined_pct > 20.0 && !f.fix_risk.insufficient_data)
         .collect();
     fix_risk_files.sort_by(|a, b| {
-        b.fix_risk
-            .combined_pct
-            .partial_cmp(&a.fix_risk.combined_pct)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        b.fix_risk.combined_pct.total_cmp(&a.fix_risk.combined_pct)
     });
 
     if fix_risk_files.is_empty() {

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -9,6 +9,10 @@ use serde::Serialize;
 // ============================================================================
 
 /// Parsed CLI flags for `skim heatmap`.
+///
+/// Contains raw user input only. Window resolution metadata (dual mode, since
+/// epochs) is separated into [`ResolvedWindow`] to avoid polluting this struct
+/// with derived state.
 #[derive(Debug, Clone)]
 pub(crate) struct HeatmapConfig {
     /// Epoch seconds — only analyze commits since this timestamp.
@@ -33,12 +37,6 @@ pub(crate) struct HeatmapConfig {
     pub(crate) window_preset: Option<String>,
     /// Limit analysis to last N commits.
     pub(crate) last_n: Option<usize>,
-    /// True when using dual default windowing.
-    pub(crate) dual_mode: bool,
-    /// Epoch of the 90-day time window (for dual mode reporting).
-    pub(crate) dual_time_since: Option<u64>,
-    /// Epoch of the 200-commit window (for dual mode reporting).
-    pub(crate) dual_count_since: Option<u64>,
 }
 
 impl Default for HeatmapConfig {
@@ -55,11 +53,30 @@ impl Default for HeatmapConfig {
             debug: false,
             window_preset: None,
             last_n: None,
-            dual_mode: false,
-            dual_time_since: None,
-            dual_count_since: None,
         }
     }
+}
+
+/// Resolved window metadata produced by [`super::resolve_effective_config`].
+///
+/// Separates derived window state from raw CLI input (`HeatmapConfig`), so
+/// `HeatmapConfig` remains a pure user-input struct and window metadata is
+/// never confused with CLI flags.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedWindow {
+    /// The effective `--since` epoch (may differ from `HeatmapConfig::since`
+    /// after preset/dual resolution).
+    pub(crate) since: Option<u64>,
+    /// True when using dual default windowing (no explicit flag was set).
+    pub(crate) dual_mode: bool,
+    /// Epoch of the 90-day time window (populated in dual mode only).
+    pub(crate) dual_time_since: Option<u64>,
+    /// Epoch of the 200-commit window (populated in dual mode only).
+    pub(crate) dual_count_since: Option<u64>,
+    /// Named window preset string (e.g. "sprint"), if one was used.
+    pub(crate) window_preset: Option<String>,
+    /// Last-N commit count, if `--last` was used.
+    pub(crate) last_n: Option<usize>,
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -33,6 +33,12 @@ pub(crate) struct HeatmapConfig {
     pub(crate) window_preset: Option<String>,
     /// Limit analysis to last N commits.
     pub(crate) last_n: Option<usize>,
+    /// True when using dual default windowing.
+    pub(crate) dual_mode: bool,
+    /// Epoch of the 90-day time window (for dual mode reporting).
+    pub(crate) dual_time_since: Option<u64>,
+    /// Epoch of the 200-commit window (for dual mode reporting).
+    pub(crate) dual_count_since: Option<u64>,
 }
 
 impl Default for HeatmapConfig {
@@ -49,6 +55,9 @@ impl Default for HeatmapConfig {
             debug: false,
             window_preset: None,
             last_n: None,
+            dual_mode: false,
+            dual_time_since: None,
+            dual_count_since: None,
         }
     }
 }

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -111,8 +111,6 @@ pub(crate) struct WindowInfo {
     pub(crate) since: String,
     pub(crate) until: String,
     pub(crate) commits_analyzed: usize,
-    pub(crate) time_commits: Option<usize>,
-    pub(crate) count_commits: Option<usize>,
     pub(crate) effective_strategy: Option<String>,
 }
 

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -1,0 +1,182 @@
+//! Data structures for the `skim heatmap` subcommand.
+//!
+//! No logic, no I/O. Pure data model.
+
+use serde::Serialize;
+
+// ============================================================================
+// CLI configuration
+// ============================================================================
+
+/// Parsed CLI flags for `skim heatmap`.
+#[derive(Debug, Clone)]
+pub(crate) struct HeatmapConfig {
+    /// Epoch seconds — only analyze commits since this timestamp.
+    pub(crate) since: Option<u64>,
+    /// Scope analysis to files under this path.
+    pub(crate) path: Option<String>,
+    /// Emit JSON output instead of text.
+    pub(crate) format_json: bool,
+    /// Maximum number of files to display (default 20).
+    pub(crate) top_n: usize,
+    /// Skip default exclude patterns.
+    pub(crate) no_exclude: bool,
+    /// Additional glob patterns to exclude.
+    pub(crate) extra_excludes: Vec<String>,
+    /// Coupling confidence threshold (default 0.5).
+    pub(crate) coupling_threshold: f64,
+    /// Fix-after-touch proximity window in commits (default 5).
+    pub(crate) fix_window: usize,
+    /// Enable debug output.
+    pub(crate) debug: bool,
+    /// Named window preset (e.g., "sprint", "quarter").
+    pub(crate) window_preset: Option<String>,
+    /// Limit analysis to last N commits.
+    pub(crate) last_n: Option<usize>,
+}
+
+impl Default for HeatmapConfig {
+    fn default() -> Self {
+        Self {
+            since: None,
+            path: None,
+            format_json: false,
+            top_n: 20,
+            no_exclude: false,
+            extra_excludes: Vec::new(),
+            coupling_threshold: 0.5,
+            fix_window: 5,
+            debug: false,
+            window_preset: None,
+            last_n: None,
+        }
+    }
+}
+
+// ============================================================================
+// Git log data
+// ============================================================================
+
+/// A single commit extracted from git log.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CommitRecord {
+    pub(crate) hash: String,
+    pub(crate) author: String,
+    /// Unix timestamp.
+    pub(crate) timestamp: u64,
+    pub(crate) subject: String,
+    pub(crate) files: Vec<FileChange>,
+}
+
+/// A file touched in a commit, with line change counts.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FileChange {
+    pub(crate) path: String,
+    pub(crate) additions: u64,
+    pub(crate) deletions: u64,
+}
+
+// ============================================================================
+// Heatmap output
+// ============================================================================
+
+/// Top-level output structure for `skim heatmap`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct HeatmapResult {
+    /// Schema version (always 1).
+    pub(crate) version: u8,
+    pub(crate) generated_at: String,
+    pub(crate) repository: String,
+    pub(crate) window: WindowInfo,
+    pub(crate) files: Vec<FileMetrics>,
+    pub(crate) modules: Vec<ModuleHealth>,
+    pub(crate) coupling_graph: Vec<CouplingEdge>,
+    pub(crate) excluded_patterns: Vec<String>,
+    pub(crate) warnings: Vec<String>,
+}
+
+/// Information about the analysis window.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct WindowInfo {
+    pub(crate) mode: String,
+    pub(crate) since: String,
+    pub(crate) until: String,
+    pub(crate) commits_analyzed: usize,
+    pub(crate) time_commits: Option<usize>,
+    pub(crate) count_commits: Option<usize>,
+    pub(crate) effective_strategy: Option<String>,
+}
+
+/// Risk and coupling metrics for a single file.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FileMetrics {
+    pub(crate) path: String,
+    pub(crate) churn: ChurnMetrics,
+    pub(crate) stability_score: u8,
+    pub(crate) authors: AuthorMetrics,
+    pub(crate) fix_risk: FixRiskMetrics,
+    pub(crate) blast_radius: Vec<CouplingEntry>,
+}
+
+/// Churn metrics for a file.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ChurnMetrics {
+    /// Number of commits touching this file.
+    pub(crate) commits: usize,
+    /// Ratio of this file's commits to total commits (0.0–1.0).
+    pub(crate) rate: f64,
+}
+
+/// Author diversity metrics for a file.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AuthorMetrics {
+    /// Unique author count (authors with >5% of commits).
+    pub(crate) count: usize,
+    /// Percentage of commits by the top author (0.0–100.0).
+    pub(crate) top_author_pct: f64,
+    /// True when a single author holds >80% of commits.
+    pub(crate) single_owner_risk: bool,
+}
+
+/// Fix-after-touch risk metrics for a file.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FixRiskMetrics {
+    /// Percentage of commits with fix keywords.
+    pub(crate) keyword_pct: f64,
+    /// Percentage of commits followed by a fix within the window.
+    pub(crate) proximity_pct: f64,
+    /// Union of keyword and proximity signals.
+    pub(crate) combined_pct: f64,
+    /// True when <2 commits — not enough data.
+    pub(crate) insufficient_data: bool,
+}
+
+/// A coupling entry in a file's blast radius.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CouplingEntry {
+    pub(crate) path: String,
+    /// Confidence score (0.0–1.0).
+    pub(crate) confidence: f64,
+    /// Number of commits where both files changed together.
+    pub(crate) support: usize,
+}
+
+/// A directed coupling edge in the global graph.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CouplingEdge {
+    pub(crate) a: String,
+    pub(crate) b: String,
+    pub(crate) confidence: f64,
+    pub(crate) support: usize,
+}
+
+/// Encapsulation health for a module directory.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ModuleHealth {
+    pub(crate) path: String,
+    /// Percentage of commits touching only this module (0.0–100.0).
+    pub(crate) encapsulation_pct: f64,
+    pub(crate) files_count: usize,
+    pub(crate) total_commits: usize,
+    pub(crate) cross_boundary_commits: usize,
+}

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -135,7 +135,7 @@ pub(crate) struct ChurnMetrics {
 }
 
 /// Author diversity metrics for a file.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub(crate) struct AuthorMetrics {
     /// Unique author count (authors with >5% of commits).
     pub(crate) count: usize,
@@ -156,6 +156,20 @@ pub(crate) struct FixRiskMetrics {
     pub(crate) combined_pct: f64,
     /// True when <2 commits — not enough data.
     pub(crate) insufficient_data: bool,
+}
+
+impl Default for FixRiskMetrics {
+    fn default() -> Self {
+        Self {
+            keyword_pct: 0.0,
+            proximity_pct: 0.0,
+            combined_pct: 0.0,
+            // Default to `true` so callers that skip the lookup (no history) are
+            // marked as having insufficient data rather than misleadingly showing
+            // zero-risk metrics.
+            insufficient_data: true,
+        }
+    }
 }
 
 /// A coupling entry in a file's blast radius.

--- a/crates/rskim/src/cmd/init/helpers.rs
+++ b/crates/rskim/src/cmd/init/helpers.rs
@@ -205,6 +205,26 @@ skim <file> --mode=types         # type definitions only
 skim <file> --mode=signatures    # function/method signatures only
 skim <file> --mode=pseudo        # logic without syntactic noise
 ```
+
+### Heatmap — Git History Risk Analysis
+
+`skim heatmap` analyzes git history to surface risk hotspots: high-churn files,
+tightly coupled file pairs, fix-after-touch patterns, module boundary violations,
+and bus-factor concentration. Run it when you need to understand where risk lives
+in a codebase before starting work.
+
+**When to use heatmap:**
+- Before a refactoring task — identify which files are risky to change
+- When triaging bugs — find files with high fix density
+- Exploring an unfamiliar codebase — understand coupling and ownership patterns
+- Before code review — check if the changed files are high-risk hotspots
+
+```
+skim heatmap                     # default: last 90 days, text output
+skim heatmap --json              # structured JSON for programmatic use
+skim heatmap --path src/lib/     # scope to a subdirectory
+skim heatmap --window sprint     # last 14 days only
+```
 <!-- skim-end -->"#,
         version = version
     )
@@ -329,6 +349,10 @@ mod tests {
         assert!(!content.contains("SKIM_PASSTHROUGH"));
         // No rskim mention in guidance body
         assert!(!content.contains("rskim"));
+        // Heatmap section present with key content
+        assert!(content.contains("Heatmap"));
+        assert!(content.contains("skim heatmap"));
+        assert!(content.contains("risk"));
     }
 
     #[test]

--- a/crates/rskim/src/cmd/mod.rs
+++ b/crates/rskim/src/cmd/mod.rs
@@ -11,6 +11,7 @@ mod completions;
 mod discover;
 mod file;
 mod git;
+mod heatmap;
 mod hook_log;
 mod hooks;
 mod infra;
@@ -154,6 +155,7 @@ pub(crate) const KNOWN_SUBCOMMANDS: &[&str] = &[
     "completions",
     "discover",
     "git",
+    "heatmap",
     "init",
     "learn",
     "log",
@@ -700,6 +702,7 @@ pub(crate) fn dispatch(
         "completions" => completions::run(args, analytics),
         "discover" => discover::run(args, analytics),
         "git" => git::run(args, analytics),
+        "heatmap" => heatmap::run(args, analytics),
         "init" => init::run(args, analytics),
         "learn" => learn::run(args, analytics),
         "log" => log::run(args, analytics),

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -194,6 +194,7 @@ SUBCOMMANDS:\n  \
     gh / aws / curl / wget                   Infrastructure tool compression\n  \
     find / grep / ls / rg / tree             File operation compression\n  \
     git                                      Git output compression (diff, status, log, ...)\n  \
+    heatmap                                  Git history risk/coupling analysis\n  \
     log                                      Log output compression\n  \
     agents                                   Show detected AI agents\n  \
     completions <SHELL>                      Generate shell completions\n  \

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -1,0 +1,613 @@
+//! Integration tests for `skim heatmap` subcommand.
+//!
+//! Tests end-to-end CLI behavior for git history risk/coupling analysis.
+//! For tests that need a git repo, we create a TempDir and set up deterministic commits.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+/// Initialize a git repo with user identity configured.
+fn git_init(dir: &Path) {
+    StdCommand::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .output()
+        .expect("git init");
+    StdCommand::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .output()
+        .expect("git config email");
+    StdCommand::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(dir)
+        .output()
+        .expect("git config name");
+    // Use main as default branch
+    StdCommand::new("git")
+        .args(["checkout", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .ok();
+}
+
+/// Write a file and make a commit.
+fn git_commit(dir: &Path, filename: &str, content: &str, message: &str, timestamp: u64) {
+    let file_path = dir.join(filename);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(&file_path, content).expect("write file");
+
+    StdCommand::new("git")
+        .args(["add", filename])
+        .current_dir(dir)
+        .output()
+        .expect("git add");
+
+    let ts = format!("{timestamp}");
+    StdCommand::new("git")
+        .args(["commit", "-m", message])
+        .env("GIT_AUTHOR_DATE", &ts)
+        .env("GIT_COMMITTER_DATE", &ts)
+        .current_dir(dir)
+        .output()
+        .expect("git commit");
+}
+
+/// Commit multiple files at once.
+fn git_commit_files(dir: &Path, files: &[(&str, &str)], message: &str, timestamp: u64) {
+    for (filename, content) in files {
+        let file_path = dir.join(filename);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(&file_path, content).expect("write file");
+        StdCommand::new("git")
+            .args(["add", filename])
+            .current_dir(dir)
+            .output()
+            .expect("git add");
+    }
+
+    let ts = format!("{timestamp}");
+    StdCommand::new("git")
+        .args(["commit", "-m", message])
+        .env("GIT_AUTHOR_DATE", &ts)
+        .env("GIT_COMMITTER_DATE", &ts)
+        .current_dir(dir)
+        .output()
+        .expect("git commit");
+}
+
+/// Current Unix timestamp minus a few days — within the default 90-day window.
+fn recent_ts() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .saturating_sub(7 * 86400) // 7 days ago
+}
+
+/// Create a test repo with 5+ commits across multiple files.
+fn create_test_repo(dir: &Path) {
+    git_init(dir);
+
+    let base_ts = recent_ts();
+
+    // 5 commits with multiple files to exercise all metrics
+    git_commit(
+        dir,
+        "src/main.rs",
+        "fn main() {}",
+        "feat: initial main",
+        base_ts,
+    );
+    git_commit(
+        dir,
+        "src/lib.rs",
+        "pub fn foo() {}",
+        "feat: add lib",
+        base_ts + 100,
+    );
+    git_commit_files(
+        dir,
+        &[
+            ("src/main.rs", "fn main() { foo(); }"),
+            ("src/lib.rs", "pub fn foo() -> i32 { 1 }"),
+        ],
+        "feat: wire main to lib",
+        base_ts + 200,
+    );
+    git_commit(
+        dir,
+        "src/main.rs",
+        "fn main() { let x = 1; }",
+        "fix: correct main",
+        base_ts + 300,
+    );
+    git_commit_files(
+        dir,
+        &[
+            ("src/main.rs", "fn main() { println!(\"hello\"); }"),
+            ("src/lib.rs", "pub fn foo() -> i32 { 42 }"),
+            ("tests/test_lib.rs", "#[test] fn it_works() {}"),
+        ],
+        "feat: add tests",
+        base_ts + 400,
+    );
+}
+
+/// Create a repo with commits touching a Cargo.lock file (for --no-exclude tests).
+fn create_repo_with_lock_file(dir: &Path) {
+    git_init(dir);
+    let base_ts = recent_ts();
+    git_commit(dir, "src/main.rs", "fn main() {}", "feat: initial", base_ts);
+    git_commit(
+        dir,
+        "Cargo.lock",
+        "# generated lock file\n[[package]]\nname = \"foo\"",
+        "chore: add lockfile",
+        base_ts + 100,
+    );
+    git_commit(
+        dir,
+        "src/lib.rs",
+        "pub fn bar() {}",
+        "feat: add lib",
+        base_ts + 200,
+    );
+}
+
+// ============================================================================
+// Help
+// ============================================================================
+
+#[test]
+fn test_heatmap_help_exits_0() {
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_heatmap_help_contains_flag_names() {
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--since"))
+        .stdout(predicate::str::contains("--last"))
+        .stdout(predicate::str::contains("--window"))
+        .stdout(predicate::str::contains("--path"))
+        .stdout(predicate::str::contains("--json"))
+        .stdout(predicate::str::contains("--top"))
+        .stdout(predicate::str::contains("--no-exclude"))
+        .stdout(predicate::str::contains("--coupling-threshold"))
+        .stdout(predicate::str::contains("--fix-window"));
+}
+
+// ============================================================================
+// Not a git repo
+// ============================================================================
+
+#[test]
+fn test_heatmap_not_git_repo_exits_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not a git repository"));
+}
+
+// ============================================================================
+// Empty repo (no commits)
+// ============================================================================
+
+#[test]
+fn test_heatmap_empty_repo_exits_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git_init(dir.path());
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("No commits found")
+                .or(predicate::str::contains("No analyzable")),
+        );
+}
+
+// ============================================================================
+// JSON output with 5+ commits
+// ============================================================================
+
+#[test]
+fn test_heatmap_json_output_valid_json() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON output");
+
+    assert_eq!(parsed["version"], 1, "version must be 1");
+    assert!(parsed["files"].is_array(), "files must be array");
+    assert!(
+        !parsed["files"].as_array().unwrap().is_empty(),
+        "files must be non-empty"
+    );
+    assert!(parsed["modules"].is_array(), "modules must be array");
+    assert!(
+        parsed["coupling_graph"].is_array(),
+        "coupling_graph must be array"
+    );
+    assert!(parsed["window"].is_object(), "window must be object");
+    assert!(parsed["warnings"].is_array(), "warnings must be array");
+}
+
+#[test]
+fn test_heatmap_json_has_all_metric_keys() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    let file = &parsed["files"][0];
+    assert!(file["churn"].is_object(), "churn must be object");
+    assert!(
+        file["stability_score"].is_number(),
+        "stability_score must be number"
+    );
+    assert!(file["authors"].is_object(), "authors must be object");
+    assert!(file["fix_risk"].is_object(), "fix_risk must be object");
+    assert!(
+        file["blast_radius"].is_array(),
+        "blast_radius must be array"
+    );
+}
+
+// ============================================================================
+// Text output
+// ============================================================================
+
+#[test]
+fn test_heatmap_text_output_contains_sections() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_test_repo(dir.path());
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Top Churn"))
+        .stdout(predicate::str::contains("Blast Radius"))
+        .stdout(predicate::str::contains("Module Health"))
+        .stdout(predicate::str::contains("Bus Factor"));
+}
+
+// ============================================================================
+// --since flag
+// ============================================================================
+
+#[test]
+fn test_heatmap_since_filters_commits() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git_init(dir.path());
+
+    // Old commit (2020)
+    git_commit(
+        dir.path(),
+        "old.rs",
+        "old content",
+        "feat: old",
+        1_580_000_000,
+    );
+    // Recent commit
+    git_commit(
+        dir.path(),
+        "new.rs",
+        "new content",
+        "feat: new",
+        1_700_000_000,
+    );
+    // Another recent commit
+    git_commit(
+        dir.path(),
+        "new2.rs",
+        "more content",
+        "feat: more",
+        1_700_000_100,
+    );
+
+    // --since=2023-01-01 (epoch 1672531200) should include only the two recent commits
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json", "--since=1672531200"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("new.rs").or(predicate::str::contains("new2.rs")));
+}
+
+// ============================================================================
+// --window preset
+// ============================================================================
+
+#[test]
+fn test_heatmap_window_sprint_preset() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_test_repo(dir.path());
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--window=sprint"])
+        .current_dir(dir.path())
+        .assert()
+        // Either succeeds (commits in window) or fails with "No commits found"
+        // depending on the commit timestamps vs now
+        .stderr(predicate::str::is_empty().or(predicate::str::contains("No commits")));
+}
+
+// ============================================================================
+// --path scoping
+// ============================================================================
+
+#[test]
+fn test_heatmap_path_scope() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json", "--path=src/", "--no-exclude"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap");
+
+    // May succeed or fail depending on git behavior, but should not crash
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    if output.status.success() && !stdout.is_empty() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&stdout).unwrap_or(serde_json::Value::Null);
+        if parsed != serde_json::Value::Null {
+            // All file paths should be under src/
+            if let Some(files) = parsed["files"].as_array() {
+                for file in files {
+                    let path = file["path"].as_str().unwrap_or("");
+                    assert!(path.starts_with("src/"), "path outside src/: {path}");
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// --no-exclude includes lock files
+// ============================================================================
+
+#[test]
+fn test_heatmap_no_exclude_includes_lock_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_repo_with_lock_file(dir.path());
+
+    let output_with_exclude = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap (default excludes)");
+
+    let output_no_exclude = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json", "--no-exclude"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap (no excludes)");
+
+    if output_no_exclude.status.success() {
+        let stdout = String::from_utf8(output_no_exclude.stdout).unwrap();
+        // With --no-exclude, Cargo.lock should appear in the files
+        assert!(
+            stdout.contains("Cargo.lock"),
+            "expected Cargo.lock in --no-exclude output"
+        );
+    }
+
+    if output_with_exclude.status.success() {
+        let stdout = String::from_utf8(output_with_exclude.stdout).unwrap();
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            // Default excludes should filter Cargo.lock out of the analyzed files
+            if let Some(files) = parsed["files"].as_array() {
+                let has_lockfile = files
+                    .iter()
+                    .any(|f| f["path"].as_str().unwrap_or("").contains("Cargo.lock"));
+                assert!(
+                    !has_lockfile,
+                    "Cargo.lock should not appear in files with default excludes"
+                );
+            }
+        }
+    }
+}
+
+// ============================================================================
+// --coupling-threshold changes coupling output
+// ============================================================================
+
+#[test]
+fn test_heatmap_coupling_threshold_flag_accepted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    create_test_repo(dir.path());
+
+    // A very low threshold should not crash
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--coupling-threshold=0.1"])
+        .current_dir(dir.path())
+        .assert()
+        .code(predicate::in_iter([0i32, 1i32])); // success or no-commits-found failure
+}
+
+// ============================================================================
+// Single-commit repo — partial report with insufficient_data markers
+// ============================================================================
+
+#[test]
+fn test_heatmap_single_commit_repo() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git_init(dir.path());
+    git_commit(
+        dir.path(),
+        "src/main.rs",
+        "fn main() {}",
+        "feat: init",
+        recent_ts(),
+    );
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap");
+
+    if output.status.success() {
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        // Files should be present
+        let files = parsed["files"].as_array().unwrap();
+        assert!(!files.is_empty());
+        // Single commit file should have insufficient_data = true
+        let fix_risk = &files[0]["fix_risk"];
+        assert_eq!(
+            fix_risk["insufficient_data"], true,
+            "single-commit file should have insufficient_data=true"
+        );
+    }
+}
+
+// ============================================================================
+// --top flag limits output
+// ============================================================================
+
+#[test]
+fn test_heatmap_top_flag_limits_output() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git_init(dir.path());
+
+    // Create many files with many commits (within 90-day window)
+    let base_ts = recent_ts();
+    for i in 0..10u64 {
+        for j in 0..3u64 {
+            git_commit(
+                dir.path(),
+                &format!("file{i}.rs"),
+                &format!("content {j}"),
+                &format!("commit {i}-{j}"),
+                base_ts + i * 10 + j,
+            );
+        }
+    }
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--json", "--top=3"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    // Top 3 filter is on rendering, not data — files array may have all files
+    // but the text output should only show 3
+    let _ = parsed["files"].as_array().unwrap().len(); // just verifying it parses
+
+    // Text output with --top=3 should show at most 3 churn entries
+    let text_output = Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--top=3"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn skim heatmap text");
+    if text_output.status.success() {
+        let text = String::from_utf8(text_output.stdout).unwrap();
+        assert!(text.contains("Top Churn"));
+    }
+}
+
+// ============================================================================
+// --last flag
+// ============================================================================
+
+#[test]
+fn test_heatmap_last_flag() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git_init(dir.path());
+
+    let base_ts = recent_ts();
+    git_commit(dir.path(), "a.rs", "a", "first", base_ts);
+    git_commit(dir.path(), "b.rs", "b", "second", base_ts + 100);
+    git_commit(dir.path(), "c.rs", "c", "third", base_ts + 200);
+
+    // --last 3 should succeed and analyze commits
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["heatmap", "--last=3", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+// ============================================================================
+// Dispatch registration: subcommand appears in --help
+// ============================================================================
+
+#[test]
+fn test_heatmap_registered_in_help() {
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("heatmap"));
+}

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -45,20 +45,30 @@ fn git_commit(dir: &Path, filename: &str, content: &str, message: &str, timestam
     }
     std::fs::write(&file_path, content).expect("write file");
 
-    StdCommand::new("git")
+    let add_out = StdCommand::new("git")
         .args(["add", filename])
         .current_dir(dir)
         .output()
         .expect("git add");
+    assert!(
+        add_out.status.success(),
+        "git add failed for {filename}: {}",
+        String::from_utf8_lossy(&add_out.stderr)
+    );
 
     let ts = format!("{timestamp}");
-    StdCommand::new("git")
+    let commit_out = StdCommand::new("git")
         .args(["commit", "-m", message])
         .env("GIT_AUTHOR_DATE", &ts)
         .env("GIT_COMMITTER_DATE", &ts)
         .current_dir(dir)
         .output()
         .expect("git commit");
+    assert!(
+        commit_out.status.success(),
+        "git commit failed for {message}: {}",
+        String::from_utf8_lossy(&commit_out.stderr)
+    );
 }
 
 /// Commit multiple files at once.
@@ -69,21 +79,31 @@ fn git_commit_files(dir: &Path, files: &[(&str, &str)], message: &str, timestamp
             std::fs::create_dir_all(parent).ok();
         }
         std::fs::write(&file_path, content).expect("write file");
-        StdCommand::new("git")
+        let add_out = StdCommand::new("git")
             .args(["add", filename])
             .current_dir(dir)
             .output()
             .expect("git add");
+        assert!(
+            add_out.status.success(),
+            "git add failed for {filename}: {}",
+            String::from_utf8_lossy(&add_out.stderr)
+        );
     }
 
     let ts = format!("{timestamp}");
-    StdCommand::new("git")
+    let commit_out = StdCommand::new("git")
         .args(["commit", "-m", message])
         .env("GIT_AUTHOR_DATE", &ts)
         .env("GIT_COMMITTER_DATE", &ts)
         .current_dir(dir)
         .output()
         .expect("git commit");
+    assert!(
+        commit_out.status.success(),
+        "git commit failed for {message}: {}",
+        String::from_utf8_lossy(&commit_out.stderr)
+    );
 }
 
 /// Current Unix timestamp minus a few days — within the default 90-day window.
@@ -365,7 +385,8 @@ fn test_heatmap_since_filters_commits() {
         .current_dir(dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("new.rs").or(predicate::str::contains("new2.rs")));
+        .stdout(predicate::str::contains("new.rs").or(predicate::str::contains("new2.rs")))
+        .stdout(predicate::str::contains("old.rs").not());
 }
 
 // ============================================================================
@@ -375,6 +396,7 @@ fn test_heatmap_since_filters_commits() {
 #[test]
 fn test_heatmap_window_sprint_preset() {
     let dir = tempfile::tempdir().expect("tempdir");
+    // create_test_repo uses recent_ts() (7 days ago), well within sprint (14 days)
     create_test_repo(dir.path());
 
     Command::cargo_bin("skim")
@@ -382,9 +404,7 @@ fn test_heatmap_window_sprint_preset() {
         .args(["heatmap", "--window=sprint"])
         .current_dir(dir.path())
         .assert()
-        // Either succeeds (commits in window) or fails with "No commits found"
-        // depending on the commit timestamps vs now
-        .stderr(predicate::str::is_empty().or(predicate::str::contains("No commits")));
+        .success();
 }
 
 // ============================================================================
@@ -403,19 +423,19 @@ fn test_heatmap_path_scope() {
         .output()
         .expect("spawn skim heatmap");
 
-    // May succeed or fail depending on git behavior, but should not crash
+    assert!(
+        output.status.success(),
+        "expected exit 0 for --path=src/, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stdout = String::from_utf8(output.stdout).unwrap();
-    if output.status.success() && !stdout.is_empty() {
-        let parsed: serde_json::Value =
-            serde_json::from_str(&stdout).unwrap_or(serde_json::Value::Null);
-        if parsed != serde_json::Value::Null {
-            // All file paths should be under src/
-            if let Some(files) = parsed["files"].as_array() {
-                for file in files {
-                    let path = file["path"].as_str().unwrap_or("");
-                    assert!(path.starts_with("src/"), "path outside src/: {path}");
-                }
-            }
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON output");
+    // All file paths should be under src/
+    if let Some(files) = parsed["files"].as_array() {
+        for file in files {
+            let path = file["path"].as_str().unwrap_or("");
+            assert!(path.starts_with("src/"), "path outside src/: {path}");
         }
     }
 }
@@ -443,29 +463,35 @@ fn test_heatmap_no_exclude_includes_lock_files() {
         .output()
         .expect("spawn skim heatmap (no excludes)");
 
-    if output_no_exclude.status.success() {
-        let stdout = String::from_utf8(output_no_exclude.stdout).unwrap();
-        // With --no-exclude, Cargo.lock should appear in the files
-        assert!(
-            stdout.contains("Cargo.lock"),
-            "expected Cargo.lock in --no-exclude output"
-        );
-    }
+    assert!(
+        output_no_exclude.status.success(),
+        "expected exit 0 with --no-exclude, stderr: {}",
+        String::from_utf8_lossy(&output_no_exclude.stderr)
+    );
+    let stdout_no_exclude = String::from_utf8(output_no_exclude.stdout).unwrap();
+    // With --no-exclude, Cargo.lock should appear in the files
+    assert!(
+        stdout_no_exclude.contains("Cargo.lock"),
+        "expected Cargo.lock in --no-exclude output"
+    );
 
-    if output_with_exclude.status.success() {
-        let stdout = String::from_utf8(output_with_exclude.stdout).unwrap();
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stdout) {
-            // Default excludes should filter Cargo.lock out of the analyzed files
-            if let Some(files) = parsed["files"].as_array() {
-                let has_lockfile = files
-                    .iter()
-                    .any(|f| f["path"].as_str().unwrap_or("").contains("Cargo.lock"));
-                assert!(
-                    !has_lockfile,
-                    "Cargo.lock should not appear in files with default excludes"
-                );
-            }
-        }
+    assert!(
+        output_with_exclude.status.success(),
+        "expected exit 0 with default excludes, stderr: {}",
+        String::from_utf8_lossy(&output_with_exclude.stderr)
+    );
+    let stdout_with_exclude = String::from_utf8(output_with_exclude.stdout).unwrap();
+    let parsed = serde_json::from_str::<serde_json::Value>(&stdout_with_exclude)
+        .expect("expected valid JSON with default excludes");
+    // Default excludes should filter Cargo.lock out of the analyzed files
+    if let Some(files) = parsed["files"].as_array() {
+        let has_lockfile = files
+            .iter()
+            .any(|f| f["path"].as_str().unwrap_or("").contains("Cargo.lock"));
+        assert!(
+            !has_lockfile,
+            "Cargo.lock should not appear in files with default excludes"
+        );
     }
 }
 
@@ -510,19 +536,23 @@ fn test_heatmap_single_commit_repo() {
         .output()
         .expect("spawn skim heatmap");
 
-    if output.status.success() {
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-        // Files should be present
-        let files = parsed["files"].as_array().unwrap();
-        assert!(!files.is_empty());
-        // Single commit file should have insufficient_data = true
-        let fix_risk = &files[0]["fix_risk"];
-        assert_eq!(
-            fix_risk["insufficient_data"], true,
-            "single-commit file should have insufficient_data=true"
-        );
-    }
+    assert!(
+        output.status.success(),
+        "expected exit 0 for single-commit repo, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON output");
+    // Files should be present
+    let files = parsed["files"].as_array().unwrap();
+    assert!(!files.is_empty());
+    // Single commit file should have insufficient_data = true
+    let fix_risk = &files[0]["fix_risk"];
+    assert_eq!(
+        fix_risk["insufficient_data"], true,
+        "single-commit file should have insufficient_data=true"
+    );
 }
 
 // ============================================================================
@@ -555,24 +585,36 @@ fn test_heatmap_top_flag_limits_output() {
         .output()
         .expect("spawn skim heatmap");
 
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "expected exit 0 for --json --top=3, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stdout = String::from_utf8(output.stdout).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    // Top 3 filter is on rendering, not data — files array may have all files
-    // but the text output should only show 3
-    let _ = parsed["files"].as_array().unwrap().len(); // just verifying it parses
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON output");
+    // In JSON mode, --top=3 truncates the files array to at most 3 entries
+    let files = parsed["files"].as_array().unwrap();
+    assert!(
+        files.len() <= 3,
+        "expected at most 3 files in JSON output with --top=3, got {}",
+        files.len()
+    );
 
-    // Text output with --top=3 should show at most 3 churn entries
+    // Text output with --top=3 should succeed and show Top Churn section
     let text_output = Command::cargo_bin("skim")
         .unwrap()
         .args(["heatmap", "--top=3"])
         .current_dir(dir.path())
         .output()
         .expect("spawn skim heatmap text");
-    if text_output.status.success() {
-        let text = String::from_utf8(text_output.stdout).unwrap();
-        assert!(text.contains("Top Churn"));
-    }
+    assert!(
+        text_output.status.success(),
+        "expected exit 0 for text --top=3, stderr: {}",
+        String::from_utf8_lossy(&text_output.stderr)
+    );
+    let text = String::from_utf8(text_output.stdout).unwrap();
+    assert!(text.contains("Top Churn"));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Adds `skim heatmap` subcommand that mines git history into a structured risk profile with 6 metrics: file churn, co-change coupling (blast radius), stability scores, author concentration (bus factor), fix-after-touch risk, and module encapsulation health
- Supports adaptive dual windowing (max of 90 days / 200 commits), auto-exclusion of lock files and build artifacts, JSON and text output, path scoping, and configurable thresholds
- Pure computation layer (zero I/O in metrics) with trait-based git abstraction for testability

## New files (7)
- `crates/rskim/src/cmd/heatmap/types.rs` — data structures
- `crates/rskim/src/cmd/heatmap/excludes.rs` — exclude patterns + GlobSet
- `crates/rskim/src/cmd/heatmap/git_source.rs` — GitDataSource trait + CLI impl
- `crates/rskim/src/cmd/heatmap/metrics.rs` — 6 pure metric functions
- `crates/rskim/src/cmd/heatmap/output.rs` — JSON + text rendering
- `crates/rskim/src/cmd/heatmap/mod.rs` — orchestration entry point
- `crates/rskim/tests/cli_heatmap.rs` — 16 integration tests

## Test plan

- [x] `cargo test --all-features` — 3,190 tests pass (87 new heatmap tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `skim heatmap --json | jq .` — valid JSON with all 6 metrics
- [x] `skim heatmap` — text output with 5 sections
- [x] `skim heatmap --top 3 --json` — limits files in JSON output
- [x] `skim heatmap --debug` — diagnostics to stderr
- [x] Non-git-repo → error with exit 1
- [x] Empty repo → error with exit 1
- [x] `skim heatmap --window half` / `--window all` — presets work
- [x] Dual default windowing — `window.mode: "dual"` in JSON