### PR TITLE
release: v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`skim heatmap` subcommand** — Git history risk and coupling analysis. Mines git log to produce 6 metrics: file churn, co-change coupling (blast radius), stability scores, author concentration (bus factor), fix-after-touch risk, and module encapsulation health. Supports adaptive dual windowing (max of 90 days / 200 commits), auto-exclusion of lock files and build artifacts, JSON and text output, and path scoping. 87 new tests.
-
 ### Changed
 
 ### Fixed
@@ -18,6 +16,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Testing
+
+## [2.9.0] - 2026-05-08
+
+Heatmap analysis, system utility parsers, curl hardening. 3,310 tests passing (up from 3,103 in v2.8.0).
+
+### Added
+- **`skim heatmap` subcommand** — Git history risk and coupling analysis. Mines git log to produce 6 metrics: file churn, co-change coupling (blast radius), stability scores, author concentration (bus factor), fix-after-touch risk, and module encapsulation health. Supports adaptive dual windowing (max of 90 days / 200 commits), auto-exclusion of lock files and build artifacts, JSON and text output, and path scoping. 87 new tests (#163)
+- **Heatmap file targeting** — positional file args, `--diff` flag for changed-files-only analysis, display filter for focusing output on specific paths (#171)
+- **System utility parsers** — `df`, `du`, `env`, `printenv`, `ps`, `wc`, `diff`, `rg`, `tree` output compression via flat dispatch subcommands (#166)
+
+### Changed
+- **Curl parser hardened** — error status detection, redirect chain compression, HTML body truncation, verbose header filtering, write-out format support (#169)
+
+### Fixed
+- **CI release workflow** — fail hard on real publish errors, skip gracefully on already-published versions (#165)
+
+### Testing
+- 3,310 tests passing (up from 3,103 in v2.8.0)
 
 ## [2.8.0] - 2026-05-07
 
@@ -899,6 +915,7 @@ npx rskim file.ts  # no install required
 
 ## Version History
 
+- **2.9.0** (2026-05-08): Heatmap analysis, system utility parsers, curl hardening (3,310 tests)
 - **2.8.0** (2026-05-07): Flat dispatch, Crush agent, multi-file args (3,103 tests)
 - **2.7.0** (2026-05-01): Line numbers, session tracking, output sanitization (3,002 tests)
 - **2.6.0** (2026-04-27): Terminal UX overhaul, non-interactive init, plugin ecosystem removal (2,883 tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (3,190 tests passing)
+- ✅ Full Rust project with comprehensive test suite (3,310 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -571,7 +571,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,190 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,310 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rskim"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "rskim-core"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "criterion",
  "insta",

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ cargo bench
 
 ## Project Status
 
-**Current**: v2.8.0 — Stable
+**Current**: v2.9.0 — Stable
 
 ✅ **Core — Code Reading (17 languages):**
 - TypeScript/JavaScript/Python/Rust/Go/Java/C/C++/C#/Ruby/SQL/Markdown/JSON/YAML/TOML
@@ -586,7 +586,7 @@ cargo bench
 
 ✅ **Distribution:**
 - cargo (`cargo install rskim`), npm (`npx rskim`), Homebrew (`brew install dean0x/tap/skim`)
-- 3,103 tests passing, 14.6ms performance (3x under target)
+- 3,310 tests passing, 14.6ms performance (3x under target)
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.
 

--- a/crates/rskim-core/Cargo.toml
+++ b/crates/rskim-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rskim-core"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 authors = ["Skim Contributors"]
 license = "MIT"

--- a/crates/rskim/Cargo.toml
+++ b/crates/rskim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rskim"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 authors = ["Skim Contributors"]
 license = "MIT"
@@ -13,7 +13,7 @@ name = "skim"
 path = "src/main.rs"
 
 [dependencies]
-rskim-core = { version = "2.8.0", path = "../rskim-core" }
+rskim-core = { version = "2.9.0", path = "../rskim-core" }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = { workspace = true }
 globset = { workspace = true }


### PR DESCRIPTION
## Summary

Release v2.9.0 — 4 commits since v2.8.0 (2026-05-07):

- **`skim heatmap` subcommand** — git history risk/coupling analysis with 6 metrics, 87 new tests (#163)
- **Heatmap file targeting** — positional file args, `--diff` flag, display filter (#171)
- **System utility parsers** — `df`, `du`, `env`, `printenv`, `ps`, `wc`, `diff`, `rg`, `tree` output compression (#166)
- **Curl parser hardened** — error status, redirect chain compression, HTML body truncation, verbose header filtering (#169)
- **CI fix** — fail hard on real publish errors, skip already-published (#165)

## Changes

- CHANGELOG: completed `[Unreleased]` → `[2.9.0] - 2026-05-08` with all 4 commits documented
- Version bump: 2.8.0 → 2.9.0 in `crates/rskim-core/Cargo.toml`, `crates/rskim/Cargo.toml` (package + dep)
- Test count sync: 3,103 → 3,310 in README.md and CLAUDE.md (2 locations)
- Version string sync: v2.8.0 → v2.9.0 in README.md

## Verification

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test --all-features` — 3,310 tests passing
- [x] Version consistent across all Cargo.toml files
- [x] CHANGELOG has dated `[2.9.0]` entry with all commits

## Post-merge

After merge: `git tag v2.9.0 && git push origin main --tags` triggers the automated release pipeline.