### PR TITLE
feat(heatmap): file targeting -- positional files, --diff flag, display filter

### DIFF
--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -66,67 +66,6 @@ impl CliGitSource {
         }
     }
 
-    /// Return `true` when the cwd is inside a git repository.
-    pub(crate) fn is_git_repo(&self) -> bool {
-        match self
-            .runner
-            .run("git", &["rev-parse", "--is-inside-work-tree"])
-        {
-            Ok(out) => out.exit_code == Some(0),
-            Err(_) => false,
-        }
-    }
-
-    /// Return the repository root path.
-    pub(crate) fn get_repo_root(&self) -> anyhow::Result<String> {
-        let out = self
-            .runner
-            .run("git", &["rev-parse", "--show-toplevel"])
-            .map_err(git_not_found)?;
-        Ok(out.stdout.trim().to_string())
-    }
-
-    /// Return `true` when the repo is a shallow clone.
-    pub(crate) fn detect_shallow_clone(&self) -> bool {
-        match self
-            .runner
-            .run("git", &["rev-parse", "--is-shallow-repository"])
-        {
-            Ok(out) => out.stdout.trim() == "true",
-            Err(_) => false,
-        }
-    }
-
-    /// Fetch the Unix timestamp of the Nth-oldest commit within the last `n` commits.
-    ///
-    /// Returns `None` when the repo has fewer than `n` commits.
-    pub(crate) fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>> {
-        if n == 0 {
-            return Ok(None);
-        }
-        let skip = n.saturating_sub(1).to_string();
-        let n_str = n.to_string();
-        let out = self.runner.run(
-            "git",
-            &[
-                "log",
-                "--format=%ad",
-                "--date=unix",
-                "-n",
-                &n_str,
-                "--skip",
-                &skip,
-            ],
-        )?;
-        let trimmed = out.stdout.trim();
-        if trimmed.is_empty() {
-            return Ok(None);
-        }
-        // trimmed is non-empty; first line is the timestamp
-        let ts: u64 = trimmed.lines().next().unwrap_or("").parse().unwrap_or(0);
-        Ok((ts > 0).then_some(ts))
-    }
-
     /// Build the git log arg list from a config.
     fn build_git_log_args(&self, config: &HeatmapConfig) -> Vec<String> {
         let mut args = vec![
@@ -181,19 +120,58 @@ impl CliGitSource {
 
 impl GitDataSource for CliGitSource {
     fn is_git_repo(&self) -> bool {
-        self.is_git_repo()
+        match self
+            .runner
+            .run("git", &["rev-parse", "--is-inside-work-tree"])
+        {
+            Ok(out) => out.exit_code == Some(0),
+            Err(_) => false,
+        }
     }
 
     fn get_repo_root(&self) -> anyhow::Result<String> {
-        self.get_repo_root()
+        let out = self
+            .runner
+            .run("git", &["rev-parse", "--show-toplevel"])
+            .map_err(git_not_found)?;
+        Ok(out.stdout.trim().to_string())
     }
 
     fn detect_shallow_clone(&self) -> bool {
-        self.detect_shallow_clone()
+        match self
+            .runner
+            .run("git", &["rev-parse", "--is-shallow-repository"])
+        {
+            Ok(out) => out.stdout.trim() == "true",
+            Err(_) => false,
+        }
     }
 
     fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>> {
-        self.fetch_commit_count_since(n)
+        if n == 0 {
+            return Ok(None);
+        }
+        let skip = n.saturating_sub(1).to_string();
+        let n_str = n.to_string();
+        let out = self.runner.run(
+            "git",
+            &[
+                "log",
+                "--format=%ad",
+                "--date=unix",
+                "-n",
+                &n_str,
+                "--skip",
+                &skip,
+            ],
+        )?;
+        let trimmed = out.stdout.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        // trimmed is non-empty; first line is the timestamp
+        let ts: u64 = trimmed.lines().next().unwrap_or("").parse().unwrap_or(0);
+        Ok((ts > 0).then_some(ts))
     }
 
     fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>> {

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -149,6 +149,34 @@ impl CliGitSource {
 
         args
     }
+
+    /// Resolve files changed between `base` and HEAD using three-dot diff.
+    ///
+    /// Uses `git diff --name-only <base>...HEAD` so that only commits reachable
+    /// from HEAD but not from `base` are included.
+    pub(crate) fn fetch_diff_files(&self, base: &str) -> anyhow::Result<Vec<String>> {
+        let arg = format!("{base}...HEAD");
+        let out = self
+            .runner
+            .run("git", &["diff", "--name-only", &arg])
+            .map_err(git_not_found)?;
+
+        if out.exit_code != Some(0) {
+            let stderr = out.stderr.trim();
+            if stderr.contains("unknown revision") || stderr.contains("bad revision") {
+                anyhow::bail!("base branch '{base}' not found");
+            }
+            anyhow::bail!("git diff failed: {stderr}");
+        }
+
+        Ok(out
+            .stdout
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(|l| l.strip_prefix("./").unwrap_or(l).to_string())
+            .collect())
+    }
 }
 
 impl GitDataSource for CliGitSource {

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -72,12 +72,12 @@ pub(crate) fn run(
     let git_source = CliGitSource::new();
 
     // Resolve --diff to concrete file list
-    if let Some(ref base) = config.diff_base.clone() {
+    if let Some(base) = config.diff_base.take() {
         if !git_source.is_git_repo() {
             eprintln!("not a git repository (or any parent up to mount point /)");
             return Ok(ExitCode::FAILURE);
         }
-        match git_source.fetch_diff_files(base) {
+        match git_source.fetch_diff_files(&base) {
             Ok(files) if files.is_empty() => {
                 eprintln!("no files changed vs '{base}'");
                 return Ok(ExitCode::FAILURE);
@@ -90,7 +90,6 @@ pub(crate) fn run(
                     }
                 }
                 config.files = files;
-                config.diff_base = None;
             }
             Err(e) => {
                 eprintln!("skim heatmap: {e}");

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -72,33 +72,56 @@ pub(crate) fn run(
     let git_source = CliGitSource::new();
 
     // Resolve --diff to concrete file list
-    if let Some(base) = config.diff_base.take() {
-        if !git_source.is_git_repo() {
-            eprintln!("not a git repository (or any parent up to mount point /)");
-            return Ok(ExitCode::FAILURE);
-        }
-        match git_source.fetch_diff_files(&base) {
-            Ok(files) if files.is_empty() => {
-                eprintln!("no files changed vs '{base}'");
-                return Ok(ExitCode::FAILURE);
-            }
-            Ok(files) => {
-                // Detect deleted files for annotation
-                for f in &files {
-                    if !std::path::Path::new(f).exists() {
-                        eprintln!("warning: file '{}' deleted on current branch", f);
-                    }
-                }
-                config.files = files;
-            }
-            Err(e) => {
-                eprintln!("skim heatmap: {e}");
-                return Ok(ExitCode::FAILURE);
-            }
-        }
+    if let Some(exit) = resolve_diff_files(&git_source, &mut config)? {
+        return Ok(exit);
     }
 
     run_with_source(&git_source, &config, analytics)
+}
+
+/// Resolve `--diff` to a concrete file list, mutating `config.files`.
+///
+/// Returns `Some(ExitCode::FAILURE)` for any early-exit condition so that `run()`
+/// can propagate it directly. Returns `Ok(None)` when resolution succeeded and the
+/// caller should continue.
+///
+/// Path correctness: git diff output is repo-root-relative, so deleted-file
+/// detection uses [`CliGitSource::get_repo_root`] to build absolute paths rather
+/// than relying on cwd. The `is_git_repo()` guard is intentionally omitted — if
+/// the cwd is not inside a repository, `fetch_diff_files` will return an error
+/// with a clear message, and `prepare_commits` already handles the non-repo case.
+fn resolve_diff_files(
+    git_source: &CliGitSource,
+    config: &mut HeatmapConfig,
+) -> anyhow::Result<Option<ExitCode>> {
+    let base = match config.diff_base.take() {
+        Some(b) => b,
+        None => return Ok(None),
+    };
+
+    match git_source.fetch_diff_files(&base) {
+        Ok(files) if files.is_empty() => {
+            eprintln!("skim heatmap: no files changed vs '{base}'");
+            Ok(Some(ExitCode::FAILURE))
+        }
+        Ok(files) => {
+            // Detect deleted files for annotation. git diff output is repo-root-relative,
+            // so resolve paths against the repo root to avoid cwd-dependent failures.
+            let root = git_source.get_repo_root().unwrap_or_default();
+            for f in &files {
+                let abs = std::path::Path::new(&root).join(f);
+                if !abs.exists() {
+                    eprintln!("skim heatmap: warning: file '{}' deleted on current branch", f);
+                }
+            }
+            config.files = files;
+            Ok(None)
+        }
+        Err(e) => {
+            eprintln!("skim heatmap: {e}");
+            Ok(Some(ExitCode::FAILURE))
+        }
+    }
 }
 
 /// Bundled output of [`prepare_commits`] — everything needed to call [`compute_heatmap`].
@@ -337,10 +360,15 @@ fn apply_file_scope(result: &mut HeatmapResult, files: &[String]) {
         .coupling_graph
         .retain(|e| target_set.contains(e.a.as_str()) || target_set.contains(e.b.as_str()));
 
-    // Filter modules: keep only modules containing targeted files
+    // Filter modules: keep only modules whose top-level directory contains a
+    // targeted file.  Modules use top-level directory names (e.g. "src",
+    // "tests") produced by `extract_top_dir`, so we must extract the first
+    // path component — not the immediate parent — to match correctly.
+    // Using `rsplit_once('/')` would yield the *deepest* parent directory
+    // (e.g. "src/cmd/heatmap") which never matches a module named "src".
     let target_dirs: HashSet<&str> = files
         .iter()
-        .filter_map(|f| f.rsplit_once('/').map(|(dir, _)| dir))
+        .filter_map(|f| f.split_once('/').map(|(top, _)| top))
         .collect();
     result
         .modules
@@ -1433,5 +1461,49 @@ mod tests {
         let mut result = make_test_result();
         apply_file_scope(&mut result, &["src/main.rs".to_string()]);
         assert_eq!(result.file_targets, Some(vec!["src/main.rs".to_string()]));
+    }
+
+    /// Regression test for deeply-nested file targets.
+    ///
+    /// When a targeted file lives multiple levels deep (e.g.
+    /// `src/cmd/heatmap/mod.rs`), the module filter must match it against the
+    /// top-level module `"src"` — not the immediate parent `"src/cmd/heatmap"`.
+    /// The previous `rsplit_once('/')` implementation extracted the deepest
+    /// parent directory and would incorrectly drop the `"src"` module.
+    #[test]
+    fn test_apply_file_scope_filters_modules_deeply_nested() {
+        use types::{ChurnMetrics, AuthorMetrics, FixRiskMetrics, FileMetrics, ModuleHealth};
+        let mut result = make_test_result();
+        // Replace the file list with a single deeply-nested path
+        result.files = vec![FileMetrics {
+            path: "src/cmd/heatmap/mod.rs".to_string(),
+            churn: ChurnMetrics { commits: 1, rate: 0.1 },
+            stability_score: 50,
+            authors: AuthorMetrics::default(),
+            fix_risk: FixRiskMetrics::default(),
+            blast_radius: vec![],
+        }];
+        // Add a matching deeply-nested module entry to the modules list
+        result.modules.push(ModuleHealth {
+            path: "src/cmd".to_string(),
+            encapsulation_pct: 70.0,
+            files_count: 1,
+            total_commits: 1,
+            cross_boundary_commits: 0,
+        });
+
+        apply_file_scope(&mut result, &["src/cmd/heatmap/mod.rs".to_string()]);
+
+        // The top-level "src" module must be retained; "tests" must be dropped;
+        // the "src/cmd" entry (not a valid top-level module) must also be dropped.
+        let module_paths: Vec<&str> = result.modules.iter().map(|m| m.path.as_str()).collect();
+        assert!(
+            module_paths.contains(&"src"),
+            "expected 'src' module to be retained for deeply-nested target, got: {module_paths:?}"
+        );
+        assert!(
+            !module_paths.contains(&"tests"),
+            "expected 'tests' module to be dropped, got: {module_paths:?}"
+        );
     }
 }

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -94,9 +94,8 @@ fn resolve_diff_files(
     git_source: &CliGitSource,
     config: &mut HeatmapConfig,
 ) -> anyhow::Result<Option<ExitCode>> {
-    let base = match config.diff_base.take() {
-        Some(b) => b,
-        None => return Ok(None),
+    let Some(base) = config.diff_base.take() else {
+        return Ok(None);
     };
 
     match git_source.fetch_diff_files(&base) {
@@ -362,10 +361,8 @@ fn apply_file_scope(result: &mut HeatmapResult, files: &[String]) {
 
     // Filter modules: keep only modules whose top-level directory contains a
     // targeted file.  Modules use top-level directory names (e.g. "src",
-    // "tests") produced by `extract_top_dir`, so we must extract the first
-    // path component — not the immediate parent — to match correctly.
-    // Using `rsplit_once('/')` would yield the *deepest* parent directory
-    // (e.g. "src/cmd/heatmap") which never matches a module named "src".
+    // "tests") produced by `extract_top_dir`, so we extract the first path
+    // component to align with those names regardless of nesting depth.
     let target_dirs: HashSet<&str> = files
         .iter()
         .filter_map(|f| f.split_once('/').map(|(top, _)| top))

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn run(
         return Ok(ExitCode::SUCCESS);
     }
 
-    let config = match parse_args(args) {
+    let mut config = match parse_args(args) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("skim heatmap: {e}");
@@ -70,6 +70,35 @@ pub(crate) fn run(
     };
 
     let git_source = CliGitSource::new();
+
+    // Resolve --diff to concrete file list
+    if let Some(ref base) = config.diff_base.clone() {
+        if !git_source.is_git_repo() {
+            eprintln!("not a git repository (or any parent up to mount point /)");
+            return Ok(ExitCode::FAILURE);
+        }
+        match git_source.fetch_diff_files(base) {
+            Ok(files) if files.is_empty() => {
+                eprintln!("no files changed vs '{base}'");
+                return Ok(ExitCode::FAILURE);
+            }
+            Ok(files) => {
+                // Detect deleted files for annotation
+                for f in &files {
+                    if !std::path::Path::new(f).exists() {
+                        eprintln!("warning: file '{}' deleted on current branch", f);
+                    }
+                }
+                config.files = files;
+                config.diff_base = None;
+            }
+            Err(e) => {
+                eprintln!("skim heatmap: {e}");
+                return Ok(ExitCode::FAILURE);
+            }
+        }
+    }
+
     run_with_source(&git_source, &config, analytics)
 }
 
@@ -229,8 +258,21 @@ fn run_with_source(
     let start_time = std::time::Instant::now();
     let mut result = compute_heatmap(commits, config, &window, now_epoch, repo_root, warnings);
 
+    // Apply file-targeting display filter (after full metric computation)
+    if !config.files.is_empty() {
+        apply_file_scope(&mut result, &config.files);
+    }
+
+    // Compute display top_n: when files are explicitly targeted and --top
+    // was not given, show all targeted files rather than the global default.
+    let display_top_n = if !config.files.is_empty() && !config.top_explicit {
+        config.files.len()
+    } else {
+        config.top_n
+    };
+
     // Apply --top N limit to files
-    result.files.truncate(config.top_n);
+    result.files.truncate(display_top_n);
 
     // Step 10: Render
     let elapsed = start_time.elapsed();
@@ -240,7 +282,7 @@ fn run_with_source(
         let json = render_json(&result)?;
         writeln!(stdout, "{json}")?;
     } else {
-        let text = render_text(&result, config.top_n);
+        let text = render_text(&result, display_top_n);
         write!(stdout, "{text}")?;
     }
 
@@ -260,6 +302,52 @@ fn run_with_source(
     );
 
     Ok(ExitCode::SUCCESS)
+}
+
+// ============================================================================
+// File-scope display filter (Step 5-alt)
+// ============================================================================
+
+/// Filter heatmap results to only include targeted files.
+///
+/// Filtering happens AFTER metric computation to preserve coupling accuracy.
+/// Coupling graph retains edges where at least one endpoint is targeted
+/// (blast radius view).
+fn apply_file_scope(result: &mut HeatmapResult, files: &[String]) {
+    use std::collections::HashSet;
+
+    let target_set: HashSet<&str> = files.iter().map(|s| s.as_str()).collect();
+
+    // Warn about targets not found in results
+    let result_paths: HashSet<&str> = result.files.iter().map(|f| f.path.as_str()).collect();
+    for target in &target_set {
+        if !result_paths.contains(target) {
+            result
+                .warnings
+                .push(format!("targeted file '{target}' not found in git history"));
+        }
+    }
+
+    // Filter files
+    result
+        .files
+        .retain(|f| target_set.contains(f.path.as_str()));
+
+    // Filter coupling graph: keep edges where at least one endpoint is targeted
+    result
+        .coupling_graph
+        .retain(|e| target_set.contains(e.a.as_str()) || target_set.contains(e.b.as_str()));
+
+    // Filter modules: keep only modules containing targeted files
+    let target_dirs: HashSet<&str> = files
+        .iter()
+        .filter_map(|f| f.rsplit_once('/').map(|(dir, _)| dir))
+        .collect();
+    result
+        .modules
+        .retain(|m| target_dirs.contains(m.path.as_str()));
+
+    result.file_targets = Some(files.to_vec());
 }
 
 // ============================================================================
@@ -382,6 +470,7 @@ fn compute_heatmap(
         coupling_graph,
         excluded_patterns,
         warnings,
+        file_targets: None,
     }
 }
 
@@ -586,6 +675,7 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
         "--coupling-threshold",
         "--fix-window",
         "--format",
+        "--diff",
     ];
 
     while i < args.len() {
@@ -617,6 +707,7 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
                 anyhow::bail!("--top must be at least 1");
             }
             config.top_n = n;
+            config.top_explicit = true;
             continue;
         }
 
@@ -677,6 +768,12 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
             continue;
         }
 
+        // --diff VALUE
+        if let Some(val) = extract_value(args, &mut i, "--diff") {
+            config.diff_base = Some(val);
+            continue;
+        }
+
         // Boolean flags
         if apply_boolean_flag(&mut config, arg)? {
             i += 1;
@@ -686,9 +783,22 @@ fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
         if arg.starts_with('-') {
             anyhow::bail!("unknown flag: {arg}");
         }
-        // Positional (non-flag) argument — `skim heatmap` takes no
-        // positional args; suggest --path if the user meant a directory.
-        anyhow::bail!("unexpected argument: '{arg}'. Did you mean --path={arg}?");
+        // Positional (non-flag) argument — file target.
+        config.files.push(arg.to_string());
+        i += 1;
+        continue;
+    }
+
+    // Post-parse validation
+    if config.diff_base.is_some() && !config.files.is_empty() {
+        anyhow::bail!("cannot combine --diff with explicit file arguments");
+    }
+
+    // Normalize file paths: strip leading ./
+    for f in &mut config.files {
+        if let Some(stripped) = f.strip_prefix("./") {
+            *f = stripped.to_string();
+        }
     }
 
     Ok(config)
@@ -762,13 +872,14 @@ fn print_help() {
 skim heatmap — git history risk and coupling analysis
 
 USAGE:
-    skim heatmap [OPTIONS]
+    skim heatmap [OPTIONS] [FILE...]
 
 OPTIONS:
     --since <VALUE>               Analyze commits since epoch (seconds) or duration (30d, 2w, 24h)
     --last <N>                    Analyze last N commits
     --window <PRESET>             Named window: sprint|month|quarter|half|year|all
     --path <DIR>                  Scope analysis to files under this path
+    --diff <BASE>                 Show only files changed vs BASE (three-dot diff)
     --json, --format json         Output JSON instead of human-readable text
     --top <N>                     Maximum files to display (default: 20)
     --no-exclude                  Disable default exclusion patterns (lock files, build dirs, etc.)
@@ -786,6 +897,17 @@ WINDOW PRESETS:
     year       365 days
     all        No time limit (analyze entire history)
 
+FILE TARGETING:
+    Positional file arguments and --diff scope the OUTPUT, not the git history.
+    Metrics are computed on full commit history for accuracy — coupling and
+    fix-risk scores reflect the complete picture, then display is narrowed.
+
+    --path scopes the git log itself (commit-level filter). File targeting and
+    --path compose: --path limits which commits are analyzed, file arguments
+    limit which results are shown.
+
+    --diff and explicit file arguments are mutually exclusive.
+
 EXAMPLES:
     skim heatmap                           # Analyze last 90 days
     skim heatmap --last 200                # Analyze last 200 commits
@@ -795,6 +917,9 @@ EXAMPLES:
     skim heatmap --path src/               # Scope to src/ directory
     skim heatmap --no-exclude              # Include lock files and build artifacts
     skim heatmap --coupling-threshold 0.3  # Lower coupling threshold
+    skim heatmap src/main.rs               # Scope output to one file
+    skim heatmap --diff main               # Show files changed vs main
+    skim heatmap --path src/ src/main.rs   # Combine path + file scoping
 
 METRICS:
     Top Churn          Files changed most frequently
@@ -966,12 +1091,73 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_args_unexpected_positional_errors() {
-        let result = parse_args(&["src/".to_string()]);
+    fn test_parse_args_positional_files() {
+        let config = parse_args(&["src/main.rs".to_string(), "src/lib.rs".to_string()]).unwrap();
+        assert_eq!(config.files, vec!["src/main.rs", "src/lib.rs"]);
+    }
+
+    #[test]
+    fn test_parse_args_diff_flag() {
+        let config = parse_args(&["--diff".to_string(), "main".to_string()]).unwrap();
+        assert_eq!(config.diff_base, Some("main".to_string()));
+    }
+
+    #[test]
+    fn test_parse_args_diff_equals() {
+        let config = parse_args(&["--diff=develop".to_string()]).unwrap();
+        assert_eq!(config.diff_base, Some("develop".to_string()));
+    }
+
+    #[test]
+    fn test_parse_args_diff_and_files_mutual_exclusion() {
+        let result = parse_args(&[
+            "--diff".to_string(),
+            "main".to_string(),
+            "file.rs".to_string(),
+        ]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("unexpected argument"), "got: {msg}");
-        assert!(msg.contains("--path=src/"), "got: {msg}");
+        assert!(msg.contains("cannot combine --diff"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_args_file_path_normalization() {
+        let config = parse_args(&["./src/main.rs".to_string()]).unwrap();
+        assert_eq!(config.files, vec!["src/main.rs"]);
+    }
+
+    #[test]
+    fn test_parse_args_top_explicit_flag() {
+        let config = parse_args(&["--top".to_string(), "5".to_string()]).unwrap();
+        assert!(config.top_explicit);
+    }
+
+    #[test]
+    fn test_parse_args_top_implicit_by_default() {
+        let config = parse_args(&[]).unwrap();
+        assert!(!config.top_explicit);
+    }
+
+    #[test]
+    fn test_parse_args_diff_without_value() {
+        let result = parse_args(&["--diff".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("requires a value"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_parse_args_files_with_other_flags() {
+        let config = parse_args(&[
+            "--since".to_string(),
+            "30d".to_string(),
+            "src/main.rs".to_string(),
+            "--json".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(config.files, vec!["src/main.rs"]);
+        assert!(config.format_json);
+        assert!(config.since.is_some());
     }
 
     #[test]
@@ -1115,5 +1301,138 @@ mod tests {
         let info = build_window_info(&window, 999, NOW);
 
         assert_eq!(info.commits_analyzed, 999);
+    }
+
+    // -----------------------------------------------------------------------
+    // apply_file_scope
+    // -----------------------------------------------------------------------
+
+    fn make_test_result() -> HeatmapResult {
+        use types::{
+            AuthorMetrics, ChurnMetrics, CouplingEdge, FileMetrics, FixRiskMetrics, ModuleHealth,
+            WindowInfo,
+        };
+        HeatmapResult {
+            version: 1,
+            generated_at: "2025-01-01".to_string(),
+            repository: "test".to_string(),
+            window: WindowInfo {
+                mode: "90d".to_string(),
+                since: "2024-10-01".to_string(),
+                until: "2025-01-01".to_string(),
+                commits_analyzed: 10,
+                effective_strategy: None,
+            },
+            files: vec![
+                FileMetrics {
+                    path: "src/main.rs".to_string(),
+                    churn: ChurnMetrics {
+                        commits: 5,
+                        rate: 0.5,
+                    },
+                    stability_score: 42,
+                    authors: AuthorMetrics::default(),
+                    fix_risk: FixRiskMetrics::default(),
+                    blast_radius: vec![],
+                },
+                FileMetrics {
+                    path: "src/lib.rs".to_string(),
+                    churn: ChurnMetrics {
+                        commits: 3,
+                        rate: 0.3,
+                    },
+                    stability_score: 60,
+                    authors: AuthorMetrics::default(),
+                    fix_risk: FixRiskMetrics::default(),
+                    blast_radius: vec![],
+                },
+                FileMetrics {
+                    path: "tests/test.rs".to_string(),
+                    churn: ChurnMetrics {
+                        commits: 2,
+                        rate: 0.2,
+                    },
+                    stability_score: 80,
+                    authors: AuthorMetrics::default(),
+                    fix_risk: FixRiskMetrics::default(),
+                    blast_radius: vec![],
+                },
+            ],
+            modules: vec![
+                ModuleHealth {
+                    path: "src".to_string(),
+                    encapsulation_pct: 80.0,
+                    files_count: 2,
+                    total_commits: 8,
+                    cross_boundary_commits: 1,
+                },
+                ModuleHealth {
+                    path: "tests".to_string(),
+                    encapsulation_pct: 90.0,
+                    files_count: 1,
+                    total_commits: 2,
+                    cross_boundary_commits: 0,
+                },
+            ],
+            coupling_graph: vec![
+                CouplingEdge {
+                    a: "src/main.rs".to_string(),
+                    b: "src/lib.rs".to_string(),
+                    confidence: 0.8,
+                    support: 4,
+                },
+                CouplingEdge {
+                    a: "tests/test.rs".to_string(),
+                    b: "src/lib.rs".to_string(),
+                    confidence: 0.6,
+                    support: 3,
+                },
+            ],
+            excluded_patterns: vec![],
+            warnings: vec![],
+            file_targets: None,
+        }
+    }
+
+    #[test]
+    fn test_apply_file_scope_filters_files() {
+        let mut result = make_test_result();
+        apply_file_scope(&mut result, &["src/main.rs".to_string()]);
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].path, "src/main.rs");
+    }
+
+    #[test]
+    fn test_apply_file_scope_filters_coupling() {
+        let mut result = make_test_result();
+        apply_file_scope(&mut result, &["src/main.rs".to_string()]);
+        // Edge with src/main.rs kept, edge without any target dropped
+        assert_eq!(result.coupling_graph.len(), 1);
+        assert_eq!(result.coupling_graph[0].a, "src/main.rs");
+    }
+
+    #[test]
+    fn test_apply_file_scope_filters_modules() {
+        let mut result = make_test_result();
+        apply_file_scope(&mut result, &["src/main.rs".to_string()]);
+        assert_eq!(result.modules.len(), 1);
+        assert_eq!(result.modules[0].path, "src");
+    }
+
+    #[test]
+    fn test_apply_file_scope_warns_missing() {
+        let mut result = make_test_result();
+        apply_file_scope(&mut result, &["nonexistent.rs".to_string()]);
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| { w.contains("nonexistent.rs") && w.contains("not found in git history") }));
+    }
+
+    #[test]
+    fn test_apply_file_scope_sets_file_targets() {
+        let mut result = make_test_result();
+        apply_file_scope(&mut result, &["src/main.rs".to_string()]);
+        assert_eq!(result.file_targets, Some(vec!["src/main.rs".to_string()]));
     }
 }

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -110,7 +110,10 @@ fn resolve_diff_files(
             for f in &files {
                 let abs = std::path::Path::new(&root).join(f);
                 if !abs.exists() {
-                    eprintln!("skim heatmap: warning: file '{}' deleted on current branch", f);
+                    eprintln!(
+                        "skim heatmap: warning: file '{}' deleted on current branch",
+                        f
+                    );
                 }
             }
             config.files = files;
@@ -1469,12 +1472,15 @@ mod tests {
     /// parent directory and would incorrectly drop the `"src"` module.
     #[test]
     fn test_apply_file_scope_filters_modules_deeply_nested() {
-        use types::{ChurnMetrics, AuthorMetrics, FixRiskMetrics, FileMetrics, ModuleHealth};
+        use types::{AuthorMetrics, ChurnMetrics, FileMetrics, FixRiskMetrics, ModuleHealth};
         let mut result = make_test_result();
         // Replace the file list with a single deeply-nested path
         result.files = vec![FileMetrics {
             path: "src/cmd/heatmap/mod.rs".to_string(),
-            churn: ChurnMetrics { commits: 1, rate: 0.1 },
+            churn: ChurnMetrics {
+                commits: 1,
+                rate: 0.1,
+            },
             stability_score: 50,
             authors: AuthorMetrics::default(),
             fix_risk: FixRiskMetrics::default(),

--- a/crates/rskim/src/cmd/heatmap/output.rs
+++ b/crates/rskim/src/cmd/heatmap/output.rs
@@ -30,9 +30,13 @@ pub(crate) fn render_text(result: &HeatmapResult, top_n: usize) -> String {
     let mut out = String::new();
 
     // Header
+    let scope_suffix = match &result.file_targets {
+        Some(targets) => format!(" (scoped to {} files)", targets.len()),
+        None => String::new(),
+    };
     let header = format!(
-        "─── Heatmap: {} ({} commits, {} window) ───",
-        result.repository, result.window.commits_analyzed, result.window.mode
+        "─── Heatmap: {} ({} commits, {} window){} ───",
+        result.repository, result.window.commits_analyzed, result.window.mode, scope_suffix
     );
     out.push_str(&header.bold().to_string());
     out.push('\n');
@@ -257,6 +261,7 @@ mod tests {
             }],
             excluded_patterns: vec!["Cargo.lock".to_string()],
             warnings: vec![],
+            file_targets: None,
         }
     }
 

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -37,6 +37,12 @@ pub(crate) struct HeatmapConfig {
     pub(crate) window_preset: Option<String>,
     /// Limit analysis to last N commits.
     pub(crate) last_n: Option<usize>,
+    /// Explicit file targets — scope display to these paths.
+    pub(crate) files: Vec<String>,
+    /// Base branch/ref for `--diff` three-dot diff.
+    pub(crate) diff_base: Option<String>,
+    /// True when `--top` was explicitly passed (vs. implied by file targeting).
+    pub(crate) top_explicit: bool,
 }
 
 impl Default for HeatmapConfig {
@@ -53,6 +59,9 @@ impl Default for HeatmapConfig {
             debug: false,
             window_preset: None,
             last_n: None,
+            files: Vec::new(),
+            diff_base: None,
+            top_explicit: false,
         }
     }
 }
@@ -119,6 +128,9 @@ pub(crate) struct HeatmapResult {
     pub(crate) coupling_graph: Vec<CouplingEdge>,
     pub(crate) excluded_patterns: Vec<String>,
     pub(crate) warnings: Vec<String>,
+    /// Files targeted by `--diff` or positional args (present only when scoped).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) file_targets: Option<Vec<String>>,
 }
 
 /// Information about the analysis window.

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -510,7 +510,7 @@ fn test_heatmap_coupling_threshold_flag_accepted() {
         .args(["heatmap", "--coupling-threshold=0.1"])
         .current_dir(dir.path())
         .assert()
-        .code(predicate::in_iter([0i32, 1i32])); // success or no-commits-found failure
+        .success();
 }
 
 // ============================================================================
@@ -810,7 +810,7 @@ fn test_heatmap_no_targets_unchanged() {
     assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert!(
-        json.get("file_targets").is_none() || json["file_targets"].is_null(),
+        json.get("file_targets").is_none(),
         "file_targets should be absent when no targets given: {json}"
     );
 }

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -214,7 +214,8 @@ fn test_heatmap_help_contains_flag_names() {
         .stdout(predicate::str::contains("--top"))
         .stdout(predicate::str::contains("--no-exclude"))
         .stdout(predicate::str::contains("--coupling-threshold"))
-        .stdout(predicate::str::contains("--fix-window"));
+        .stdout(predicate::str::contains("--fix-window"))
+        .stdout(predicate::str::contains("--diff"));
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -653,3 +653,275 @@ fn test_heatmap_registered_in_help() {
         .success()
         .stdout(predicate::str::contains("heatmap"));
 }
+
+// ============================================================================
+// File targeting
+// ============================================================================
+
+#[test]
+fn test_heatmap_explicit_files() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--json")
+        .arg("src/main.rs")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Only targeted file in results
+    let files = json["files"].as_array().unwrap();
+    assert!(
+        files
+            .iter()
+            .all(|f| f["path"].as_str().unwrap() == "src/main.rs"),
+        "unexpected files: {files:?}"
+    );
+
+    // file_targets present
+    let targets = json["file_targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].as_str().unwrap(), "src/main.rs");
+}
+
+#[test]
+fn test_heatmap_explicit_files_text_header() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("src/main.rs")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("scoped to 1 files"),
+        "header missing scope: {stdout}"
+    );
+}
+
+#[test]
+fn test_heatmap_diff_and_files_mutual_exclusion() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--diff")
+        .arg("main")
+        .arg("src/file.rs")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot combine --diff"));
+}
+
+#[test]
+fn test_heatmap_diff_bad_ref() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--diff")
+        .arg("nonexistent-branch")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "base branch 'nonexistent-branch' not found",
+        ));
+}
+
+#[test]
+fn test_heatmap_file_not_in_history() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--json")
+        .arg("nonexistent.rs")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let warnings = json["warnings"].as_array().unwrap();
+    assert!(
+        warnings.iter().any(|w| {
+            let s = w.as_str().unwrap();
+            s.contains("nonexistent.rs") && s.contains("not found in git history")
+        }),
+        "expected warning not found in: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_heatmap_files_no_top_truncation() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--json")
+        .arg("src/main.rs")
+        .arg("src/lib.rs")
+        .arg("tests/test_lib.rs")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let targets = json["file_targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 3);
+}
+
+#[test]
+fn test_heatmap_no_targets_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--json")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json.get("file_targets").is_none() || json["file_targets"].is_null(),
+        "file_targets should be absent when no targets given: {json}"
+    );
+}
+
+#[test]
+fn test_heatmap_diff_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    // Create a branch from the current state
+    StdCommand::new("git")
+        .args(["checkout", "-b", "feature-test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Add a new file on the branch
+    git_commit(
+        dir.path(),
+        "src/new_file.rs",
+        "fn new() {}",
+        "add new file",
+        recent_ts(),
+    );
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--diff")
+        .arg("main")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // The diff output should include the scope annotation
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("scoped to"),
+        "should show scoped header: {stdout}"
+    );
+}
+
+#[test]
+fn test_heatmap_diff_no_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    create_test_repo(dir.path());
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--diff")
+        .arg("HEAD")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no files changed vs 'HEAD'"));
+}
+
+#[test]
+fn test_heatmap_coupling_preserved_with_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    let ts = recent_ts();
+
+    git_init(dir.path());
+    // Create coupled files — always committed together
+    for i in 0..6u64 {
+        git_commit_files(
+            dir.path(),
+            &[
+                ("src/config.rs", &format!("// v{i}\nfn config() {{}}")),
+                ("src/main.rs", &format!("// v{i}\nfn main() {{}}")),
+            ],
+            &format!("update pair {i}"),
+            ts + i * 86400,
+        );
+    }
+    // Additional solo commits to make coupling < 1.0
+    git_commit(
+        dir.path(),
+        "src/main.rs",
+        "// solo",
+        "solo main",
+        ts + 7 * 86400,
+    );
+
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .arg("heatmap")
+        .arg("--json")
+        .arg("src/main.rs")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Coupling graph should include edge between main.rs and config.rs
+    let coupling = json["coupling_graph"].as_array().unwrap();
+    let has_config_edge = coupling.iter().any(|e| {
+        let a = e["a"].as_str().unwrap();
+        let b = e["b"].as_str().unwrap();
+        (a == "src/main.rs" && b == "src/config.rs") || (a == "src/config.rs" && b == "src/main.rs")
+    });
+    assert!(
+        has_config_edge,
+        "coupling graph should include config.rs edge: {coupling:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Positional file arguments**: `skim heatmap src/main.rs` scopes display to that file; metrics are computed on full history for accuracy, then narrowed
- **`--diff <BASE>` flag**: resolves files changed between `BASE...HEAD` (three-dot diff) and uses them as file targets
- **Mutual exclusion**: `--diff` and explicit file args cannot be combined
- **Coupling graph preserved**: edges are kept when at least one endpoint is targeted (blast radius view)
- **Scope suffix in text header**: `(scoped to N files)` when targeting is active
- **`file_targets` in JSON**: `null`/absent when no targeting, populated when scoped

## Changes

- `types.rs` — `HeatmapConfig`: `files`, `diff_base`, `top_explicit` fields; `HeatmapResult`: `file_targets` field with `skip_serializing_if`
- `mod.rs` — `parse_args`: positional accumulation, `--diff`, `top_explicit` tracking, `./` normalization, post-parse validation; `apply_file_scope()`: filter files/coupling/modules after metric computation; `run_with_source()`: apply scope + dynamic `display_top_n`; `run()`: `--diff` resolution via `fetch_diff_files`; help text with FILE TARGETING section
- `git_source.rs` — `CliGitSource::fetch_diff_files()`: `git diff --name-only base...HEAD` with actionable error on unknown revision
- `output.rs` — `render_text()` scope suffix in header; test `make_result()` helper updated
- `cli_heatmap.rs` — 11 new integration tests

## Test plan

- [x] `cargo test --all-features` — 2,228+ tests pass (3 pre-existing `cli_init` failures unrelated to this PR)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo build --release` — clean
- [x] Unit tests: 10 parse_args tests + 5 apply_file_scope tests (TDD: RED then GREEN)
- [x] Integration tests: explicit files, text header scope, --diff, --diff bad ref, --diff no changes, mutual exclusion, missing file warning, no-top-truncation, no-targets-unchanged, coupling preserved with targets