### PR TITLE
feat(#179): gix-based git log parser with shared temporal types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +28,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -84,6 +96,21 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
@@ -159,6 +186,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -257,6 +290,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.0",
+]
 
 [[package]]
 name = "colorchoice"
@@ -373,6 +415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +492,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +589,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -531,6 +613,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -572,6 +663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,12 +696,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -681,6 +819,707 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01237e8d3d78581f71642be8b0c2ae8c0b2b5c251c9c5d9ebbea3c1ea280dce8"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.35.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987a51a7e66db6ef4dc030418eb2a42af6b913a79edd8670766122d8af3ba59e"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50d813d5c2ce9463ba0c29eea90060df08e38ad8f34b8a192259f8bce5c078"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e150161b8a75b5860521cb876b506879a3376d3adc857ec7a9d35e7c6a5e531"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f9c425730a654835351e6da8c3c69ba1804f8b8d4e96d027254151138d5c64"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-hash",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f3c8f357ae049bfb77493c2ec9010f58cfc924ae485e1116c3718fc0f0d881"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c489abb061c74b0c3ad790e24a606ef968cebab48ec673d6a891ece7d5aef64"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661245d045aa7c16ba4244daaabd823c562c3e45f1f25b816be2c57ee09f2171"
+dependencies = [
+ "bstr",
+ "itoa",
+ "jiff",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9b43e95fe352da82a969f0c84ff860c2de3e724d93f6681fedbcd6c917f252"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed"
+dependencies = [
+ "crc32fast",
+ "crossbeam-channel",
+ "flate2",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf004912949bbcf308d71aac4458321748ecb59f4d046830d25214208c471f1"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline-blocking",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90181472925b587f6079698f79065ff64786e6d6c14089517a1972bca99fb6e9"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38e919efd59cb8275d23ad2394b2ab9d002007b27620e145d866d546403b665"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.14.5",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.69.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868f703905fdbcfc1bd750942f82419903ecb7039f5288adb5206d6de405e0c9"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d49c55d69c8449f2a0a5a77eb9cbacfebb6b0e2f1215f0fc23a4cb60528a450"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64286a8b5148e76ab80932e72762dd27ccf6169dd7a134b027c8a262a8262fcf"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-packetline-blocking"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c59c3ad41e68cb38547d849e9ef5ccfc0d00f282244ba1441ae856be54d001"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce061c50e5f8f7c830cacb3da3e999ae935e283ce8522249f0ce2256d110979d"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c17d78bb0414f8d60b5f952196dc2e47ec320dca885de9128ecdb4a0e38401"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445ed14e3db78e8e79980085e3723df94e1c8163b3ae5bc8ed6a8fe6cf983b42"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d0b8e5cbd1c329e25383e088cb8f17439414021a643b30afa5146b71e3c65d"
+dependencies = [
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd"
+dependencies = [
+ "bitflags",
+ "gix-path",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9a6f6e34d6ede08f522d89e5c7990b4f60524b8ae6ebf8e850963828119ad4"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f51472f05a450cc61bc91ed2f62fb06e31e2bbb31c420bc4be8793f26c8b0c1"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfe22ba26d4b65c17879f12b9882eafe65d3c8611c933b272fce2c10f546f59"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8648172f85aca3d6e919c06504b7ac26baef54e04c55eb0100fa588c102cc33"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a1ad0b04a5718b5cb233e6888e52a9b627846296161d81dcc5eb9203ec84b8"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "percent-encoding",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f1916f8d928268300c977d773dd70a8746b646873b77add0a34876a8c847e9"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,12 +1543,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -717,6 +1575,11 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -725,6 +1588,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -740,6 +1613,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +1729,15 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -836,6 +1821,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +1869,15 @@ checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -886,6 +1921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +1948,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -996,6 +2058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +2110,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,10 +2167,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.41"
+name = "prodash"
+version = "29.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc"
+dependencies = [
+ "log",
+ "parking_lot",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1251,7 +2347,10 @@ name = "rskim-search"
 version = "0.1.0"
 dependencies = [
  "crc32fast",
+ "gix",
  "memmap2",
+ "once_cell",
+ "regex",
  "rskim-core",
  "serde",
  "serde_json",
@@ -1442,6 +2541,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +2571,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1490,6 +2616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +2638,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -1537,6 +2681,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1603,6 +2758,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +2776,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -1820,10 +3000,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1848,6 +3052,24 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2198,6 +3420,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,3 +3467,63 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,6 @@ dependencies = [
  "crc32fast",
  "gix",
  "memmap2",
- "once_cell",
  "regex",
  "rskim-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ serial_test = "3.0"
 libc = "0.2"
 filetime = "0.2"
 gix = { version = "0.72", default-features = false, features = ["max-performance-safe", "blob-diff"] }
-once_cell = "1"
 
 [workspace.metadata.dist]
 cargo-dist-version = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ criterion = "0.5"
 serial_test = "3.0"
 libc = "0.2"
 filetime = "0.2"
+gix = { version = "0.72", default-features = false, features = ["max-performance-safe", "blob-diff"] }
+once_cell = "1"
 
 [workspace.metadata.dist]
 cargo-dist-version = "0.14.0"

--- a/crates/rskim-search/Cargo.toml
+++ b/crates/rskim-search/Cargo.toml
@@ -23,7 +23,6 @@ crc32fast = { workspace = true }
 tempfile = { workspace = true }
 gix = { workspace = true }
 regex = { workspace = true }
-once_cell = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/rskim-search/Cargo.toml
+++ b/crates/rskim-search/Cargo.toml
@@ -21,6 +21,9 @@ serde = { workspace = true }
 memmap2 = { workspace = true }
 crc32fast = { workspace = true }
 tempfile = { workspace = true }
+gix = { workspace = true }
+regex = { workspace = true }
+once_cell = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -5,12 +5,14 @@
 //! - Core types (`types` module) are **pure**: no I/O, no side effects.
 //! - The `index` module provides on-disk persistence via memory-mapped files.
 //! - The `ngram` module handles bigram extraction (pure, no I/O).
+//! - The `temporal` module parses git history via gix for temporal scoring.
 //! - Returns Result types throughout — no panics in non-test code.
 //!
 //! CLI/binary code in `crates/rskim/src/cmd/search.rs` handles user-facing I/O.
 
 pub mod index;
 pub mod ngram;
+pub mod temporal;
 mod types;
 pub mod weights;
 
@@ -19,8 +21,10 @@ pub use ngram::{
     BORDER_MULTIPLIER, Ngram, extract_ngrams, extract_ngrams_with_weights, extract_query_ngrams,
     extract_query_ngrams_with_weights,
 };
+pub use temporal::{GixSource, is_fix_commit};
 pub use types::{
-    FieldClassifier, FileId, IndexStats, LayerBuilder, NodeInfo, Result, SearchError, SearchField,
-    SearchLayer, SearchQuery, SearchResult, TemporalFlags,
+    CommitInfo, FieldClassifier, FileChangeInfo, FileId, HistoryResult, IndexStats, LayerBuilder,
+    NodeInfo, Result, SearchError, SearchField, SearchLayer, SearchQuery, SearchResult,
+    TemporalFlags, TemporalMetadata, TemporalSource,
 };
 pub use weights::{BIGRAM_WEIGHTS, DEFAULT_WEIGHT, bigram_weight};

--- a/crates/rskim-search/src/temporal/git_parser.rs
+++ b/crates/rskim-search/src/temporal/git_parser.rs
@@ -70,6 +70,10 @@ impl TemporalSource for GixSource {
 // Implementation
 // ============================================================================
 
+/// Safety cap on commit traversal to prevent OOM on very large repositories
+/// (e.g. linux kernel: 1M+ commits) when `lookback_days = 0`.
+const MAX_COMMITS: usize = 100_000;
+
 fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryResult> {
     // Open repository, discovering .git in parent directories
     let mut repo = gix::discover(repo_path).map_err(gix_err)?;
@@ -93,11 +97,14 @@ fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryRes
         }
     };
 
-    // Compute lookback cutoff (seconds since unix epoch)
+    // Compute lookback cutoff (seconds since unix epoch).
+    // Fail explicitly if the system clock predates the Unix epoch — silently
+    // returning 0 would make cutoff_secs negative, causing all commits to pass
+    // the filter and effectively ignoring the lookback window.
     let cutoff_secs: Option<i64> = if lookback_days > 0 {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
+            .map_err(|_| SearchError::Git("system clock is before Unix epoch".into()))?
             .as_secs() as i64;
         Some(now - i64::from(lookback_days) * 86_400)
     } else {
@@ -123,13 +130,24 @@ fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryRes
     let mut commits: Vec<CommitInfo> = Vec::new();
 
     for info_result in walk {
+        // Guard against OOM on very large repositories (e.g. linux kernel).
+        if commits.len() >= MAX_COMMITS {
+            eprintln!(
+                "skim: parse_history reached the {MAX_COMMITS}-commit safety cap; \
+                 truncating history. Pass lookback_days > 0 to scope the traversal."
+            );
+            break;
+        }
+
         let info = match info_result {
             Ok(info) => info,
             Err(_) if is_shallow => break,
             Err(e) => return Err(gix_err(e)),
         };
 
-        // Decode the full commit object for author/message fields
+        // Decode the full commit object for author/message fields.
+        // The same object is reused in changed_files_for_commit below to avoid
+        // a second object-store lookup per commit.
         let commit_obj = info.object().map_err(gix_err)?;
         let commit_ref = commit_obj.decode().map_err(gix_err)?;
 
@@ -154,8 +172,9 @@ fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryRes
         let message = first_line_of(msg_bytes.to_str_lossy().as_ref()).to_owned();
 
         // Compute changed files (tree diff vs. first parent or empty tree).
+        // Pass the already-decoded commit object to avoid a second object lookup.
         // In shallow clones, the parent object may be missing — treat as empty.
-        let changed_files = match changed_files_for_commit(&repo, &info) {
+        let changed_files = match changed_files_for_commit(&repo, &commit_obj, &info.parent_ids) {
             Ok(files) => files,
             Err(_) if is_shallow => Vec::new(),
             Err(e) => return Err(e),
@@ -171,26 +190,34 @@ fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryRes
     }
 
     let commit_count = commits.len();
-    Ok(HistoryResult {
+    let result = HistoryResult {
         commits,
         metadata: TemporalMetadata {
             is_shallow,
             commit_count,
         },
-    })
+    };
+    debug_assert_eq!(
+        result.metadata.commit_count,
+        result.commits.len(),
+        "commit_count must equal commits.len()"
+    );
+    Ok(result)
 }
 
 /// Return the changed files in a commit by diffing its tree against its first
 /// parent (or the empty tree for root commits).
 ///
+/// Accepts the already-decoded `commit` object from the caller to avoid a
+/// second object-store lookup per commit.
+///
 /// Uses `Tree::changes().for_each_to_obtain_tree()` which is the high-level
 /// gix API. Requires the `blob-diff` feature.
 fn changed_files_for_commit(
     repo: &gix::Repository,
-    info: &gix::revision::walk::Info<'_>,
+    commit: &gix::Commit<'_>,
+    parent_ids: &gix::traverse::commit::ParentIds,
 ) -> Result<Vec<FileChangeInfo>> {
-    let commit = info.object().map_err(gix_err)?;
-
     // Get the new (this commit's) tree
     let new_tree = commit.tree().map_err(gix_err)?;
 
@@ -198,7 +225,7 @@ fn changed_files_for_commit(
     let old_tree: gix::Tree<'_>;
     let empty_tree: gix::Tree<'_>;
 
-    let lhs: &gix::Tree<'_> = if let Some(&parent_id) = info.parent_ids.first() {
+    let lhs: &gix::Tree<'_> = if let Some(&parent_id) = parent_ids.first() {
         let parent_obj = repo.find_object(parent_id).map_err(gix_err)?;
         let parent_commit = parent_obj
             .try_into_commit()
@@ -225,14 +252,12 @@ fn changed_files_for_commit(
                 | Change::Modification { location, entry_mode, .. }
                 | Change::Rewrite { location, entry_mode, .. } => (location, entry_mode),
             };
-            let path_opt = if entry_mode.is_no_tree() && !location.is_empty() {
-                Some(location.to_str_lossy().into_owned())
-            } else {
-                None
-            };
-            if let Some(path) = path_opt {
+            // Build PathBuf from the location bytes. `to_str_lossy()` returns a
+            // `Cow<str>`; using `.as_ref()` avoids the intermediate owned String
+            // allocation when the path is already valid UTF-8 (Cow::Borrowed).
+            if entry_mode.is_no_tree() && !location.is_empty() {
                 changed_files.push(FileChangeInfo {
-                    path: PathBuf::from(path),
+                    path: PathBuf::from(location.to_str_lossy().as_ref()),
                     additions: 0,
                     deletions: 0,
                 });

--- a/crates/rskim-search/src/temporal/git_parser.rs
+++ b/crates/rskim-search/src/temporal/git_parser.rs
@@ -123,7 +123,11 @@ fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryRes
     let mut commits: Vec<CommitInfo> = Vec::new();
 
     for info_result in walk {
-        let info = info_result.map_err(gix_err)?;
+        let info = match info_result {
+            Ok(info) => info,
+            Err(_) if is_shallow => break,
+            Err(e) => return Err(gix_err(e)),
+        };
 
         // Decode the full commit object for author/message fields
         let commit_obj = info.object().map_err(gix_err)?;
@@ -149,8 +153,13 @@ fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryRes
         let msg_bytes = commit_ref.message;
         let message = first_line_of(msg_bytes.to_str_lossy().as_ref()).to_owned();
 
-        // Compute changed files (tree diff vs. first parent or empty tree)
-        let changed_files = changed_files_for_commit(&repo, &info)?;
+        // Compute changed files (tree diff vs. first parent or empty tree).
+        // In shallow clones, the parent object may be missing — treat as empty.
+        let changed_files = match changed_files_for_commit(&repo, &info) {
+            Ok(files) => files,
+            Err(_) if is_shallow => Vec::new(),
+            Err(e) => return Err(e),
+        };
 
         commits.push(CommitInfo {
             hash,
@@ -270,5 +279,6 @@ fn first_line_of(s: &str) -> &str {
 // ============================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 #[path = "git_parser_tests.rs"]
 mod tests;

--- a/crates/rskim-search/src/temporal/git_parser.rs
+++ b/crates/rskim-search/src/temporal/git_parser.rs
@@ -208,36 +208,18 @@ fn changed_files_for_commit(
         .map_err(gix_err)?
         .for_each_to_obtain_tree(&new_tree, |change| -> std::result::Result<_, std::convert::Infallible> {
             use gix::object::tree::diff::Change;
-            let path_opt = match &change {
-                Change::Addition { location, entry_mode, .. } => {
-                    if entry_mode.is_no_tree() && !location.is_empty() {
-                        Some(location.to_str_lossy().into_owned())
-                    } else {
-                        None
-                    }
-                }
-                Change::Deletion { location, entry_mode, .. } => {
-                    if entry_mode.is_no_tree() && !location.is_empty() {
-                        Some(location.to_str_lossy().into_owned())
-                    } else {
-                        None
-                    }
-                }
-                Change::Modification { location, entry_mode, .. } => {
-                    if entry_mode.is_no_tree() && !location.is_empty() {
-                        Some(location.to_str_lossy().into_owned())
-                    } else {
-                        None
-                    }
-                }
-                Change::Rewrite { location, entry_mode, .. } => {
-                    // Renames: use destination path
-                    if entry_mode.is_no_tree() && !location.is_empty() {
-                        Some(location.to_str_lossy().into_owned())
-                    } else {
-                        None
-                    }
-                }
+            // All change kinds use the destination location.
+            // Renames (Rewrite) also provide the new path via `location`.
+            let (location, entry_mode) = match &change {
+                Change::Addition { location, entry_mode, .. }
+                | Change::Deletion { location, entry_mode, .. }
+                | Change::Modification { location, entry_mode, .. }
+                | Change::Rewrite { location, entry_mode, .. } => (location, entry_mode),
+            };
+            let path_opt = if entry_mode.is_no_tree() && !location.is_empty() {
+                Some(location.to_str_lossy().into_owned())
+            } else {
+                None
             };
             if let Some(path) = path_opt {
                 changed_files.push(FileChangeInfo {

--- a/crates/rskim-search/src/temporal/git_parser.rs
+++ b/crates/rskim-search/src/temporal/git_parser.rs
@@ -1,0 +1,292 @@
+//! [`GixSource`] — gix-based implementation of [`TemporalSource`].
+//!
+//! # Architecture
+//!
+//! - Stateless: each `parse_history` call opens a fresh repository handle.
+//!   This keeps `GixSource` trivially `Send + Sync` without any locking.
+//! - All gix types are converted to [`CommitInfo`]/[`FileChangeInfo`] at the
+//!   parser boundary. No gix types appear in the public API.
+//! - Error conversion via `gix_err()`: every gix failure maps to
+//!   `SearchError::Git(String)`.
+//!
+//! # Traversal strategy
+//!
+//! Commits are visited from newest to oldest using gix's `ByCommitTime(NewestFirst)`
+//! sort order. When `lookback_days > 0`, a `ByCommitTimeCutoff` sort stops the walk
+//! as soon as the traversal queue contains no commits newer than the cutoff, which
+//! is far more efficient than a full traversal with post-hoc filtering.
+//!
+//! For each commit we diff its tree against its first parent's tree using
+//! `Tree::changes()` (requires the `blob-diff` gix feature). Root commits
+//! (no parent) are diffed against the empty tree.
+//!
+//! # Limitations
+//!
+//! - Line counts (`additions`/`deletions`) are set to `0` — tracking which files
+//!   changed is sufficient for temporal scoring; blob-level line counts require a full
+//!   diff per file per commit, which is prohibitively slow for large repositories.
+//! - Binary files are included in `changed_files` (with 0 add/del counts).
+//! - Tree entries (directories) are skipped; only file-mode entries are returned.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use gix::bstr::ByteSlice;
+use gix::revision::walk::Sorting;
+use gix::traverse::commit::simple::CommitTimeOrder;
+
+use crate::types::{
+    CommitInfo, FileChangeInfo, HistoryResult, Result, SearchError, TemporalMetadata,
+    TemporalSource,
+};
+
+// ============================================================================
+// Error helper
+// ============================================================================
+
+/// Convert any displayable error into `SearchError::Git(String)`.
+#[inline]
+fn gix_err(e: impl std::fmt::Display) -> SearchError {
+    SearchError::Git(e.to_string())
+}
+
+// ============================================================================
+// GixSource
+// ============================================================================
+
+/// Stateless gix-based git history parser.
+///
+/// Implements [`TemporalSource`]; thread-safe (`Send + Sync`) and cheap to copy.
+#[derive(Debug, Clone, Copy)]
+pub struct GixSource;
+
+impl TemporalSource for GixSource {
+    fn parse_history(&self, repo_path: &Path, lookback_days: u32) -> Result<HistoryResult> {
+        parse_history_impl(repo_path, lookback_days)
+    }
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+fn parse_history_impl(repo_path: &Path, lookback_days: u32) -> Result<HistoryResult> {
+    // Open repository, discovering .git in parent directories
+    let mut repo = gix::discover(repo_path).map_err(gix_err)?;
+
+    // Enable object cache — recommended for ByCommitTime traversals that look
+    // up each commit at least twice
+    repo.object_cache_size_if_unset(4 * 1024 * 1024);
+
+    // Check shallow clone status
+    let is_shallow = repo.is_shallow();
+
+    // Resolve HEAD — gracefully handle unborn/empty repos
+    let head_id = match repo.head_id() {
+        Ok(id) => id.detach(),
+        Err(e) => {
+            let msg = e.to_string().to_ascii_lowercase();
+            if is_unborn_error(&msg) {
+                return Ok(empty_result(is_shallow));
+            }
+            return Err(gix_err(e));
+        }
+    };
+
+    // Compute lookback cutoff (seconds since unix epoch)
+    let cutoff_secs: Option<i64> = if lookback_days > 0 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        Some(now - i64::from(lookback_days) * 86_400)
+    } else {
+        None
+    };
+
+    // Configure rev-walk sorting
+    let sorting = match cutoff_secs {
+        Some(cutoff) => Sorting::ByCommitTimeCutoff {
+            order: CommitTimeOrder::NewestFirst,
+            seconds: cutoff,
+        },
+        None => Sorting::ByCommitTime(CommitTimeOrder::NewestFirst),
+    };
+
+    let walk = repo
+        .rev_walk([head_id])
+        .first_parent_only()
+        .sorting(sorting)
+        .all()
+        .map_err(gix_err)?;
+
+    let mut commits: Vec<CommitInfo> = Vec::new();
+
+    for info_result in walk {
+        let info = info_result.map_err(gix_err)?;
+
+        // Decode the full commit object for author/message fields
+        let commit_obj = info.object().map_err(gix_err)?;
+        let commit_ref = commit_obj.decode().map_err(gix_err)?;
+
+        // Author timestamp (i64 — can be negative for pre-epoch commits)
+        let timestamp: i64 = match commit_ref.author().time().ok() {
+            Some(t) => t.seconds,
+            None => {
+                // Malformed timestamp — skip this commit rather than failing
+                continue;
+            }
+        };
+
+        // Safety check: if the commit predates the cutoff, stop walking
+        if cutoff_secs.is_some_and(|cutoff| timestamp < cutoff) {
+            break;
+        }
+
+        let hash = info.id.to_string();
+        let author = commit_ref.author().name.to_str_lossy().into_owned();
+        // Use first line of commit message only
+        let msg_bytes = commit_ref.message;
+        let message = first_line_of(msg_bytes.to_str_lossy().as_ref()).to_owned();
+
+        // Compute changed files (tree diff vs. first parent or empty tree)
+        let changed_files = changed_files_for_commit(&repo, &info)?;
+
+        commits.push(CommitInfo {
+            hash,
+            timestamp,
+            author,
+            message,
+            changed_files,
+        });
+    }
+
+    let commit_count = commits.len();
+    Ok(HistoryResult {
+        commits,
+        metadata: TemporalMetadata {
+            is_shallow,
+            commit_count,
+        },
+    })
+}
+
+/// Return the changed files in a commit by diffing its tree against its first
+/// parent (or the empty tree for root commits).
+///
+/// Uses `Tree::changes().for_each_to_obtain_tree()` which is the high-level
+/// gix API. Requires the `blob-diff` feature.
+fn changed_files_for_commit(
+    repo: &gix::Repository,
+    info: &gix::revision::walk::Info<'_>,
+) -> Result<Vec<FileChangeInfo>> {
+    let commit = info.object().map_err(gix_err)?;
+
+    // Get the new (this commit's) tree
+    let new_tree = commit.tree().map_err(gix_err)?;
+
+    // Get old (parent's) tree, or empty tree for root commits
+    let old_tree: gix::Tree<'_>;
+    let empty_tree: gix::Tree<'_>;
+
+    let lhs: &gix::Tree<'_> = if let Some(&parent_id) = info.parent_ids.first() {
+        let parent_obj = repo.find_object(parent_id).map_err(gix_err)?;
+        let parent_commit = parent_obj
+            .try_into_commit()
+            .map_err(|e| gix_err(format!("parent is not a commit: {e}")))?;
+        old_tree = parent_commit.tree().map_err(gix_err)?;
+        &old_tree
+    } else {
+        empty_tree = repo.empty_tree();
+        &empty_tree
+    };
+
+    // Collect changed file paths via gix's tree-diff platform
+    let mut changed_files: Vec<FileChangeInfo> = Vec::new();
+
+    lhs.changes()
+        .map_err(gix_err)?
+        .for_each_to_obtain_tree(&new_tree, |change| -> std::result::Result<_, std::convert::Infallible> {
+            use gix::object::tree::diff::Change;
+            let path_opt = match &change {
+                Change::Addition { location, entry_mode, .. } => {
+                    if entry_mode.is_no_tree() && !location.is_empty() {
+                        Some(location.to_str_lossy().into_owned())
+                    } else {
+                        None
+                    }
+                }
+                Change::Deletion { location, entry_mode, .. } => {
+                    if entry_mode.is_no_tree() && !location.is_empty() {
+                        Some(location.to_str_lossy().into_owned())
+                    } else {
+                        None
+                    }
+                }
+                Change::Modification { location, entry_mode, .. } => {
+                    if entry_mode.is_no_tree() && !location.is_empty() {
+                        Some(location.to_str_lossy().into_owned())
+                    } else {
+                        None
+                    }
+                }
+                Change::Rewrite { location, entry_mode, .. } => {
+                    // Renames: use destination path
+                    if entry_mode.is_no_tree() && !location.is_empty() {
+                        Some(location.to_str_lossy().into_owned())
+                    } else {
+                        None
+                    }
+                }
+            };
+            if let Some(path) = path_opt {
+                changed_files.push(FileChangeInfo {
+                    path: PathBuf::from(path),
+                    additions: 0,
+                    deletions: 0,
+                });
+            }
+            Ok(gix::object::tree::diff::Action::Continue)
+        })
+        .map_err(gix_err)?;
+
+    Ok(changed_files)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Return `true` when an error message signals an unborn (empty) repository.
+fn is_unborn_error(msg: &str) -> bool {
+    msg.contains("unborn")
+        || msg.contains("cannot resolve head")
+        || msg.contains("does not exist")
+        || msg.contains("not found")
+        || msg.contains("no reference was found")
+        || msg.contains("does not have any commits")
+}
+
+/// Build an empty `HistoryResult` for a repo with no commits.
+fn empty_result(is_shallow: bool) -> HistoryResult {
+    HistoryResult {
+        commits: Vec::new(),
+        metadata: TemporalMetadata {
+            is_shallow,
+            commit_count: 0,
+        },
+    }
+}
+
+/// Return the first non-empty line of `s`, trimmed.
+fn first_line_of(s: &str) -> &str {
+    s.lines().next().unwrap_or(s).trim()
+}
+
+// ============================================================================
+// Co-located tests
+// ============================================================================
+
+#[cfg(test)]
+#[path = "git_parser_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/temporal/git_parser.rs
+++ b/crates/rskim-search/src/temporal/git_parser.rs
@@ -242,28 +242,47 @@ fn changed_files_for_commit(
 
     lhs.changes()
         .map_err(gix_err)?
-        .for_each_to_obtain_tree(&new_tree, |change| -> std::result::Result<_, std::convert::Infallible> {
-            use gix::object::tree::diff::Change;
-            // All change kinds use the destination location.
-            // Renames (Rewrite) also provide the new path via `location`.
-            let (location, entry_mode) = match &change {
-                Change::Addition { location, entry_mode, .. }
-                | Change::Deletion { location, entry_mode, .. }
-                | Change::Modification { location, entry_mode, .. }
-                | Change::Rewrite { location, entry_mode, .. } => (location, entry_mode),
-            };
-            // Build PathBuf from the location bytes. `to_str_lossy()` returns a
-            // `Cow<str>`; using `.as_ref()` avoids the intermediate owned String
-            // allocation when the path is already valid UTF-8 (Cow::Borrowed).
-            if entry_mode.is_no_tree() && !location.is_empty() {
-                changed_files.push(FileChangeInfo {
-                    path: PathBuf::from(location.to_str_lossy().as_ref()),
-                    additions: 0,
-                    deletions: 0,
-                });
-            }
-            Ok(gix::object::tree::diff::Action::Continue)
-        })
+        .for_each_to_obtain_tree(
+            &new_tree,
+            |change| -> std::result::Result<_, std::convert::Infallible> {
+                use gix::object::tree::diff::Change;
+                // All change kinds use the destination location.
+                // Renames (Rewrite) also provide the new path via `location`.
+                let (location, entry_mode) = match &change {
+                    Change::Addition {
+                        location,
+                        entry_mode,
+                        ..
+                    }
+                    | Change::Deletion {
+                        location,
+                        entry_mode,
+                        ..
+                    }
+                    | Change::Modification {
+                        location,
+                        entry_mode,
+                        ..
+                    }
+                    | Change::Rewrite {
+                        location,
+                        entry_mode,
+                        ..
+                    } => (location, entry_mode),
+                };
+                // Build PathBuf from the location bytes. `to_str_lossy()` returns a
+                // `Cow<str>`; using `.as_ref()` avoids the intermediate owned String
+                // allocation when the path is already valid UTF-8 (Cow::Borrowed).
+                if entry_mode.is_no_tree() && !location.is_empty() {
+                    changed_files.push(FileChangeInfo {
+                        path: PathBuf::from(location.to_str_lossy().as_ref()),
+                        additions: 0,
+                        deletions: 0,
+                    });
+                }
+                Ok(gix::object::tree::diff::Action::Continue)
+            },
+        )
         .map_err(gix_err)?;
 
     Ok(changed_files)

--- a/crates/rskim-search/src/temporal/git_parser_tests.rs
+++ b/crates/rskim-search/src/temporal/git_parser_tests.rs
@@ -167,6 +167,40 @@ fn test_single_commit_fields() {
     assert!(commit.timestamp > 0, "timestamp should be positive");
     assert!(!commit.author.is_empty(), "author should be non-empty");
     assert_eq!(commit.message, "feat: first commit");
+    assert!(!history.metadata.is_shallow, "normal repo should not be shallow");
+}
+
+#[test]
+fn test_shallow_clone_detected() {
+    if !git_available() {
+        return;
+    }
+    let Some(origin) = init_git_repo() else { return };
+    assert!(git_commit_file(origin.path(), "a.txt", "a", "first"));
+    assert!(git_commit_file(origin.path(), "b.txt", "b", "second"));
+    assert!(git_commit_file(origin.path(), "c.txt", "c", "third"));
+
+    let shallow_dir = tempfile::tempdir().expect("tempdir");
+    let origin_url = format!("file://{}", origin.path().display());
+    let ok = Command::new("git")
+        .args(["clone", "--depth", "1"])
+        .arg(&origin_url)
+        .arg(shallow_dir.path().join("repo"))
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !ok {
+        return;
+    }
+
+    let src = GixSource;
+    let history = src
+        .parse_history(&shallow_dir.path().join("repo"), 0)
+        .expect("shallow parse");
+    assert!(history.metadata.is_shallow, "shallow clone should be detected");
+    assert!(
+        !history.commits.is_empty(),
+        "shallow clone should still return available commits"
+    );
 }
 
 #[test]

--- a/crates/rskim-search/src/temporal/git_parser_tests.rs
+++ b/crates/rskim-search/src/temporal/git_parser_tests.rs
@@ -152,7 +152,12 @@ fn test_single_commit_fields() {
         return;
     }
     let Some(dir) = init_git_repo() else { return };
-    assert!(git_commit_file(dir.path(), "hello.txt", "world", "feat: first commit"));
+    assert!(git_commit_file(
+        dir.path(),
+        "hello.txt",
+        "world",
+        "feat: first commit"
+    ));
 
     let src = GixSource;
     let history = src.parse_history(dir.path(), 0).expect("parse_history");
@@ -160,7 +165,12 @@ fn test_single_commit_fields() {
 
     let commit = &history.commits[0];
     // Hash should be 40 hex chars
-    assert_eq!(commit.hash.len(), 40, "hash should be 40 chars: {}", commit.hash);
+    assert_eq!(
+        commit.hash.len(),
+        40,
+        "hash should be 40 chars: {}",
+        commit.hash
+    );
     assert!(
         commit.hash.chars().all(|c| c.is_ascii_hexdigit()),
         "hash should be hex: {}",
@@ -169,7 +179,10 @@ fn test_single_commit_fields() {
     assert!(commit.timestamp > 0, "timestamp should be positive");
     assert!(!commit.author.is_empty(), "author should be non-empty");
     assert_eq!(commit.message, "feat: first commit");
-    assert!(!history.metadata.is_shallow, "normal repo should not be shallow");
+    assert!(
+        !history.metadata.is_shallow,
+        "normal repo should not be shallow"
+    );
 }
 
 #[test]
@@ -178,7 +191,9 @@ fn test_shallow_clone_detected() {
         eprintln!("SKIPPED: git not available on PATH");
         return;
     }
-    let Some(origin) = init_git_repo() else { return };
+    let Some(origin) = init_git_repo() else {
+        return;
+    };
     assert!(git_commit_file(origin.path(), "a.txt", "a", "first"));
     assert!(git_commit_file(origin.path(), "b.txt", "b", "second"));
     assert!(git_commit_file(origin.path(), "c.txt", "c", "third"));
@@ -199,7 +214,10 @@ fn test_shallow_clone_detected() {
     let history = src
         .parse_history(&shallow_dir.path().join("repo"), 0)
         .expect("shallow parse");
-    assert!(history.metadata.is_shallow, "shallow clone should be detected");
+    assert!(
+        history.metadata.is_shallow,
+        "shallow clone should be detected"
+    );
     assert!(
         !history.commits.is_empty(),
         "shallow clone should still return available commits"
@@ -241,7 +259,12 @@ fn test_root_commit_includes_changed_files() {
         return;
     }
     let Some(dir) = init_git_repo() else { return };
-    assert!(git_commit_file(dir.path(), "main.rs", "fn main(){}", "add main"));
+    assert!(git_commit_file(
+        dir.path(),
+        "main.rs",
+        "fn main(){}",
+        "add main"
+    ));
 
     let src = GixSource;
     let history = src.parse_history(dir.path(), 0).expect("parse_history");
@@ -313,7 +336,11 @@ fn test_lookback_zero_returns_all_history() {
 
     let src = GixSource;
     let history = src.parse_history(dir.path(), 0).expect("parse_history");
-    assert_eq!(history.commits.len(), 2, "lookback_days=0 should return all commits");
+    assert_eq!(
+        history.commits.len(),
+        2,
+        "lookback_days=0 should return all commits"
+    );
 }
 
 #[test]
@@ -329,7 +356,11 @@ fn test_lookback_large_value_returns_recent() {
     let src = GixSource;
     // lookback_days=365 should include commits from the last year (both are very recent)
     let history = src.parse_history(dir.path(), 365).expect("parse_history");
-    assert_eq!(history.commits.len(), 2, "both recent commits should be within 365 days");
+    assert_eq!(
+        history.commits.len(),
+        2,
+        "both recent commits should be within 365 days"
+    );
 }
 
 #[test]
@@ -361,7 +392,12 @@ fn test_lookback_excludes_old_commits() {
     assert!(committed, "git commit with old date failed");
 
     // Also create a recent commit so the repo isn't empty after filtering.
-    assert!(git_commit_file(dir.path(), "recent.txt", "new", "recent commit"));
+    assert!(git_commit_file(
+        dir.path(),
+        "recent.txt",
+        "new",
+        "recent commit"
+    ));
 
     let src = GixSource;
     // lookback_days=30 should include only the recent commit; the 2000-dated
@@ -371,7 +407,11 @@ fn test_lookback_excludes_old_commits() {
         history.commits.len(),
         1,
         "expected only 1 recent commit within 30-day window, got: {:?}",
-        history.commits.iter().map(|c| &c.message).collect::<Vec<_>>()
+        history
+            .commits
+            .iter()
+            .map(|c| &c.message)
+            .collect::<Vec<_>>()
     );
     assert_eq!(
         history.commits[0].message, "recent commit",
@@ -390,11 +430,20 @@ fn test_file_addition_appears_in_changed_files() {
         return;
     }
     let Some(dir) = init_git_repo() else { return };
-    assert!(git_commit_file(dir.path(), "new_feature.rs", "pub fn feature(){}", "add feature"));
+    assert!(git_commit_file(
+        dir.path(),
+        "new_feature.rs",
+        "pub fn feature(){}",
+        "add feature"
+    ));
 
     let src = GixSource;
     let history = src.parse_history(dir.path(), 0).expect("parse_history");
-    let files: Vec<&PathBuf> = history.commits[0].changed_files.iter().map(|f| &f.path).collect();
+    let files: Vec<&PathBuf> = history.commits[0]
+        .changed_files
+        .iter()
+        .map(|f| &f.path)
+        .collect();
     assert!(
         files.iter().any(|p| p.as_os_str() == "new_feature.rs"),
         "expected new_feature.rs in changed_files, got: {files:?}"
@@ -408,7 +457,12 @@ fn test_file_deletion_appears_in_changed_files() {
         return;
     }
     let Some(dir) = init_git_repo() else { return };
-    assert!(git_commit_file(dir.path(), "old.rs", "content", "add old.rs"));
+    assert!(git_commit_file(
+        dir.path(),
+        "old.rs",
+        "content",
+        "add old.rs"
+    ));
     assert!(git_delete_file(dir.path(), "old.rs", "delete old.rs"));
 
     let src = GixSource;
@@ -416,7 +470,11 @@ fn test_file_deletion_appears_in_changed_files() {
     assert_eq!(history.commits.len(), 2);
     // The deletion commit (newest, commits[0]) should mention old.rs
     let delete_commit = &history.commits[0];
-    let files: Vec<&PathBuf> = delete_commit.changed_files.iter().map(|f| &f.path).collect();
+    let files: Vec<&PathBuf> = delete_commit
+        .changed_files
+        .iter()
+        .map(|f| &f.path)
+        .collect();
     assert!(
         files.iter().any(|p| p.as_os_str() == "old.rs"),
         "expected old.rs in deletion commit, got: {files:?}"
@@ -431,7 +489,12 @@ fn test_file_modification_appears_in_changed_files() {
     }
     let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "lib.rs", "v1", "initial"));
-    assert!(git_commit_file(dir.path(), "lib.rs", "v2 with more content", "update lib.rs"));
+    assert!(git_commit_file(
+        dir.path(),
+        "lib.rs",
+        "v2 with more content",
+        "update lib.rs"
+    ));
 
     let src = GixSource;
     let history = src.parse_history(dir.path(), 0).expect("parse_history");
@@ -453,7 +516,12 @@ fn test_file_rename_appears_in_changed_files() {
     let Some(dir) = init_git_repo() else { return };
 
     // Create original file and commit it.
-    assert!(git_commit_file(dir.path(), "original.rs", "pub fn hello(){}", "add original.rs"));
+    assert!(git_commit_file(
+        dir.path(),
+        "original.rs",
+        "pub fn hello(){}",
+        "add original.rs"
+    ));
 
     // Rename via `git mv` and commit.
     let moved = Command::new("git")
@@ -477,7 +545,11 @@ fn test_file_rename_appears_in_changed_files() {
 
     // The rename commit is newest (commits[0]).
     let rename_commit = &history.commits[0];
-    let files: Vec<&PathBuf> = rename_commit.changed_files.iter().map(|f| &f.path).collect();
+    let files: Vec<&PathBuf> = rename_commit
+        .changed_files
+        .iter()
+        .map(|f| &f.path)
+        .collect();
     assert!(
         files.iter().any(|p| p.as_os_str() == "renamed.rs"),
         "expected renamed.rs (new path) in rename commit changed_files, got: {files:?}"
@@ -611,7 +683,10 @@ fn test_commit_info_serialization_roundtrip() {
     assert_eq!(restored.author, original.author);
     assert_eq!(restored.message, original.message);
     assert_eq!(restored.changed_files.len(), 1);
-    assert_eq!(restored.changed_files[0].path, original.changed_files[0].path);
+    assert_eq!(
+        restored.changed_files[0].path,
+        original.changed_files[0].path
+    );
     assert_eq!(restored.changed_files[0].additions, 10);
     assert_eq!(restored.changed_files[0].deletions, 3);
 }

--- a/crates/rskim-search/src/temporal/git_parser_tests.rs
+++ b/crates/rskim-search/src/temporal/git_parser_tests.rs
@@ -23,26 +23,25 @@ use crate::types::{SearchError, TemporalSource};
 /// Tests that require git skip themselves gracefully.
 fn init_git_repo() -> Option<TempDir> {
     let dir = tempfile::tempdir().ok()?;
-    let ok = Command::new("git")
+
+    // Try `git init -b main` first (git ≥2.28); fall back to plain `git init`.
+    let init_ok = Command::new("git")
         .args(["init", "-b", "main"])
         .current_dir(dir.path())
         .output()
-        .ok()?
-        .status
-        .success();
-    if !ok {
-        // Try without -b flag (older git)
-        let ok2 = Command::new("git")
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+        || Command::new("git")
             .args(["init"])
             .current_dir(dir.path())
             .output()
-            .ok()?
-            .status
-            .success();
-        if !ok2 {
-            return None;
-        }
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+    if !init_ok {
+        return None;
     }
+
     // Configure identity so commits work
     Command::new("git")
         .args(["config", "user.email", "test@example.com"])
@@ -108,10 +107,7 @@ fn test_empty_repo_returns_ok_empty() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     let src = GixSource;
     let result = src.parse_history(dir.path(), 90);
     let history = result.expect("empty repo should succeed");
@@ -153,10 +149,7 @@ fn test_single_commit_fields() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "hello.txt", "world", "feat: first commit"));
 
     let src = GixSource;
@@ -181,10 +174,7 @@ fn test_multiple_commits_ordering() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "a.txt", "a", "commit one"));
     assert!(git_commit_file(dir.path(), "b.txt", "b", "commit two"));
     assert!(git_commit_file(dir.path(), "c.txt", "c", "commit three"));
@@ -211,10 +201,7 @@ fn test_root_commit_includes_changed_files() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "main.rs", "fn main(){}", "add main"));
 
     let src = GixSource;
@@ -237,10 +224,7 @@ fn test_commit_with_multiple_files() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     // Create 3 files and commit them together
     std::fs::write(dir.path().join("a.rs"), "a").unwrap();
     std::fs::write(dir.path().join("b.rs"), "b").unwrap();
@@ -282,10 +266,7 @@ fn test_lookback_zero_returns_all_history() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "a.txt", "a", "old commit"));
     assert!(git_commit_file(dir.path(), "b.txt", "b", "new commit"));
 
@@ -299,10 +280,7 @@ fn test_lookback_large_value_returns_recent() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "a.txt", "a", "commit A"));
     assert!(git_commit_file(dir.path(), "b.txt", "b", "commit B"));
 
@@ -321,10 +299,7 @@ fn test_file_addition_appears_in_changed_files() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "new_feature.rs", "pub fn feature(){}", "add feature"));
 
     let src = GixSource;
@@ -341,10 +316,7 @@ fn test_file_deletion_appears_in_changed_files() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "old.rs", "content", "add old.rs"));
     assert!(git_delete_file(dir.path(), "old.rs", "delete old.rs"));
 
@@ -365,10 +337,7 @@ fn test_file_modification_appears_in_changed_files() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "lib.rs", "v1", "initial"));
     assert!(git_commit_file(dir.path(), "lib.rs", "v2 with more content", "update lib.rs"));
 
@@ -392,10 +361,7 @@ fn test_commit_count_matches_vec_len() {
     if !git_available() {
         return;
     }
-    let dir = match init_git_repo() {
-        Some(d) => d,
-        None => return,
-    };
+    let Some(dir) = init_git_repo() else { return };
     assert!(git_commit_file(dir.path(), "a.txt", "a", "one"));
     assert!(git_commit_file(dir.path(), "b.txt", "b", "two"));
     assert!(git_commit_file(dir.path(), "c.txt", "c", "three"));

--- a/crates/rskim-search/src/temporal/git_parser_tests.rs
+++ b/crates/rskim-search/src/temporal/git_parser_tests.rs
@@ -1,0 +1,518 @@
+//! Tests for [`GixSource`] — written test-first (RED phase before implementation).
+//!
+//! Each group tests one behavioural contract of `parse_history`. Tests create
+//! temporary git repositories via `gix::init` and the `git` CLI helper so we can
+//! exercise the real parser against real git objects without requiring an external
+//! git binary for most tests (using gix init + commit directly).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use crate::temporal::{GixSource, is_fix_commit};
+use crate::types::{SearchError, TemporalSource};
+
+// ============================================================================
+// Test infrastructure
+// ============================================================================
+
+/// Create a minimal git repo via the `git` CLI.
+///
+/// Returns `None` when git isn't available (CI environments without git).
+/// Tests that require git skip themselves gracefully.
+fn init_git_repo() -> Option<TempDir> {
+    let dir = tempfile::tempdir().ok()?;
+    let ok = Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir.path())
+        .output()
+        .ok()?
+        .status
+        .success();
+    if !ok {
+        // Try without -b flag (older git)
+        let ok2 = Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .ok()?
+            .status
+            .success();
+        if !ok2 {
+            return None;
+        }
+    }
+    // Configure identity so commits work
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir.path())
+        .output()
+        .ok()?;
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(dir.path())
+        .output()
+        .ok()?;
+    Some(dir)
+}
+
+/// Check git is available for tests that require it.
+fn git_available() -> bool {
+    Command::new("git")
+        .args(["--version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Add a file and commit it in `dir`.
+fn git_commit_file(dir: &Path, filename: &str, content: &str, message: &str) -> bool {
+    std::fs::write(dir.join(filename), content).is_ok()
+        && Command::new("git")
+            .args(["add", filename])
+            .current_dir(dir)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        && Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(dir)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+
+/// Delete a file and commit the deletion.
+fn git_delete_file(dir: &Path, filename: &str, message: &str) -> bool {
+    Command::new("git")
+        .args(["rm", filename])
+        .current_dir(dir)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+        && Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(dir)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+}
+
+// ============================================================================
+// Repository opening
+// ============================================================================
+
+#[test]
+fn test_empty_repo_returns_ok_empty() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    let src = GixSource;
+    let result = src.parse_history(dir.path(), 90);
+    let history = result.expect("empty repo should succeed");
+    assert!(
+        history.commits.is_empty(),
+        "expected no commits in empty repo, got {}",
+        history.commits.len()
+    );
+    assert_eq!(history.metadata.commit_count, 0);
+}
+
+#[test]
+fn test_nonexistent_path_returns_git_error() {
+    let src = GixSource;
+    let result = src.parse_history(Path::new("/nonexistent/__no_such_path__"), 90);
+    assert!(
+        matches!(result, Err(SearchError::Git(_))),
+        "expected Git error for nonexistent path, got: {result:?}"
+    );
+}
+
+#[test]
+fn test_not_a_git_repo_returns_git_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = GixSource;
+    let result = src.parse_history(dir.path(), 90);
+    assert!(
+        matches!(result, Err(SearchError::Git(_))),
+        "expected Git error for non-repo dir, got: {result:?}"
+    );
+}
+
+// ============================================================================
+// Commit parsing
+// ============================================================================
+
+#[test]
+fn test_single_commit_fields() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "hello.txt", "world", "feat: first commit"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 1);
+
+    let commit = &history.commits[0];
+    // Hash should be 40 hex chars
+    assert_eq!(commit.hash.len(), 40, "hash should be 40 chars: {}", commit.hash);
+    assert!(
+        commit.hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {}",
+        commit.hash
+    );
+    assert!(commit.timestamp > 0, "timestamp should be positive");
+    assert!(!commit.author.is_empty(), "author should be non-empty");
+    assert_eq!(commit.message, "feat: first commit");
+}
+
+#[test]
+fn test_multiple_commits_ordering() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "a.txt", "a", "commit one"));
+    assert!(git_commit_file(dir.path(), "b.txt", "b", "commit two"));
+    assert!(git_commit_file(dir.path(), "c.txt", "c", "commit three"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 3);
+    // Newest first: commits[0] should be "commit three"
+    assert_eq!(history.commits[0].message, "commit three");
+    assert_eq!(history.commits[2].message, "commit one");
+    // Timestamps should be non-increasing (newest first ordering)
+    for window in history.commits.windows(2) {
+        assert!(
+            window[0].timestamp >= window[1].timestamp,
+            "commits should be ordered newest first: {} < {}",
+            window[0].timestamp,
+            window[1].timestamp
+        );
+    }
+}
+
+#[test]
+fn test_root_commit_includes_changed_files() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "main.rs", "fn main(){}", "add main"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 1);
+    // Root commit diffed against empty tree — should contain main.rs
+    let files: Vec<&PathBuf> = history.commits[0]
+        .changed_files
+        .iter()
+        .map(|f| &f.path)
+        .collect();
+    assert!(
+        files.iter().any(|p| p.as_os_str() == "main.rs"),
+        "expected main.rs in changed_files, got: {files:?}"
+    );
+}
+
+#[test]
+fn test_commit_with_multiple_files() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    // Create 3 files and commit them together
+    std::fs::write(dir.path().join("a.rs"), "a").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "b").unwrap();
+    std::fs::write(dir.path().join("c.rs"), "c").unwrap();
+    assert!(
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    );
+    assert!(
+        Command::new("git")
+            .args(["commit", "-m", "add three files"])
+            .current_dir(dir.path())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    );
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 1);
+    assert_eq!(
+        history.commits[0].changed_files.len(),
+        3,
+        "expected 3 changed files, got: {:?}",
+        history.commits[0].changed_files
+    );
+}
+
+// ============================================================================
+// Lookback filtering
+// ============================================================================
+
+#[test]
+fn test_lookback_zero_returns_all_history() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "a.txt", "a", "old commit"));
+    assert!(git_commit_file(dir.path(), "b.txt", "b", "new commit"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 2, "lookback_days=0 should return all commits");
+}
+
+#[test]
+fn test_lookback_large_value_returns_recent() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "a.txt", "a", "commit A"));
+    assert!(git_commit_file(dir.path(), "b.txt", "b", "commit B"));
+
+    let src = GixSource;
+    // lookback_days=365 should include commits from the last year (both are very recent)
+    let history = src.parse_history(dir.path(), 365).expect("parse_history");
+    assert_eq!(history.commits.len(), 2, "both recent commits should be within 365 days");
+}
+
+// ============================================================================
+// File tracking
+// ============================================================================
+
+#[test]
+fn test_file_addition_appears_in_changed_files() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "new_feature.rs", "pub fn feature(){}", "add feature"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    let files: Vec<&PathBuf> = history.commits[0].changed_files.iter().map(|f| &f.path).collect();
+    assert!(
+        files.iter().any(|p| p.as_os_str() == "new_feature.rs"),
+        "expected new_feature.rs in changed_files, got: {files:?}"
+    );
+}
+
+#[test]
+fn test_file_deletion_appears_in_changed_files() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "old.rs", "content", "add old.rs"));
+    assert!(git_delete_file(dir.path(), "old.rs", "delete old.rs"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 2);
+    // The deletion commit (newest, commits[0]) should mention old.rs
+    let delete_commit = &history.commits[0];
+    let files: Vec<&PathBuf> = delete_commit.changed_files.iter().map(|f| &f.path).collect();
+    assert!(
+        files.iter().any(|p| p.as_os_str() == "old.rs"),
+        "expected old.rs in deletion commit, got: {files:?}"
+    );
+}
+
+#[test]
+fn test_file_modification_appears_in_changed_files() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "lib.rs", "v1", "initial"));
+    assert!(git_commit_file(dir.path(), "lib.rs", "v2 with more content", "update lib.rs"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 2);
+    let mod_commit = &history.commits[0]; // newest = modification commit
+    let files: Vec<&PathBuf> = mod_commit.changed_files.iter().map(|f| &f.path).collect();
+    assert!(
+        files.iter().any(|p| p.as_os_str() == "lib.rs"),
+        "expected lib.rs in modification commit, got: {files:?}"
+    );
+}
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+#[test]
+fn test_commit_count_matches_vec_len() {
+    if !git_available() {
+        return;
+    }
+    let dir = match init_git_repo() {
+        Some(d) => d,
+        None => return,
+    };
+    assert!(git_commit_file(dir.path(), "a.txt", "a", "one"));
+    assert!(git_commit_file(dir.path(), "b.txt", "b", "two"));
+    assert!(git_commit_file(dir.path(), "c.txt", "c", "three"));
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(
+        history.metadata.commit_count,
+        history.commits.len(),
+        "metadata.commit_count must equal commits.len()"
+    );
+    assert_eq!(history.metadata.commit_count, 3);
+}
+
+// ============================================================================
+// Fix classification
+// ============================================================================
+
+#[test]
+fn test_is_fix_commit_matches_fix() {
+    assert!(is_fix_commit("fix: null pointer dereference"));
+    assert!(is_fix_commit("Fix typo in README"));
+    assert!(is_fix_commit("FIX: urgent security issue"));
+}
+
+#[test]
+fn test_is_fix_commit_matches_bug() {
+    assert!(is_fix_commit("bug: crash on empty input"));
+    assert!(is_fix_commit("BUG: wrong calculation"));
+}
+
+#[test]
+fn test_is_fix_commit_matches_hotfix() {
+    assert!(is_fix_commit("hotfix: production outage"));
+    assert!(is_fix_commit("HOTFIX: urgent"));
+}
+
+#[test]
+fn test_is_fix_commit_matches_patch() {
+    assert!(is_fix_commit("patch: minor adjustment"));
+    assert!(is_fix_commit("PATCH: something"));
+}
+
+#[test]
+fn test_is_fix_commit_matches_revert() {
+    assert!(is_fix_commit("revert: bad change"));
+    assert!(is_fix_commit("Revert \"some feature\""));
+    assert!(is_fix_commit("REVERT: rollback"));
+}
+
+#[test]
+fn test_is_fix_commit_case_insensitive() {
+    assert!(is_fix_commit("FIX: something"));
+    assert!(is_fix_commit("Bug report addressed"));
+    assert!(is_fix_commit("hoTFiX applied"));
+}
+
+#[test]
+fn test_is_fix_commit_word_boundary() {
+    // "prefix" and "suffix" should not match "fix" due to word boundary
+    assert!(!is_fix_commit("prefix the thing"));
+    assert!(!is_fix_commit("bugfix: this is a compound"));
+    assert!(!is_fix_commit("hotfixing something"));
+}
+
+#[test]
+fn test_is_fix_commit_no_match() {
+    assert!(!is_fix_commit("add new feature"));
+    assert!(!is_fix_commit("refactor: improve readability"));
+    assert!(!is_fix_commit("feat: initial implementation"));
+    assert!(!is_fix_commit("chore: update dependencies"));
+}
+
+// ============================================================================
+// Trait & type safety
+// ============================================================================
+
+#[test]
+fn test_temporal_source_is_object_safe() {
+    // This test exists to ensure the trait compiles as a trait object.
+    // If TemporalSource is not object-safe, this won't compile.
+    fn accepts_trait_object(_: &dyn TemporalSource) {}
+    let src = GixSource;
+    accepts_trait_object(&src);
+}
+
+#[test]
+fn test_gix_source_is_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<GixSource>();
+}
+
+#[test]
+fn test_commit_info_serialization_roundtrip() {
+    use crate::types::{CommitInfo, FileChangeInfo};
+
+    let original = CommitInfo {
+        hash: "a".repeat(40),
+        timestamp: 1_700_000_000,
+        author: "Alice".to_string(),
+        message: "feat: something".to_string(),
+        changed_files: vec![FileChangeInfo {
+            path: PathBuf::from("src/main.rs"),
+            additions: 10,
+            deletions: 3,
+        }],
+    };
+
+    let json = serde_json::to_string(&original).expect("serialize");
+    let restored: CommitInfo = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(restored.hash, original.hash);
+    assert_eq!(restored.timestamp, original.timestamp);
+    assert_eq!(restored.author, original.author);
+    assert_eq!(restored.message, original.message);
+    assert_eq!(restored.changed_files.len(), 1);
+    assert_eq!(restored.changed_files[0].path, original.changed_files[0].path);
+    assert_eq!(restored.changed_files[0].additions, 10);
+    assert_eq!(restored.changed_files[0].deletions, 3);
+}

--- a/crates/rskim-search/src/temporal/git_parser_tests.rs
+++ b/crates/rskim-search/src/temporal/git_parser_tests.rs
@@ -105,6 +105,7 @@ fn git_delete_file(dir: &Path, filename: &str, message: &str) -> bool {
 #[test]
 fn test_empty_repo_returns_ok_empty() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -147,6 +148,7 @@ fn test_not_a_git_repo_returns_git_error() {
 #[test]
 fn test_single_commit_fields() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -173,6 +175,7 @@ fn test_single_commit_fields() {
 #[test]
 fn test_shallow_clone_detected() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(origin) = init_git_repo() else { return };
@@ -206,6 +209,7 @@ fn test_shallow_clone_detected() {
 #[test]
 fn test_multiple_commits_ordering() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -233,6 +237,7 @@ fn test_multiple_commits_ordering() {
 #[test]
 fn test_root_commit_includes_changed_files() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -256,6 +261,7 @@ fn test_root_commit_includes_changed_files() {
 #[test]
 fn test_commit_with_multiple_files() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -298,6 +304,7 @@ fn test_commit_with_multiple_files() {
 #[test]
 fn test_lookback_zero_returns_all_history() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -312,6 +319,7 @@ fn test_lookback_zero_returns_all_history() {
 #[test]
 fn test_lookback_large_value_returns_recent() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -324,6 +332,53 @@ fn test_lookback_large_value_returns_recent() {
     assert_eq!(history.commits.len(), 2, "both recent commits should be within 365 days");
 }
 
+#[test]
+fn test_lookback_excludes_old_commits() {
+    if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
+        return;
+    }
+    let Some(dir) = init_git_repo() else { return };
+
+    // Create a commit dated 180 days ago via GIT_AUTHOR_DATE / GIT_COMMITTER_DATE.
+    let old_date = "2000-01-01T00:00:00+0000";
+    std::fs::write(dir.path().join("old.txt"), "old content").unwrap();
+    let staged = Command::new("git")
+        .args(["add", "old.txt"])
+        .current_dir(dir.path())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(staged, "git add failed");
+    let committed = Command::new("git")
+        .args(["commit", "-m", "old commit"])
+        .env("GIT_AUTHOR_DATE", old_date)
+        .env("GIT_COMMITTER_DATE", old_date)
+        .current_dir(dir.path())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(committed, "git commit with old date failed");
+
+    // Also create a recent commit so the repo isn't empty after filtering.
+    assert!(git_commit_file(dir.path(), "recent.txt", "new", "recent commit"));
+
+    let src = GixSource;
+    // lookback_days=30 should include only the recent commit; the 2000-dated
+    // commit is ~9000 days in the past and must be excluded.
+    let history = src.parse_history(dir.path(), 30).expect("parse_history");
+    assert_eq!(
+        history.commits.len(),
+        1,
+        "expected only 1 recent commit within 30-day window, got: {:?}",
+        history.commits.iter().map(|c| &c.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        history.commits[0].message, "recent commit",
+        "the surviving commit should be the recent one"
+    );
+}
+
 // ============================================================================
 // File tracking
 // ============================================================================
@@ -331,6 +386,7 @@ fn test_lookback_large_value_returns_recent() {
 #[test]
 fn test_file_addition_appears_in_changed_files() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -348,6 +404,7 @@ fn test_file_addition_appears_in_changed_files() {
 #[test]
 fn test_file_deletion_appears_in_changed_files() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -369,6 +426,7 @@ fn test_file_deletion_appears_in_changed_files() {
 #[test]
 fn test_file_modification_appears_in_changed_files() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };
@@ -386,6 +444,46 @@ fn test_file_modification_appears_in_changed_files() {
     );
 }
 
+#[test]
+fn test_file_rename_appears_in_changed_files() {
+    if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
+        return;
+    }
+    let Some(dir) = init_git_repo() else { return };
+
+    // Create original file and commit it.
+    assert!(git_commit_file(dir.path(), "original.rs", "pub fn hello(){}", "add original.rs"));
+
+    // Rename via `git mv` and commit.
+    let moved = Command::new("git")
+        .args(["mv", "original.rs", "renamed.rs"])
+        .current_dir(dir.path())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(moved, "git mv failed");
+    let committed = Command::new("git")
+        .args(["commit", "-m", "rename original.rs to renamed.rs"])
+        .current_dir(dir.path())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(committed, "git commit after rename failed");
+
+    let src = GixSource;
+    let history = src.parse_history(dir.path(), 0).expect("parse_history");
+    assert_eq!(history.commits.len(), 2);
+
+    // The rename commit is newest (commits[0]).
+    let rename_commit = &history.commits[0];
+    let files: Vec<&PathBuf> = rename_commit.changed_files.iter().map(|f| &f.path).collect();
+    assert!(
+        files.iter().any(|p| p.as_os_str() == "renamed.rs"),
+        "expected renamed.rs (new path) in rename commit changed_files, got: {files:?}"
+    );
+}
+
 // ============================================================================
 // Metadata
 // ============================================================================
@@ -393,6 +491,7 @@ fn test_file_modification_appears_in_changed_files() {
 #[test]
 fn test_commit_count_matches_vec_len() {
     if !git_available() {
+        eprintln!("SKIPPED: git not available on PATH");
         return;
     }
     let Some(dir) = init_git_repo() else { return };

--- a/crates/rskim-search/src/temporal/mod.rs
+++ b/crates/rskim-search/src/temporal/mod.rs
@@ -12,15 +12,15 @@ mod git_parser;
 
 pub use git_parser::GixSource;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 /// Regex that identifies "fix" commits by subject keywords.
 ///
-/// Compiled once and reused via `once_cell::sync::Lazy`.
+/// Compiled once and reused via `std::sync::LazyLock`.
 #[allow(clippy::expect_used)] // hardcoded pattern is always valid
-static FIX_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)\b(fix|bug|hotfix|patch|revert)\b").expect("valid regex"));
+static FIX_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"(?i)\b(fix|bug|hotfix|patch|revert)\b").expect("valid regex")
+});
 
 /// Returns `true` when the commit message matches a fix-related keyword.
 ///

--- a/crates/rskim-search/src/temporal/mod.rs
+++ b/crates/rskim-search/src/temporal/mod.rs
@@ -17,7 +17,6 @@ use regex::Regex;
 
 /// Regex that identifies "fix" commits by subject keywords.
 ///
-/// Same pattern as `crates/rskim/src/cmd/heatmap/metrics.rs::build_fix_regex()`.
 /// Compiled once and reused via `once_cell::sync::Lazy`.
 #[allow(clippy::expect_used)] // hardcoded pattern is always valid
 static FIX_REGEX: Lazy<Regex> =

--- a/crates/rskim-search/src/temporal/mod.rs
+++ b/crates/rskim-search/src/temporal/mod.rs
@@ -1,0 +1,44 @@
+//! Temporal git history parsing for downstream ranking signals.
+//!
+//! # Architecture
+//!
+//! - [`GixSource`]: pure gix-based implementation of [`TemporalSource`].
+//! - [`is_fix_commit`]: standalone fix-classification predicate.
+//!
+//! No I/O outside of [`GixSource::parse_history`]. All gix types are converted
+//! to shared [`CommitInfo`]/[`FileChangeInfo`] types at the parser boundary.
+
+mod git_parser;
+
+pub use git_parser::GixSource;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Regex that identifies "fix" commits by subject keywords.
+///
+/// Same pattern as `crates/rskim/src/cmd/heatmap/metrics.rs::build_fix_regex()`.
+/// Compiled once and reused via `once_cell::sync::Lazy`.
+#[allow(clippy::expect_used)] // hardcoded pattern is always valid
+static FIX_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)\b(fix|bug|hotfix|patch|revert)\b").expect("valid regex"));
+
+/// Returns `true` when the commit message matches a fix-related keyword.
+///
+/// Recognised keywords (case-insensitive, word-boundary anchored):
+/// `fix`, `bug`, `hotfix`, `patch`, `revert`.
+///
+/// # Examples
+///
+/// ```rust
+/// use rskim_search::is_fix_commit;
+///
+/// assert!(is_fix_commit("fix: null pointer dereference"));
+/// assert!(is_fix_commit("Revert \"bad change\""));
+/// assert!(!is_fix_commit("add feature X"));
+/// assert!(!is_fix_commit("prefix_word"));  // word-boundary, not substring
+/// ```
+#[must_use]
+pub fn is_fix_commit(message: &str) -> bool {
+    FIX_REGEX.is_match(message)
+}

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -471,7 +471,7 @@ mod tests {
             file_id: FileId(1),
             score: 0.95,
             line_range: 10..20,
-            match_positions: vec![5..10],
+            match_positions: vec![5..8, 12..15],
             field: SearchField::FunctionSignature,
             snippet: Some("fn foo()".to_string()),
         };
@@ -484,7 +484,9 @@ mod tests {
         assert_eq!(v["line_range"]["start"], serde_json::json!(10));
         assert_eq!(v["line_range"]["end"], serde_json::json!(20));
         assert_eq!(v["match_positions"][0]["start"], serde_json::json!(5));
-        assert_eq!(v["match_positions"][0]["end"], serde_json::json!(10));
+        assert_eq!(v["match_positions"][0]["end"], serde_json::json!(8));
+        assert_eq!(v["match_positions"][1]["start"], serde_json::json!(12));
+        assert_eq!(v["match_positions"][1]["end"], serde_json::json!(15));
         assert_eq!(v["field"], serde_json::json!("function_signature"));
         assert_eq!(v["snippet"], serde_json::json!("fn foo()"));
     }

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -233,11 +233,7 @@ pub trait TemporalSource: Send + Sync {
     /// # Errors
     /// Returns [`SearchError::Git`] on any git-level failure (not a repo,
     /// unreadable objects, etc.).
-    fn parse_history(
-        &self,
-        repo_path: &Path,
-        lookback_days: u32,
-    ) -> Result<HistoryResult>;
+    fn parse_history(&self, repo_path: &Path, lookback_days: u32) -> Result<HistoryResult>;
 }
 
 // ============================================================================

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -170,6 +170,19 @@ pub struct FileChangeInfo {
     pub deletions: u64,
 }
 
+impl FileChangeInfo {
+    /// Returns the path as a string slice, using lossy UTF-8 conversion.
+    ///
+    /// Git paths are always valid UTF-8 in practice, so lossy conversion is
+    /// safe and consistent with the rest of the codebase. Returns a `Cow<str>`
+    /// to avoid an unnecessary allocation when the path is already valid UTF-8.
+    #[must_use]
+    #[inline]
+    pub fn path_str(&self) -> std::borrow::Cow<'_, str> {
+        self.path.to_string_lossy()
+    }
+}
+
 /// Metadata extracted from a single git commit.
 ///
 /// Intentionally free of gix types — all gix values are converted at the

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -10,6 +10,7 @@
 
 use std::fmt;
 use std::ops::Range;
+use std::path::{Path, PathBuf};
 
 // Search types derive Serialize/Deserialize because search results are serialized
 // to JSON for `--json` CLI output. rskim-core types do not need serde — they are
@@ -148,6 +149,82 @@ impl SearchField {
 pub struct TemporalFlags {
     /// Restrict results to files modified within the given number of days.
     pub modified_within_days: Option<u32>,
+}
+
+// ============================================================================
+// Git history types (Wave 2a)
+// ============================================================================
+
+/// A single file touched in a commit, with line-change counts.
+///
+/// Shared between the `temporal` module (git history parsing) and any consumer
+/// that needs file-level change metadata. Both `additions` and `deletions` use
+/// `u64` to accommodate large generated files without overflow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileChangeInfo {
+    /// Repo-root-relative path of the file.
+    pub path: PathBuf,
+    /// Number of lines added.
+    pub additions: u64,
+    /// Number of lines deleted.
+    pub deletions: u64,
+}
+
+/// Metadata extracted from a single git commit.
+///
+/// Intentionally free of gix types — all gix values are converted at the
+/// parser boundary so no gix dependency leaks into the public API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitInfo {
+    /// Full 40-character hex SHA of the commit.
+    pub hash: String,
+    /// Unix timestamp (seconds since epoch, UTC).
+    pub timestamp: i64,
+    /// Author name (from git `author.name`).
+    pub author: String,
+    /// First line of the commit message.
+    pub message: String,
+    /// Files touched by this commit.
+    pub changed_files: Vec<FileChangeInfo>,
+}
+
+/// Summary metadata about a parsed history result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemporalMetadata {
+    /// True when the repository is a shallow clone (history may be incomplete).
+    pub is_shallow: bool,
+    /// Number of commits included in this result (equals `commits.len()`).
+    pub commit_count: usize,
+}
+
+/// Output of [`TemporalSource::parse_history`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryResult {
+    /// Commits ordered from newest to oldest.
+    pub commits: Vec<CommitInfo>,
+    /// Summary metadata about the history traversal.
+    pub metadata: TemporalMetadata,
+}
+
+/// Trait for git history parsers.
+///
+/// Implementations must be `Send + Sync` so they can be used from worker
+/// threads. Object safety is preserved — no associated types or generics.
+pub trait TemporalSource: Send + Sync {
+    /// Parse git history for the repository at `repo_path`.
+    ///
+    /// Returns commits ordered from newest to oldest, filtered to those whose
+    /// author timestamp falls within the last `lookback_days` days.
+    /// When `lookback_days` is `0`, all history is returned (no time filter).
+    ///
+    /// # Errors
+    /// Returns [`SearchError::Git`] on any git-level failure (not a repo,
+    /// unreadable objects, etc.).
+    fn parse_history(
+        &self,
+        repo_path: &Path,
+        lookback_days: u32,
+    ) -> Result<HistoryResult>;
 }
 
 // ============================================================================
@@ -346,6 +423,11 @@ pub enum SearchError {
     /// I/O error (primarily for future persistence layers)
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Git operation error — all gix/libgit2 errors are converted to strings
+    /// at the parser boundary so no git library types leak into this enum.
+    #[error("Git error: {0}")]
+    Git(String),
 }
 
 /// Result type alias for all rskim-search operations.

--- a/crates/rskim/Cargo.toml
+++ b/crates/rskim/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 rskim-core = { version = "2.10.0", path = "../rskim-core" }
+rskim-search = { path = "../rskim-search" }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = { workspace = true }
 globset = { workspace = true }
@@ -44,10 +45,6 @@ tree-sitter = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
-# Compile-time canary: ensures rskim-search's public API surface remains valid
-# as a downstream consumer. API breakage surfaces here before re-adding as a
-# runtime dependency.
-rskim-search = { path = "../rskim-search" }
 assert_cmd = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -51,7 +51,7 @@ pub(crate) trait GitDataSource {
     /// Returns `None` when the repo has fewer than `n` commits.
     fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>>;
 
-    /// Fetch commit records according to `config`.
+    /// Fetch commits according to `config`.
     fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>>;
 }
 

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -213,9 +213,9 @@ pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord
             current = Some(CommitRecord {
                 hash,
                 author,
-                timestamp,
-                subject,
-                files: Vec::new(),
+                timestamp: timestamp as i64,
+                message: subject,
+                changed_files: Vec::new(),
             });
         } else if line.trim().is_empty() {
             // Blank lines separate commits — skip
@@ -226,7 +226,7 @@ pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord
             if let Some(record) = current.as_mut()
                 && let Some(file_change) = parse_numstat_line(line)
             {
-                record.files.push(file_change);
+                record.changed_files.push(file_change);
             }
         }
     }
@@ -265,7 +265,7 @@ fn parse_numstat_line(line: &str) -> Option<FileChange> {
     let path = resolve_rename(raw_path);
 
     Some(FileChange {
-        path,
+        path: std::path::PathBuf::from(path),
         additions,
         deletions,
     })
@@ -323,9 +323,9 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].hash, "abc123");
         assert_eq!(result[0].author, "Alice");
-        assert_eq!(result[0].timestamp, 1_700_000_000);
-        assert_eq!(result[0].subject, "fix: something");
-        assert!(result[0].files.is_empty());
+        assert_eq!(result[0].timestamp, 1_700_000_000i64);
+        assert_eq!(result[0].message, "fix: something");
+        assert!(result[0].changed_files.is_empty());
     }
 
     #[test]
@@ -333,10 +333,10 @@ mod tests {
         let input = "COMMIT:abc123|Alice|1700000000|chore: update\n5\t2\tsrc/main.rs\n3\t1\tlib/utils.rs\n\n";
         let result = parse_git_log_output(input).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].files.len(), 2);
-        assert_eq!(result[0].files[0].path, "src/main.rs");
-        assert_eq!(result[0].files[0].additions, 5);
-        assert_eq!(result[0].files[0].deletions, 2);
+        assert_eq!(result[0].changed_files.len(), 2);
+        assert_eq!(result[0].changed_files[0].path, std::path::Path::new("src/main.rs"));
+        assert_eq!(result[0].changed_files[0].additions, 5);
+        assert_eq!(result[0].changed_files[0].deletions, 2);
     }
 
     #[test]
@@ -367,8 +367,8 @@ mod tests {
     fn test_binary_files_skipped() {
         let input = "COMMIT:abc|Alice|1000|msg\n-\t-\tbinary.bin\n5\t2\treal.rs\n\n";
         let result = parse_git_log_output(input).unwrap();
-        assert_eq!(result[0].files.len(), 1);
-        assert_eq!(result[0].files[0].path, "real.rs");
+        assert_eq!(result[0].changed_files.len(), 1);
+        assert_eq!(result[0].changed_files[0].path, std::path::Path::new("real.rs"));
     }
 
     #[test]
@@ -399,7 +399,7 @@ mod tests {
         // Subject may contain the separator — splitn(4) protects us
         let input = "COMMIT:abc|Alice|1000|feat: add foo|bar\n\n";
         let result = parse_git_log_output(input).unwrap();
-        assert_eq!(result[0].subject, "feat: add foo|bar");
+        assert_eq!(result[0].message, "feat: add foo|bar");
     }
 
     #[test]
@@ -407,6 +407,6 @@ mod tests {
         let input = "COMMIT:abc|Alice|1000|msg\nnot-a-numstat-line\n\n";
         let result = parse_git_log_output(input).unwrap();
         // The malformed line should be silently ignored
-        assert_eq!(result[0].files.len(), 0);
+        assert_eq!(result[0].changed_files.len(), 0);
     }
 }

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -339,7 +339,10 @@ mod tests {
         let result = parse_git_log_output(input).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].changed_files.len(), 2);
-        assert_eq!(result[0].changed_files[0].path, std::path::Path::new("src/main.rs"));
+        assert_eq!(
+            result[0].changed_files[0].path,
+            std::path::Path::new("src/main.rs")
+        );
         assert_eq!(result[0].changed_files[0].additions, 5);
         assert_eq!(result[0].changed_files[0].deletions, 2);
     }
@@ -373,7 +376,10 @@ mod tests {
         let input = "COMMIT:abc|Alice|1000|msg\n-\t-\tbinary.bin\n5\t2\treal.rs\n\n";
         let result = parse_git_log_output(input).unwrap();
         assert_eq!(result[0].changed_files.len(), 1);
-        assert_eq!(result[0].changed_files[0].path, std::path::Path::new("real.rs"));
+        assert_eq!(
+            result[0].changed_files[0].path,
+            std::path::Path::new("real.rs")
+        );
     }
 
     #[test]

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -213,7 +213,7 @@ pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord
             current = Some(CommitRecord {
                 hash,
                 author,
-                timestamp: timestamp as i64,
+                timestamp: i64::try_from(timestamp).unwrap_or(i64::MAX),
                 message: subject,
                 changed_files: Vec::new(),
             });

--- a/crates/rskim/src/cmd/heatmap/git_source.rs
+++ b/crates/rskim/src/cmd/heatmap/git_source.rs
@@ -1,13 +1,13 @@
 //! Git data source for `skim heatmap` — the ONLY I/O file in this module.
 //!
 //! Uses `CommandRunner` to execute git commands and parses their output into
-//! `CommitRecord` values via a simple state machine.
+//! `CommitInfo` values via a simple state machine.
 
 use std::time::Duration;
 
 use crate::runner::{CommandRunner, is_spawn_error};
 
-use super::types::{CommitRecord, FileChange, HeatmapConfig};
+use super::types::{CommitInfo, FileChangeInfo, HeatmapConfig};
 
 /// Map a `CommandRunner` error to a friendly "git not installed" message when appropriate.
 fn git_not_found(e: anyhow::Error) -> anyhow::Error {
@@ -27,10 +27,15 @@ fn git_not_found(e: anyhow::Error) -> anyhow::Error {
 /// The only implementation is [`CliGitSource`]; the trait enables unit-testing
 /// the orchestration logic in `mod.rs` without spawning a real git process.
 ///
+/// Heatmap-specific git data source — wraps CLI `git` binary via `CommandRunner`.
+///
 /// Infra methods (`is_git_repo`, `get_repo_root`, `detect_shallow_clone`,
 /// `fetch_commit_count_since`) are included so `run_with_source` can accept a
 /// single `&dyn GitDataSource` instead of splitting into a concrete `&CliGitSource`
 /// for infrastructure and a trait object for data fetch.
+///
+/// Long-term, this trait will be replaced by `rskim_search::TemporalSource` +
+/// `GixSource` once the heatmap pipeline migrates from CLI git to the gix library.
 pub(crate) trait GitDataSource {
     /// Return `true` when the cwd is inside a git repository.
     fn is_git_repo(&self) -> bool;
@@ -47,7 +52,7 @@ pub(crate) trait GitDataSource {
     fn fetch_commit_count_since(&self, n: usize) -> anyhow::Result<Option<u64>>;
 
     /// Fetch commit records according to `config`.
-    fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>>;
+    fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>>;
 }
 
 // ============================================================================
@@ -174,7 +179,7 @@ impl GitDataSource for CliGitSource {
         Ok((ts > 0).then_some(ts))
     }
 
-    fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitRecord>> {
+    fn fetch_commits(&self, config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>> {
         let owned_args = self.build_git_log_args(config);
         let args: Vec<&str> = owned_args.iter().map(String::as_str).collect();
         let output = self.runner.run("git", &args).map_err(git_not_found)?;
@@ -190,9 +195,9 @@ impl GitDataSource for CliGitSource {
 ///
 /// Exposed as `pub(crate)` so unit tests can exercise the parser on hardcoded
 /// strings without spawning a real git process.
-pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord>> {
-    let mut commits: Vec<CommitRecord> = Vec::new();
-    let mut current: Option<CommitRecord> = None;
+pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitInfo>> {
+    let mut commits: Vec<CommitInfo> = Vec::new();
+    let mut current: Option<CommitInfo> = None;
 
     for line in raw.lines() {
         if let Some(rest) = line.strip_prefix("COMMIT:") {
@@ -210,7 +215,7 @@ pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord
             let timestamp: u64 = parts[2].trim().parse().unwrap_or(0);
             let subject = parts[3].trim().to_string();
 
-            current = Some(CommitRecord {
+            current = Some(CommitInfo {
                 hash,
                 author,
                 timestamp: i64::try_from(timestamp).unwrap_or(i64::MAX),
@@ -239,11 +244,11 @@ pub(crate) fn parse_git_log_output(raw: &str) -> anyhow::Result<Vec<CommitRecord
     Ok(commits)
 }
 
-/// Parse a single git numstat line into a `FileChange`.
+/// Parse a single git numstat line into a `FileChangeInfo`.
 ///
 /// Returns `None` for binary files (marked with `-` in both columns) or
 /// malformed lines.
-fn parse_numstat_line(line: &str) -> Option<FileChange> {
+fn parse_numstat_line(line: &str) -> Option<FileChangeInfo> {
     let parts: Vec<&str> = line.splitn(3, '\t').collect();
     if parts.len() < 3 {
         return None;
@@ -264,7 +269,7 @@ fn parse_numstat_line(line: &str) -> Option<FileChange> {
     // Resolve renames: `{old => new}` or `dir/{old => new}/rest`
     let path = resolve_rename(raw_path);
 
-    Some(FileChange {
+    Some(FileChangeInfo {
         path: std::path::PathBuf::from(path),
         additions,
         deletions,

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -197,14 +197,14 @@ pub(crate) fn compute_stability(
     for commit in commits {
         let is_fix = rskim_search::is_fix_commit(&commit.message);
         for file in &commit.changed_files {
-            let path_str = file.path_str().into_owned();
+            let path = file.path_str().into_owned();
+            if is_fix {
+                *file_fix_count.entry(path.clone()).or_insert(0) += 1;
+            }
             file_commits
-                .entry(path_str.clone())
+                .entry(path)
                 .or_default()
                 .push(commit.timestamp.max(0) as u64);
-            if is_fix {
-                *file_fix_count.entry(path_str).or_insert(0) += 1;
-            }
         }
     }
 
@@ -399,16 +399,14 @@ pub(crate) fn compute_fix_after_touch(
 ///
 /// Returns `None` for root-level files (no directory component), e.g. `Makefile`.
 /// Returns `Some("src")` for `src/lib.rs`, `Some("tests")` for `tests/foo.rs`.
-fn extract_top_dir(path: &str) -> Option<String> {
-    let p = std::path::Path::new(path);
+fn extract_top_dir(path: &std::path::Path) -> Option<String> {
     // Require at least one parent directory (not root-level files)
-    let parent = p.parent()?;
-    let s = parent.to_string_lossy();
-    if s.is_empty() || s == "." {
+    let parent = path.parent()?;
+    if parent == std::path::Path::new("") || parent == std::path::Path::new(".") {
         return None;
     }
     // Return the first path component as the module name
-    p.components()
+    path.components()
         .next()
         .and_then(|c| c.as_os_str().to_str().map(String::from))
 }
@@ -435,7 +433,7 @@ pub(crate) fn compute_encapsulation(
         let file_dirs: Vec<Option<String>> = commit
             .changed_files
             .iter()
-            .map(|f| extract_top_dir(&f.path_str()))
+            .map(|f| extract_top_dir(&f.path))
             .collect();
 
         // Collect unique top-level directories for this commit
@@ -881,17 +879,23 @@ mod tests {
 
     #[test]
     fn test_extract_top_dir_root_level_file() {
-        assert_eq!(extract_top_dir("Makefile"), None);
-        assert_eq!(extract_top_dir("README.md"), None);
+        assert_eq!(extract_top_dir(std::path::Path::new("Makefile")), None);
+        assert_eq!(extract_top_dir(std::path::Path::new("README.md")), None);
     }
 
     #[test]
     fn test_extract_top_dir_nested_file() {
-        assert_eq!(extract_top_dir("src/lib.rs"), Some("src".to_string()));
         assert_eq!(
-            extract_top_dir("src/cmd/heatmap/mod.rs"),
+            extract_top_dir(std::path::Path::new("src/lib.rs")),
             Some("src".to_string())
         );
-        assert_eq!(extract_top_dir("tests/foo.rs"), Some("tests".to_string()));
+        assert_eq!(
+            extract_top_dir(std::path::Path::new("src/cmd/heatmap/mod.rs")),
+            Some("src".to_string())
+        );
+        assert_eq!(
+            extract_top_dir(std::path::Path::new("tests/foo.rs")),
+            Some("tests".to_string())
+        );
     }
 }

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -5,21 +5,10 @@
 
 use std::collections::{HashMap, HashSet};
 
-use regex::Regex;
-
 use super::types::{
     AuthorMetrics, ChurnMetrics, CommitRecord, CouplingEdge, CouplingEntry, FixRiskMetrics,
     ModuleHealth,
 };
-
-// ============================================================================
-// Fix keyword regex
-// ============================================================================
-
-/// Build the regex that identifies "fix" commits by subject keywords.
-pub(crate) fn build_fix_regex() -> Regex {
-    Regex::new(r"(?i)\b(fix|bug|hotfix|patch|revert)\b").expect("valid regex")
-}
 
 // ============================================================================
 // Metric 1: Churn
@@ -33,7 +22,7 @@ pub(crate) fn compute_churn(commits: &[CommitRecord]) -> HashMap<String, ChurnMe
     for commit in commits {
         for file in &commit.changed_files {
             *counts
-                .entry(file.path.to_string_lossy().into_owned())
+                .entry(file.path_str().into_owned())
                 .or_insert(0) += 1;
         }
     }
@@ -86,8 +75,9 @@ pub(crate) fn compute_coupling(
     min_support: usize,
 ) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
     // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b).
-    // &str keys borrow from CommitRecord.changed_files[].path — valid for entire
-    // function because `commits` (and therefore all CommitRecords) outlive these maps.
+    // &str keys borrow from PathBuf::to_str() on each FileChangeInfo.path — valid
+    // for the entire function because `commits` (and all CommitRecords) outlive
+    // these maps. Non-UTF-8 paths fall back to "" via unwrap_or_default().
     let mut co_occur: HashMap<(&str, &str), (f64, usize)> = HashMap::new();
     // weighted_total[a] = weighted sum of commits touching a
     let mut weighted_total: HashMap<&str, f64> = HashMap::new();
@@ -96,7 +86,7 @@ pub(crate) fn compute_coupling(
         let files: Vec<&str> = commit
             .changed_files
             .iter()
-            .map(|f| f.path.to_str().unwrap_or(""))
+            .map(|f| f.path.to_str().unwrap_or_default())
             .collect();
         let n = files.len();
         let weight = 1.0 / (n as f64).sqrt();
@@ -197,7 +187,6 @@ pub(crate) fn compute_coupling(
 /// `now_epoch` is a parameter so tests are deterministic.
 pub(crate) fn compute_stability(
     commits: &[CommitRecord],
-    fix_regex: &Regex,
     max_churn: usize,
     now_epoch: u64,
 ) -> HashMap<String, u8> {
@@ -206,13 +195,13 @@ pub(crate) fn compute_stability(
     let mut file_fix_count: HashMap<String, usize> = HashMap::new();
 
     for commit in commits {
-        let is_fix = fix_regex.is_match(&commit.message);
+        let is_fix = rskim_search::is_fix_commit(&commit.message);
         for file in &commit.changed_files {
-            let path_str = file.path.to_string_lossy().into_owned();
+            let path_str = file.path_str().into_owned();
             file_commits
                 .entry(path_str.clone())
                 .or_default()
-                .push(commit.timestamp as u64);
+                .push(commit.timestamp.max(0) as u64);
             if is_fix {
                 *file_fix_count.entry(path_str).or_insert(0) += 1;
             }
@@ -265,7 +254,7 @@ pub(crate) fn compute_authors(commits: &[CommitRecord]) -> HashMap<String, Autho
     for commit in commits {
         for file in &commit.changed_files {
             *file_author_counts
-                .entry(file.path.to_string_lossy().into_owned())
+                .entry(file.path_str().into_owned())
                 .or_default()
                 .entry(commit.author.clone())
                 .or_insert(0) += 1;
@@ -320,13 +309,12 @@ pub(crate) fn compute_authors(commits: &[CommitRecord]) -> HashMap<String, Autho
 /// - `insufficient_data`: true when the file has <2 commits.
 pub(crate) fn compute_fix_after_touch(
     commits: &[CommitRecord],
-    fix_regex: &Regex,
     window: usize,
 ) -> HashMap<String, FixRiskMetrics> {
     // Classify every commit
     let is_fix: Vec<bool> = commits
         .iter()
-        .map(|c| fix_regex.is_match(&c.message))
+        .map(|c| rskim_search::is_fix_commit(&c.message))
         .collect();
 
     // Per-file: which commit indices touch it?
@@ -334,7 +322,7 @@ pub(crate) fn compute_fix_after_touch(
     for (i, commit) in commits.iter().enumerate() {
         for file in &commit.changed_files {
             file_indices
-                .entry(file.path.to_string_lossy().into_owned())
+                .entry(file.path_str().into_owned())
                 .or_default()
                 .push(i);
         }
@@ -447,7 +435,7 @@ pub(crate) fn compute_encapsulation(
         let file_dirs: Vec<Option<String>> = commit
             .changed_files
             .iter()
-            .map(|f| extract_top_dir(&f.path.to_string_lossy()))
+            .map(|f| extract_top_dir(&f.path_str()))
             .collect();
 
         // Collect unique top-level directories for this commit
@@ -459,7 +447,7 @@ pub(crate) fn compute_encapsulation(
                 module_files
                     .entry(d.clone())
                     .or_default()
-                    .insert(file.path.to_string_lossy().into_owned());
+                    .insert(file.path_str().into_owned());
             }
         }
 
@@ -649,14 +637,12 @@ mod tests {
 
     #[test]
     fn test_stability_empty() {
-        let fix_re = build_fix_regex();
-        let result = compute_stability(&[], &fix_re, 0, 0);
+        let result = compute_stability(&[], 0, 0);
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_stability_moderate_for_max_churn_old_file() {
-        let fix_re = build_fix_regex();
         // One commit, old (365 days ago), no fix keywords, but max churn (1/1)
         let old_ts = 0u64;
         let now = 365 * 86400u64;
@@ -667,7 +653,7 @@ mod tests {
             "feat: initial",
             &["stable.rs"],
         )];
-        let result = compute_stability(&commits, &fix_re, 1, now);
+        let result = compute_stability(&commits, 1, now);
         let score = result["stable.rs"];
         // Churn = 1/1 = 1.0 → penalty 40, recency ≈ 0 (old), volatility = 0
         // penalty ≈ 40, score ≈ 60
@@ -679,7 +665,6 @@ mod tests {
 
     #[test]
     fn test_stability_recent_fix_lowers_score() {
-        let fix_re = build_fix_regex();
         let now = 1_000_000u64;
         let commits = vec![make_commit(
             "h1",
@@ -688,7 +673,7 @@ mod tests {
             "fix: critical bug",
             &["risky.rs"],
         )];
-        let result = compute_stability(&commits, &fix_re, 1, now);
+        let result = compute_stability(&commits, 1, now);
         let score = result["risky.rs"];
         // Recent fix commit → low stability
         assert!(score < 50, "expected low score for recent fix, got {score}");
@@ -750,16 +735,14 @@ mod tests {
 
     #[test]
     fn test_fix_risk_empty() {
-        let fix_re = build_fix_regex();
-        let result = compute_fix_after_touch(&[], &fix_re, 5);
+        let result = compute_fix_after_touch(&[], 5);
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_fix_risk_single_commit_insufficient_data() {
         let commits = vec![make_commit("h1", "Alice", 1, "feat: add", &["a.rs"])];
-        let fix_re = build_fix_regex();
-        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let result = compute_fix_after_touch(&commits, 5);
         assert!(result["a.rs"].insufficient_data);
     }
 
@@ -769,8 +752,7 @@ mod tests {
             make_commit("h1", "Alice", 1, "feat: add", &["a.rs"]),
             make_commit("h2", "Alice", 2, "fix: bug in a", &["a.rs"]),
         ];
-        let fix_re = build_fix_regex();
-        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let result = compute_fix_after_touch(&commits, 5);
         let m = &result["a.rs"];
         assert!(!m.insufficient_data);
         // 1 fix commit out of 2 = 50%
@@ -785,8 +767,7 @@ mod tests {
             make_commit("h1", "Alice", 1, "feat: add", &["a.rs"]),
             make_commit("h2", "Alice", 2, "fix: quick patch", &["a.rs"]),
         ];
-        let fix_re = build_fix_regex();
-        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let result = compute_fix_after_touch(&commits, 5);
         let m = &result["a.rs"];
         assert!(!m.insufficient_data);
         // total=2, proximity_set={0}, proximity_pct = 1/2*100 = 50%
@@ -811,8 +792,7 @@ mod tests {
             make_commit("h2", "Alice", 2, "fix: bug in a", &["a.rs"]),
             make_commit("h3", "Alice", 3, "feat: more work", &["a.rs"]),
         ];
-        let fix_re = build_fix_regex();
-        let result = compute_fix_after_touch(&commits, &fix_re, 5);
+        let result = compute_fix_after_touch(&commits, 5);
         let m = &result["a.rs"];
 
         assert!(!m.insufficient_data);

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -12,9 +12,6 @@ use super::types::{
     ModuleHealth,
 };
 
-// CommitRecord is an alias for rskim_search::CommitInfo; its fields are:
-//   .message (was .subject), .changed_files (was .files), .timestamp: i64 (was u64)
-
 // ============================================================================
 // Fix keyword regex
 // ============================================================================
@@ -89,8 +86,8 @@ pub(crate) fn compute_coupling(
     min_support: usize,
 ) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
     // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b).
-    // &str keys borrow from CommitRecord.files[].path — valid for entire function
-    // because `commits` (and therefore all CommitRecords) outlive these maps.
+    // &str keys borrow from CommitRecord.changed_files[].path — valid for entire
+    // function because `commits` (and therefore all CommitRecords) outlive these maps.
     let mut co_occur: HashMap<(&str, &str), (f64, usize)> = HashMap::new();
     // weighted_total[a] = weighted sum of commits touching a
     let mut weighted_total: HashMap<&str, f64> = HashMap::new();

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -75,7 +75,7 @@ pub(crate) fn compute_coupling(
     min_support: usize,
 ) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
     // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b).
-    // &str keys borrow from PathBuf::to_str() on each FileChangeInfoInfo.path — valid
+    // &str keys borrow from PathBuf::to_str() on each FileChangeInfo.path — valid
     // for the entire function because `commits` (and all CommitInfos) outlive
     // these maps. Non-UTF-8 paths fall back to "" via unwrap_or_default().
     let mut co_occur: HashMap<(&str, &str), (f64, usize)> = HashMap::new();

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -21,9 +21,7 @@ pub(crate) fn compute_churn(commits: &[CommitInfo]) -> HashMap<String, ChurnMetr
 
     for commit in commits {
         for file in &commit.changed_files {
-            *counts
-                .entry(file.path_str().into_owned())
-                .or_insert(0) += 1;
+            *counts.entry(file.path_str().into_owned()).or_insert(0) += 1;
         }
     }
 
@@ -499,13 +497,7 @@ mod tests {
     use super::*;
     use crate::cmd::heatmap::types::FileChangeInfo;
 
-    fn make_commit(
-        hash: &str,
-        author: &str,
-        ts: u64,
-        subject: &str,
-        files: &[&str],
-    ) -> CommitInfo {
+    fn make_commit(hash: &str, author: &str, ts: u64, subject: &str, files: &[&str]) -> CommitInfo {
         CommitInfo {
             hash: hash.to_string(),
             author: author.to_string(),

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -12,6 +12,9 @@ use super::types::{
     ModuleHealth,
 };
 
+// CommitRecord is an alias for rskim_search::CommitInfo; its fields are:
+//   .message (was .subject), .changed_files (was .files), .timestamp: i64 (was u64)
+
 // ============================================================================
 // Fix keyword regex
 // ============================================================================
@@ -31,8 +34,10 @@ pub(crate) fn compute_churn(commits: &[CommitRecord]) -> HashMap<String, ChurnMe
     let mut counts: HashMap<String, usize> = HashMap::new();
 
     for commit in commits {
-        for file in &commit.files {
-            *counts.entry(file.path.clone()).or_insert(0) += 1;
+        for file in &commit.changed_files {
+            *counts
+                .entry(file.path.to_string_lossy().into_owned())
+                .or_insert(0) += 1;
         }
     }
 
@@ -91,7 +96,11 @@ pub(crate) fn compute_coupling(
     let mut weighted_total: HashMap<&str, f64> = HashMap::new();
 
     for commit in commits {
-        let files: Vec<&str> = commit.files.iter().map(|f| f.path.as_str()).collect();
+        let files: Vec<&str> = commit
+            .changed_files
+            .iter()
+            .map(|f| f.path.to_str().unwrap_or(""))
+            .collect();
         let n = files.len();
         let weight = 1.0 / (n as f64).sqrt();
 
@@ -200,14 +209,15 @@ pub(crate) fn compute_stability(
     let mut file_fix_count: HashMap<String, usize> = HashMap::new();
 
     for commit in commits {
-        let is_fix = fix_regex.is_match(&commit.subject);
-        for file in &commit.files {
+        let is_fix = fix_regex.is_match(&commit.message);
+        for file in &commit.changed_files {
+            let path_str = file.path.to_string_lossy().into_owned();
             file_commits
-                .entry(file.path.clone())
+                .entry(path_str.clone())
                 .or_default()
-                .push(commit.timestamp);
+                .push(commit.timestamp as u64);
             if is_fix {
-                *file_fix_count.entry(file.path.clone()).or_insert(0) += 1;
+                *file_fix_count.entry(path_str).or_insert(0) += 1;
             }
         }
     }
@@ -256,9 +266,9 @@ pub(crate) fn compute_authors(commits: &[CommitRecord]) -> HashMap<String, Autho
     let mut file_author_counts: HashMap<String, HashMap<String, usize>> = HashMap::new();
 
     for commit in commits {
-        for file in &commit.files {
+        for file in &commit.changed_files {
             *file_author_counts
-                .entry(file.path.clone())
+                .entry(file.path.to_string_lossy().into_owned())
                 .or_default()
                 .entry(commit.author.clone())
                 .or_insert(0) += 1;
@@ -319,14 +329,17 @@ pub(crate) fn compute_fix_after_touch(
     // Classify every commit
     let is_fix: Vec<bool> = commits
         .iter()
-        .map(|c| fix_regex.is_match(&c.subject))
+        .map(|c| fix_regex.is_match(&c.message))
         .collect();
 
     // Per-file: which commit indices touch it?
     let mut file_indices: HashMap<String, Vec<usize>> = HashMap::new();
     for (i, commit) in commits.iter().enumerate() {
-        for file in &commit.files {
-            file_indices.entry(file.path.clone()).or_default().push(i);
+        for file in &commit.changed_files {
+            file_indices
+                .entry(file.path.to_string_lossy().into_owned())
+                .or_default()
+                .push(i);
         }
     }
 
@@ -435,21 +448,21 @@ pub(crate) fn compute_encapsulation(
         // Precompute top-level directory for each file once to avoid calling
         // extract_top_dir twice per file (once for dirs, once for module_files).
         let file_dirs: Vec<Option<String>> = commit
-            .files
+            .changed_files
             .iter()
-            .map(|f| extract_top_dir(&f.path))
+            .map(|f| extract_top_dir(&f.path.to_string_lossy()))
             .collect();
 
         // Collect unique top-level directories for this commit
         let dirs: HashSet<&str> = file_dirs.iter().filter_map(|d| d.as_deref()).collect();
 
         // Track files per module
-        for (file, dir) in commit.files.iter().zip(file_dirs.iter()) {
+        for (file, dir) in commit.changed_files.iter().zip(file_dirs.iter()) {
             if let Some(d) = dir {
                 module_files
                     .entry(d.clone())
                     .or_default()
-                    .insert(file.path.clone());
+                    .insert(file.path.to_string_lossy().into_owned());
             }
         }
 
@@ -513,12 +526,12 @@ mod tests {
         CommitRecord {
             hash: hash.to_string(),
             author: author.to_string(),
-            timestamp: ts,
-            subject: subject.to_string(),
-            files: files
+            timestamp: ts as i64,
+            message: subject.to_string(),
+            changed_files: files
                 .iter()
                 .map(|p| FileChange {
-                    path: p.to_string(),
+                    path: std::path::PathBuf::from(p),
                     additions: 1,
                     deletions: 0,
                 })

--- a/crates/rskim/src/cmd/heatmap/metrics.rs
+++ b/crates/rskim/src/cmd/heatmap/metrics.rs
@@ -1,12 +1,12 @@
 //! Pure computation functions for `skim heatmap` — 6 risk metrics.
 //!
-//! Zero I/O. All functions accept `&[CommitRecord]` and return computed values.
+//! Zero I/O. All functions accept `&[CommitInfo]` and return computed values.
 //! `now_epoch` is a parameter (not `SystemTime::now()`) for deterministic tests.
 
 use std::collections::{HashMap, HashSet};
 
 use super::types::{
-    AuthorMetrics, ChurnMetrics, CommitRecord, CouplingEdge, CouplingEntry, FixRiskMetrics,
+    AuthorMetrics, ChurnMetrics, CommitInfo, CouplingEdge, CouplingEntry, FixRiskMetrics,
     ModuleHealth,
 };
 
@@ -15,7 +15,7 @@ use super::types::{
 // ============================================================================
 
 /// Count commits per file and compute rate = file_commits / total_commits.
-pub(crate) fn compute_churn(commits: &[CommitRecord]) -> HashMap<String, ChurnMetrics> {
+pub(crate) fn compute_churn(commits: &[CommitInfo]) -> HashMap<String, ChurnMetrics> {
     let total = commits.len();
     let mut counts: HashMap<String, usize> = HashMap::new();
 
@@ -70,13 +70,13 @@ const COUPLING_MAX_FILES: usize = 50;
 /// - per-file blast radius map: `HashMap<String, Vec<CouplingEntry>>`
 /// - global coupling graph: `Vec<CouplingEdge>`
 pub(crate) fn compute_coupling(
-    commits: &[CommitRecord],
+    commits: &[CommitInfo],
     threshold: f64,
     min_support: usize,
 ) -> (HashMap<String, Vec<CouplingEntry>>, Vec<CouplingEdge>) {
     // co_occur[(a, b)] = (weighted_sum, raw_count) for ordered pair (a, b).
-    // &str keys borrow from PathBuf::to_str() on each FileChangeInfo.path — valid
-    // for the entire function because `commits` (and all CommitRecords) outlive
+    // &str keys borrow from PathBuf::to_str() on each FileChangeInfoInfo.path — valid
+    // for the entire function because `commits` (and all CommitInfos) outlive
     // these maps. Non-UTF-8 paths fall back to "" via unwrap_or_default().
     let mut co_occur: HashMap<(&str, &str), (f64, usize)> = HashMap::new();
     // weighted_total[a] = weighted sum of commits touching a
@@ -186,7 +186,7 @@ pub(crate) fn compute_coupling(
 ///
 /// `now_epoch` is a parameter so tests are deterministic.
 pub(crate) fn compute_stability(
-    commits: &[CommitRecord],
+    commits: &[CommitInfo],
     max_churn: usize,
     now_epoch: u64,
 ) -> HashMap<String, u8> {
@@ -247,7 +247,7 @@ pub(crate) fn compute_stability(
 // ============================================================================
 
 /// Compute author diversity metrics per file.
-pub(crate) fn compute_authors(commits: &[CommitRecord]) -> HashMap<String, AuthorMetrics> {
+pub(crate) fn compute_authors(commits: &[CommitInfo]) -> HashMap<String, AuthorMetrics> {
     // file -> author -> commit_count
     let mut file_author_counts: HashMap<String, HashMap<String, usize>> = HashMap::new();
 
@@ -308,7 +308,7 @@ pub(crate) fn compute_authors(commits: &[CommitRecord]) -> HashMap<String, Autho
 /// - `combined_pct`: union (not sum) of the two signals.
 /// - `insufficient_data`: true when the file has <2 commits.
 pub(crate) fn compute_fix_after_touch(
-    commits: &[CommitRecord],
+    commits: &[CommitInfo],
     window: usize,
 ) -> HashMap<String, FixRiskMetrics> {
     // Classify every commit
@@ -419,7 +419,7 @@ fn extract_top_dir(path: &std::path::Path) -> Option<String> {
 /// Filters modules with fewer than `min_commits` total commits.
 /// Returns results sorted by encapsulation_pct ascending (worst first).
 pub(crate) fn compute_encapsulation(
-    commits: &[CommitRecord],
+    commits: &[CommitInfo],
     min_commits: usize,
 ) -> Vec<ModuleHealth> {
     // module -> files seen
@@ -497,7 +497,7 @@ pub(crate) fn compute_encapsulation(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::cmd::heatmap::types::FileChange;
+    use crate::cmd::heatmap::types::FileChangeInfo;
 
     fn make_commit(
         hash: &str,
@@ -505,15 +505,15 @@ mod tests {
         ts: u64,
         subject: &str,
         files: &[&str],
-    ) -> CommitRecord {
-        CommitRecord {
+    ) -> CommitInfo {
+        CommitInfo {
             hash: hash.to_string(),
             author: author.to_string(),
             timestamp: ts as i64,
             message: subject.to_string(),
             changed_files: files
                 .iter()
-                .map(|p| FileChange {
+                .map(|p| FileChangeInfo {
                     path: std::path::PathBuf::from(p),
                     additions: 1,
                     deletions: 0,

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -220,7 +220,7 @@ fn prepare_commits(
     for commit in &mut commits {
         commit
             .changed_files
-            .retain(|f| !should_exclude(f.path.to_str().unwrap_or(""), &exclude_set));
+            .retain(|f| !should_exclude(&f.path.to_string_lossy(), &exclude_set));
     }
     // Remove commits that are now file-less after exclusion
     commits.retain(|c| !c.changed_files.is_empty());

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -32,7 +32,7 @@ use metrics::{
     compute_fix_after_touch, compute_stability,
 };
 use output::{render_insights_json, render_insights_text, render_json, render_text};
-use types::{CommitRecord, FileMetrics, HeatmapConfig, HeatmapResult, ResolvedWindow};
+use types::{CommitInfo, FileMetrics, HeatmapConfig, HeatmapResult, ResolvedWindow};
 use window::{build_window_info, format_epoch, resolve_effective_config};
 
 // ============================================================================
@@ -117,7 +117,7 @@ fn resolve_diff_files(
 
 /// Bundled output of [`prepare_commits`] — everything needed to call [`compute_heatmap`].
 struct PreparedCommits {
-    commits: Vec<CommitRecord>,
+    commits: Vec<CommitInfo>,
     window: ResolvedWindow,
     now_epoch: u64,
     repo_root: String,
@@ -406,7 +406,7 @@ const MIN_SUPPORT_THRESHOLD: usize = 3;
 ///
 /// Debug timing is emitted to stderr when `config.debug` is enabled.
 fn compute_heatmap(
-    commits: Vec<CommitRecord>,
+    commits: Vec<CommitInfo>,
     config: &HeatmapConfig,
     window: &ResolvedWindow,
     now_epoch: u64,

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -219,11 +219,11 @@ fn prepare_commits(
     let mut commits = raw_commits;
     for commit in &mut commits {
         commit
-            .files
-            .retain(|f| !should_exclude(&f.path, &exclude_set));
+            .changed_files
+            .retain(|f| !should_exclude(f.path.to_str().unwrap_or(""), &exclude_set));
     }
     // Remove commits that are now file-less after exclusion
-    commits.retain(|c| !c.files.is_empty());
+    commits.retain(|c| !c.changed_files.is_empty());
 
     if config.debug {
         eprintln!(

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -28,7 +28,7 @@ use excludes::{build_exclude_set, should_exclude};
 use git_source::{CliGitSource, GitDataSource};
 use insights::{build_insights_result, compute_insights};
 use metrics::{
-    build_fix_regex, compute_authors, compute_churn, compute_coupling, compute_encapsulation,
+    compute_authors, compute_churn, compute_coupling, compute_encapsulation,
     compute_fix_after_touch, compute_stability,
 };
 use output::{render_insights_json, render_insights_text, render_json, render_text};
@@ -414,7 +414,6 @@ fn compute_heatmap(
     warnings: Vec<String>,
 ) -> HeatmapResult {
     let t0 = Instant::now();
-    let fix_regex = build_fix_regex();
 
     // Step 5: Compute metrics
     // Phase 1: churn must run first — max_churn feeds into stability.
@@ -430,7 +429,7 @@ fn compute_heatmap(
     ) = rayon::join(
         || {
             rayon::join(
-                || compute_stability(&commits, &fix_regex, max_churn, now_epoch),
+                || compute_stability(&commits, max_churn, now_epoch),
                 || compute_authors(&commits),
             )
         },
@@ -438,7 +437,7 @@ fn compute_heatmap(
             rayon::join(
                 || {
                     rayon::join(
-                        || compute_fix_after_touch(&commits, &fix_regex, fix_window),
+                        || compute_fix_after_touch(&commits, fix_window),
                         || compute_coupling(&commits, coupling_threshold, MIN_SUPPORT_THRESHOLD),
                     )
                 },

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -4,6 +4,10 @@
 
 use serde::Serialize;
 
+// Re-export shared commit/file types from rskim-search so heatmap modules
+// use a single canonical definition (eliminates the local duplicate).
+pub(crate) use rskim_search::{CommitInfo as CommitRecord, FileChangeInfo as FileChange};
+
 // ============================================================================
 // CLI configuration
 // ============================================================================
@@ -89,29 +93,6 @@ pub(crate) struct ResolvedWindow {
     pub(crate) window_preset: Option<String>,
     /// Last-N commit count, if `--last` was used.
     pub(crate) last_n: Option<usize>,
-}
-
-// ============================================================================
-// Git log data
-// ============================================================================
-
-/// A single commit extracted from git log.
-#[derive(Debug, Clone, Serialize)]
-pub(crate) struct CommitRecord {
-    pub(crate) hash: String,
-    pub(crate) author: String,
-    /// Unix timestamp.
-    pub(crate) timestamp: u64,
-    pub(crate) subject: String,
-    pub(crate) files: Vec<FileChange>,
-}
-
-/// A file touched in a commit, with line change counts.
-#[derive(Debug, Clone, Serialize)]
-pub(crate) struct FileChange {
-    pub(crate) path: String,
-    pub(crate) additions: u64,
-    pub(crate) deletions: u64,
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 // Re-export shared commit/file types from rskim-search so heatmap modules
 // use a single canonical definition (eliminates the local duplicate).
-pub(crate) use rskim_search::{CommitInfo as CommitRecord, FileChangeInfo as FileChange};
+pub(crate) use rskim_search::{CommitInfo, FileChangeInfo};
 
 // ============================================================================
 // CLI configuration


### PR DESCRIPTION
## Summary

- Adds `rskim-search::temporal` module with `GixSource`, a pure-Rust gix 0.72 git history parser implementing the new `TemporalSource` trait
- Introduces canonical shared types (`CommitInfo`, `FileChangeInfo`, `HistoryResult`, `TemporalMetadata`) and `is_fix_commit()` predicate in `rskim-search`
- Migrates `skim heatmap` from its local `CommitRecord`/`FileChange` duplicates to the shared types, eliminating the duplication

## Key Changes

**New: `rskim-search/src/temporal/`**
- `GixSource`: stateless `Send + Sync` git parser using `gix::discover()` → `rev_walk()` with `ByCommitTimeCutoff` for efficient lookback filtering and `Tree::changes().for_each_to_obtain_tree()` for per-commit file tracking
- `is_fix_commit()`: word-boundary anchored regex for fix/bug/hotfix/patch/revert keywords, compiled once via `once_cell::sync::Lazy`
- 24 co-located tests covering empty repos, multi-commit ordering, lookback filtering, file tracking (additions, deletions), metadata, fix classification, and type/trait safety

**Updated: `rskim-search/src/types.rs`**
- `CommitInfo` / `FileChangeInfo` / `HistoryResult` / `TemporalMetadata` structs
- `TemporalSource` trait (object-safe, `Send + Sync`)
- `SearchError::Git(String)` variant

**Updated: `rskim/src/cmd/heatmap/`**
- `types.rs`: removes local `CommitRecord`/`FileChange` structs; re-exports `CommitInfo as CommitRecord` and `FileChangeInfo as FileChange` from `rskim_search`
- `git_source.rs` / `metrics.rs` / `mod.rs`: updated field names (`message`, `changed_files`, `i64` timestamps, `PathBuf` paths)

## Breaking Changes

None. The heatmap type aliases (`CommitRecord`, `FileChange`) preserve the existing public-facing names within the heatmap module.

## Reviewer Focus Areas

- `git_parser.rs`: gix API usage — especially `info.object()` returning `Commit` directly, `Tree::changes().for_each_to_obtain_tree()` closure, and `is_unborn_error()` message matching
- `types.rs`: `TemporalSource` trait object-safety (no generics, `Send + Sync` bounds)
- `heatmap/types.rs`: type alias approach — confirm it correctly bridges `CommitInfo` (i64 timestamp, PathBuf path) to the heatmap codebase (was u64 timestamp, String path)