### PR TITLE
release: v2.10.0

### DIFF
--- a/.release/.gitignore
+++ b/.release/.gitignore
@@ -1,0 +1,2 @@
+.progress.json
+.lock/

--- a/.release/RELEASE-FLOW.md
+++ b/.release/RELEASE-FLOW.md
@@ -1,0 +1,75 @@
+---
+format_version: 1
+project_type: rust
+version_strategy: manual
+tag_format: "v{version}"
+created: 2026-05-13T00:00:00Z
+last_updated: 2026-05-13T00:00:00Z
+---
+
+## Packages
+
+Single workspace with two published crates (order matters):
+
+| Crate | Version File | Publish Target |
+|-------|-------------|----------------|
+| rskim-core | `crates/rskim-core/Cargo.toml` | crates.io |
+| rskim | `crates/rskim/Cargo.toml` (package version + rskim-core dependency version) | crates.io + npm |
+
+## Pre-release Checks
+
+1. Working directory clean (`git status --porcelain`)
+2. On a release branch (`release/v{version}`)
+3. Tag does not already exist
+4. `cargo fmt -- --check`
+5. `cargo clippy -- -D warnings`
+6. `cargo test --all-features`
+
+## Changelog
+
+Format: keep-a-changelog
+Unreleased section: `## [Unreleased]`
+Release section: `## [{version}] - {YYYY-MM-DD}`
+
+## Build & Test
+
+- build_tool: cargo
+- test_tool: cargo
+- release_prep_script: `./scripts/release-prep.sh {version}`
+
+## Publish
+
+- Method: CI-driven (triggered by tag push)
+- Pipeline: `.github/workflows/release.yml`
+- Sequence: test -> build (7 targets) -> GitHub Release -> crates.io (rskim-core first, then rskim) -> npm (7 platform pkgs + main) -> Homebrew tap dispatch
+
+## Version Bump (3 files, 4 edits)
+
+Automated by `release-prep.sh`:
+- `crates/rskim-core/Cargo.toml` — package version
+- `crates/rskim/Cargo.toml` — package version + rskim-core dependency version
+- `cargo check` to update `Cargo.lock`
+- Syncs test count in README.md and CLAUDE.md
+- Syncs version string in README.md
+
+## Release Branch Workflow
+
+1. Create branch: `git checkout -b release/v{version} main`
+2. Run `./scripts/release-prep.sh {version}` (pre-flight + version bumps + doc sync)
+3. Write CHANGELOG entry manually
+4. Update CLAUDE.md subcommand descriptions if changed
+5. Commit: `release: v{version} — {summary}`
+6. Push branch, open PR to main
+7. After merge: `git tag v{version}` on main, `git push origin main --tags`
+
+## Post-release Verification
+
+1. `cargo install rskim` — shows new version
+2. `npx rskim --version` — shows new version
+3. GitHub Release page — 7 binary assets attached
+4. `brew update && brew info dean0x/tap/skim` — formula updated (PF-001)
+
+## Post-release Cleanup
+
+- Delete release branch: `git branch -d release/v{version}`
+- Rebuild local dev binary: `cargo build --release`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-05-13
+
+Container, cloud, database compression; search crate foundation; heatmap insights. 3,558 tests passing (up from 3,310 in v2.9.0).
+
 ### Added
-- **`skim heatmap --insights` flag** — threshold-filtered one-liner findings for focused risk analysis. Reports only CRITICAL/WARNING severity metrics (fix-risk, bus-factor, churn, coupling) in text and JSON formats, skipping healthy files
+- **`rskim-search` crate (Wave 0)** — New workspace crate providing the search foundation: `SearchLayer`, `LayerBuilder`, and `FieldClassifier` traits, `SearchQuery`/`SearchResult`/`IndexStats` types, AST-aware `SearchField` classification (8 field variants), and typed `SearchError` hierarchy. Pure library with no I/O — CLI integration in future waves (#213)
+- **`skim heatmap --insights` flag** — threshold-filtered one-liner findings for focused risk analysis. Reports only CRITICAL/WARNING severity metrics (fix-risk, bus-factor, churn, coupling) in text and JSON formats, skipping healthy files (#215)
 - **`skim psql` subcommand** — PostgreSQL query output compression via three-tier degradation: Tier 1 (tabular `----+----` format), Tier 2 (regex row-count extraction), Tier 3 (passthrough). Supports `--json` for structured `DbResult` output (#117)
 - **`skim mysql` subcommand** — MySQL query output compression: Tier 1 (TSV batch output), Tier 2 (bordered `+---+` table format), Tier 3 (passthrough). Handles empty-set detection and multi-result sets. Supports `--json` (#117)
 - **`skim sqlite3` subcommand** — SQLite query output compression: Tier 1 (pipe-separated with `-header -separator |` injection), Tier 3 (passthrough for schema dumps and meta-commands). Supports `--json` (#117)
 - **`DbResult` canonical type** — Structured database query result with column/row data, row count, truncation flag, and pre-rendered aligned table output. Part of the canonical output type system (#117)
-- **`skim docker` subcommand** — Docker output compression for `ps`, `images`, `inspect`, `build`, `logs`, `compose` via three-tier degradation. Previously added in Part 1 (#117)
-- **`skim kubectl` subcommand** — Kubernetes output compression for `get`, `describe`, `logs`. Injects `-o json` for `get` (skipped for watch/existing format flags). Previously added in Part 1 (#117)
-- **`skim terraform` subcommand** — Terraform output compression for `plan` and `apply`: Tier 1 (NDJSON from `-json`), Tier 2 (regex on human-readable text). Safety invariant: never injects `-json` for plan/apply to preserve interactive approval prompts. Previously added in Part 1 (#117)
+- **`skim docker` subcommand** — Docker output compression for `ps`, `images`, `inspect`, `build`, `logs`, `compose` via three-tier degradation (#117)
+- **`skim kubectl` subcommand** — Kubernetes output compression for `get`, `describe`, `logs`. Injects `-o json` for `get` (skipped for watch/existing format flags) (#117)
+- **`skim terraform` subcommand** — Terraform output compression for `plan` and `apply`: Tier 1 (NDJSON from `-json`), Tier 2 (regex on human-readable text). Safety invariant: never injects `-json` for plan/apply to preserve interactive approval prompts (#117)
 - **15 new rewrite rules** — Docker (ps, images, build, inspect, logs, compose ps, compose logs), kubectl (get, describe, logs), terraform (plan, apply), psql (-c), mysql (-e), sqlite3. Total: 122 rules across 8 categories (#117)
-
-### Changed
 
 ### Fixed
 - **DB family ANSI strip bypass** — `strip_ansi_escapes` was stripping ASCII tab characters (0x09) from stdin content, causing MySQL TSV parsers to receive tab-free data and fall through to passthrough. DB family commands now bypass ANSI stripping to preserve tab separators (#117)
-
-### Removed
+- **Heatmap `set_var`/`remove_var` unsafe blocks** — Rust 2024 edition requires explicit `unsafe {}` blocks for `std::env::set_var` and `std::env::remove_var` in test code
+- **Test isolation for `SKIM_PASSTHROUGH`** — Hook and parser E2E tests now clear `SKIM_PASSTHROUGH` from inherited environment, preventing false failures when tests run inside a skim hook session
 
 ### Testing
-- 3,442 tests passing (up from 3,310 in v2.9.0)
+- 3,558 tests passing (up from 3,310 in v2.9.0)
 - 14 new E2E parser tests: psql (tier 1, empty, tier 2, tier 3, JSON), mysql (tier 1 TSV, tier 2 bordered, tier 3, empty set, JSON), sqlite3 (tier 1, empty, tier 3 schema, JSON)
 - 19 new E2E rewrite tests: docker (5 positive, 1 skip), kubectl (3 positive, 2 skip), terraform (2 positive, 1 skip), DB tools (3 positive, 1 skip)
+- 22 new `rskim-search` unit tests: type roundtrips, trait contracts, field classifier, serde agreement (#213)
 
 ## [2.9.0] - 2026-05-08
 
@@ -928,6 +932,7 @@ npx rskim file.ts  # no install required
 
 ## Version History
 
+- **2.10.0** (2026-05-13): Container/cloud/database compression, search crate foundation, heatmap insights (3,558 tests)
 - **2.9.0** (2026-05-08): Heatmap analysis, system utility parsers, curl hardening (3,310 tests)
 - **2.8.0** (2026-05-07): Flat dispatch, Crush agent, multi-file args (3,103 tests)
 - **2.7.0** (2026-05-01): Line numbers, session tracking, output sanitization (3,002 tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (3,310 tests passing)
+- ✅ Full Rust project with comprehensive test suite (3,558 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -572,7 +572,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,310 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,558 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rskim"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "rskim-core"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "criterion",
  "insta",

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ cargo bench
 
 ## Project Status
 
-**Current**: v2.9.0 — Stable
+**Current**: v2.10.0 — Stable
 
 ✅ **Core — Code Reading (17 languages):**
 - TypeScript/JavaScript/Python/Rust/Go/Java/C/C++/C#/Ruby/SQL/Markdown/JSON/YAML/TOML
@@ -599,7 +599,7 @@ cargo bench
 
 ✅ **Distribution:**
 - cargo (`cargo install rskim`), npm (`npx rskim`), Homebrew (`brew install dean0x/tap/skim`)
-- 3,310 tests passing, 14.6ms performance (3x under target)
+- 3,558 tests passing, 14.6ms performance (3x under target)
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.
 

--- a/crates/rskim-core/Cargo.toml
+++ b/crates/rskim-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rskim-core"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2024"
 authors = ["Skim Contributors"]
 license = "MIT"

--- a/crates/rskim/Cargo.toml
+++ b/crates/rskim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rskim"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2024"
 authors = ["Skim Contributors"]
 license = "MIT"
@@ -13,7 +13,7 @@ name = "skim"
 path = "src/main.rs"
 
 [dependencies]
-rskim-core = { version = "2.9.0", path = "../rskim-core" }
+rskim-core = { version = "2.10.0", path = "../rskim-core" }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = { workspace = true }
 globset = { workspace = true }

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -717,7 +717,8 @@ mod tests {
 
         let _ = crate::analytics::AnalyticsDb::open(tmp.path()).unwrap();
 
-        std::env::set_var("SKIM_ANALYTICS_DB", &db_path);
+        // SAFETY: test is single-threaded; no concurrent env reads.
+        unsafe { std::env::set_var("SKIM_ANALYTICS_DB", &db_path) };
 
         let analytics = crate::analytics::AnalyticsConfig {
             enabled: true,
@@ -741,6 +742,7 @@ mod tests {
             cmds.iter().map(|c| &c.original_cmd).collect::<Vec<_>>()
         );
 
-        std::env::remove_var("SKIM_ANALYTICS_DB");
+        // SAFETY: test is single-threaded; no concurrent env reads.
+        unsafe { std::env::remove_var("SKIM_ANALYTICS_DB") };
     }
 }

--- a/crates/rskim/tests/cli_init.rs
+++ b/crates/rskim/tests/cli_init.rs
@@ -612,6 +612,7 @@ fn test_hook_cargo_test_match() {
     let output = Command::cargo_bin("skim")
         .unwrap()
         .args(["rewrite", "--hook"])
+        .env_remove("SKIM_PASSTHROUGH")
         .write_stdin(hook_payload("cargo test"))
         .assert()
         .success();
@@ -726,6 +727,7 @@ fn test_hook_compound_command_rewrite() {
     let output = Command::cargo_bin("skim")
         .unwrap()
         .args(["rewrite", "--hook"])
+        .env_remove("SKIM_PASSTHROUGH")
         .write_stdin(hook_payload("cargo test && cargo clippy"))
         .assert()
         .success();
@@ -778,6 +780,7 @@ fn test_hook_version_mismatch_warning() {
     let output = Command::cargo_bin("skim")
         .unwrap()
         .args(["rewrite", "--hook"])
+        .env_remove("SKIM_PASSTHROUGH")
         .env("SKIM_HOOK_VERSION", "0.0.1")
         .env("SKIM_CACHE_DIR", cache_dir.path().as_os_str())
         .write_stdin(hook_payload("cargo test"))

--- a/crates/rskim/tests/cli_integrity.rs
+++ b/crates/rskim/tests/cli_integrity.rs
@@ -24,7 +24,8 @@ fn skim_init_cmd(config_dir: &std::path::Path) -> Command {
 fn skim_rewrite_hook_cmd(config_dir: &std::path::Path) -> Command {
     let mut cmd = Command::cargo_bin("skim").unwrap();
     cmd.args(["rewrite", "--hook"])
-        .env("CLAUDE_CONFIG_DIR", config_dir.as_os_str());
+        .env("CLAUDE_CONFIG_DIR", config_dir.as_os_str())
+        .env_remove("SKIM_PASSTHROUGH");
     cmd
 }
 

--- a/crates/rskim/tests/cli_test_cargo.rs
+++ b/crates/rskim/tests/cli_test_cargo.rs
@@ -19,6 +19,7 @@ fn test_skim_test_cargo_in_this_repo() {
     let assert = Command::cargo_bin("skim")
         .unwrap()
         .args(["cargo", "test", "-p", "rskim-core"])
+        .env_remove("SKIM_PASSTHROUGH")
         .timeout(std::time::Duration::from_secs(120))
         .assert();
 

--- a/crates/rskim/tests/cli_test_pytest.rs
+++ b/crates/rskim/tests/cli_test_pytest.rs
@@ -9,6 +9,12 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::process;
 
+fn skim_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("skim").unwrap();
+    cmd.env_remove("SKIM_PASSTHROUGH");
+    cmd
+}
+
 // ============================================================================
 // Help and subcommand routing
 // ============================================================================
@@ -46,8 +52,7 @@ fn test_skim_pytest_help() {
 #[test]
 fn test_piped_all_pass() {
     let fixture = include_str!("fixtures/cmd/test/pytest_pass.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .args(["pytest"])
         .write_stdin(fixture)
         .assert()
@@ -59,8 +64,7 @@ fn test_piped_all_pass() {
 #[test]
 fn test_piped_with_failures() {
     let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .args(["pytest"])
         .write_stdin(fixture)
         .assert()
@@ -73,8 +77,7 @@ fn test_piped_with_failures() {
 #[test]
 fn test_piped_mixed() {
     let fixture = include_str!("fixtures/cmd/test/pytest_mixed.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .args(["pytest"])
         .write_stdin(fixture)
         .assert()
@@ -87,8 +90,7 @@ fn test_piped_mixed() {
 #[test]
 fn test_piped_all_failures() {
     let fixture = include_str!("fixtures/cmd/test/pytest_all_fail.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .args(["pytest"])
         .write_stdin(fixture)
         .assert()
@@ -139,8 +141,7 @@ fn test_piped_passthrough_mode_skips_compression() {
 #[test]
 fn test_failure_context_appended_on_failures() {
     let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .args(["pytest"])
         .write_stdin(fixture)
         .assert()
@@ -153,8 +154,7 @@ fn test_failure_context_appended_on_failures() {
 #[test]
 fn test_failure_context_absent_on_all_pass() {
     let fixture = include_str!("fixtures/cmd/test/pytest_pass.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .args(["pytest"])
         .write_stdin(fixture)
         .assert()
@@ -193,8 +193,7 @@ fn test_real_pytest_if_available() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = skim_cmd()
         .args(["pytest", test_file.to_str().unwrap()])
         .output()
         .unwrap();

--- a/crates/rskim/tests/cli_test_vitest.rs
+++ b/crates/rskim/tests/cli_test_vitest.rs
@@ -20,6 +20,12 @@ fn read_fixture(name: &str) -> String {
         .unwrap_or_else(|e| panic!("Failed to read fixture {name}: {e}"))
 }
 
+fn skim_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("skim").unwrap();
+    cmd.env_remove("SKIM_PASSTHROUGH");
+    cmd
+}
+
 // ============================================================================
 // Help output
 // ============================================================================
@@ -44,8 +50,7 @@ fn test_skim_vitest_help() {
 fn test_skim_test_vitest_stdin_pass() {
     let fixture = read_fixture("vitest_pass.json");
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .arg("vitest")
         .write_stdin(fixture)
         .assert()
@@ -58,8 +63,7 @@ fn test_skim_test_vitest_stdin_pass() {
 fn test_skim_test_vitest_stdin_fail() {
     let fixture = read_fixture("vitest_fail.json");
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .arg("vitest")
         .write_stdin(fixture)
         .assert()
@@ -74,8 +78,7 @@ fn test_skim_test_vitest_stdin_fail() {
 fn test_skim_test_vitest_stdin_pnpm_prefix() {
     let fixture = read_fixture("vitest_pnpm_prefix.json");
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .arg("vitest")
         .write_stdin(fixture)
         .assert()
@@ -92,8 +95,7 @@ fn test_skim_test_vitest_stdin_pnpm_prefix() {
 fn test_skim_test_vitest_stdin_regex_fallback() {
     let input = "Tests  5 passed | 1 failed | 6 total";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .arg("--debug")
         .arg("vitest")
         .write_stdin(input)
@@ -112,8 +114,7 @@ fn test_skim_test_vitest_stdin_regex_fallback() {
 fn test_skim_test_vitest_stdin_passthrough() {
     let input = "completely unparseable output";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .arg("--debug")
         .arg("vitest")
         .write_stdin(input)
@@ -140,8 +141,7 @@ fn test_skim_test_jest_alias_works() {
     let fixture = read_fixture("vitest_pass.json");
 
     // `skim jest` should route to the vitest parser (compatible format)
-    Command::cargo_bin("skim")
-        .unwrap()
+    skim_cmd()
         .arg("jest")
         .write_stdin(fixture)
         .assert()


### PR DESCRIPTION
## Summary

- **Container, cloud & database compression** — docker, kubectl, terraform, psql, mysql, sqlite3 parsers with three-tier degradation + 15 new rewrite rules (#117, #212)
- **rskim-search crate foundation (Wave 0)** — SearchLayer, LayerBuilder, FieldClassifier traits; pure library with no I/O (#213)
- **Heatmap `--insights` flag** — threshold-filtered one-liner findings for focused risk analysis (#215)

## Fixes

- Rust 2024 `unsafe {}` blocks for `set_var`/`remove_var` in heatmap tests
- `SKIM_PASSTHROUGH` test isolation — hook and parser E2E tests now clear inherited env var
- DB family ANSI strip bypass for MySQL TSV parsing

## Test plan

- [x] 3,558 tests passing (up from 3,310)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Tests pass even under `SKIM_PASSTHROUGH=1` (env leak scenario)
- [ ] CI passes on all 7 targets
- [ ] After merge: tag v2.10.0, push tags, verify release pipeline