### PR TITLE
feat(#193): custom field mapping for JSON/YAML/TOML/Markdown (Wave 1g)

### DIFF
--- a/crates/rskim-search/src/fields/fields_tests.rs
+++ b/crates/rskim-search/src/fields/fields_tests.rs
@@ -1,0 +1,701 @@
+//! Tests for format-specific field classifiers (JSON, YAML, TOML, Markdown).
+//!
+//! Written in TDD order: tests were written before production code.
+//! Tests cover the contract invariants plus format-specific field mapping.
+
+#![allow(clippy::unwrap_used)]
+
+use std::ops::Range;
+
+use crate::SearchField;
+use crate::lexical::classify_source;
+
+use super::serde_fields::{classify_json, classify_toml, classify_yaml};
+
+// ============================================================================
+// Contract helpers
+// ============================================================================
+
+/// Assert that ranges cover the full source length without gaps or overlaps.
+fn assert_contiguous(ranges: &[(Range<usize>, SearchField)], len: usize) {
+    if len == 0 {
+        assert!(
+            ranges.is_empty(),
+            "empty source should produce empty ranges, got: {ranges:?}"
+        );
+        return;
+    }
+    let mut expected = 0usize;
+    for (range, _) in ranges {
+        assert_eq!(
+            range.start, expected,
+            "gap at {expected}: range starts at {}; full ranges: {ranges:?}",
+            range.start
+        );
+        assert!(
+            range.end > range.start,
+            "range must be non-empty; got {range:?}"
+        );
+        expected = range.end;
+    }
+    assert_eq!(
+        expected, len,
+        "ranges do not cover full source: covered {expected}, source len {len}; ranges: {ranges:?}"
+    );
+}
+
+/// Assert that the sum of range lengths equals source_len.
+fn assert_field_lengths_sum(ranges: &[(Range<usize>, SearchField)], len: usize) {
+    let total: usize = ranges.iter().map(|(r, _)| r.end - r.start).sum();
+    assert_eq!(
+        total, len,
+        "sum of range lengths {total} != source len {len}"
+    );
+}
+
+/// Returns true if any range has the given field.
+fn has_field(ranges: &[(Range<usize>, SearchField)], field: SearchField) -> bool {
+    ranges.iter().any(|(_, f)| *f == field)
+}
+
+/// Collect the source text slices for all ranges matching the given field.
+fn field_text<'a>(
+    source: &'a str,
+    ranges: &[(Range<usize>, SearchField)],
+    field: SearchField,
+) -> Vec<&'a str> {
+    ranges
+        .iter()
+        .filter(|(_, f)| *f == field)
+        .map(|(r, _)| &source[r.clone()])
+        .collect()
+}
+
+// ============================================================================
+// JSON tests
+// ============================================================================
+
+/// F-JSON-01: simple object — key is SymbolName, value is StringLiteral.
+#[test]
+fn f_json_01_key_is_symbol_name_value_is_string_literal() {
+    let source = r#"{"name": "skim"}"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+
+    let key_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        key_texts.iter().any(|t| t.contains("name")),
+        "key 'name' should be SymbolName; symbol texts: {key_texts:?}; ranges: {ranges:?}"
+    );
+
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("skim")),
+        "value 'skim' should be StringLiteral; string texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-JSON-02: depth-0 key whose value is an object → TypeDefinition.
+#[test]
+fn f_json_02_depth0_key_with_object_value_is_type_definition() {
+    let source = r#"{"deps": {"serde": "1.0"}}"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("deps")),
+        "'deps' should be TypeDefinition (depth-0, value is object); type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-JSON-03: depth-0 key with scalar value → SymbolName, NOT TypeDefinition.
+#[test]
+fn f_json_03_depth0_key_with_scalar_value_is_symbol_name() {
+    let source = r#"{"name": "skim"}"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+
+    // "name" has a scalar string value, so it must NOT be TypeDefinition.
+    assert!(
+        !has_field(&ranges, SearchField::TypeDefinition),
+        "'name' with scalar value must NOT produce TypeDefinition; ranges: {ranges:?}"
+    );
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("name")),
+        "'name' must be SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-JSON-04: key and value with escaped quotes — must not panic, must be contiguous.
+#[test]
+fn f_json_04_escaped_quotes_no_panic() {
+    let source = r#"{"key": "val with \"quotes\""}"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+}
+
+/// F-JSON-05: empty object → contiguous (all Other).
+#[test]
+fn f_json_05_empty_object_all_other() {
+    let source = "{}";
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+}
+
+/// F-JSON-06: deep nesting — root key is TypeDefinition, inner keys are SymbolName.
+#[test]
+fn f_json_06_deep_nesting_root_type_def_inner_symbol() {
+    let source = r#"{"a":{"b":{"c":"deep"}}}"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+
+    // "a" at depth 0 with object value → TypeDefinition
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("a")),
+        "'a' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+
+    // Inner keys "b", "c" → SymbolName
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("b")) || sym_texts.iter().any(|t| t.contains("c")),
+        "inner keys should be SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-JSON-07: array at root — keys inside array objects are SymbolName (not TypeDefinition).
+#[test]
+fn f_json_07_array_at_root_keys_are_symbol_name() {
+    let source = r#"[{"id": 1}, {"id": 2}]"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+
+    // Inside array-at-root, no keys should be TypeDefinition.
+    assert!(
+        !has_field(&ranges, SearchField::TypeDefinition),
+        "keys inside root array must NOT be TypeDefinition; ranges: {ranges:?}"
+    );
+}
+
+/// F-JSON-08: non-string values (numbers, booleans) are Other.
+#[test]
+fn f_json_08_non_string_values_are_other() {
+    let source = r#"{"key": 42, "flag": true}"#;
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+    // Just verifies it doesn't panic and is contiguous.
+}
+
+// ============================================================================
+// YAML tests
+// ============================================================================
+
+/// F-YAML-01: top-level key is TypeDefinition, nested key is SymbolName.
+#[test]
+fn f_yaml_01_top_level_type_def_nested_symbol_name() {
+    let source = "database:\n  host: localhost\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("database")),
+        "'database' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("host")),
+        "'host' should be SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-YAML-02: comment line is classified as Comment.
+#[test]
+fn f_yaml_02_comment_line_is_comment() {
+    let source = "# comment\nkey: val\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::Comment),
+        "comment line should produce Comment field; ranges: {ranges:?}"
+    );
+}
+
+/// F-YAML-03: quoted string value is StringLiteral.
+#[test]
+fn f_yaml_03_quoted_string_value_is_string_literal() {
+    let source = "name: \"skim\"\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("skim")),
+        "quoted value 'skim' should be StringLiteral; str texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-YAML-04: multi-level nesting — root TypeDefinition, deeper keys SymbolName.
+#[test]
+fn f_yaml_04_multi_level_nesting() {
+    let source = "a:\n  b:\n    c: val\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("a")),
+        "'a' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("b")) || sym_texts.iter().any(|t| t.contains("c")),
+        "nested keys should be SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-YAML-05: multi-document separators handled gracefully.
+#[test]
+fn f_yaml_05_multi_doc_separators() {
+    let source = "---\ntitle: test\n---\nother: val\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+}
+
+/// F-YAML-06: list item key is SymbolName, parent key is TypeDefinition.
+#[test]
+fn f_yaml_06_list_parent_type_def_item_key_symbol() {
+    let source = "items:\n  - name: foo\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("items")),
+        "'items' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+// ============================================================================
+// TOML tests
+// ============================================================================
+
+/// F-TOML-01: [package] header is TypeDefinition, key is SymbolName, value is StringLiteral.
+#[test]
+fn f_toml_01_section_header_key_value() {
+    let source = "[package]\nname = \"skim\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+
+    // [package] → TypeDefinition
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("package")),
+        "'[package]' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+
+    // name → SymbolName
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("name")),
+        "'name' should be SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+
+    // "skim" → StringLiteral
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("skim")),
+        "'skim' should be StringLiteral; str texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-02: [[bin]] array header is TypeDefinition.
+#[test]
+fn f_toml_02_array_section_type_def() {
+    let source = "[[bin]]\nname = \"skim\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let type_def_texts = field_text(source, &ranges, SearchField::TypeDefinition);
+    assert!(
+        type_def_texts.iter().any(|t| t.contains("bin")),
+        "'[[bin]]' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-03: comment line is Comment.
+#[test]
+fn f_toml_03_comment_line() {
+    let source = "# Config\n[db]\nurl = \"pg\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::Comment),
+        "'# Config' should be Comment; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-04: inline comment after value is Comment.
+#[test]
+fn f_toml_04_inline_comment() {
+    let source = "[db]\nurl = \"pg\" # inline\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let comment_texts = field_text(source, &ranges, SearchField::Comment);
+    assert!(
+        comment_texts.iter().any(|t| t.contains("inline")),
+        "inline comment should be Comment; comment texts: {comment_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-05: dotted key is SymbolName.
+#[test]
+fn f_toml_05_dotted_key_is_symbol_name() {
+    let source = "a.b.c = \"val\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("a.b.c")),
+        "'a.b.c' should be SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-06: AC-4 acceptance test — section, key, and long string value.
+#[test]
+fn f_toml_06_acceptance_test() {
+    let source = "[database]\ndatabase_url = \"postgres://localhost/mydb\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "should have TypeDefinition for [database]; ranges: {ranges:?}"
+    );
+    assert!(
+        has_field(&ranges, SearchField::SymbolName),
+        "should have SymbolName for key; ranges: {ranges:?}"
+    );
+    assert!(
+        has_field(&ranges, SearchField::StringLiteral),
+        "should have StringLiteral for URL value; ranges: {ranges:?}"
+    );
+}
+
+// ============================================================================
+// Markdown tests
+// ============================================================================
+
+use super::markdown::classify_markdown;
+
+/// F-MD-01: H1 heading is TypeDefinition, body text is Comment.
+#[test]
+fn f_md_01_h1_type_def_body_comment() {
+    let source = "# Title\n\nBody text.\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "H1 should be TypeDefinition; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-02: H3 heading is TypeDefinition.
+#[test]
+fn f_md_02_h3_type_def() {
+    let source = "### H3\n\nText.\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "H3 should be TypeDefinition; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-03: H4 heading is NOT TypeDefinition (Other).
+#[test]
+fn f_md_03_h4_is_not_type_def() {
+    let source = "#### H4\n\nText.\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    // H4 must not produce TypeDefinition — it maps to Other.
+    assert!(
+        !has_field(&ranges, SearchField::TypeDefinition),
+        "H4 must NOT be TypeDefinition; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-04: fenced code block is FunctionBody.
+#[test]
+fn f_md_04_fenced_code_block_is_function_body() {
+    let source = "# T\n\n```rust\nfn f(){}\n```\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::FunctionBody),
+        "fenced code block should be FunctionBody; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-05: link reference definition is ImportExport.
+#[test]
+fn f_md_05_link_ref_def_is_import_export() {
+    let source = "# T\n\n[ref]: https://example.com\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::ImportExport),
+        "link reference definition should be ImportExport; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-06: setext H1 heading is TypeDefinition.
+#[test]
+fn f_md_06_setext_h1_type_def() {
+    let source = "Title\n=====\n\nBody.\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "setext H1 should be TypeDefinition; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-07: blockquote is Comment.
+#[test]
+fn f_md_07_blockquote_is_comment() {
+    let source = "# T\n\n> quote text\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::Comment),
+        "blockquote should be Comment; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-08: list items are Comment.
+#[test]
+fn f_md_08_list_is_comment() {
+    let source = "# T\n\n- item 1\n- item 2\n";
+    let ranges = classify_markdown(source).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::Comment),
+        "list should be Comment; ranges: {ranges:?}"
+    );
+}
+
+// ============================================================================
+// Contract tests (apply to all serde scanners)
+// ============================================================================
+
+/// C-01: JSON output is sorted.
+#[test]
+fn c_01_json_sorted() {
+    let source = r#"{"a":"1","b":"2","c":"3"}"#;
+    let ranges = classify_json(source);
+    for i in 0..ranges.len().saturating_sub(1) {
+        assert!(
+            ranges[i].0.start <= ranges[i + 1].0.start,
+            "ranges not sorted at index {i}; ranges: {ranges:?}"
+        );
+    }
+}
+
+/// C-02: YAML output is non-overlapping.
+#[test]
+fn c_02_yaml_non_overlapping() {
+    let source = "a:\n  b: c\nd: e\n";
+    let ranges = classify_yaml(source);
+    for i in 0..ranges.len().saturating_sub(1) {
+        assert_eq!(
+            ranges[i].0.end,
+            ranges[i + 1].0.start,
+            "overlap or gap at index {i}; ranges: {ranges:?}"
+        );
+    }
+}
+
+/// C-03: TOML output is contiguous.
+#[test]
+fn c_03_toml_contiguous() {
+    let source = "[pkg]\nname = \"x\"\nversion = \"1.0\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+}
+
+/// C-04: empty JSON source → empty Vec.
+#[test]
+fn c_04_empty_json_empty_vec() {
+    let ranges = classify_json("");
+    assert!(
+        ranges.is_empty(),
+        "empty JSON source should return empty Vec; got: {ranges:?}"
+    );
+}
+
+/// C-05: empty YAML source → empty Vec.
+#[test]
+fn c_05_empty_yaml_empty_vec() {
+    let ranges = classify_yaml("");
+    assert!(
+        ranges.is_empty(),
+        "empty YAML source should return empty Vec; got: {ranges:?}"
+    );
+}
+
+/// C-06: empty TOML source → empty Vec.
+#[test]
+fn c_06_empty_toml_empty_vec() {
+    let ranges = classify_toml("");
+    assert!(
+        ranges.is_empty(),
+        "empty TOML source should return empty Vec; got: {ranges:?}"
+    );
+}
+
+/// C-07: malformed JSON does not panic, returns valid contiguous output.
+#[test]
+fn c_07_malformed_json_no_panic() {
+    let source = "{bad json!!}";
+    let ranges = classify_json(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+}
+
+/// C-08: malformed YAML does not panic, returns valid contiguous output.
+#[test]
+fn c_08_malformed_yaml_no_panic() {
+    let source = ": this is weird\n  :\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+}
+
+/// C-09: malformed TOML does not panic, returns valid contiguous output.
+#[test]
+fn c_09_malformed_toml_no_panic() {
+    let source = "[invalid\nkey = = = value\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+}
+
+/// C-10: scanners are infallible (classify_json/yaml/toml return Vec, not Result).
+/// This is a compile-time property, verified by calling them without error handling.
+#[test]
+fn c_10_scanners_infallible() {
+    let _j = classify_json("{}");
+    let _y = classify_yaml("key: val\n");
+    let _t = classify_toml("[s]\nk = \"v\"\n");
+    // If they compiled and ran without errors, the test passes.
+}
+
+// ============================================================================
+// Integration tests (through classify_source dispatch)
+// ============================================================================
+
+/// I-01: classify_source dispatches JSON to the format-specific scanner.
+#[test]
+fn i_01_classify_source_json_dispatch() {
+    let source = r#"{"name": "skim"}"#;
+    let ranges = classify_source(source, rskim_core::Language::Json).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    // With format-specific classification, JSON should no longer be all-Other.
+    // At minimum, the key "name" should be SymbolName.
+    assert!(
+        has_field(&ranges, SearchField::SymbolName),
+        "JSON classify_source should produce SymbolName for key; ranges: {ranges:?}"
+    );
+}
+
+/// I-02: classify_source dispatches YAML to the format-specific scanner.
+#[test]
+fn i_02_classify_source_yaml_dispatch() {
+    let source = "host: localhost\n";
+    let ranges = classify_source(source, rskim_core::Language::Yaml).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition) || has_field(&ranges, SearchField::SymbolName),
+        "YAML classify_source should produce TypeDefinition or SymbolName; ranges: {ranges:?}"
+    );
+}
+
+/// I-03: classify_source dispatches TOML to the format-specific scanner.
+#[test]
+fn i_03_classify_source_toml_dispatch() {
+    let source = "[package]\nname = \"skim\"\n";
+    let ranges = classify_source(source, rskim_core::Language::Toml).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "TOML classify_source should produce TypeDefinition for section; ranges: {ranges:?}"
+    );
+}
+
+/// I-04: classify_source dispatches Markdown to the format-specific scanner.
+#[test]
+fn i_04_classify_source_markdown_dispatch() {
+    let source = "# Title\n\nBody.\n";
+    let ranges = classify_source(source, rskim_core::Language::Markdown).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "Markdown classify_source should produce TypeDefinition for H1; ranges: {ranges:?}"
+    );
+}
+
+/// I-05: classify_source still works correctly for tree-sitter languages.
+#[test]
+fn i_05_classify_source_rust_unchanged() {
+    let source = "struct Foo { x: u32 }";
+    let ranges = classify_source(source, rskim_core::Language::Rust).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "Rust struct should still have TypeDefinition; ranges: {ranges:?}"
+    );
+}
+
+/// I-06: Markdown is now dispatched to the tree-sitter-based classifier.
+///
+/// Verifies that classify_source for Markdown produces non-trivial field
+/// classification (not all-Other) for a document with a heading.
+#[test]
+fn i_06_classify_source_markdown_produces_type_def_for_heading() {
+    let source = "## Section\n\nContent.\n";
+    let ranges = classify_source(source, rskim_core::Language::Markdown).unwrap();
+    assert_contiguous(&ranges, source.len());
+
+    assert!(
+        has_field(&ranges, SearchField::TypeDefinition),
+        "Markdown H2 should produce TypeDefinition via classify_source; ranges: {ranges:?}"
+    );
+}

--- a/crates/rskim-search/src/fields/fields_tests.rs
+++ b/crates/rskim-search/src/fields/fields_tests.rs
@@ -192,6 +192,36 @@ fn f_json_08_non_string_values_are_other() {
     // Just verifies it doesn't panic and is contiguous.
 }
 
+/// F-JSON-09: JSON nested beyond MAX_JSON_DEPTH (1024) does not panic and
+/// produces contiguous output covering the full source.
+///
+/// Exercises the asymmetry guard in the `}` handler: braces beyond the cap
+/// must not pop entries from shallower scopes.
+#[test]
+fn f_json_09_depth_beyond_max_json_depth_cap() {
+    // Build a JSON object nested to 1025 levels (one past MAX_JSON_DEPTH).
+    let depth = 1025usize;
+    let mut source = String::with_capacity(depth * 2 + 20);
+    // Opening braces with a key at the innermost level.
+    for _ in 0..depth {
+        source.push('{');
+    }
+    source.push_str(r#""k":"v""#);
+    for _ in 0..depth {
+        source.push('}');
+    }
+
+    let ranges = classify_json(&source);
+    // Must not panic and output must be contiguous.
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+    // Output must not be empty (at minimum the key/value strings are classified).
+    assert!(
+        !ranges.is_empty(),
+        "ranges must not be empty for deeply nested JSON; ranges: {ranges:?}"
+    );
+}
+
 // ============================================================================
 // YAML tests
 // ============================================================================
@@ -284,6 +314,41 @@ fn f_yaml_06_list_parent_type_def_item_key_symbol() {
         type_def_texts.iter().any(|t| t.contains("items")),
         "'items' should be TypeDefinition; type_def texts: {type_def_texts:?}; ranges: {ranges:?}"
     );
+}
+
+/// F-YAML-07: quoted string value StringLiteral range excludes the trailing newline byte.
+///
+/// The scanner explicitly trims `\n` (and `\r` for CRLF) so the newline is not
+/// boosted with StringLiteral weight in BM25F scoring.
+#[test]
+fn f_yaml_07_quoted_string_excludes_trailing_newline() {
+    let source = "key: \"value\"\n";
+    let ranges = classify_yaml(source);
+    assert_contiguous(&ranges, source.len());
+
+    // Find the StringLiteral range.
+    let str_ranges: Vec<_> = ranges
+        .iter()
+        .filter(|(_, f)| *f == SearchField::StringLiteral)
+        .collect();
+    assert!(
+        !str_ranges.is_empty(),
+        "expected a StringLiteral range; ranges: {ranges:?}"
+    );
+
+    for (r, _) in &str_ranges {
+        let last_byte = source.as_bytes()[r.end - 1];
+        assert_ne!(
+            last_byte, b'\n',
+            "StringLiteral range must not end with \\n; range: {r:?}, text: {:?}",
+            &source[r.clone()]
+        );
+        assert_ne!(
+            last_byte, b'\r',
+            "StringLiteral range must not end with \\r; range: {r:?}, text: {:?}",
+            &source[r.clone()]
+        );
+    }
 }
 
 // ============================================================================
@@ -459,6 +524,26 @@ fn f_toml_10_triple_single_quote_backslash_literal() {
     );
 }
 
+/// F-TOML-11: quoted TOML key containing `=` is classified as a single SymbolName.
+///
+/// `find_toml_eq_sign` skips over `=` inside double-quoted key strings.
+/// This test exercises that backslash-escape-aware path.
+#[test]
+fn f_toml_11_escaped_eq_in_quoted_key() {
+    // TOML spec: quoted keys may contain any characters including `=`.
+    // The `=` inside the quotes must NOT be treated as the key-value separator.
+    let source = "\"path=here\" = \"value\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+
+    let sym_texts = field_text(source, &ranges, SearchField::SymbolName);
+    assert!(
+        sym_texts.iter().any(|t| t.contains("path=here")),
+        "quoted key with '=' inside must be a single SymbolName; sym texts: {sym_texts:?}; ranges: {ranges:?}"
+    );
+}
+
 // ============================================================================
 // Markdown tests
 // ============================================================================
@@ -567,6 +652,34 @@ fn f_md_08_list_is_comment() {
     assert!(
         has_field(&ranges, SearchField::Comment),
         "list should be Comment; ranges: {ranges:?}"
+    );
+}
+
+/// F-MD-09: classify_markdown's own size guard fires before tree-sitter work.
+///
+/// The Markdown classifier has an independent `MAX_SOURCE_BYTES` check (lines
+/// 50-55 of markdown.rs) separate from the dispatcher guard in `classify_source`.
+/// This test calls `classify_markdown` directly with a source that is exactly one
+/// byte over the limit and verifies that `SearchError::FileTooLarge` is returned
+/// with the correct `size` and `limit` values.
+///
+/// The input is a flat space-padded string; the size check fires before any
+/// tree-sitter parsing, so this does not cause a slow parse.
+#[test]
+fn f_md_09_size_guard_returns_file_too_large() {
+    use crate::lexical::classifier::MAX_SOURCE_BYTES;
+    use crate::SearchError;
+
+    let oversized = " ".repeat(MAX_SOURCE_BYTES + 1);
+    let err = classify_markdown(&oversized)
+        .expect_err("classify_markdown must return Err for sources over MAX_SOURCE_BYTES");
+
+    assert!(
+        matches!(err, SearchError::FileTooLarge { size, limit }
+            if size == MAX_SOURCE_BYTES + 1 && limit == MAX_SOURCE_BYTES),
+        "expected FileTooLarge {{ size: {}, limit: {} }}, got: {err:?}",
+        MAX_SOURCE_BYTES + 1,
+        MAX_SOURCE_BYTES,
     );
 }
 

--- a/crates/rskim-search/src/fields/fields_tests.rs
+++ b/crates/rskim-search/src/fields/fields_tests.rs
@@ -640,7 +640,8 @@ fn i_02_classify_source_yaml_dispatch() {
     assert_contiguous(&ranges, source.len());
 
     assert!(
-        has_field(&ranges, SearchField::TypeDefinition) || has_field(&ranges, SearchField::SymbolName),
+        has_field(&ranges, SearchField::TypeDefinition)
+            || has_field(&ranges, SearchField::SymbolName),
         "YAML classify_source should produce TypeDefinition or SymbolName; ranges: {ranges:?}"
     );
 }

--- a/crates/rskim-search/src/fields/fields_tests.rs
+++ b/crates/rskim-search/src/fields/fields_tests.rs
@@ -657,11 +657,11 @@ fn f_md_08_list_is_comment() {
 
 /// F-MD-09: classify_markdown's own size guard fires before tree-sitter work.
 ///
-/// The Markdown classifier has an independent `MAX_SOURCE_BYTES` check (lines
-/// 50-55 of markdown.rs) separate from the dispatcher guard in `classify_source`.
-/// This test calls `classify_markdown` directly with a source that is exactly one
-/// byte over the limit and verifies that `SearchError::FileTooLarge` is returned
-/// with the correct `size` and `limit` values.
+/// The Markdown classifier has an independent `MAX_SOURCE_BYTES` check separate
+/// from the dispatcher guard in `classify_source`. This test calls
+/// `classify_markdown` directly with a source that is exactly one byte over the
+/// limit and verifies that `SearchError::FileTooLarge` is returned with the
+/// correct `size` and `limit` values.
 ///
 /// The input is a flat space-padded string; the size check fires before any
 /// tree-sitter parsing, so this does not cause a slow parse.

--- a/crates/rskim-search/src/fields/fields_tests.rs
+++ b/crates/rskim-search/src/fields/fields_tests.rs
@@ -339,12 +339,14 @@ fn f_yaml_07_quoted_string_excludes_trailing_newline() {
     for (r, _) in &str_ranges {
         let last_byte = source.as_bytes()[r.end - 1];
         assert_ne!(
-            last_byte, b'\n',
+            last_byte,
+            b'\n',
             "StringLiteral range must not end with \\n; range: {r:?}, text: {:?}",
             &source[r.clone()]
         );
         assert_ne!(
-            last_byte, b'\r',
+            last_byte,
+            b'\r',
             "StringLiteral range must not end with \\r; range: {r:?}, text: {:?}",
             &source[r.clone()]
         );
@@ -667,8 +669,8 @@ fn f_md_08_list_is_comment() {
 /// tree-sitter parsing, so this does not cause a slow parse.
 #[test]
 fn f_md_09_size_guard_returns_file_too_large() {
-    use crate::lexical::classifier::MAX_SOURCE_BYTES;
     use crate::SearchError;
+    use crate::lexical::classifier::MAX_SOURCE_BYTES;
 
     let oversized = " ".repeat(MAX_SOURCE_BYTES + 1);
     let err = classify_markdown(&oversized)

--- a/crates/rskim-search/src/fields/fields_tests.rs
+++ b/crates/rskim-search/src/fields/fields_tests.rs
@@ -396,6 +396,69 @@ fn f_toml_06_acceptance_test() {
     );
 }
 
+/// F-TOML-07: triple-double-quote basic multi-line string is StringLiteral.
+#[test]
+fn f_toml_07_triple_double_quote_is_string_literal() {
+    let source = "desc = \"\"\"\nline one\nline two\n\"\"\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("line one")),
+        "triple-double-quote value should be StringLiteral; str texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-08: triple-single-quote literal multi-line string is StringLiteral.
+#[test]
+fn f_toml_08_triple_single_quote_is_string_literal() {
+    let source = "desc = '''\nline one\nline two\n'''\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("line one")),
+        "triple-single-quote value should be StringLiteral; str texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-09: triple-double-quote string with embedded quotes inside.
+#[test]
+fn f_toml_09_triple_double_quote_with_embedded_quotes() {
+    // A triple-double-quoted string may contain `"` and `""` without terminating.
+    let source = "msg = \"\"\"\nHe said \"hello\" to me.\n\"\"\"\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("hello")),
+        "embedded quotes inside triple-double-quote should remain StringLiteral; str texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
+/// F-TOML-10: triple-single-quote string with embedded backslash (treated literally, not as escape).
+#[test]
+fn f_toml_10_triple_single_quote_backslash_literal() {
+    // In TOML literal strings (single-quoted), backslash is NOT an escape.
+    // This also holds for triple-single-quoted strings.
+    let source = "path = '''\nC:\\Users\\skim\n'''\n";
+    let ranges = classify_toml(source);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+
+    let str_texts = field_text(source, &ranges, SearchField::StringLiteral);
+    assert!(
+        str_texts.iter().any(|t| t.contains("skim")),
+        "backslash in triple-single-quote should be literal, content still StringLiteral; str texts: {str_texts:?}; ranges: {ranges:?}"
+    );
+}
+
 // ============================================================================
 // Markdown tests
 // ============================================================================

--- a/crates/rskim-search/src/fields/markdown.rs
+++ b/crates/rskim-search/src/fields/markdown.rs
@@ -1,0 +1,147 @@
+//! Tree-sitter-based field classifier for Markdown documents.
+//!
+//! Uses the `rskim_core` parser (tree-sitter-md grammar) to produce
+//! byte-range classifications for headings, code blocks, prose, and link
+//! reference definitions.
+//!
+//! # Field mapping
+//!
+//! | Node kind | Field |
+//! |-----------|-------|
+//! | `atx_heading` (H1–H3) | [`SearchField::TypeDefinition`] |
+//! | `atx_heading` (H4+) | [`SearchField::Other`] |
+//! | `setext_heading` (always H1 or H2) | [`SearchField::TypeDefinition`] |
+//! | `fenced_code_block` / `indented_code_block` / `code_fence_content` | [`SearchField::FunctionBody`] |
+//! | `paragraph` / `list` / `list_item` / `block_quote` | [`SearchField::Comment`] |
+//! | `link_reference_definition` | [`SearchField::ImportExport`] |
+//! | Everything else | [`SearchField::Other`] |
+//!
+//! # Error fallback
+//!
+//! If the tree-sitter parser fails to initialise (e.g., grammar not compiled),
+//! the entire source is returned as a single `Other` range. This mirrors the
+//! behaviour of [`crate::lexical::classifier`] for unsupported languages.
+
+use std::ops::Range;
+
+use rskim_core::Language;
+
+use crate::SearchField;
+use crate::lexical::classifier::build_field_ranges;
+
+/// Classify byte ranges in a Markdown source string using tree-sitter.
+///
+/// Returns a sorted, non-overlapping, contiguous `Vec` of
+/// `(Range<usize>, SearchField)` tuples covering every byte `0..source.len()`.
+///
+/// # Errors
+///
+/// Returns [`crate::SearchError`] only if the size guard in
+/// [`crate::lexical::classifier::classify_source`] fires. The Markdown parser
+/// itself is fault-tolerant — syntax errors produce error nodes rather than
+/// parse failures.
+pub(crate) fn classify_markdown(
+    source: &str,
+) -> crate::Result<Vec<(Range<usize>, SearchField)>> {
+    if source.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let len = source.len();
+
+    // Attempt to parse with the Markdown grammar. If the parser cannot be
+    // initialised (grammar missing), return a single Other range.
+    let mut parser = match rskim_core::Parser::new(Language::Markdown) {
+        Ok(p) => p,
+        Err(_) => {
+            return Ok(vec![(0..len, SearchField::Other)]);
+        }
+    };
+
+    let tree = match parser.parse(source) {
+        Ok(t) => t,
+        Err(_) => {
+            return Ok(vec![(0..len, SearchField::Other)]);
+        }
+    };
+
+    let root = tree.root_node();
+    let bytes = source.as_bytes();
+
+    // Collect non-Other node ranges in pre-order (same pattern as classify_source).
+    let mut node_ranges: Vec<(Range<usize>, SearchField)> = Vec::new();
+    let mut cursor = root.walk();
+
+    loop {
+        let node = cursor.node();
+        let byte_range = node.byte_range();
+
+        let start = byte_range.start.min(len);
+        let end = byte_range.end.min(len);
+
+        if start < end {
+            let kind = node.kind();
+            let field = map_markdown_kind(kind, bytes, start, len);
+            if field != SearchField::Other {
+                node_ranges.push((start..end, field));
+            }
+        }
+
+        // Advance in pre-order.
+        if cursor.goto_first_child() {
+            continue;
+        }
+        loop {
+            if cursor.goto_next_sibling() {
+                break;
+            }
+            if !cursor.goto_parent() {
+                return Ok(build_field_ranges(node_ranges, len));
+            }
+        }
+    }
+}
+
+/// Map a Markdown tree-sitter node kind to a [`SearchField`].
+///
+/// For `atx_heading`, counts the leading `#` characters to determine heading
+/// level: 1–3 → TypeDefinition, 4+ → Other.
+///
+/// `bytes` is the full source as bytes; `start` is the node's start byte offset.
+fn map_markdown_kind(kind: &str, bytes: &[u8], start: usize, source_len: usize) -> SearchField {
+    match kind {
+        "atx_heading" => {
+            // Count leading `#` chars to determine heading level.
+            let level = count_atx_heading_level(bytes, start, source_len);
+            if (1..=3).contains(&level) {
+                SearchField::TypeDefinition
+            } else {
+                SearchField::Other
+            }
+        }
+        "setext_heading" => {
+            // Setext headings are always H1 (underline `===`) or H2 (underline `---`).
+            SearchField::TypeDefinition
+        }
+        "fenced_code_block" | "indented_code_block" | "code_fence_content" => {
+            SearchField::FunctionBody
+        }
+        "paragraph" | "list" | "list_item" | "block_quote" => SearchField::Comment,
+        "link_reference_definition" => SearchField::ImportExport,
+        // document, section, html_block, thematic_break, and everything else → Other (skip).
+        _ => SearchField::Other,
+    }
+}
+
+/// Count the number of leading `#` characters in an ATX heading node.
+///
+/// Skips the heading's start in `bytes` and counts consecutive `#` bytes.
+fn count_atx_heading_level(bytes: &[u8], start: usize, len: usize) -> usize {
+    let mut count = 0;
+    let mut i = start;
+    while i < len && bytes[i] == b'#' {
+        count += 1;
+        i += 1;
+    }
+    count
+}

--- a/crates/rskim-search/src/fields/markdown.rs
+++ b/crates/rskim-search/src/fields/markdown.rs
@@ -40,9 +40,7 @@ use crate::lexical::classifier::build_field_ranges;
 /// [`crate::lexical::classifier::classify_source`] fires. The Markdown parser
 /// itself is fault-tolerant — syntax errors produce error nodes rather than
 /// parse failures.
-pub(crate) fn classify_markdown(
-    source: &str,
-) -> crate::Result<Vec<(Range<usize>, SearchField)>> {
+pub(crate) fn classify_markdown(source: &str) -> crate::Result<Vec<(Range<usize>, SearchField)>> {
     if source.is_empty() {
         return Ok(Vec::new());
     }

--- a/crates/rskim-search/src/fields/markdown.rs
+++ b/crates/rskim-search/src/fields/markdown.rs
@@ -47,6 +47,13 @@ pub(crate) fn classify_markdown(source: &str) -> crate::Result<Vec<(Range<usize>
 
     let len = source.len();
 
+    if len > crate::lexical::classifier::MAX_SOURCE_BYTES {
+        return Err(crate::SearchError::FileTooLarge {
+            size: len,
+            limit: crate::lexical::classifier::MAX_SOURCE_BYTES,
+        });
+    }
+
     // Attempt to parse with the Markdown grammar. If the parser cannot be
     // initialised (grammar missing), return a single Other range.
     let mut parser = match rskim_core::Parser::new(Language::Markdown) {

--- a/crates/rskim-search/src/fields/mod.rs
+++ b/crates/rskim-search/src/fields/mod.rs
@@ -1,0 +1,90 @@
+//! Format-specific byte-range classifiers for non-tree-sitter formats and Markdown.
+//!
+//! # Module layout
+//!
+//! - [`serde_fields`] — Lightweight scanners for JSON, YAML, and TOML. All are
+//!   **infallible** (return `Vec`, not `Result`) and use only `std`.
+//! - [`markdown`] — Tree-sitter-based classifier for Markdown headings, code
+//!   blocks, and prose. Returns `Result` but catches parser errors via fallback.
+//!
+//! # Shared helper
+//!
+//! [`fill_gaps_and_merge`] is the shared post-processing step for the serde
+//! scanners: it sorts their non-overlapping, non-contiguous ranges, fills gaps
+//! with `SearchField::Other`, and coalesces adjacent same-field ranges.
+//!
+//! Markdown uses [`crate::lexical::classifier::build_field_ranges`] directly
+//! (the tree-sitter "innermost wins" algorithm) because it may receive
+//! overlapping parent/child node ranges.
+
+use std::ops::Range;
+
+use crate::SearchField;
+
+pub(crate) mod markdown;
+pub(crate) mod serde_fields;
+
+#[cfg(test)]
+#[path = "fields_tests.rs"]
+mod tests;
+
+/// Fill gaps between classified ranges with [`SearchField::Other`] and merge
+/// adjacent same-field ranges.
+///
+/// This is the shared post-processing step for serde scanners (JSON, YAML,
+/// TOML). Their byte-range outputs are:
+/// - Non-overlapping (each scanner never emits overlapping ranges)
+/// - Non-contiguous (gaps between classified regions exist and must be filled)
+///
+/// The function:
+/// 1. Sorts `ranges` by start position.
+/// 2. Inserts `Other` ranges for every uncovered byte span.
+/// 3. Calls [`crate::lexical::classifier::merge_adjacent`] to coalesce
+///    adjacent ranges that share the same field.
+///
+/// # Preconditions
+/// - `ranges` must be non-overlapping (caller responsibility).
+/// - All `Range` values must be within `0..source_len`.
+///
+/// # Output invariants
+/// - Sorted ascending by `range.start`.
+/// - Non-overlapping.
+/// - Contiguous: covers every byte `0..source_len`.
+/// - For `source_len == 0`, returns an empty `Vec`.
+pub(crate) fn fill_gaps_and_merge(
+    mut ranges: Vec<(Range<usize>, SearchField)>,
+    source_len: usize,
+) -> Vec<(Range<usize>, SearchField)> {
+    if source_len == 0 {
+        return Vec::new();
+    }
+
+    // Sort by start position so we can do a single linear gap-fill pass.
+    ranges.sort_unstable_by_key(|(r, _)| r.start);
+
+    let mut result: Vec<(Range<usize>, SearchField)> = Vec::with_capacity(ranges.len() * 2 + 1);
+    let mut cursor = 0usize;
+
+    for (range, field) in ranges {
+        // Clamp to source bounds (safety against rounding errors in scanners).
+        let start = range.start.min(source_len);
+        let end = range.end.min(source_len);
+        if start >= end {
+            continue;
+        }
+        if cursor < start {
+            // Gap before this range → fill with Other.
+            result.push((cursor..start, SearchField::Other));
+        }
+        result.push((start..end, field));
+        cursor = end;
+    }
+
+    // Trailing gap → fill with Other.
+    if cursor < source_len {
+        result.push((cursor..source_len, SearchField::Other));
+    }
+
+    crate::lexical::classifier::merge_adjacent(&mut result);
+    result
+}

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -86,11 +86,9 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 i += 1;
             }
             b'}' => {
-                // Guard pop symmetrically with the push: only pop when the
-                // matching `{` was shallow enough to have pushed an entry.
-                // brace_depth > MAX_JSON_DEPTH means the opening `{` did NOT push,
-                // so do not pop. Check BEFORE saturating_sub so the comparison
-                // is against the depth at which the `{` was processed.
+                // Only pop if we pushed: opening braces beyond MAX_JSON_DEPTH
+                // do not push, so closing ones must not pop. Check before
+                // saturating_sub so the comparison uses the pre-decrement depth.
                 if brace_depth <= MAX_JSON_DEPTH {
                     in_key_stack.pop();
                 }
@@ -183,9 +181,7 @@ fn classify_json_key_at_depth0(bytes: &[u8], after_key: usize, len: usize) -> Se
 #[inline]
 fn skip_json_whitespace(bytes: &[u8], pos: usize, len: usize) -> usize {
     let mut i = pos;
-    while i < len
-        && (bytes[i] == b' ' || bytes[i] == b'\t' || bytes[i] == b'\n' || bytes[i] == b'\r')
-    {
+    while i < len && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
         i += 1;
     }
     i
@@ -347,7 +343,7 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                     let first_val_byte = bytes[actual_val_start];
                     if first_val_byte == b'"' || first_val_byte == b'\'' {
                         // Quoted string value → StringLiteral.
-                        // Trim the trailing newline so the '\n' byte is not boosted
+                        // Trim trailing \n and \r so line-ending bytes are not boosted
                         // with StringLiteral weight, which would skew BM25F scores.
                         // Inline comment detection is not implemented: values like
                         // "http://x.com # not a comment" would cause false positives.
@@ -356,8 +352,6 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                         if str_end > actual_val_start && bytes[str_end - 1] == b'\n' {
                             str_end -= 1;
                         }
-                        // Also strip \r for Windows-style \r\n line endings, consistent
-                        // with CRLF handling elsewhere in this scanner.
                         if str_end > actual_val_start && bytes[str_end - 1] == b'\r' {
                             str_end -= 1;
                         }

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -56,6 +56,11 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
 
     let mut ranges: Vec<(Range<usize>, SearchField)> = Vec::new();
 
+    // Maximum nesting depth tracked on `in_key_stack`. Beyond this depth we
+    // still parse correctly (brace_depth keeps counting) but stop pushing new
+    // entries to avoid unbounded heap growth on pathologically deep input.
+    const MAX_JSON_DEPTH: usize = 1024;
+
     // Stack-based depth tracking:
     // - brace_depth: count of currently open `{` objects
     // - bracket_depth: count of currently open `[` arrays
@@ -65,7 +70,7 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
     //   * flips back to true after `,` or `{`
     let mut brace_depth: usize = 0;
     let mut bracket_depth: usize = 0;
-    let mut in_key_stack: Vec<bool> = Vec::new(); // one entry per `{` opened
+    let mut in_key_stack: Vec<bool> = Vec::new(); // one entry per `{` opened (up to MAX_JSON_DEPTH)
     let mut i = 0;
 
     while i < len {
@@ -74,7 +79,10 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
             b'{' => {
                 brace_depth += 1;
                 // Start of an object: next token expected is a key (or `}`).
-                in_key_stack.push(true);
+                // Only track state up to MAX_JSON_DEPTH to bound heap usage.
+                if brace_depth <= MAX_JSON_DEPTH {
+                    in_key_stack.push(true);
+                }
                 i += 1;
             }
             b'}' => {
@@ -341,10 +349,18 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                     let first_val_byte = bytes[actual_val_start];
                     if first_val_byte == b'"' || first_val_byte == b'\'' {
                         // Quoted string value → StringLiteral.
+                        // Trim the trailing newline so the '\n' byte is not boosted
+                        // with StringLiteral weight, which would skew BM25F scores.
                         // Inline comment detection is not implemented: values like
                         // "http://x.com # not a comment" would cause false positives.
                         // TODO: YAML spec coverage — inline comment classification.
-                        ranges.push((actual_val_start..line_end, SearchField::StringLiteral));
+                        let mut str_end = line_end;
+                        if str_end > actual_val_start && bytes[str_end - 1] == b'\n' {
+                            str_end -= 1;
+                        }
+                        if str_end > actual_val_start {
+                            ranges.push((actual_val_start..str_end, SearchField::StringLiteral));
+                        }
                     }
                     // Unquoted values (scalars, flow indicators) → Other (gap fill).
                 }
@@ -432,7 +448,7 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
             b'#' => {
                 // Full-line comment.
                 ranges.push((i..eol, SearchField::Comment));
-                i = eol + 1;
+                i = (eol + 1).min(len);
                 continue;
             }
             b'[' => {
@@ -447,7 +463,7 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                     // Malformed — skip to EOL.
                     ranges.push((header_start..header_end, SearchField::TypeDefinition));
                 }
-                i = eol + 1;
+                i = (eol + 1).min(len);
                 continue;
             }
             _ => {
@@ -486,7 +502,7 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 }
                 // Advance to end of line (classify_toml_value may have advanced `i` for multi-line strings).
                 if i <= eol {
-                    i = eol + 1;
+                    i = (eol + 1).min(len);
                 }
             }
         }
@@ -587,8 +603,17 @@ fn classify_toml_inline_comment(
 fn find_toml_eq_sign(content: &[u8]) -> Option<usize> {
     let mut in_str = false;
     let mut str_char = b'"';
-    for (i, &b) in content.iter().enumerate() {
+    let mut i = 0;
+    while i < content.len() {
+        let b = content[i];
         if in_str {
+            // Handle backslash escape inside double-quoted strings only.
+            // Single-quoted TOML literal strings treat backslash as literal.
+            if b == b'\\' && str_char == b'"' {
+                // Skip the escaped character entirely.
+                i += 2;
+                continue;
+            }
             if b == str_char {
                 in_str = false;
             }
@@ -603,6 +628,7 @@ fn find_toml_eq_sign(content: &[u8]) -> Option<usize> {
                 _ => {}
             }
         }
+        i += 1;
     }
     None
 }

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -126,7 +126,12 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
                         let after_key = str_end;
                         let mut j = after_key;
                         // Skip whitespace
-                        while j < len && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r') {
+                        while j < len
+                            && (bytes[j] == b' '
+                                || bytes[j] == b'\t'
+                                || bytes[j] == b'\n'
+                                || bytes[j] == b'\r')
+                        {
                             j += 1;
                         }
                         // Skip colon
@@ -134,7 +139,12 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
                             j += 1;
                         }
                         // Skip whitespace
-                        while j < len && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r') {
+                        while j < len
+                            && (bytes[j] == b' '
+                                || bytes[j] == b'\t'
+                                || bytes[j] == b'\n'
+                                || bytes[j] == b'\r')
+                        {
                             j += 1;
                         }
                         // Check if next char is `{` or `[`
@@ -276,15 +286,20 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
         // --- List items: `- ` or `- ` then key/value on same line
         // List item lines can have an inline key: `  - name: foo`
         // We strip the `- ` prefix and re-classify the remainder.
-        let (eff_indent, eff_rest_start, eff_rest) = if rest.starts_with(b"- ") || rest == b"-\n" || rest == b"-\r\n" || rest == b"-" {
-            let list_item_offset = if rest.len() >= 2 && rest[1] == b' ' { 2 } else { 1 };
-            let new_rest_start = rest_start + list_item_offset;
-            let new_rest = &bytes[new_rest_start..line_end];
-            // List items get an effective indent of indent + 1 (nested under the list key).
-            (indent + 1, new_rest_start, new_rest)
-        } else {
-            (indent, rest_start, rest)
-        };
+        let (eff_indent, eff_rest_start, eff_rest) =
+            if rest.starts_with(b"- ") || rest == b"-\n" || rest == b"-\r\n" || rest == b"-" {
+                let list_item_offset = if rest.len() >= 2 && rest[1] == b' ' {
+                    2
+                } else {
+                    1
+                };
+                let new_rest_start = rest_start + list_item_offset;
+                let new_rest = &bytes[new_rest_start..line_end];
+                // List items get an effective indent of indent + 1 (nested under the list key).
+                (indent + 1, new_rest_start, new_rest)
+            } else {
+                (indent, rest_start, rest)
+            };
 
         // --- Key detection: look for `: ` or `:\n` or `:\r\n` or end-of-line-colon.
         // We need to find the key text and the colon position.
@@ -301,7 +316,12 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
 
             // Trim trailing whitespace from key.
             let key_text = &bytes[key_start..key_end];
-            let trimmed_end = key_end - key_text.iter().rev().take_while(|&&b| b == b' ' || b == b'\t').count();
+            let trimmed_end = key_end
+                - key_text
+                    .iter()
+                    .rev()
+                    .take_while(|&&b| b == b' ' || b == b'\t')
+                    .count();
             if trimmed_end > key_start {
                 ranges.push((key_start..trimmed_end, key_field));
             }
@@ -311,7 +331,10 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
             if value_start_rel < eff_rest.len() {
                 let value_bytes = &eff_rest[value_start_rel..];
                 // Skip leading space after colon.
-                let space_skip = value_bytes.iter().take_while(|&&b| b == b' ' || b == b'\t').count();
+                let space_skip = value_bytes
+                    .iter()
+                    .take_while(|&&b| b == b' ' || b == b'\t')
+                    .count();
                 let actual_val_start = eff_rest_start + value_start_rel + space_skip;
 
                 if actual_val_start < line_end {
@@ -394,7 +417,11 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
         }
 
         // Find end of line.
-        let eol = bytes[i..].iter().position(|&b| b == b'\n').map(|p| i + p).unwrap_or(len);
+        let eol = bytes[i..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| i + p)
+            .unwrap_or(len);
 
         match bytes[i] {
             b'\n' | b'\r' => {
@@ -431,7 +458,12 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                     // Key: from i to eq_abs (trimming trailing whitespace).
                     let key_end = eq_abs;
                     let key_text = &bytes[i..key_end];
-                    let trimmed_key_end = key_end - key_text.iter().rev().take_while(|&&b| b == b' ' || b == b'\t').count();
+                    let trimmed_key_end = key_end
+                        - key_text
+                            .iter()
+                            .rev()
+                            .take_while(|&&b| b == b' ' || b == b'\t')
+                            .count();
                     if trimmed_key_end > i {
                         ranges.push((i..trimmed_key_end, SearchField::SymbolName));
                     }
@@ -441,7 +473,10 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                     if val_region_start < eol {
                         let val_bytes = &bytes[val_region_start..eol];
                         // Skip leading whitespace.
-                        let ws_skip = val_bytes.iter().take_while(|&&b| b == b' ' || b == b'\t').count();
+                        let ws_skip = val_bytes
+                            .iter()
+                            .take_while(|&&b| b == b' ' || b == b'\t')
+                            .count();
                         let val_start = val_region_start + ws_skip;
 
                         if val_start < eol {
@@ -499,7 +534,8 @@ fn classify_toml_value(
         }
         b'\'' => {
             // Check for triple-quote (literal string).
-            if bytes.get(val_start + 1) == Some(&b'\'') && bytes.get(val_start + 2) == Some(&b'\'') {
+            if bytes.get(val_start + 1) == Some(&b'\'') && bytes.get(val_start + 2) == Some(&b'\'')
+            {
                 let end = scan_triple_quote(bytes, val_start, b'\'', len);
                 ranges.push((val_start..end, SearchField::StringLiteral));
                 *i = end;
@@ -535,7 +571,8 @@ fn classify_toml_inline_comment(
         if b == b'#' {
             let hash_abs = from + j;
             // Make sure it's preceded by whitespace (not inside a string or URL).
-            let preceded_by_ws = hash_abs == 0 || bytes[hash_abs - 1] == b' ' || bytes[hash_abs - 1] == b'\t';
+            let preceded_by_ws =
+                hash_abs == 0 || bytes[hash_abs - 1] == b' ' || bytes[hash_abs - 1] == b'\t';
             if preceded_by_ws {
                 ranges.push((hash_abs..eol, SearchField::Comment));
                 return;

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -1,0 +1,661 @@
+//! Lightweight byte-range scanners for JSON, YAML, and TOML.
+//!
+//! All functions are **infallible**: they accept `&str` and return
+//! `Vec<(Range<usize>, SearchField)>` without `Result`. Invalid or
+//! malformed input degrades gracefully — the output is always a valid,
+//! contiguous, sorted range list.
+//!
+//! # JSON scanner
+//!
+//! Byte-by-byte state machine tracking brace/bracket depth and
+//! key-vs-value position. String values are scanned with
+//! [`scan_json_string`] which handles `\"`, `\\`, and `\uXXXX` escapes.
+//!
+//! # YAML scanner
+//!
+//! Line-by-line scanner. Only block-style YAML is classified; flow-style
+//! falls to Other.
+//!
+//! Documented scope limitations (inline TODO comments):
+//! - Flow-style `{key: value}` → Other
+//! - Multi-line scalars `|`, `>` → continuation lines fall to Other
+//! - Anchors `&name` / aliases `*name` → fall to Other
+//! - Complex keys `? key\n: value` → fall to Other
+//!
+//! # TOML scanner
+//!
+//! Line-by-line scanner handling `[section]` headers, `[[array]]` headers,
+//! `key = value` lines, `# comments`, dotted keys, and multi-line strings.
+
+use std::ops::Range;
+
+use crate::SearchField;
+
+use super::fill_gaps_and_merge;
+
+// ============================================================================
+// JSON scanner
+// ============================================================================
+
+/// Classify byte ranges in a JSON source string.
+///
+/// Field mapping:
+/// - Depth-0 key whose value is `{` or `[` → [`SearchField::TypeDefinition`]
+/// - Other keys → [`SearchField::SymbolName`]
+/// - String values → [`SearchField::StringLiteral`]
+/// - Everything else (numbers, booleans, null, structural chars) → [`SearchField::Other`]
+///
+/// The output satisfies all contiguity invariants via [`fill_gaps_and_merge`].
+pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+
+    let mut ranges: Vec<(Range<usize>, SearchField)> = Vec::new();
+
+    // Stack-based depth tracking:
+    // - brace_depth: count of currently open `{` objects
+    // - bracket_depth: count of currently open `[` arrays
+    // - in_key: true when we expect to read a key (vs. a value) at current depth
+    //   * starts true at object open `{`
+    //   * flips to false after reading the key's `:` separator
+    //   * flips back to true after `,` or `{`
+    let mut brace_depth: usize = 0;
+    let mut bracket_depth: usize = 0;
+    let mut in_key_stack: Vec<bool> = Vec::new(); // one entry per `{` opened
+    let mut i = 0;
+
+    while i < len {
+        let b = bytes[i];
+        match b {
+            b'{' => {
+                brace_depth += 1;
+                // Start of an object: next token expected is a key (or `}`).
+                in_key_stack.push(true);
+                i += 1;
+            }
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                in_key_stack.pop();
+                i += 1;
+            }
+            b'[' => {
+                bracket_depth += 1;
+                i += 1;
+            }
+            b']' => {
+                bracket_depth = bracket_depth.saturating_sub(1);
+                i += 1;
+            }
+            b':' => {
+                // Separator between key and value: flip to "expecting value".
+                if let Some(top) = in_key_stack.last_mut() {
+                    *top = false;
+                }
+                i += 1;
+            }
+            b',' => {
+                // After a value: flip back to "expecting key" if we're in an object.
+                if let Some(top) = in_key_stack.last_mut() {
+                    *top = true;
+                }
+                i += 1;
+            }
+            b'"' => {
+                // String token: scan to the end of the string.
+                let str_start = i;
+                let str_end = scan_json_string(bytes, i);
+
+                let in_key = in_key_stack.last().copied().unwrap_or(false);
+                let in_object = !in_key_stack.is_empty();
+                // bracket_depth > 0 means we're inside an array.
+                let inside_array_at_root = bracket_depth > 0 && brace_depth <= bracket_depth;
+
+                if in_object && in_key {
+                    // Key string: determine whether this should be TypeDefinition or SymbolName.
+                    // TypeDefinition: depth-0 key (brace_depth == 1) AND value is object/array.
+                    // We determine this by looking ahead past whitespace after the colon.
+                    // The current position is the key's opening quote, so we need to check
+                    // what follows the closing quote + colon + whitespace.
+                    let field = if brace_depth == 1 && !inside_array_at_root {
+                        // Look ahead: skip past this string, whitespace, colon, whitespace
+                        // to see if the next char is `{` or `[`.
+                        let after_key = str_end;
+                        let mut j = after_key;
+                        // Skip whitespace
+                        while j < len && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r') {
+                            j += 1;
+                        }
+                        // Skip colon
+                        if j < len && bytes[j] == b':' {
+                            j += 1;
+                        }
+                        // Skip whitespace
+                        while j < len && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r') {
+                            j += 1;
+                        }
+                        // Check if next char is `{` or `[`
+                        if j < len && (bytes[j] == b'{' || bytes[j] == b'[') {
+                            SearchField::TypeDefinition
+                        } else {
+                            SearchField::SymbolName
+                        }
+                    } else {
+                        SearchField::SymbolName
+                    };
+                    ranges.push((str_start..str_end, field));
+                } else {
+                    // Value string → StringLiteral.
+                    ranges.push((str_start..str_end, SearchField::StringLiteral));
+                }
+
+                i = str_end;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    fill_gaps_and_merge(ranges, len)
+}
+
+/// Scan a JSON string starting at `pos` (the opening `"`).
+///
+/// Returns the byte index **after** the closing `"`. Handles:
+/// - `\"` escaped quotes
+/// - `\\` escaped backslashes
+/// - `\uXXXX` unicode escapes
+/// - End-of-input (unterminated string) → returns `bytes.len()`
+fn scan_json_string(bytes: &[u8], pos: usize) -> usize {
+    debug_assert!(pos < bytes.len() && bytes[pos] == b'"');
+    let len = bytes.len();
+    let mut i = pos + 1; // skip opening `"`
+    while i < len {
+        match bytes[i] {
+            b'"' => {
+                return i + 1; // past closing `"`
+            }
+            b'\\' => {
+                // Skip the escape character and the escaped character.
+                i += 1;
+                if i < len {
+                    if bytes[i] == b'u' {
+                        // \uXXXX: skip 4 hex digits (if present).
+                        i += 1;
+                        let end = (i + 4).min(len);
+                        i = end;
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    // Unterminated string.
+    len
+}
+
+// ============================================================================
+// YAML scanner
+// ============================================================================
+
+/// Classify byte ranges in a YAML source string (block-style only).
+///
+/// Field mapping:
+/// - Indent-0 keys → [`SearchField::TypeDefinition`]
+/// - Indent-1+ keys → [`SearchField::SymbolName`]
+/// - Quoted string values after `:` → [`SearchField::StringLiteral`]
+/// - `#` comments → [`SearchField::Comment`]
+/// - Multi-document `---` and `...` markers → Other
+/// - List items `- item` → Other (content is value, not key)
+///
+/// # Scope limitations
+///
+/// - Flow-style `{key: value}` → falls to Other
+///   (TODO: YAML spec coverage — flow-style mapping classification not implemented)
+/// - Multi-line scalars `|`, `>` → continuation lines fall to Other
+///   (TODO: YAML spec coverage — literal/folded block scalar continuation)
+/// - Anchors `&name` / aliases `*name` → fall to Other
+///   (TODO: YAML spec coverage — anchor/alias classification)
+/// - Complex keys `? key\n: value` → fall to Other
+///   (TODO: YAML spec coverage — complex key classification)
+pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut ranges: Vec<(Range<usize>, SearchField)> = Vec::new();
+
+    let mut line_start = 0usize;
+
+    while line_start < len {
+        // Find end of line.
+        let line_end = bytes[line_start..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| line_start + p + 1) // include the newline
+            .unwrap_or(len);
+
+        let line = &bytes[line_start..line_end];
+        let line_len = line_end - line_start;
+
+        // Calculate indent (leading spaces).
+        let indent = line.iter().take_while(|&&b| b == b' ').count();
+        let rest_start = line_start + indent;
+        let rest = &bytes[rest_start..line_end];
+
+        // Skip blank lines.
+        if rest.is_empty() || rest[0] == b'\n' || rest[0] == b'\r' {
+            line_start = line_end;
+            continue;
+        }
+
+        // --- Full-line comment (# at start of content).
+        if rest[0] == b'#' {
+            // Classify the entire comment from `#` to end of line.
+            ranges.push((rest_start..line_end, SearchField::Comment));
+            line_start = line_end;
+            continue;
+        }
+
+        // --- Multi-document markers: `---` or `...`
+        if rest.starts_with(b"---") || rest.starts_with(b"...") {
+            // Leave as Other (gap fill).
+            line_start = line_end;
+            continue;
+        }
+
+        // --- List items: `- ` or `- ` then key/value on same line
+        // List item lines can have an inline key: `  - name: foo`
+        // We strip the `- ` prefix and re-classify the remainder.
+        let (eff_indent, eff_rest_start, eff_rest) = if rest.starts_with(b"- ") || rest == b"-\n" || rest == b"-\r\n" || rest == b"-" {
+            let list_item_offset = if rest.len() >= 2 && rest[1] == b' ' { 2 } else { 1 };
+            let new_rest_start = rest_start + list_item_offset;
+            let new_rest = &bytes[new_rest_start..line_end];
+            // List items get an effective indent of indent + 1 (nested under the list key).
+            (indent + 1, new_rest_start, new_rest)
+        } else {
+            (indent, rest_start, rest)
+        };
+
+        // --- Key detection: look for `: ` or `:\n` or `:\r\n` or end-of-line-colon.
+        // We need to find the key text and the colon position.
+        if let Some(colon_rel) = find_yaml_key_colon(eff_rest) {
+            let key_start = eff_rest_start;
+            let key_end = eff_rest_start + colon_rel;
+
+            // Key field based on effective indent.
+            let key_field = if eff_indent == 0 {
+                SearchField::TypeDefinition
+            } else {
+                SearchField::SymbolName
+            };
+
+            // Trim trailing whitespace from key.
+            let key_text = &bytes[key_start..key_end];
+            let trimmed_end = key_end - key_text.iter().rev().take_while(|&&b| b == b' ' || b == b'\t').count();
+            if trimmed_end > key_start {
+                ranges.push((key_start..trimmed_end, key_field));
+            }
+
+            // Look for a value on the same line after the colon.
+            let value_start_rel = colon_rel + 1; // skip `:`
+            if value_start_rel < eff_rest.len() {
+                let value_bytes = &eff_rest[value_start_rel..];
+                // Skip leading space after colon.
+                let space_skip = value_bytes.iter().take_while(|&&b| b == b' ' || b == b'\t').count();
+                let actual_val_start = eff_rest_start + value_start_rel + space_skip;
+
+                if actual_val_start < line_end {
+                    let remaining = &bytes[actual_val_start..line_end];
+                    // Check for inline comment.
+                    let val_content_end = find_yaml_inline_comment_start(remaining, actual_val_start, line_end);
+
+                    if actual_val_start < val_content_end {
+                        let first_val_byte = bytes[actual_val_start];
+                        if first_val_byte == b'"' || first_val_byte == b'\'' {
+                            // Quoted string value → StringLiteral.
+                            ranges.push((actual_val_start..val_content_end, SearchField::StringLiteral));
+                        }
+                        // Unquoted values (scalars, flow indicators) → Other (gap fill).
+                    }
+
+                    // Classify inline comment if present.
+                    if val_content_end < line_end {
+                        // Find the `#` position.
+                        let comment_content = &bytes[val_content_end..line_end];
+                        if let Some(hash_rel) = comment_content.iter().position(|&b| b == b'#') {
+                            let hash_abs = val_content_end + hash_rel;
+                            ranges.push((hash_abs..line_end, SearchField::Comment));
+                        }
+                    }
+                }
+            }
+        }
+
+        line_start = line_end;
+        let _ = line_len;
+    }
+
+    fill_gaps_and_merge(ranges, len)
+}
+
+/// Find the position of the `:` in a YAML key on a line's content bytes.
+///
+/// Returns `Some(offset)` where `offset` is the byte offset of `:` within
+/// `line_content`. Returns `None` if no YAML key colon is found.
+///
+/// A YAML key colon is `:` followed by space, tab, newline, `\r`, or end of
+/// content. This avoids false positives on URLs (`http://example.com`).
+fn find_yaml_key_colon(line_content: &[u8]) -> Option<usize> {
+    for (i, &b) in line_content.iter().enumerate() {
+        if b == b':' {
+            let next = line_content.get(i + 1).copied();
+            match next {
+                None | Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') => {
+                    return Some(i);
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+/// Find the start of an inline YAML comment within a value region.
+///
+/// Returns the absolute byte offset of the `#` that starts the comment, or
+/// `line_end` if no inline comment is present.
+///
+/// A YAML inline comment is ` #` (space + hash) that is not inside a quoted
+/// string. This is a simplified heuristic: it looks for ` #` that is not
+/// preceded by an odd number of quote characters.
+fn find_yaml_inline_comment_start(
+    _remaining: &[u8],
+    val_start: usize,
+    line_end: usize,
+) -> usize {
+    // Simplified: trim trailing whitespace+newline from value region.
+    // Inline comments would need more state to handle properly inside quotes.
+    // For now, return line_end to mark the entire value as content.
+    // This avoids false positives on values like "http://x.com # not a comment".
+    let _ = (val_start, line_end); // suppress unused warnings
+    line_end
+}
+
+// ============================================================================
+// TOML scanner
+// ============================================================================
+
+/// Classify byte ranges in a TOML source string.
+///
+/// Field mapping:
+/// - `[section]` headers → [`SearchField::TypeDefinition`]
+/// - `[[array]]` headers → [`SearchField::TypeDefinition`]
+/// - Keys (including dotted keys like `a.b.c`) → [`SearchField::SymbolName`]
+/// - Quoted string values (`"..."`, `'...'`) → [`SearchField::StringLiteral`]
+/// - `# comments` → [`SearchField::Comment`]
+/// - Everything else → [`SearchField::Other`]
+///
+/// Multi-line strings (`"""..."""`, `'''...'''`) are scanned to their closing
+/// delimiter and the entire span is classified as [`SearchField::StringLiteral`].
+pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut ranges: Vec<(Range<usize>, SearchField)> = Vec::new();
+
+    let mut i = 0usize;
+
+    while i < len {
+        // Skip leading whitespace on the current line.
+        let line_start = i;
+        // Skip spaces/tabs.
+        while i < len && (bytes[i] == b' ' || bytes[i] == b'\t') {
+            i += 1;
+        }
+
+        if i >= len {
+            break;
+        }
+
+        // Find end of line.
+        let eol = bytes[i..].iter().position(|&b| b == b'\n').map(|p| i + p).unwrap_or(len);
+
+        match bytes[i] {
+            b'\n' | b'\r' => {
+                // Blank line — advance.
+                i += 1;
+                continue;
+            }
+            b'#' => {
+                // Full-line comment.
+                ranges.push((i..eol, SearchField::Comment));
+                i = eol + 1;
+                continue;
+            }
+            b'[' => {
+                // Section header: `[section]` or `[[array]]`.
+                let header_start = i;
+                let header_end = eol;
+                // Find the closing `]` (or `]]`).
+                if let Some(close) = bytes[i..eol].iter().rposition(|&b| b == b']') {
+                    let close_abs = i + close + 1;
+                    ranges.push((header_start..close_abs, SearchField::TypeDefinition));
+                } else {
+                    // Malformed — skip to EOL.
+                    ranges.push((header_start..header_end, SearchField::TypeDefinition));
+                }
+                i = eol + 1;
+                continue;
+            }
+            _ => {
+                // Possibly a key = value line.
+                // Find the `=` sign (but not inside a string).
+                if let Some(eq_rel) = find_toml_eq_sign(&bytes[i..eol]) {
+                    let eq_abs = i + eq_rel;
+                    // Key: from i to eq_abs (trimming trailing whitespace).
+                    let key_end = eq_abs;
+                    let key_text = &bytes[i..key_end];
+                    let trimmed_key_end = key_end - key_text.iter().rev().take_while(|&&b| b == b' ' || b == b'\t').count();
+                    if trimmed_key_end > i {
+                        ranges.push((i..trimmed_key_end, SearchField::SymbolName));
+                    }
+
+                    // Value: from eq_abs+1 to eol.
+                    let val_region_start = eq_abs + 1;
+                    if val_region_start < eol {
+                        let val_bytes = &bytes[val_region_start..eol];
+                        // Skip leading whitespace.
+                        let ws_skip = val_bytes.iter().take_while(|&&b| b == b' ' || b == b'\t').count();
+                        let val_start = val_region_start + ws_skip;
+
+                        if val_start < eol {
+                            classify_toml_value(bytes, val_start, eol, len, &mut ranges, &mut i);
+                        }
+                    }
+                }
+                // Advance to end of line (classify_toml_value may have advanced `i` for multi-line strings).
+                if i <= eol {
+                    i = eol + 1;
+                }
+            }
+        }
+
+        let _ = line_start;
+    }
+
+    fill_gaps_and_merge(ranges, len)
+}
+
+/// Classify a TOML value starting at `val_start` within the source bytes.
+///
+/// Handles:
+/// - Triple-quoted strings (`"""..."""`, `'''...'''`) — multi-line, scan to closing delimiter.
+/// - Single-quoted strings (`"..."`, `'...'`) — single-line.
+/// - Inline comments (`# ...`) after the value.
+/// - Non-string values (numbers, booleans, etc.) — left as gaps (Other).
+fn classify_toml_value(
+    bytes: &[u8],
+    val_start: usize,
+    eol: usize,
+    len: usize,
+    ranges: &mut Vec<(Range<usize>, SearchField)>,
+    i: &mut usize,
+) {
+    if val_start >= len {
+        return;
+    }
+
+    let b = bytes[val_start];
+
+    match b {
+        b'"' => {
+            // Check for triple-quote.
+            if bytes.get(val_start + 1) == Some(&b'"') && bytes.get(val_start + 2) == Some(&b'"') {
+                // Multi-line basic string.
+                let end = scan_triple_quote(bytes, val_start, b'"', len);
+                ranges.push((val_start..end, SearchField::StringLiteral));
+                *i = end;
+            } else {
+                // Single-line basic string.
+                let end = scan_single_quote_toml(bytes, val_start, b'"', len);
+                ranges.push((val_start..end, SearchField::StringLiteral));
+                // Look for inline comment.
+                classify_toml_inline_comment(bytes, end, eol, ranges);
+            }
+        }
+        b'\'' => {
+            // Check for triple-quote (literal string).
+            if bytes.get(val_start + 1) == Some(&b'\'') && bytes.get(val_start + 2) == Some(&b'\'') {
+                let end = scan_triple_quote(bytes, val_start, b'\'', len);
+                ranges.push((val_start..end, SearchField::StringLiteral));
+                *i = end;
+            } else {
+                // Single-line literal string.
+                let end = scan_single_quote_toml(bytes, val_start, b'\'', len);
+                ranges.push((val_start..end, SearchField::StringLiteral));
+                classify_toml_inline_comment(bytes, end, eol, ranges);
+            }
+        }
+        b'#' => {
+            // Value is actually a comment (rare: `key = # comment`).
+            ranges.push((val_start..eol, SearchField::Comment));
+        }
+        _ => {
+            // Non-string value (number, boolean, datetime, inline table, array).
+            // Look for an inline comment.
+            classify_toml_inline_comment(bytes, val_start, eol, ranges);
+        }
+    }
+}
+
+/// Find an inline `# comment` after a value region and classify it.
+fn classify_toml_inline_comment(
+    bytes: &[u8],
+    from: usize,
+    eol: usize,
+    ranges: &mut Vec<(Range<usize>, SearchField)>,
+) {
+    // Look for ` #` pattern (space + hash) between `from` and `eol`.
+    let region = &bytes[from..eol];
+    for (j, &b) in region.iter().enumerate() {
+        if b == b'#' {
+            let hash_abs = from + j;
+            // Make sure it's preceded by whitespace (not inside a string or URL).
+            let preceded_by_ws = hash_abs == 0 || bytes[hash_abs - 1] == b' ' || bytes[hash_abs - 1] == b'\t';
+            if preceded_by_ws {
+                ranges.push((hash_abs..eol, SearchField::Comment));
+                return;
+            }
+        }
+    }
+}
+
+/// Find the `=` sign in a TOML key-value line content (not inside a string).
+///
+/// Returns the byte offset of `=` within `content`, or `None` if not found.
+fn find_toml_eq_sign(content: &[u8]) -> Option<usize> {
+    let mut in_str = false;
+    let mut str_char = b'"';
+    for (i, &b) in content.iter().enumerate() {
+        if in_str {
+            if b == str_char {
+                in_str = false;
+            }
+        } else {
+            match b {
+                b'"' | b'\'' => {
+                    in_str = true;
+                    str_char = b;
+                }
+                b'=' => return Some(i),
+                b'#' => return None, // comment before `=` → not a key-value line
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+/// Scan a single-line TOML string (basic `"..."` or literal `'...'`).
+///
+/// Returns the byte offset after the closing delimiter.
+fn scan_single_quote_toml(bytes: &[u8], start: usize, delim: u8, len: usize) -> usize {
+    debug_assert!(start < len && bytes[start] == delim);
+    let mut i = start + 1;
+    while i < len {
+        let b = bytes[i];
+        if b == delim {
+            return i + 1;
+        }
+        if b == b'\\' && delim == b'"' {
+            // Skip escaped character.
+            i += 2;
+            continue;
+        }
+        if b == b'\n' {
+            // Unterminated single-line string.
+            return i;
+        }
+        i += 1;
+    }
+    len
+}
+
+/// Scan a multi-line TOML triple-quoted string to its closing `"""` or `'''`.
+///
+/// `start` is the position of the first `"` or `'` of the opening triple.
+/// Returns the byte offset after the closing triple delimiter.
+fn scan_triple_quote(bytes: &[u8], start: usize, delim: u8, len: usize) -> usize {
+    debug_assert!(
+        bytes.get(start) == Some(&delim)
+            && bytes.get(start + 1) == Some(&delim)
+            && bytes.get(start + 2) == Some(&delim)
+    );
+    let mut i = start + 3; // skip opening triple
+    while i + 2 < len {
+        if bytes[i] == delim && bytes[i + 1] == delim && bytes[i + 2] == delim {
+            return i + 3; // past closing triple
+        }
+        // Handle escape in basic strings.
+        if delim == b'"' && bytes[i] == b'\\' {
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    len
+}

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -125,42 +125,8 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 if in_object && in_key {
                     // Key string: determine whether this should be TypeDefinition or SymbolName.
                     // TypeDefinition: depth-0 key (brace_depth == 1) AND value is object/array.
-                    // We determine this by looking ahead past whitespace after the colon.
-                    // The current position is the key's opening quote, so we need to check
-                    // what follows the closing quote + colon + whitespace.
                     let field = if brace_depth == 1 && !inside_array_at_root {
-                        // Look ahead: skip past this string, whitespace, colon, whitespace
-                        // to see if the next char is `{` or `[`.
-                        let after_key = str_end;
-                        let mut j = after_key;
-                        // Skip whitespace
-                        while j < len
-                            && (bytes[j] == b' '
-                                || bytes[j] == b'\t'
-                                || bytes[j] == b'\n'
-                                || bytes[j] == b'\r')
-                        {
-                            j += 1;
-                        }
-                        // Skip colon
-                        if j < len && bytes[j] == b':' {
-                            j += 1;
-                        }
-                        // Skip whitespace
-                        while j < len
-                            && (bytes[j] == b' '
-                                || bytes[j] == b'\t'
-                                || bytes[j] == b'\n'
-                                || bytes[j] == b'\r')
-                        {
-                            j += 1;
-                        }
-                        // Check if next char is `{` or `[`
-                        if j < len && (bytes[j] == b'{' || bytes[j] == b'[') {
-                            SearchField::TypeDefinition
-                        } else {
-                            SearchField::SymbolName
-                        }
+                        classify_json_key_at_depth0(bytes, str_end, len)
                     } else {
                         SearchField::SymbolName
                     };
@@ -179,6 +145,40 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
     }
 
     fill_gaps_and_merge(ranges, len)
+}
+
+/// Determine the [`SearchField`] for a depth-0 JSON key by looking ahead past
+/// the closing quote, optional whitespace, colon, and optional whitespace to
+/// check whether the next character is `{` or `[`.
+///
+/// Returns [`SearchField::TypeDefinition`] if the value is an object or array,
+/// [`SearchField::SymbolName`] otherwise.
+///
+/// `after_key` is the byte index immediately after the key's closing `"`.
+fn classify_json_key_at_depth0(bytes: &[u8], after_key: usize, len: usize) -> SearchField {
+    let mut j = after_key;
+    // Skip whitespace before colon.
+    while j < len
+        && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r')
+    {
+        j += 1;
+    }
+    // Skip colon.
+    if j < len && bytes[j] == b':' {
+        j += 1;
+    }
+    // Skip whitespace after colon.
+    while j < len
+        && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r')
+    {
+        j += 1;
+    }
+    // If the next character opens an object or array, this key names a container.
+    if j < len && (bytes[j] == b'{' || bytes[j] == b'[') {
+        SearchField::TypeDefinition
+    } else {
+        SearchField::SymbolName
+    }
 }
 
 /// Scan a JSON string starting at `pos` (the opening `"`).
@@ -295,19 +295,7 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
         // List item lines can have an inline key: `  - name: foo`
         // We strip the `- ` prefix and re-classify the remainder.
         let (eff_indent, eff_rest_start, eff_rest) =
-            if rest.starts_with(b"- ") || rest == b"-\n" || rest == b"-\r\n" || rest == b"-" {
-                let list_item_offset = if rest.len() >= 2 && rest[1] == b' ' {
-                    2
-                } else {
-                    1
-                };
-                let new_rest_start = rest_start + list_item_offset;
-                let new_rest = &bytes[new_rest_start..line_end];
-                // List items get an effective indent of indent + 1 (nested under the list key).
-                (indent + 1, new_rest_start, new_rest)
-            } else {
-                (indent, rest_start, rest)
-            };
+            strip_list_prefix(bytes, indent, rest_start, rest, line_end);
 
         // --- Key detection: look for `: ` or `:\n` or `:\r\n` or end-of-line-colon.
         // We need to find the key text and the colon position.
@@ -371,6 +359,37 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
     }
 
     fill_gaps_and_merge(ranges, len)
+}
+
+/// Strip the YAML list-item prefix (`- ` or `-`) from a line's content bytes.
+///
+/// Returns `(effective_indent, effective_rest_start, effective_rest)`:
+/// - `effective_indent`: the indent level to use for key classification
+///   (incremented by 1 for list items so they are treated as nested)
+/// - `effective_rest_start`: absolute byte index of the content after the prefix
+/// - `effective_rest`: byte slice of the remaining line content
+///
+/// If the line does not start with a list prefix, the inputs are returned unchanged.
+fn strip_list_prefix<'a>(
+    bytes: &'a [u8],
+    indent: usize,
+    rest_start: usize,
+    rest: &'a [u8],
+    line_end: usize,
+) -> (usize, usize, &'a [u8]) {
+    if rest.starts_with(b"- ") || rest == b"-\n" || rest == b"-\r\n" || rest == b"-" {
+        let list_item_offset = if rest.len() >= 2 && rest[1] == b' ' {
+            2
+        } else {
+            1
+        };
+        let new_rest_start = rest_start + list_item_offset;
+        let new_rest = &bytes[new_rest_start..line_end];
+        // List items get an effective indent of indent + 1 (nested under the list key).
+        (indent + 1, new_rest_start, new_rest)
+    } else {
+        (indent, rest_start, rest)
+    }
 }
 
 /// Find the position of the `:` in a YAML key on a line's content bytes.

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -86,8 +86,15 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 i += 1;
             }
             b'}' => {
+                // Guard pop symmetrically with the push: only pop when the
+                // matching `{` was shallow enough to have pushed an entry.
+                // brace_depth > MAX_JSON_DEPTH means the opening `{` did NOT push,
+                // so do not pop. Check BEFORE saturating_sub so the comparison
+                // is against the depth at which the `{` was processed.
+                if brace_depth <= MAX_JSON_DEPTH {
+                    in_key_stack.pop();
+                }
                 brace_depth = brace_depth.saturating_sub(1);
-                in_key_stack.pop();
                 i += 1;
             }
             b'[' => {
@@ -157,28 +164,31 @@ pub(crate) fn classify_json(source: &str) -> Vec<(Range<usize>, SearchField)> {
 /// `after_key` is the byte index immediately after the key's closing `"`.
 fn classify_json_key_at_depth0(bytes: &[u8], after_key: usize, len: usize) -> SearchField {
     let mut j = after_key;
-    // Skip whitespace before colon.
-    while j < len
-        && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r')
-    {
-        j += 1;
-    }
-    // Skip colon.
+    j = skip_json_whitespace(bytes, j, len);
     if j < len && bytes[j] == b':' {
         j += 1;
     }
-    // Skip whitespace after colon.
-    while j < len
-        && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r')
-    {
-        j += 1;
-    }
-    // If the next character opens an object or array, this key names a container.
+    j = skip_json_whitespace(bytes, j, len);
     if j < len && (bytes[j] == b'{' || bytes[j] == b'[') {
         SearchField::TypeDefinition
     } else {
         SearchField::SymbolName
     }
+}
+
+/// Skip JSON whitespace (space, tab, newline, carriage-return) from `pos`.
+///
+/// Returns the index of the first non-whitespace byte, or `len` if the end
+/// of input is reached.
+#[inline]
+fn skip_json_whitespace(bytes: &[u8], pos: usize, len: usize) -> usize {
+    let mut i = pos;
+    while i < len
+        && (bytes[i] == b' ' || bytes[i] == b'\t' || bytes[i] == b'\n' || bytes[i] == b'\r')
+    {
+        i += 1;
+    }
+    i
 }
 
 /// Scan a JSON string starting at `pos` (the opening `"`).
@@ -346,6 +356,11 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                         if str_end > actual_val_start && bytes[str_end - 1] == b'\n' {
                             str_end -= 1;
                         }
+                        // Also strip \r for Windows-style \r\n line endings, consistent
+                        // with CRLF handling elsewhere in this scanner.
+                        if str_end > actual_val_start && bytes[str_end - 1] == b'\r' {
+                            str_end -= 1;
+                        }
                         if str_end > actual_val_start {
                             ranges.push((actual_val_start..str_end, SearchField::StringLiteral));
                         }
@@ -378,11 +393,7 @@ fn strip_list_prefix<'a>(
     line_end: usize,
 ) -> (usize, usize, &'a [u8]) {
     if rest.starts_with(b"- ") || rest == b"-\n" || rest == b"-\r\n" || rest == b"-" {
-        let list_item_offset = if rest.len() >= 2 && rest[1] == b' ' {
-            2
-        } else {
-            1
-        };
+        let list_item_offset = if rest.starts_with(b"- ") { 2 } else { 1 };
         let new_rest_start = rest_start + list_item_offset;
         let new_rest = &bytes[new_rest_start..line_end];
         // List items get an effective indent of indent + 1 (nested under the list key).
@@ -472,16 +483,13 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
             }
             b'[' => {
                 // Section header: `[section]` or `[[array]]`.
-                let header_start = i;
-                let header_end = eol;
-                // Find the closing `]` (or `]]`).
-                if let Some(close) = bytes[i..eol].iter().rposition(|&b| b == b']') {
-                    let close_abs = i + close + 1;
-                    ranges.push((header_start..close_abs, SearchField::TypeDefinition));
-                } else {
-                    // Malformed — skip to EOL.
-                    ranges.push((header_start..header_end, SearchField::TypeDefinition));
-                }
+                // Find the closing `]` (or `]]`); fall back to EOL for malformed input.
+                let header_end = bytes[i..eol]
+                    .iter()
+                    .rposition(|&b| b == b']')
+                    .map(|close| i + close + 1)
+                    .unwrap_or(eol);
+                ranges.push((i..header_end, SearchField::TypeDefinition));
                 i = (eol + 1).min(len);
                 continue;
             }
@@ -490,11 +498,9 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 // Find the `=` sign (but not inside a string).
                 if let Some(eq_rel) = find_toml_eq_sign(&bytes[i..eol]) {
                     let eq_abs = i + eq_rel;
-                    // Key: from i to eq_abs (trimming trailing whitespace).
-                    let key_end = eq_abs;
-                    let key_text = &bytes[i..key_end];
-                    let trimmed_key_end = key_end
-                        - key_text
+                    // Key: from i to eq_abs, trimming trailing whitespace.
+                    let trimmed_key_end = eq_abs
+                        - bytes[i..eq_abs]
                             .iter()
                             .rev()
                             .take_while(|&&b| b == b' ' || b == b'\t')

--- a/crates/rskim-search/src/fields/serde_fields.rs
+++ b/crates/rskim-search/src/fields/serde_fields.rs
@@ -246,7 +246,6 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
             .unwrap_or(len);
 
         let line = &bytes[line_start..line_end];
-        let line_len = line_end - line_start;
 
         // Calculate indent (leading spaces).
         let indent = line.iter().take_while(|&&b| b == b' ').count();
@@ -316,34 +315,20 @@ pub(crate) fn classify_yaml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 let actual_val_start = eff_rest_start + value_start_rel + space_skip;
 
                 if actual_val_start < line_end {
-                    let remaining = &bytes[actual_val_start..line_end];
-                    // Check for inline comment.
-                    let val_content_end = find_yaml_inline_comment_start(remaining, actual_val_start, line_end);
-
-                    if actual_val_start < val_content_end {
-                        let first_val_byte = bytes[actual_val_start];
-                        if first_val_byte == b'"' || first_val_byte == b'\'' {
-                            // Quoted string value → StringLiteral.
-                            ranges.push((actual_val_start..val_content_end, SearchField::StringLiteral));
-                        }
-                        // Unquoted values (scalars, flow indicators) → Other (gap fill).
+                    let first_val_byte = bytes[actual_val_start];
+                    if first_val_byte == b'"' || first_val_byte == b'\'' {
+                        // Quoted string value → StringLiteral.
+                        // Inline comment detection is not implemented: values like
+                        // "http://x.com # not a comment" would cause false positives.
+                        // TODO: YAML spec coverage — inline comment classification.
+                        ranges.push((actual_val_start..line_end, SearchField::StringLiteral));
                     }
-
-                    // Classify inline comment if present.
-                    if val_content_end < line_end {
-                        // Find the `#` position.
-                        let comment_content = &bytes[val_content_end..line_end];
-                        if let Some(hash_rel) = comment_content.iter().position(|&b| b == b'#') {
-                            let hash_abs = val_content_end + hash_rel;
-                            ranges.push((hash_abs..line_end, SearchField::Comment));
-                        }
-                    }
+                    // Unquoted values (scalars, flow indicators) → Other (gap fill).
                 }
             }
         }
 
         line_start = line_end;
-        let _ = line_len;
     }
 
     fill_gaps_and_merge(ranges, len)
@@ -369,27 +354,6 @@ fn find_yaml_key_colon(line_content: &[u8]) -> Option<usize> {
         }
     }
     None
-}
-
-/// Find the start of an inline YAML comment within a value region.
-///
-/// Returns the absolute byte offset of the `#` that starts the comment, or
-/// `line_end` if no inline comment is present.
-///
-/// A YAML inline comment is ` #` (space + hash) that is not inside a quoted
-/// string. This is a simplified heuristic: it looks for ` #` that is not
-/// preceded by an odd number of quote characters.
-fn find_yaml_inline_comment_start(
-    _remaining: &[u8],
-    val_start: usize,
-    line_end: usize,
-) -> usize {
-    // Simplified: trim trailing whitespace+newline from value region.
-    // Inline comments would need more state to handle properly inside quotes.
-    // For now, return line_end to mark the entire value as content.
-    // This avoids false positives on values like "http://x.com # not a comment".
-    let _ = (val_start, line_end); // suppress unused warnings
-    line_end
 }
 
 // ============================================================================
@@ -420,9 +384,7 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
     let mut i = 0usize;
 
     while i < len {
-        // Skip leading whitespace on the current line.
-        let line_start = i;
-        // Skip spaces/tabs.
+        // Skip leading whitespace on the current line (spaces/tabs only).
         while i < len && (bytes[i] == b' ' || bytes[i] == b'\t') {
             i += 1;
         }
@@ -493,8 +455,6 @@ pub(crate) fn classify_toml(source: &str) -> Vec<(Range<usize>, SearchField)> {
                 }
             }
         }
-
-        let _ = line_start;
     }
 
     fill_gaps_and_merge(ranges, len)

--- a/crates/rskim-search/src/lexical/classifier.rs
+++ b/crates/rskim-search/src/lexical/classifier.rs
@@ -143,7 +143,26 @@ pub fn classify_source(
         });
     }
 
-    // For non-tree-sitter languages (JSON, YAML, TOML), classify all bytes as Other.
+    // Format-specific classifiers dispatched BEFORE the generic tree-sitter path.
+    // These scanners handle non-tree-sitter formats (JSON, YAML, TOML) and the
+    // Markdown tree-sitter grammar which needs custom heading-level logic.
+    match lang {
+        Language::Json => {
+            return Ok(crate::fields::serde_fields::classify_json(source));
+        }
+        Language::Yaml => {
+            return Ok(crate::fields::serde_fields::classify_yaml(source));
+        }
+        Language::Toml => {
+            return Ok(crate::fields::serde_fields::classify_toml(source));
+        }
+        Language::Markdown => {
+            return crate::fields::markdown::classify_markdown(source);
+        }
+        _ => {}
+    }
+
+    // Generic tree-sitter path for all other languages.
     let mut parser = match rskim_core::Parser::new(lang) {
         Ok(p) => p,
         Err(_) => {
@@ -198,7 +217,25 @@ pub fn classify_source(
 /// Implements "innermost wins": processes ranges in reverse (children first)
 /// so deeper nodes claim bytes before their parents. Uncovered bytes become
 /// [`SearchField::Other`]. Adjacent same-field ranges are merged.
-fn build_field_ranges(
+///
+/// # Preconditions
+///
+/// - `node_ranges` must be in **pre-order** (parents before children). The
+///   reverse-iteration loop relies on children appearing after their parents.
+/// - Ranges may overlap; the algorithm resolves overlaps via interval subtraction
+///   so the deepest (innermost) node wins each byte.
+/// - `source_len` must equal the byte length of the source that was parsed.
+///
+/// # Output guarantees
+///
+/// The returned `Vec` is:
+/// - Sorted ascending by `range.start`.
+/// - Non-overlapping (no two ranges share a byte).
+/// - Contiguous (covers every byte `0..source_len`).
+/// - `sum(range.end - range.start) == source_len`.
+/// - For empty input (`node_ranges.is_empty()`), returns a single `Other`
+///   range covering `0..source_len`.
+pub(crate) fn build_field_ranges(
     node_ranges: Vec<(Range<usize>, SearchField)>,
     source_len: usize,
 ) -> Vec<(Range<usize>, SearchField)> {
@@ -247,7 +284,7 @@ fn build_field_ranges(
 }
 
 /// Merge adjacent ranges that share the same field into a single range.
-fn merge_adjacent(ranges: &mut Vec<(Range<usize>, SearchField)>) {
+pub(crate) fn merge_adjacent(ranges: &mut Vec<(Range<usize>, SearchField)>) {
     if ranges.len() <= 1 {
         return;
     }

--- a/crates/rskim-search/src/lexical/classifier.rs
+++ b/crates/rskim-search/src/lexical/classifier.rs
@@ -10,11 +10,16 @@
 //! 4. Fill uncovered gaps with `SearchField::Other`, then merge adjacent same-field
 //!    ranges.
 //!
-//! # Non-tree-sitter languages
+//! # Format-specific dispatchers
 //!
-//! For languages where [`rskim_core::Language::to_tree_sitter`] returns `None`
-//! (JSON, YAML, TOML), the entire source is classified as
-//! [`SearchField::Other`] — a single range `0..source.len()`.
+//! JSON, YAML, TOML, and Markdown are dispatched to dedicated classifiers
+//! **before** the generic tree-sitter path:
+//!
+//! - JSON/YAML/TOML: lightweight std-only scanners (infallible, no tree-sitter).
+//! - Markdown: tree-sitter via [`rskim_core`] with custom heading-level logic.
+//!
+//! Only languages that are not handled by a dedicated classifier reach the
+//! generic tree-sitter path below.
 //!
 //! # Invariants
 //!

--- a/crates/rskim-search/src/lexical/classifier_tests.rs
+++ b/crates/rskim-search/src/lexical/classifier_tests.rs
@@ -83,13 +83,12 @@ fn test_source_exceeding_limit_returns_error() {
 #[ignore = "allocates 100 MiB — run explicitly with --ignored"]
 fn test_source_at_limit_boundary_does_not_error() {
     // A source of exactly MAX_SOURCE_BYTES bytes must NOT be rejected.
-    // We use JSON (non-tree-sitter) so this stays fast even at 100 MiB;
-    // it returns a single Other range without touching the parser.
+    // We use JSON so this stays fast even at 100 MiB; the format-specific
+    // scanner classifies without tree-sitter overhead.
     let at_limit = " ".repeat(MAX_SOURCE_BYTES);
     let result = classify_source(&at_limit, rskim_core::Language::Json);
-    // Json parser returns an error (unsupported for tree-sitter), but the
-    // size guard must not fire — the error, if any, comes from the parser,
-    // not from FileTooLarge.
+    // The size guard must not fire at exactly the limit — any result other
+    // than FileTooLarge (Ok or a scanner error) is acceptable here.
     match result {
         Err(crate::SearchError::FileTooLarge { .. }) => {
             panic!("MAX_SOURCE_BYTES itself must not trigger FileTooLarge");

--- a/crates/rskim-search/src/lexical/classifier_tests.rs
+++ b/crates/rskim-search/src/lexical/classifier_tests.rs
@@ -102,34 +102,52 @@ fn test_source_at_limit_boundary_does_not_error() {
 // Non-tree-sitter languages (JSON, YAML, TOML)
 // -----------------------------------------------------------------------
 
+/// JSON is now classified with format-specific field mapping (not single-Other).
+/// Verifies contiguity and presence of structural fields.
 #[test]
-fn test_json_classified_as_single_other() {
+fn test_json_field_mapping_non_trivial() {
     let source = r#"{"key": "value"}"#;
     let ranges = classify_source(source, rskim_core::Language::Json).unwrap();
-    assert_eq!(ranges.len(), 1, "JSON should return single range");
-    assert_eq!(
-        ranges[0].1,
-        SearchField::Other,
-        "JSON range should be Other"
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+    // With format-specific classification, "key" must be SymbolName.
+    let has_symbol = ranges.iter().any(|(_, f)| *f == SearchField::SymbolName);
+    assert!(
+        has_symbol,
+        "JSON classify_source must produce SymbolName for key; got: {ranges:?}"
     );
-    assert_eq!(ranges[0].0.start, 0);
-    assert_eq!(ranges[0].0.end, source.len());
 }
 
+/// YAML is now classified with format-specific field mapping (not single-Other).
+/// Verifies contiguity and presence of structural fields.
 #[test]
-fn test_yaml_classified_as_single_other() {
+fn test_yaml_field_mapping_non_trivial() {
     let source = "key: value\n";
     let ranges = classify_source(source, rskim_core::Language::Yaml).unwrap();
-    assert_eq!(ranges.len(), 1);
-    assert_eq!(ranges[0].1, SearchField::Other);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+    // "key" at indent-0 must be TypeDefinition.
+    let has_type_def = ranges.iter().any(|(_, f)| *f == SearchField::TypeDefinition);
+    assert!(
+        has_type_def,
+        "YAML classify_source must produce TypeDefinition for root key; got: {ranges:?}"
+    );
 }
 
+/// TOML is now classified with format-specific field mapping (not single-Other).
+/// Verifies contiguity and presence of structural fields.
 #[test]
-fn test_toml_classified_as_single_other() {
+fn test_toml_field_mapping_non_trivial() {
     let source = "[package]\nname = \"skim\"\n";
     let ranges = classify_source(source, rskim_core::Language::Toml).unwrap();
-    assert_eq!(ranges.len(), 1);
-    assert_eq!(ranges[0].1, SearchField::Other);
+    assert_contiguous(&ranges, source.len());
+    assert_field_lengths_sum(&ranges, source.len());
+    // [package] must be TypeDefinition.
+    let has_type_def = ranges.iter().any(|(_, f)| *f == SearchField::TypeDefinition);
+    assert!(
+        has_type_def,
+        "TOML classify_source must produce TypeDefinition for section; got: {ranges:?}"
+    );
 }
 
 // -----------------------------------------------------------------------

--- a/crates/rskim-search/src/lexical/classifier_tests.rs
+++ b/crates/rskim-search/src/lexical/classifier_tests.rs
@@ -127,7 +127,9 @@ fn test_yaml_field_mapping_non_trivial() {
     assert_contiguous(&ranges, source.len());
     assert_field_lengths_sum(&ranges, source.len());
     // "key" at indent-0 must be TypeDefinition.
-    let has_type_def = ranges.iter().any(|(_, f)| *f == SearchField::TypeDefinition);
+    let has_type_def = ranges
+        .iter()
+        .any(|(_, f)| *f == SearchField::TypeDefinition);
     assert!(
         has_type_def,
         "YAML classify_source must produce TypeDefinition for root key; got: {ranges:?}"
@@ -143,7 +145,9 @@ fn test_toml_field_mapping_non_trivial() {
     assert_contiguous(&ranges, source.len());
     assert_field_lengths_sum(&ranges, source.len());
     // [package] must be TypeDefinition.
-    let has_type_def = ranges.iter().any(|(_, f)| *f == SearchField::TypeDefinition);
+    let has_type_def = ranges
+        .iter()
+        .any(|(_, f)| *f == SearchField::TypeDefinition);
     assert!(
         has_type_def,
         "TOML classify_source must produce TypeDefinition for section; got: {ranges:?}"

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! CLI/binary code in `crates/rskim/src/cmd/search/mod.rs` handles user-facing I/O.
 
+pub(crate) mod fields;
 pub mod index;
 pub mod lexical;
 pub mod ngram;

--- a/crates/rskim/src/cmd/search/manifest.rs
+++ b/crates/rskim/src/cmd/search/manifest.rs
@@ -122,7 +122,12 @@ impl FileManifest {
     pub const MANIFEST_FILENAME: &'static str = "index.skfiles";
 
     /// Current format version — bump this on any breaking schema change.
-    pub const FORMAT_VERSION: u32 = 1;
+    ///
+    /// v1 → v2: Custom field mapping for JSON/YAML/TOML/Markdown (Issue #193).
+    /// Existing v1 indexes must be re-indexed because field classifications have
+    /// changed: previously all bytes were Other; now structural elements receive
+    /// TypeDefinition, SymbolName, StringLiteral, etc.
+    pub const FORMAT_VERSION: u32 = 2;
 
     // -----------------------------------------------------------------------
     // Constructors

--- a/crates/rskim/src/cmd/search/manifest_tests.rs
+++ b/crates/rskim/src/cmd/search/manifest_tests.rs
@@ -236,8 +236,9 @@ fn test_load_stops_at_entry_cap() {
     let path = cache_dir.join("index.skfiles");
     let mut f = std::fs::File::create(&path).unwrap();
 
-    // Header line
-    let header = serde_json::json!({"version": 1, "root": root.to_string_lossy()});
+    // Header line — use current FORMAT_VERSION so the version check passes
+    // and load actually parses entry lines (testing the entry cap, not version mismatch).
+    let header = serde_json::json!({"version": FileManifest::FORMAT_VERSION, "root": root.to_string_lossy()});
     writeln!(f, "{header}").unwrap();
 
     // Write MAX_MANIFEST_ENTRIES + 10 entry lines.
@@ -409,7 +410,8 @@ fn test_git_head_roundtrip() {
     );
 }
 
-/// Backward compat: old manifest without git_head → stored_git_head returns None.
+/// Backward compat: manifest at current FORMAT_VERSION but without `git_head`
+/// in the header JSON → `stored_git_head()` returns `None` via `serde(default)`.
 #[test]
 fn test_git_head_backward_compat_none() {
     use std::io::Write as _;
@@ -420,8 +422,9 @@ fn test_git_head_backward_compat_none() {
     let path = cache_dir.join("index.skfiles");
 
     let mut f = std::fs::File::create(&path).unwrap();
-    // Write header without git_head field (old format).
-    let header = serde_json::json!({"version": 1, "root": root.to_string_lossy()});
+    // Write header at current FORMAT_VERSION but omit git_head — tests
+    // that serde(default) correctly yields None for the missing field.
+    let header = serde_json::json!({"version": FileManifest::FORMAT_VERSION, "root": root.to_string_lossy()});
     writeln!(f, "{header}").unwrap();
     drop(f);
 
@@ -429,7 +432,7 @@ fn test_git_head_backward_compat_none() {
     assert_eq!(
         manifest.stored_git_head(),
         None,
-        "old manifest without git_head should return None"
+        "manifest without git_head field should return None via serde(default)"
     );
 }
 

--- a/crates/rskim/src/cmd/search/manifest_tests.rs
+++ b/crates/rskim/src/cmd/search/manifest_tests.rs
@@ -346,10 +346,16 @@ fn test_mtime_persisted_in_manifest() {
     );
 }
 
-/// A manifest written without a `mtime` field (e.g. by an older version of
-/// skim) must deserialize cleanly with `mtime: None`.
+/// A manifest written with a stale `version` field (e.g. by an older version
+/// of skim) must be silently discarded and replaced with an empty manifest.
+///
+/// This test was previously named `test_mtime_backward_compat_none` and verified
+/// that a v1 manifest entry without a `mtime` field was loaded with `mtime: None`.
+/// After bumping FORMAT_VERSION to 2 (Issue #193: custom field mapping for
+/// JSON/YAML/TOML/Markdown), v1 manifests are intentionally rejected — skim
+/// must re-index from scratch to pick up the new field classifications.
 #[test]
-fn test_mtime_backward_compat_none() {
+fn test_stale_version_manifest_triggers_cold_start() {
     use std::io::Write as _;
 
     let dir = tempfile::tempdir().unwrap();
@@ -357,11 +363,10 @@ fn test_mtime_backward_compat_none() {
     let cache_dir = root.clone();
     let path = cache_dir.join("index.skfiles");
 
-    // Write a manifest with no `mtime` field in the entry.
+    // Write a v1 manifest (FORMAT_VERSION is now 2).
     let mut f = std::fs::File::create(&path).unwrap();
     let header = serde_json::json!({"version": 1, "root": root.to_string_lossy()});
     writeln!(f, "{header}").unwrap();
-    // Deliberately omit `mtime` to simulate an old manifest format.
     let entry_json = serde_json::json!({
         "path": "src/old.rs",
         "sha256": "b".repeat(64),
@@ -371,11 +376,12 @@ fn test_mtime_backward_compat_none() {
     writeln!(f, "{entry_json}").unwrap();
     drop(f);
 
+    // Loading a v1 manifest against FORMAT_VERSION 2 must produce an empty
+    // manifest (cold start), not preserve the v1 entries.
     let manifest = FileManifest::load(root, cache_dir).unwrap();
-    let found = manifest.lookup("src/old.rs").unwrap();
-    assert_eq!(
-        found.mtime, None,
-        "mtime should be None when field is absent (backward compat)"
+    assert!(
+        manifest.lookup("src/old.rs").is_none(),
+        "v1 manifest must be discarded on version mismatch — cold start required"
     );
 }
 


### PR DESCRIPTION
## Summary

Config files, data files, and Markdown documents were all classified as Other (1.0x boost), meaning config keys ranked the same as whitespace in BM25F scoring. This adds format-specific byte-range classifiers so structural elements receive appropriate field boosts.

- JSON/YAML/TOML use lightweight std-only scanners (infallible, return Vec)
- Markdown uses the existing tree-sitter grammar with custom heading-level detection
- Manifest FORMAT_VERSION bumped 1→2 forces one-time full re-index after upgrade

## Changes

**New files:**
- `crates/rskim-search/src/fields/mod.rs` — module + `fill_gaps_and_merge` shared helper
- `crates/rskim-search/src/fields/serde_fields.rs` — JSON/YAML/TOML scanners
- `crates/rskim-search/src/fields/markdown.rs` — tree-sitter Markdown classifier
- `crates/rskim-search/src/fields/fields_tests.rs` — 56 tests (F-*, C-*, I-* naming)

**Modified files:**
- `crates/rskim-search/src/lexical/classifier.rs` — dispatch block before tree-sitter path; `build_field_ranges`/`merge_adjacent` promoted to `pub(crate)`
- `crates/rskim-search/src/lexical/classifier_tests.rs` — replaced 3 single-Other tests with field-mapping tests
- `crates/rskim-search/src/lib.rs` — added `pub(crate) mod fields`
- `crates/rskim/src/cmd/search/manifest.rs` — FORMAT_VERSION 1→2
- `crates/rskim/src/cmd/search/manifest_tests.rs` — updated stale-version test to reflect cold-start behavior

**Field mapping:**

| Format | Element | SearchField |
|--------|---------|-------------|
| JSON | Depth-0 key → object/array value | TypeDefinition |
| JSON | Other keys | SymbolName |
| JSON | String values | StringLiteral |
| YAML | Top-level keys (indent 0) | TypeDefinition |
| YAML | Nested keys (indent 1+) | SymbolName |
| YAML | Quoted string values | StringLiteral |
| YAML | `#` comments | Comment |
| TOML | `[section]` / `[[array]]` headers | TypeDefinition |
| TOML | Keys (including dotted) | SymbolName |
| TOML | Quoted string values | StringLiteral |
| TOML | `#` comments | Comment |
| Markdown | H1–H3 headings (atx + setext) | TypeDefinition |
| Markdown | Code blocks (fenced + indented) | FunctionBody |
| Markdown | Prose (paragraph, list, blockquote) | Comment |
| Markdown | Link reference definitions | ImportExport |
| Markdown | H4+, everything else | Other |

## Breaking Changes

Manifest FORMAT_VERSION 1→2 forces one-time full re-index after upgrade. Existing indexes are automatically discarded and rebuilt on the next `skim search` invocation. No index format changes (same SearchField discriminants).

## Reviewer Focus Areas

1. **`scan_json_string` escape handling** (`serde_fields.rs`) — verifies `\"`, `\\`, `\uXXXX`, and unterminated strings
2. **Markdown heading level detection** (`markdown.rs`) — `count_atx_heading_level` counting `#` bytes; H4+ → Other per spec
3. **Contiguity invariant in `fill_gaps_and_merge`** (`mod.rs`) — gap-fill pass with sort + merge_adjacent
4. **Dispatch ordering in `classify_source`** (`classifier.rs`) — format-specific dispatch fires BEFORE `Parser::new` so JSON/YAML/TOML/Markdown never reach the generic tree-sitter path
5. **YAML scope limitations** — flow-style, multi-line scalars, anchors/aliases, and complex keys are intentionally out of scope (documented with TODO comments)

## Test plan

- [ ] All 286 rskim-search tests pass (was 230 before this PR — 56 new)
- [ ] Full workspace (all crates): `cargo test --workspace` — 2464 passed, 0 failed
- [ ] Clippy clean: `cargo clippy -p rskim-search -- -D warnings`
- [ ] Snyk code scan: 0 issues
- [ ] F-JSON-01 through F-JSON-08: JSON field mapping
- [ ] F-YAML-01 through F-YAML-06: YAML field mapping
- [ ] F-TOML-01 through F-TOML-06: TOML field mapping
- [ ] F-MD-01 through F-MD-08: Markdown field mapping
- [ ] C-01 through C-10: Contract invariants (sorted, non-overlapping, contiguous, infallible)
- [ ] I-01 through I-06: Integration via classify_source dispatch