### PR TITLE
feat: populate SearchResult.line_range with real line numbers

### DIFF
--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -31,6 +31,6 @@ pub use temporal::{GixSource, is_fix_commit};
 pub use types::{
     CommitInfo, FieldClassifier, FileChangeInfo, FileId, HistoryResult, IndexStats, LayerBuilder,
     NodeInfo, Result, SearchError, SearchField, SearchLayer, SearchQuery, SearchResult,
-    TemporalFlags, TemporalMetadata, TemporalSource,
+    TemporalFlags, TemporalMetadata, TemporalSource, byte_offset_to_line, compute_line_range,
 };
 pub use weights::{BIGRAM_WEIGHTS, DEFAULT_WEIGHT, bigram_weight};

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -347,10 +347,7 @@ pub struct SearchResult {
 /// Counts newlines in `content[..offset]`. The offset is clamped to
 /// `content.len()` so out-of-bounds values never panic. Returns `1` for
 /// offset `0` or any offset in empty content.
-///
-/// This is the library counterpart of the CLI's `snippet::byte_offset_to_line`;
-/// the two are intentionally kept separate — this one returns `usize` while
-/// the CLI copy returns `u32` for display formatting.
+#[must_use]
 pub fn byte_offset_to_line(content: &[u8], offset: usize) -> usize {
     let safe_offset = offset.min(content.len());
     let newlines = content[..safe_offset]
@@ -367,23 +364,18 @@ pub fn byte_offset_to_line(content: &[u8], offset: usize) -> usize {
 /// 1-indexed), matching the convention used by [`SearchResult::line_range`].
 ///
 /// Returns `0..0` when `match_positions` is empty.
+#[must_use]
 pub fn compute_line_range(content: &[u8], match_positions: &[Range<usize>]) -> Range<usize> {
     if match_positions.is_empty() {
         return 0..0;
     }
 
-    let mut min_line = usize::MAX;
-    let mut max_line = 0usize;
+    let lines = match_positions
+        .iter()
+        .map(|pos| byte_offset_to_line(content, pos.start));
 
-    for pos in match_positions {
-        let line = byte_offset_to_line(content, pos.start);
-        if line < min_line {
-            min_line = line;
-        }
-        if line > max_line {
-            max_line = line;
-        }
-    }
+    let min_line = lines.clone().min().unwrap_or(1);
+    let max_line = lines.max().unwrap_or(1);
 
     min_line..(max_line + 1)
 }

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -339,6 +339,56 @@ pub struct SearchResult {
 }
 
 // ============================================================================
+// Line-range utilities
+// ============================================================================
+
+/// Map a byte offset within `content` to a **1-indexed** line number.
+///
+/// Counts newlines in `content[..offset]`. The offset is clamped to
+/// `content.len()` so out-of-bounds values never panic. Returns `1` for
+/// offset `0` or any offset in empty content.
+///
+/// This is the library counterpart of the CLI's `snippet::byte_offset_to_line`;
+/// the two are intentionally kept separate — this one returns `usize` while
+/// the CLI copy returns `u32` for display formatting.
+pub fn byte_offset_to_line(content: &[u8], offset: usize) -> usize {
+    let safe_offset = offset.min(content.len());
+    let newlines = content[..safe_offset]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count();
+    newlines + 1
+}
+
+/// Compute the line range spanned by a set of byte-position `match_positions`.
+///
+/// For each position the start byte is converted to a 1-indexed line number via
+/// [`byte_offset_to_line`]. Returns `min_line..(max_line + 1)` (exclusive end,
+/// 1-indexed), matching the convention used by [`SearchResult::line_range`].
+///
+/// Returns `0..0` when `match_positions` is empty.
+pub fn compute_line_range(content: &[u8], match_positions: &[Range<usize>]) -> Range<usize> {
+    if match_positions.is_empty() {
+        return 0..0;
+    }
+
+    let mut min_line = usize::MAX;
+    let mut max_line = 0usize;
+
+    for pos in match_positions {
+        let line = byte_offset_to_line(content, pos.start);
+        if line < min_line {
+            min_line = line;
+        }
+        if line > max_line {
+            max_line = line;
+        }
+    }
+
+    min_line..(max_line + 1)
+}
+
+// ============================================================================
 // Index Statistics
 // ============================================================================
 
@@ -983,5 +1033,77 @@ mod tests {
             q.bm25f_config.is_none(),
             "new() should initialise bm25f_config to None"
         );
+    }
+
+    // ========================================================================
+    // byte_offset_to_line (library version, returns usize, 1-indexed)
+    // ========================================================================
+
+    #[test]
+    fn test_lib_byte_offset_start_of_file() {
+        assert_eq!(byte_offset_to_line(b"hello\nworld", 0), 1);
+    }
+
+    #[test]
+    fn test_lib_byte_offset_second_line() {
+        assert_eq!(byte_offset_to_line(b"hello\nworld", 6), 2);
+    }
+
+    #[test]
+    fn test_lib_byte_offset_at_newline() {
+        // newline byte itself is end of line 1
+        assert_eq!(byte_offset_to_line(b"hello\nworld", 5), 1);
+    }
+
+    #[test]
+    fn test_lib_byte_offset_middle_of_line() {
+        assert_eq!(byte_offset_to_line(b"hello\nworld", 8), 2);
+    }
+
+    #[test]
+    fn test_lib_byte_offset_empty_content() {
+        assert_eq!(byte_offset_to_line(b"", 0), 1);
+    }
+
+    #[test]
+    fn test_lib_byte_offset_clamped() {
+        assert_eq!(byte_offset_to_line(b"hello", 999), 1);
+    }
+
+    #[test]
+    fn test_lib_byte_offset_last_byte() {
+        assert_eq!(byte_offset_to_line(b"a\nb\nc", 4), 3);
+    }
+
+    // ========================================================================
+    // compute_line_range
+    // ========================================================================
+
+    #[test]
+    fn test_line_range_empty_positions() {
+        assert_eq!(compute_line_range(b"hello\nworld", &[]), 0..0);
+    }
+
+    #[test]
+    fn test_line_range_single_position() {
+        // offset 2 on "a\nb\nc" -> line 2 (byte 2 = 'b')
+        assert_eq!(compute_line_range(b"a\nb\nc", &[2..3]), 2..3);
+    }
+
+    #[test]
+    fn test_line_range_multi_line_span() {
+        // offsets 0 (line 1) and 6 (line 4) on "a\nb\nc\nd\ne"
+        assert_eq!(compute_line_range(b"a\nb\nc\nd\ne", &[0..1, 6..7]), 1..5);
+    }
+
+    #[test]
+    fn test_line_range_same_line() {
+        assert_eq!(compute_line_range(b"hello world", &[0..3, 6..9]), 1..2);
+    }
+
+    #[test]
+    fn test_line_range_adjacent_lines() {
+        // offsets 0 (line 1) and 2 (line 2) on "a\nb\nc"
+        assert_eq!(compute_line_range(b"a\nb\nc", &[0..1, 2..3]), 1..3);
     }
 }

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -373,7 +373,9 @@ pub fn compute_line_range(content: &[u8], match_positions: &[Range<usize>]) -> R
     let (min_line, max_line) = match_positions
         .iter()
         .map(|pos| byte_offset_to_line(content, pos.start))
-        .fold((usize::MAX, 0usize), |(mn, mx), line| (mn.min(line), mx.max(line)));
+        .fold((usize::MAX, 0usize), |(mn, mx), line| {
+            (mn.min(line), mx.max(line))
+        });
 
     min_line..(max_line + 1)
 }
@@ -1075,6 +1077,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::single_range_in_vec_init)]
     fn test_line_range_single_position() {
         // offset 2 on "a\nb\nc" -> line 2 (byte 2 = 'b')
         assert_eq!(compute_line_range(b"a\nb\nc", &[2..3]), 2..3);

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -328,7 +328,7 @@ pub struct SearchResult {
     pub file_id: FileId,
     /// Relevance score (higher is more relevant); layer-specific scale
     pub score: f64,
-    /// Source lines spanned by this match (0-indexed, exclusive end)
+    /// Source lines spanned by this match (1-indexed, exclusive end; 0..0 when not yet computed)
     pub line_range: Range<usize>,
     /// Byte-position ranges within the source where query terms appear
     pub match_positions: Vec<Range<usize>>,
@@ -370,12 +370,10 @@ pub fn compute_line_range(content: &[u8], match_positions: &[Range<usize>]) -> R
         return 0..0;
     }
 
-    let lines = match_positions
+    let (min_line, max_line) = match_positions
         .iter()
-        .map(|pos| byte_offset_to_line(content, pos.start));
-
-    let min_line = lines.clone().min().unwrap_or(1);
-    let max_line = lines.max().unwrap_or(1);
+        .map(|pos| byte_offset_to_line(content, pos.start))
+        .fold((usize::MAX, 0usize), |(mn, mx), line| (mn.min(line), mx.max(line)));
 
     min_line..(max_line + 1)
 }

--- a/crates/rskim/src/cmd/search/query.rs
+++ b/crates/rskim/src/cmd/search/query.rs
@@ -99,11 +99,11 @@ fn resolve_paths_and_snippets(
 
             let manifest_entry = manifest.lookup(path);
 
-            let (line_number, snippet, stale) =
+            let (line_number, line_range, snippet, stale) =
                 match extract_snippet(root, path, &r.match_positions, manifest_entry) {
-                    SnippetOutcome::Ok(ln, ctx) => (Some(ln), Some(ctx), false),
-                    SnippetOutcome::Stale => (None, None, true),
-                    SnippetOutcome::Unavailable => (None, None, false),
+                    SnippetOutcome::Ok(ln, lr, ctx) => (Some(ln), Some(lr), Some(ctx), false),
+                    SnippetOutcome::Stale => (None, None, None, true),
+                    SnippetOutcome::Unavailable => (None, None, None, false),
                 };
 
             Some(ResolvedResult {
@@ -111,6 +111,7 @@ fn resolve_paths_and_snippets(
                 score: r.score,
                 field: r.field.name().to_string(),
                 line_number,
+                line_range,
                 snippet,
                 stale,
                 match_positions: r.match_positions.clone(),

--- a/crates/rskim/src/cmd/search/query.rs
+++ b/crates/rskim/src/cmd/search/query.rs
@@ -101,7 +101,9 @@ fn resolve_paths_and_snippets(
 
             let (line_number, line_range, snippet, stale) =
                 match extract_snippet(root, path, &r.match_positions, manifest_entry) {
-                    SnippetOutcome::Ok(ln, lr, ctx) => (Some(ln), Some(lr), Some(ctx), false),
+                    SnippetOutcome::Ok { match_line, line_range, context } => {
+                        (Some(match_line), Some(line_range), Some(context), false)
+                    }
                     SnippetOutcome::Stale => (None, None, None, true),
                     SnippetOutcome::Unavailable => (None, None, None, false),
                 };

--- a/crates/rskim/src/cmd/search/query.rs
+++ b/crates/rskim/src/cmd/search/query.rs
@@ -101,9 +101,11 @@ fn resolve_paths_and_snippets(
 
             let (line_number, line_range, snippet, stale) =
                 match extract_snippet(root, path, &r.match_positions, manifest_entry) {
-                    SnippetOutcome::Ok { match_line, line_range, context } => {
-                        (Some(match_line), Some(line_range), Some(context), false)
-                    }
+                    SnippetOutcome::Ok {
+                        match_line,
+                        line_range,
+                        context,
+                    } => (Some(match_line), Some(line_range), Some(context), false),
                     SnippetOutcome::Stale => (None, None, None, true),
                     SnippetOutcome::Unavailable => (None, None, None, false),
                 };

--- a/crates/rskim/src/cmd/search/query_tests.rs
+++ b/crates/rskim/src/cmd/search/query_tests.rs
@@ -319,10 +319,7 @@ fn test_resolved_result_line_range_some_serializes_start_end() {
         value["line_range"]["start"], 5,
         "line_range.start must be 5"
     );
-    assert_eq!(
-        value["line_range"]["end"], 13,
-        "line_range.end must be 13"
-    );
+    assert_eq!(value["line_range"]["end"], 13, "line_range.end must be 13");
 }
 
 /// line_range: None must serialise as JSON null.

--- a/crates/rskim/src/cmd/search/query_tests.rs
+++ b/crates/rskim/src/cmd/search/query_tests.rs
@@ -159,6 +159,7 @@ fn test_format_text_output_includes_path_and_score() {
         score: 12.34,
         field: "function_signature".to_string(),
         line_number: Some(2),
+        line_range: Some(2..3),
         snippet: Some(SnippetContext {
             lines: vec![
                 SnippetLine {
@@ -204,6 +205,7 @@ fn test_format_text_output_includes_stale_marker() {
         score: 5.0,
         field: "function_signature".to_string(),
         line_number: Some(10),
+        line_range: Some(10..11),
         snippet: Some(SnippetContext {
             lines: vec![SnippetLine {
                 line_number: 10,

--- a/crates/rskim/src/cmd/search/query_tests.rs
+++ b/crates/rskim/src/cmd/search/query_tests.rs
@@ -295,6 +295,61 @@ fn test_execute_query_corrupt_index_returns_err_not_panic() {
 }
 
 // ============================================================================
+// ResolvedResult JSON serialization
+// ============================================================================
+
+/// line_range: Some(5..13) must serialise as {"start":5,"end":13} in JSON output.
+#[test]
+fn test_resolved_result_line_range_some_serializes_start_end() {
+    use crate::cmd::search::types::ResolvedResult;
+
+    let result = ResolvedResult {
+        path: "src/lib.rs".to_string(),
+        score: 1.0,
+        field: "function_signature".to_string(),
+        line_number: Some(5),
+        line_range: Some(5..13),
+        snippet: None,
+        stale: false,
+        match_positions: vec![],
+    };
+
+    let value = serde_json::to_value(&result).expect("ResolvedResult must serialize");
+    assert_eq!(
+        value["line_range"]["start"], 5,
+        "line_range.start must be 5"
+    );
+    assert_eq!(
+        value["line_range"]["end"], 13,
+        "line_range.end must be 13"
+    );
+}
+
+/// line_range: None must serialise as JSON null.
+#[test]
+fn test_resolved_result_line_range_none_serializes_null() {
+    use crate::cmd::search::types::ResolvedResult;
+
+    let result = ResolvedResult {
+        path: "src/lib.rs".to_string(),
+        score: 1.0,
+        field: "function_signature".to_string(),
+        line_number: None,
+        line_range: None,
+        snippet: None,
+        stale: false,
+        match_positions: vec![],
+    };
+
+    let value = serde_json::to_value(&result).expect("ResolvedResult must serialize");
+    assert!(
+        value["line_range"].is_null(),
+        "line_range must be null when None, got: {:?}",
+        value["line_range"]
+    );
+}
+
+// ============================================================================
 // format_json_output
 // ============================================================================
 

--- a/crates/rskim/src/cmd/search/snippet.rs
+++ b/crates/rskim/src/cmd/search/snippet.rs
@@ -24,7 +24,15 @@ pub(super) const DEFAULT_CONTEXT: u32 = 3;
 #[derive(Debug)]
 pub(super) enum SnippetOutcome {
     /// Successfully extracted a snippet.
-    Ok(u32, SnippetContext),
+    ///
+    /// Fields: `(primary_match_line_u32, line_range, context)`.
+    ///
+    /// - `primary_match_line_u32` — 1-indexed line number of the first match
+    ///   position, as a `u32` for display formatting.
+    /// - `line_range` — 1-indexed, exclusive-end `Range<usize>` spanning all
+    ///   match positions, computed by [`rskim_search::compute_line_range`].
+    /// - `context` — source lines surrounding the primary match.
+    Ok(u32, std::ops::Range<usize>, SnippetContext),
     /// File has changed since indexing (mtime mismatch) — positions may be stale.
     Stale,
     /// File deleted, unreadable, empty positions, or non-UTF8.
@@ -154,12 +162,14 @@ pub(super) fn extract_snippet(
 
     let match_line = byte_offset_to_line(&content, match_positions[0].start);
 
+    let line_range = rskim_search::compute_line_range(&content, match_positions);
+
     let ctx_lines = extract_context_window(text, match_line, DEFAULT_CONTEXT);
     if ctx_lines.is_empty() {
         return SnippetOutcome::Unavailable;
     }
 
-    SnippetOutcome::Ok(match_line, SnippetContext { lines: ctx_lines })
+    SnippetOutcome::Ok(match_line, line_range, SnippetContext { lines: ctx_lines })
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/search/snippet.rs
+++ b/crates/rskim/src/cmd/search/snippet.rs
@@ -25,32 +25,21 @@ pub(super) const DEFAULT_CONTEXT: u32 = 3;
 pub(super) enum SnippetOutcome {
     /// Successfully extracted a snippet.
     ///
-    /// `(match_line, line_range, context)` where `match_line` is the 1-indexed
-    /// line number of the first match position (as `u32` for display formatting),
-    /// `line_range` is the 1-indexed exclusive-end range spanning all match
-    /// positions, and `context` is the surrounding source lines.
-    Ok(u32, std::ops::Range<usize>, SnippetContext),
+    /// - `match_line`: 1-indexed line number of the **first** match position
+    ///   (as `u32` for display formatting).
+    /// - `line_range`: 1-indexed exclusive-end range spanning **all** match
+    ///   positions (may differ from `match_line` when the first position is not
+    ///   the minimum-line position across all positions).
+    /// - `context`: surrounding source lines.
+    Ok {
+        match_line: u32,
+        line_range: std::ops::Range<usize>,
+        context: SnippetContext,
+    },
     /// File has changed since indexing (mtime mismatch) — positions may be stale.
     Stale,
     /// File deleted, unreadable, empty positions, or non-UTF8.
     Unavailable,
-}
-
-// ============================================================================
-// Byte-offset → line number
-// ============================================================================
-
-/// Map a byte offset within `content` to a 1-indexed line number.
-///
-/// Counts newlines in `content[..offset]`. Returns `1` for offset `0` or
-/// any offset in an empty file.
-pub(super) fn byte_offset_to_line(content: &[u8], offset: usize) -> u32 {
-    let safe_offset = offset.min(content.len());
-    let newlines = content[..safe_offset]
-        .iter()
-        .filter(|&&b| b == b'\n')
-        .count();
-    (newlines as u32).saturating_add(1)
 }
 
 // ============================================================================
@@ -157,7 +146,8 @@ pub(super) fn extract_snippet(
         Err(_) => return SnippetOutcome::Unavailable,
     };
 
-    let match_line = byte_offset_to_line(&content, match_positions[0].start);
+    let match_line =
+        rskim_search::byte_offset_to_line(&content, match_positions[0].start) as u32;
 
     let line_range = rskim_search::compute_line_range(&content, match_positions);
 
@@ -166,7 +156,11 @@ pub(super) fn extract_snippet(
         return SnippetOutcome::Unavailable;
     }
 
-    SnippetOutcome::Ok(match_line, line_range, SnippetContext { lines: ctx_lines })
+    SnippetOutcome::Ok {
+        match_line,
+        line_range,
+        context: SnippetContext { lines: ctx_lines },
+    }
 }
 
 // ============================================================================

--- a/crates/rskim/src/cmd/search/snippet.rs
+++ b/crates/rskim/src/cmd/search/snippet.rs
@@ -146,8 +146,7 @@ pub(super) fn extract_snippet(
         Err(_) => return SnippetOutcome::Unavailable,
     };
 
-    let match_line =
-        rskim_search::byte_offset_to_line(&content, match_positions[0].start) as u32;
+    let match_line = rskim_search::byte_offset_to_line(&content, match_positions[0].start) as u32;
 
     let line_range = rskim_search::compute_line_range(&content, match_positions);
 

--- a/crates/rskim/src/cmd/search/snippet.rs
+++ b/crates/rskim/src/cmd/search/snippet.rs
@@ -25,13 +25,10 @@ pub(super) const DEFAULT_CONTEXT: u32 = 3;
 pub(super) enum SnippetOutcome {
     /// Successfully extracted a snippet.
     ///
-    /// Fields: `(primary_match_line_u32, line_range, context)`.
-    ///
-    /// - `primary_match_line_u32` — 1-indexed line number of the first match
-    ///   position, as a `u32` for display formatting.
-    /// - `line_range` — 1-indexed, exclusive-end `Range<usize>` spanning all
-    ///   match positions, computed by [`rskim_search::compute_line_range`].
-    /// - `context` — source lines surrounding the primary match.
+    /// `(match_line, line_range, context)` where `match_line` is the 1-indexed
+    /// line number of the first match position (as `u32` for display formatting),
+    /// `line_range` is the 1-indexed exclusive-end range spanning all match
+    /// positions, and `context` is the surrounding source lines.
     Ok(u32, std::ops::Range<usize>, SnippetContext),
     /// File has changed since indexing (mtime mismatch) — positions may be stale.
     Stale,
@@ -111,7 +108,7 @@ pub(super) fn extract_context_window(
 /// Extract a snippet for a search result.
 ///
 /// Returns:
-/// - `SnippetOutcome::Ok(line, ctx)` on success.
+/// - `SnippetOutcome::Ok(line, line_range, ctx)` on success.
 /// - `SnippetOutcome::Stale` when the file's mtime differs from manifest (changed since indexing).
 /// - `SnippetOutcome::Unavailable` when positions are empty, file is deleted/unreadable, or non-UTF8.
 pub(super) fn extract_snippet(

--- a/crates/rskim/src/cmd/search/snippet_tests.rs
+++ b/crates/rskim/src/cmd/search/snippet_tests.rs
@@ -107,16 +107,20 @@ fn test_extract_snippet_basic_match() {
     fs::write(src_dir.join("lib.rs"), content).unwrap();
 
     let result = extract_snippet(&root, "src/lib.rs", &[0..3], None);
-    let (line_no, _lr, ctx) = match result {
-        SnippetOutcome::Ok { match_line, line_range, context } => (match_line, line_range, context),
-        other => panic!("expected Ok, got {other:?}"),
+    let SnippetOutcome::Ok {
+        match_line,
+        context: ctx,
+        ..
+    } = result
+    else {
+        panic!("expected Ok, got {result:?}");
     };
-    assert_eq!(line_no, 1, "match at offset 0 → line 1");
+    assert_eq!(match_line, 1, "match at offset 0 → line 1");
     assert!(!ctx.lines.is_empty());
     // The match line should be marked
-    let match_line = ctx.lines.iter().find(|l| l.is_match).unwrap();
-    assert_eq!(match_line.line_number, 1);
-    assert!(match_line.content.contains("fn foo"));
+    let matched = ctx.lines.iter().find(|l| l.is_match).unwrap();
+    assert_eq!(matched.line_number, 1);
+    assert!(matched.content.contains("fn foo"));
 }
 
 #[test]
@@ -132,12 +136,20 @@ fn test_extract_snippet_computes_line_range() {
 
     // Match positions on line 2 (offset 3) and line 4 (offset 9)
     let result = extract_snippet(&root, "src/multi.rs", &[3..5, 9..11], None);
-    let (line_no, lr, _ctx) = match result {
-        SnippetOutcome::Ok { match_line, line_range, context } => (match_line, line_range, context),
-        other => panic!("expected Ok, got {other:?}"),
+    let SnippetOutcome::Ok {
+        match_line,
+        line_range,
+        ..
+    } = result
+    else {
+        panic!("expected Ok, got {result:?}");
     };
-    assert_eq!(line_no, 2, "primary match line from first position");
-    assert_eq!(lr, 2..5, "line_range spans lines 2-4 inclusive (2..5 exclusive)");
+    assert_eq!(match_line, 2, "primary match line from first position");
+    assert_eq!(
+        line_range,
+        2..5,
+        "line_range spans lines 2-4 inclusive (2..5 exclusive)"
+    );
 }
 
 #[test]

--- a/crates/rskim/src/cmd/search/snippet_tests.rs
+++ b/crates/rskim/src/cmd/search/snippet_tests.rs
@@ -7,77 +7,7 @@ use std::fs;
 
 use tempfile::tempdir;
 
-use super::{SnippetOutcome, byte_offset_to_line, extract_context_window, extract_snippet};
-
-// ============================================================================
-// byte_offset_to_line
-// ============================================================================
-
-#[test]
-fn test_byte_offset_to_line_start_of_file() {
-    let content = b"line1\nline2\nline3\n";
-    assert_eq!(byte_offset_to_line(content, 0), 1, "offset 0 → line 1");
-}
-
-#[test]
-fn test_byte_offset_to_line_second_line() {
-    let content = b"line1\nline2\nline3\n";
-    // "line2" starts at offset 6
-    assert_eq!(
-        byte_offset_to_line(content, 6),
-        2,
-        "start of line2 → line 2"
-    );
-}
-
-#[test]
-fn test_byte_offset_to_line_middle_of_line() {
-    let content = b"hello\nworld\n";
-    // offset 8 is in "world" (after the 'o')
-    assert_eq!(
-        byte_offset_to_line(content, 8),
-        2,
-        "middle of second line → line 2"
-    );
-}
-
-#[test]
-fn test_byte_offset_to_line_last_line_no_trailing_newline() {
-    let content = b"a\nb\nc";
-    // offset 4 is 'c' on line 3 (no trailing newline)
-    assert_eq!(byte_offset_to_line(content, 4), 3);
-}
-
-#[test]
-fn test_byte_offset_to_line_empty_file() {
-    let content = b"";
-    // Edge: empty file, offset 0
-    assert_eq!(byte_offset_to_line(content, 0), 1);
-}
-
-#[test]
-fn test_byte_offset_to_line_offset_at_newline() {
-    let content = b"abc\ndef\n";
-    // offset 3 is the newline at end of "abc" — still on line 1
-    assert_eq!(byte_offset_to_line(content, 3), 1);
-}
-
-#[test]
-fn test_byte_offset_to_line_out_of_bounds_offset_is_clamped() {
-    // Offset larger than content length must not panic and must return a valid
-    // (clamped) line number — specifically the last line of the file.
-    let content = b"line1\nline2\n";
-    let huge_offset = content.len() + 9999;
-    // The safe_offset clamp in byte_offset_to_line means this is equivalent to
-    // passing content.len() exactly, which counts both newlines → line 3.
-    let result = byte_offset_to_line(content, huge_offset);
-    assert!(
-        result >= 1,
-        "out-of-bounds offset must yield a positive line number, got {result}"
-    );
-    // Clamping to content.len() (12) counts 2 newlines → reports line 3.
-    assert_eq!(result, 3, "clamped to end-of-content → line 3");
-}
+use super::{SnippetOutcome, extract_context_window, extract_snippet};
 
 // ============================================================================
 // extract_context_window
@@ -178,7 +108,7 @@ fn test_extract_snippet_basic_match() {
 
     let result = extract_snippet(&root, "src/lib.rs", &[0..3], None);
     let (line_no, _lr, ctx) = match result {
-        SnippetOutcome::Ok(ln, lr, ctx) => (ln, lr, ctx),
+        SnippetOutcome::Ok { match_line, line_range, context } => (match_line, line_range, context),
         other => panic!("expected Ok, got {other:?}"),
     };
     assert_eq!(line_no, 1, "match at offset 0 → line 1");
@@ -203,7 +133,7 @@ fn test_extract_snippet_computes_line_range() {
     // Match positions on line 2 (offset 3) and line 4 (offset 9)
     let result = extract_snippet(&root, "src/multi.rs", &[3..5, 9..11], None);
     let (line_no, lr, _ctx) = match result {
-        SnippetOutcome::Ok(ln, lr, ctx) => (ln, lr, ctx),
+        SnippetOutcome::Ok { match_line, line_range, context } => (match_line, line_range, context),
         other => panic!("expected Ok, got {other:?}"),
     };
     assert_eq!(line_no, 2, "primary match line from first position");

--- a/crates/rskim/src/cmd/search/snippet_tests.rs
+++ b/crates/rskim/src/cmd/search/snippet_tests.rs
@@ -177,8 +177,8 @@ fn test_extract_snippet_basic_match() {
     fs::write(src_dir.join("lib.rs"), content).unwrap();
 
     let result = extract_snippet(&root, "src/lib.rs", &[0..3], None);
-    let (line_no, ctx) = match result {
-        SnippetOutcome::Ok(ln, ctx) => (ln, ctx),
+    let (line_no, _lr, ctx) = match result {
+        SnippetOutcome::Ok(ln, lr, ctx) => (ln, lr, ctx),
         other => panic!("expected Ok, got {other:?}"),
     };
     assert_eq!(line_no, 1, "match at offset 0 → line 1");
@@ -187,6 +187,27 @@ fn test_extract_snippet_basic_match() {
     let match_line = ctx.lines.iter().find(|l| l.is_match).unwrap();
     assert_eq!(match_line.line_number, 1);
     assert!(match_line.content.contains("fn foo"));
+}
+
+#[test]
+fn test_extract_snippet_computes_line_range() {
+    let dir = tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let src_dir = root.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    // 5 lines: "aa\n" = 3 bytes each, last "ee\n" = 3 bytes
+    // line 1 offset 0, line 2 offset 3, line 3 offset 6, line 4 offset 9, line 5 offset 12
+    let content = "aa\nbb\ncc\ndd\nee\n";
+    fs::write(src_dir.join("multi.rs"), content).unwrap();
+
+    // Match positions on line 2 (offset 3) and line 4 (offset 9)
+    let result = extract_snippet(&root, "src/multi.rs", &[3..5, 9..11], None);
+    let (line_no, lr, _ctx) = match result {
+        SnippetOutcome::Ok(ln, lr, ctx) => (ln, lr, ctx),
+        other => panic!("expected Ok, got {other:?}"),
+    };
+    assert_eq!(line_no, 2, "primary match line from first position");
+    assert_eq!(lr, 2..5, "line_range spans lines 2-4 inclusive (2..5 exclusive)");
 }
 
 #[test]

--- a/crates/rskim/src/cmd/search/types.rs
+++ b/crates/rskim/src/cmd/search/types.rs
@@ -63,6 +63,12 @@ pub(super) struct ResolvedResult {
     pub field: String,
     /// 1-indexed line number of the primary match within the file.
     pub line_number: Option<u32>,
+    /// 1-indexed, exclusive-end line range spanned by all match positions.
+    ///
+    /// `None` when snippet extraction is unavailable (stale, deleted, or non-UTF8).
+    /// Populated from [`rskim_search::compute_line_range`] during snippet extraction.
+    /// Serialises as `{"start": N, "end": M}` in `--format json` output.
+    pub line_range: Option<Range<usize>>,
     /// Source context window surrounding the match.
     pub snippet: Option<SnippetContext>,
     /// `true` when the file has changed since indexing (mtime mismatch or deleted).


### PR DESCRIPTION
## Summary

- `SearchResult.line_range` was hardcoded to `0..0` by the index reader. This PR populates it with real 1-indexed line numbers computed from `match_positions` during snippet extraction, where file content is already in memory.
- Two new public functions `byte_offset_to_line` and `compute_line_range` are added to `rskim-search::types` and re-exported from the crate root.
- A new `line_range: Option<Range<usize>>` field on `ResolvedResult` makes the range available in `--format json` output automatically via `serde`.

## Changes

- **`crates/rskim-search/src/types.rs`** — added `byte_offset_to_line` (returns `usize`, 1-indexed) and `compute_line_range`; 12 new unit tests
- **`crates/rskim-search/src/lib.rs`** — exported both new functions from the crate root
- **`crates/rskim/src/cmd/search/snippet.rs`** — extended `SnippetOutcome::Ok` to carry `Range<usize>` line_range; calls `rskim_search::compute_line_range` after file read
- **`crates/rskim/src/cmd/search/query.rs`** — threaded `line_range` through `resolve_paths_and_snippets` into `ResolvedResult`
- **`crates/rskim/src/cmd/search/types.rs`** — added `line_range: Option<Range<usize>>` field to `ResolvedResult`
- **`crates/rskim/src/cmd/search/snippet_tests.rs`** — updated existing test destructuring; added `test_extract_snippet_computes_line_range`
- **`crates/rskim/src/cmd/search/query_tests.rs`** — added `line_range` field to two `ResolvedResult` literals

## Breaking Changes

None. `SearchResult.line_range` was already part of the public API (previously always `0..0`). The new `ResolvedResult.line_range` field is additive — existing JSON consumers that ignore unknown fields are unaffected.

## Reviewer Focus Areas

- `compute_line_range` in `types.rs` — ensure the exclusive-end semantics (`min..(max+1)`) match the existing `SearchResult::line_range` doc comment ("0-indexed, exclusive end" — note: new functions use 1-indexed, which is what the CLI needs)
- `SnippetOutcome::Ok` tuple arity change — all three match sites updated: `snippet.rs`, `snippet_tests.rs`, `query.rs`
- No changes to `reader.rs` (which still emits `0..0`) or `FORMAT_VERSION` — index format is unchanged