### PR TITLE
feat(#181): co-change matrix builder with Jaccard similarity and binary persistence

### DIFF
--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -13,7 +13,8 @@ use tempfile::NamedTempFile;
 
 use super::format::{
     FILE_COMMIT_ENTRY_SIZE, FORMAT_VERSION, FileCommitEntry, HEADER_SIZE, PAIR_ENTRY_SIZE,
-    PairEntry, SKCC_MAGIC, SkccHeader, encode_file_commit, encode_header, encode_pair,
+    PairEntry, SKCC_MAGIC, SkccHeader, compute_checksum, encode_file_commit, encode_header,
+    encode_pair,
 };
 use crate::{CochangeStats, FileId, HistoryResult, Result, SearchError};
 
@@ -47,6 +48,7 @@ impl CochangeMatrixBuilder {
     /// # Errors
     ///
     /// Returns [`SearchError::Io`] if `output_dir` does not exist.
+    #[must_use = "this returns a Result that should be checked"]
     pub fn new(output_dir: PathBuf) -> Result<Self> {
         if !output_dir.exists() {
             return Err(SearchError::Io(std::io::Error::new(
@@ -71,6 +73,7 @@ impl CochangeMatrixBuilder {
     /// - [`SearchError::IndexCorrupted`] if the number of accumulated pairs
     ///   exceeds [`MAX_PAIRS`].
     /// - [`SearchError::Io`] if writing fails.
+    #[must_use = "this returns a Result that should be checked"]
     pub fn build(
         &self,
         history: &HistoryResult,
@@ -200,9 +203,22 @@ fn serialize(
         .collect();
     pair_entries.sort_unstable_by_key(|p| (p.file_a, p.file_b));
 
-    // Serialise file_commit and pair arrays.
-    let fc_bytes = file_entries.len() * FILE_COMMIT_ENTRY_SIZE;
-    let pair_bytes = pair_entries.len() * PAIR_ENTRY_SIZE;
+    // Serialise file_commit and pair arrays — use checked arithmetic to match
+    // reader.rs and catch hypothetical overflow on 32-bit targets.
+    let fc_bytes = file_entries
+        .len()
+        .checked_mul(FILE_COMMIT_ENTRY_SIZE)
+        .ok_or_else(|| {
+            SearchError::IndexCorrupted(
+                "file_count * FILE_COMMIT_ENTRY_SIZE overflow".into(),
+            )
+        })?;
+    let pair_bytes = pair_entries
+        .len()
+        .checked_mul(PAIR_ENTRY_SIZE)
+        .ok_or_else(|| {
+            SearchError::IndexCorrupted("pair_count * PAIR_ENTRY_SIZE overflow".into())
+        })?;
 
     let mut fc_buf: Vec<u8> = Vec::with_capacity(fc_bytes);
     for e in &file_entries {
@@ -213,11 +229,12 @@ fn serialize(
         pair_buf.extend_from_slice(&encode_pair(p));
     }
 
-    // CRC32 over file_commit ++ pair bytes.
-    let mut hasher = crc32fast::Hasher::new();
-    hasher.update(&fc_buf);
-    hasher.update(&pair_buf);
-    let checksum = hasher.finalize();
+    // CRC32 over file_commit ++ pair bytes — delegate to format.rs so there
+    // is a single source of truth for the checksum algorithm.
+    let mut payload: Vec<u8> = Vec::with_capacity(fc_bytes + pair_bytes);
+    payload.extend_from_slice(&fc_buf);
+    payload.extend_from_slice(&pair_buf);
+    let checksum = compute_checksum(&payload);
 
     // Build header.
     let pair_count = u32::try_from(pair_entries.len()).map_err(|_| {
@@ -240,8 +257,12 @@ fn serialize(
         checksum,
     };
 
-    // Assemble: header + file_commit + pairs.
-    let total = HEADER_SIZE + fc_bytes + pair_bytes;
+    // Assemble: header + file_commit + pairs — use checked arithmetic to
+    // match reader.rs and guard against overflow on 32-bit targets.
+    let total = HEADER_SIZE
+        .checked_add(fc_bytes)
+        .and_then(|s| s.checked_add(pair_bytes))
+        .ok_or_else(|| SearchError::IndexCorrupted("total buffer size overflow".into()))?;
     let mut buf = Vec::with_capacity(total);
     buf.extend_from_slice(&encode_header(&header));
     buf.extend_from_slice(&fc_buf);
@@ -251,10 +272,20 @@ fn serialize(
 }
 
 /// Atomically write `data` to `path` using a temp file in `dir`.
+///
+/// Sets explicit `0o644` permissions on Unix before persisting so that a
+/// permissive process umask cannot leave the file world-writable.
 fn atomic_write(dir: &Path, path: &Path, data: &[u8]) -> Result<()> {
     let mut tmp = NamedTempFile::new_in(dir)?;
     use std::io::Write as _;
     tmp.write_all(data)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o644))?;
+    }
+
     tmp.persist(path).map_err(|e| e.error)?;
     Ok(())
 }

--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use super::format::{
-    FILE_COMMIT_ENTRY_SIZE, FileCommitEntry, HEADER_SIZE, PAIR_ENTRY_SIZE, PairEntry, SKCC_MAGIC,
-    SkccHeader, encode_file_commit, encode_header, encode_pair, FORMAT_VERSION,
+    FILE_COMMIT_ENTRY_SIZE, FORMAT_VERSION, FileCommitEntry, HEADER_SIZE, PAIR_ENTRY_SIZE,
+    PairEntry, SKCC_MAGIC, SkccHeader, encode_file_commit, encode_header, encode_pair,
 };
 use crate::{CochangeStats, FileId, HistoryResult, Result, SearchError};
 
@@ -105,8 +105,7 @@ fn accumulate_pairs(
 ) -> Result<AccumulatedPairs> {
     let mut pair_counts: HashMap<(u32, u32), u32> =
         HashMap::with_capacity(history.commits.len().saturating_mul(4));
-    let mut file_commit_counts: HashMap<u32, u32> =
-        HashMap::with_capacity(path_map.len());
+    let mut file_commit_counts: HashMap<u32, u32> = HashMap::with_capacity(path_map.len());
 
     let mut commits_processed: u32 = 0;
     let mut commits_skipped_too_large: u32 = 0;
@@ -165,8 +164,8 @@ fn accumulate_pairs(
     }
 
     let stats = CochangeStats {
-        pair_count: 0,  // filled in after accumulation
-        file_count: 0,  // filled in after accumulation
+        pair_count: 0, // filled in after accumulation
+        file_count: 0, // filled in after accumulation
         commits_processed,
         commits_skipped_too_large,
         unknown_paths_skipped,
@@ -183,14 +182,21 @@ fn serialize(
     // Sort file_commit entries by file_id ascending.
     let mut file_entries: Vec<FileCommitEntry> = file_commit_counts
         .iter()
-        .map(|(&file_id, &commit_count)| FileCommitEntry { file_id, commit_count })
+        .map(|(&file_id, &commit_count)| FileCommitEntry {
+            file_id,
+            commit_count,
+        })
         .collect();
     file_entries.sort_unstable_by_key(|e| e.file_id);
 
     // Sort pair entries by (file_a, file_b) ascending.
     let mut pair_entries: Vec<PairEntry> = pair_counts
         .iter()
-        .map(|(&(file_a, file_b), &count)| PairEntry { file_a, file_b, count })
+        .map(|(&(file_a, file_b), &count)| PairEntry {
+            file_a,
+            file_b,
+            count,
+        })
         .collect();
     pair_entries.sort_unstable_by_key(|p| (p.file_a, p.file_b));
 

--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -231,8 +231,7 @@ fn serialize(
         .collect();
     pair_entries.sort_unstable_by_key(|p| (p.file_a, p.file_b));
 
-    // Serialise file_commit and pair arrays — use checked arithmetic to match
-    // reader.rs and catch hypothetical overflow on 32-bit targets.
+    // Compute byte counts with checked arithmetic to catch overflow on 32-bit targets.
     let fc_bytes = file_entries
         .len()
         .checked_mul(FILE_COMMIT_ENTRY_SIZE)
@@ -248,23 +247,24 @@ fn serialize(
             SearchError::IndexCorrupted("pair_count * PAIR_ENTRY_SIZE overflow".into())
         })?;
 
-    let mut fc_buf: Vec<u8> = Vec::with_capacity(fc_bytes);
+    // Assemble: header placeholder + file_commit + pairs.
+    let total = HEADER_SIZE
+        .checked_add(fc_bytes)
+        .and_then(|s| s.checked_add(pair_bytes))
+        .ok_or_else(|| SearchError::IndexCorrupted("total buffer size overflow".into()))?;
+    let mut buf = Vec::with_capacity(total);
+    buf.extend([0u8; HEADER_SIZE]); // placeholder, overwritten below
     for e in &file_entries {
-        fc_buf.extend_from_slice(&encode_file_commit(e));
+        buf.extend_from_slice(&encode_file_commit(e));
     }
-    let mut pair_buf: Vec<u8> = Vec::with_capacity(pair_bytes);
     for p in &pair_entries {
-        pair_buf.extend_from_slice(&encode_pair(p));
+        buf.extend_from_slice(&encode_pair(p));
     }
 
     // CRC32 over file_commit ++ pair bytes — delegate to format.rs so there
     // is a single source of truth for the checksum algorithm.
-    let mut payload: Vec<u8> = Vec::with_capacity(fc_bytes + pair_bytes);
-    payload.extend_from_slice(&fc_buf);
-    payload.extend_from_slice(&pair_buf);
-    let checksum = compute_checksum(&payload);
+    let checksum = compute_checksum(&buf[HEADER_SIZE..]);
 
-    // Build header.
     let pair_count = u32::try_from(pair_entries.len()).map_err(|_| {
         SearchError::IndexCorrupted(format!(
             "pair_count {} exceeds u32::MAX",
@@ -284,17 +284,7 @@ fn serialize(
         file_count,
         checksum,
     };
-
-    // Assemble: header + file_commit + pairs — use checked arithmetic to
-    // match reader.rs and guard against overflow on 32-bit targets.
-    let total = HEADER_SIZE
-        .checked_add(fc_bytes)
-        .and_then(|s| s.checked_add(pair_bytes))
-        .ok_or_else(|| SearchError::IndexCorrupted("total buffer size overflow".into()))?;
-    let mut buf = Vec::with_capacity(total);
-    buf.extend_from_slice(&encode_header(&header));
-    buf.extend_from_slice(&fc_buf);
-    buf.extend_from_slice(&pair_buf);
+    buf[..HEADER_SIZE].copy_from_slice(&encode_header(&header));
 
     Ok(buf)
 }

--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -1,0 +1,257 @@
+//! [`CochangeMatrixBuilder`] — accumulates co-change pairs from git history
+//! and serialises them to a single `cochange.skcc` file.
+//!
+//! # Atomicity contract
+//!
+//! The output file is written atomically via [`tempfile::NamedTempFile`] + `persist`
+//! (rename), so readers never observe a partial write.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use tempfile::NamedTempFile;
+
+use super::format::{
+    FILE_COMMIT_ENTRY_SIZE, FileCommitEntry, HEADER_SIZE, PAIR_ENTRY_SIZE, PairEntry, SKCC_MAGIC,
+    SkccHeader, encode_file_commit, encode_header, encode_pair, FORMAT_VERSION,
+};
+use crate::{CochangeStats, FileId, HistoryResult, Result, SearchError};
+
+/// Maximum number of files in a commit before the commit is skipped.
+///
+/// Commits that touch more than this many files are bulk refactors / merges
+/// that would pollute the coupling signal.
+pub(crate) const COUPLING_MAX_FILES: usize = 50;
+
+/// Maximum number of distinct co-change pairs the builder will accumulate.
+///
+/// Exceeding this limit returns `SearchError::IndexCorrupted` to protect
+/// against unbounded memory growth.
+pub(crate) const MAX_PAIRS: usize = 2_000_000;
+
+/// Return type of [`accumulate_pairs`]: (pair_counts, file_commit_counts, stats).
+type AccumulateResult = (HashMap<(u32, u32), u32>, HashMap<u32, u32>, CochangeStats);
+
+// ============================================================================
+// Public builder struct
+// ============================================================================
+
+/// Builds a co-change matrix from git history and writes it to a directory.
+///
+/// Does NOT implement [`crate::LayerBuilder`] — it takes a [`HistoryResult`]
+/// rather than raw file content.
+pub struct CochangeMatrixBuilder {
+    output_dir: PathBuf,
+}
+
+impl CochangeMatrixBuilder {
+    /// Create a new builder that will write `cochange.skcc` into `output_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::Io`] if `output_dir` does not exist.
+    pub fn new(output_dir: PathBuf) -> Result<Self> {
+        if !output_dir.exists() {
+            return Err(SearchError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("output_dir does not exist: {}", output_dir.display()),
+            )));
+        }
+        Ok(Self { output_dir })
+    }
+
+    /// Accumulate co-change pairs from `history` and write `cochange.skcc`.
+    ///
+    /// # Arguments
+    ///
+    /// - `history` — parsed git history from [`crate::TemporalSource`].
+    /// - `path_map` — caller-managed mapping from repo-root-relative paths to
+    ///   [`FileId`]. Paths absent from the map are silently skipped and counted
+    ///   in [`CochangeStats::unknown_paths_skipped`].
+    ///
+    /// # Errors
+    ///
+    /// - [`SearchError::IndexCorrupted`] if the number of accumulated pairs
+    ///   exceeds [`MAX_PAIRS`].
+    /// - [`SearchError::Io`] if writing fails.
+    pub fn build(
+        &self,
+        history: &HistoryResult,
+        path_map: &HashMap<PathBuf, FileId>,
+    ) -> Result<CochangeStats> {
+        let (pairs, file_counts, mut stats) = accumulate_pairs(history, path_map)?;
+        stats.pair_count = u32::try_from(pairs.len()).unwrap_or(u32::MAX);
+        stats.file_count = u32::try_from(file_counts.len()).unwrap_or(u32::MAX);
+
+        let data = serialize(&pairs, &file_counts)?;
+        let out_path = self.output_dir.join("cochange.skcc");
+        atomic_write(&self.output_dir, &out_path, &data)?;
+
+        Ok(stats)
+    }
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/// Iterate all commits, resolve paths, generate canonical (min,max) pairs,
+/// and track per-file commit counts.
+///
+/// Returns `(pair_counts, file_commit_counts, stats)`.
+fn accumulate_pairs(
+    history: &HistoryResult,
+    path_map: &HashMap<PathBuf, FileId>,
+) -> Result<AccumulateResult> {
+    let mut pair_counts: HashMap<(u32, u32), u32> =
+        HashMap::with_capacity(history.commits.len().saturating_mul(4));
+    let mut file_commit_counts: HashMap<u32, u32> =
+        HashMap::with_capacity(path_map.len());
+
+    let mut commits_processed: u32 = 0;
+    let mut commits_skipped_too_large: u32 = 0;
+    let mut unknown_paths_skipped: u32 = 0;
+
+    for commit in &history.commits {
+        commits_processed = commits_processed.saturating_add(1);
+
+        // Skip commits touching too many files.
+        if commit.changed_files.len() > COUPLING_MAX_FILES {
+            commits_skipped_too_large = commits_skipped_too_large.saturating_add(1);
+            continue;
+        }
+
+        // Resolve file IDs for this commit's changed files.
+        let mut ids: Vec<u32> = Vec::with_capacity(commit.changed_files.len());
+        for fc in &commit.changed_files {
+            match path_map.get(&fc.path) {
+                Some(fid) => ids.push(fid.0),
+                None => {
+                    unknown_paths_skipped = unknown_paths_skipped.saturating_add(1);
+                }
+            }
+        }
+
+        // Update per-file commit counts.
+        for &id in &ids {
+            let entry = file_commit_counts.entry(id).or_insert(0);
+            *entry = entry.saturating_add(1);
+        }
+
+        // Generate canonical (min, max) pairs — skip self-pairs implicitly.
+        for i in 0..ids.len() {
+            for j in (i + 1)..ids.len() {
+                let a = ids[i].min(ids[j]);
+                let b = ids[i].max(ids[j]);
+                // a < b guaranteed by construction; self-pairs (a==b) impossible
+                // when i != j and all IDs in a commit are distinct paths.
+                debug_assert!(a < b, "canonical pair invariant: a({a}) < b({b})");
+
+                // Check MAX_PAIRS before inserting a new entry.
+                if !pair_counts.contains_key(&(a, b)) && pair_counts.len() >= MAX_PAIRS {
+                    return Err(SearchError::IndexCorrupted(
+                        "co-change pair count exceeds safety limit".into(),
+                    ));
+                }
+                let entry = pair_counts.entry((a, b)).or_insert(0);
+                *entry = entry.saturating_add(1);
+            }
+        }
+    }
+
+    let stats = CochangeStats {
+        pair_count: 0,  // filled in after accumulation
+        file_count: 0,  // filled in after accumulation
+        commits_processed,
+        commits_skipped_too_large,
+        unknown_paths_skipped,
+    };
+
+    Ok((pair_counts, file_commit_counts, stats))
+}
+
+/// Serialise accumulated data into the `cochange.skcc` on-disk format.
+fn serialize(
+    pair_counts: &HashMap<(u32, u32), u32>,
+    file_commit_counts: &HashMap<u32, u32>,
+) -> Result<Vec<u8>> {
+    // Sort file_commit entries by file_id ascending.
+    let mut file_entries: Vec<FileCommitEntry> = file_commit_counts
+        .iter()
+        .map(|(&file_id, &commit_count)| FileCommitEntry { file_id, commit_count })
+        .collect();
+    file_entries.sort_unstable_by_key(|e| e.file_id);
+
+    // Sort pair entries by (file_a, file_b) ascending.
+    let mut pair_entries: Vec<PairEntry> = pair_counts
+        .iter()
+        .map(|(&(file_a, file_b), &count)| PairEntry { file_a, file_b, count })
+        .collect();
+    pair_entries.sort_unstable_by_key(|p| (p.file_a, p.file_b));
+
+    // Serialise file_commit and pair arrays.
+    let fc_bytes = file_entries.len() * FILE_COMMIT_ENTRY_SIZE;
+    let pair_bytes = pair_entries.len() * PAIR_ENTRY_SIZE;
+
+    let mut fc_buf: Vec<u8> = Vec::with_capacity(fc_bytes);
+    for e in &file_entries {
+        fc_buf.extend_from_slice(&encode_file_commit(e));
+    }
+    let mut pair_buf: Vec<u8> = Vec::with_capacity(pair_bytes);
+    for p in &pair_entries {
+        pair_buf.extend_from_slice(&encode_pair(p));
+    }
+
+    // CRC32 over file_commit ++ pair bytes.
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&fc_buf);
+    hasher.update(&pair_buf);
+    let checksum = hasher.finalize();
+
+    // Build header.
+    let pair_count = u32::try_from(pair_entries.len()).map_err(|_| {
+        SearchError::IndexCorrupted(format!(
+            "pair_count {} exceeds u32::MAX",
+            pair_entries.len()
+        ))
+    })?;
+    let file_count = u32::try_from(file_entries.len()).map_err(|_| {
+        SearchError::IndexCorrupted(format!(
+            "file_count {} exceeds u32::MAX",
+            file_entries.len()
+        ))
+    })?;
+    let header = SkccHeader {
+        magic: *SKCC_MAGIC,
+        version: FORMAT_VERSION,
+        pair_count,
+        file_count,
+        checksum,
+    };
+
+    // Assemble: header + file_commit + pairs.
+    let total = HEADER_SIZE + fc_bytes + pair_bytes;
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(&encode_header(&header));
+    buf.extend_from_slice(&fc_buf);
+    buf.extend_from_slice(&pair_buf);
+
+    Ok(buf)
+}
+
+/// Atomically write `data` to `path` using a temp file in `dir`.
+fn atomic_write(dir: &Path, path: &Path, data: &[u8]) -> Result<()> {
+    let mut tmp = NamedTempFile::new_in(dir)?;
+    use std::io::Write as _;
+    tmp.write_all(data)?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[path = "builder_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -236,9 +236,7 @@ fn serialize(
         .len()
         .checked_mul(FILE_COMMIT_ENTRY_SIZE)
         .ok_or_else(|| {
-            SearchError::IndexCorrupted(
-                "file_count * FILE_COMMIT_ENTRY_SIZE overflow".into(),
-            )
+            SearchError::IndexCorrupted("file_count * FILE_COMMIT_ENTRY_SIZE overflow".into())
         })?;
     let pair_bytes = pair_entries
         .len()

--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -29,9 +29,6 @@ pub(crate) const COUPLING_MAX_FILES: usize = 50;
 /// against unbounded memory growth.
 pub(crate) const MAX_PAIRS: usize = 2_000_000;
 
-/// Return type of [`accumulate_pairs`]: (pair_counts, file_commit_counts, stats).
-type AccumulateResult = (HashMap<(u32, u32), u32>, HashMap<u32, u32>, CochangeStats);
-
 // ============================================================================
 // Public builder struct
 // ============================================================================
@@ -95,6 +92,9 @@ impl CochangeMatrixBuilder {
 // Private helpers
 // ============================================================================
 
+/// Intermediate accumulation result: `(pair_counts, file_commit_counts, stats)`.
+type AccumulatedPairs = (HashMap<(u32, u32), u32>, HashMap<u32, u32>, CochangeStats);
+
 /// Iterate all commits, resolve paths, generate canonical (min,max) pairs,
 /// and track per-file commit counts.
 ///
@@ -102,7 +102,7 @@ impl CochangeMatrixBuilder {
 fn accumulate_pairs(
     history: &HistoryResult,
     path_map: &HashMap<PathBuf, FileId>,
-) -> Result<AccumulateResult> {
+) -> Result<AccumulatedPairs> {
     let mut pair_counts: HashMap<(u32, u32), u32> =
         HashMap::with_capacity(history.commits.len().saturating_mul(4));
     let mut file_commit_counts: HashMap<u32, u32> =
@@ -122,6 +122,9 @@ fn accumulate_pairs(
         }
 
         // Resolve file IDs for this commit's changed files.
+        // Deduplicate because the same path can appear more than once in a
+        // commit (e.g. rename with modify). Without dedup, self-pairs (a==a)
+        // would violate the canonical-ordering invariant.
         let mut ids: Vec<u32> = Vec::with_capacity(commit.changed_files.len());
         for fc in &commit.changed_files {
             match path_map.get(&fc.path) {
@@ -131,6 +134,8 @@ fn accumulate_pairs(
                 }
             }
         }
+        ids.sort_unstable();
+        ids.dedup();
 
         // Update per-file commit counts.
         for &id in &ids {

--- a/crates/rskim-search/src/cochange/builder.rs
+++ b/crates/rskim-search/src/cochange/builder.rs
@@ -79,7 +79,30 @@ impl CochangeMatrixBuilder {
         history: &HistoryResult,
         path_map: &HashMap<PathBuf, FileId>,
     ) -> Result<CochangeStats> {
-        let (pairs, file_counts, mut stats) = accumulate_pairs(history, path_map)?;
+        self.build_with_limit(history, path_map, MAX_PAIRS)
+    }
+
+    /// Like [`build`] but with a caller-supplied `max_pairs` limit.
+    ///
+    /// Intended for unit tests that need to trigger the safety cap without
+    /// generating 2 million distinct pairs.
+    #[cfg(test)]
+    pub(crate) fn build_with_max_pairs(
+        &self,
+        history: &HistoryResult,
+        path_map: &HashMap<PathBuf, FileId>,
+        max_pairs: usize,
+    ) -> Result<CochangeStats> {
+        self.build_with_limit(history, path_map, max_pairs)
+    }
+
+    fn build_with_limit(
+        &self,
+        history: &HistoryResult,
+        path_map: &HashMap<PathBuf, FileId>,
+        max_pairs: usize,
+    ) -> Result<CochangeStats> {
+        let (pairs, file_counts, mut stats) = accumulate_pairs(history, path_map, max_pairs)?;
         stats.pair_count = u32::try_from(pairs.len()).unwrap_or(u32::MAX);
         stats.file_count = u32::try_from(file_counts.len()).unwrap_or(u32::MAX);
 
@@ -101,10 +124,15 @@ type AccumulatedPairs = (HashMap<(u32, u32), u32>, HashMap<u32, u32>, CochangeSt
 /// Iterate all commits, resolve paths, generate canonical (min,max) pairs,
 /// and track per-file commit counts.
 ///
+/// `max_pairs` caps the number of distinct pairs; exceeding it returns
+/// [`SearchError::IndexCorrupted`].  Production callers pass [`MAX_PAIRS`];
+/// tests may pass a smaller value to exercise the error path cheaply.
+///
 /// Returns `(pair_counts, file_commit_counts, stats)`.
 fn accumulate_pairs(
     history: &HistoryResult,
     path_map: &HashMap<PathBuf, FileId>,
+    max_pairs: usize,
 ) -> Result<AccumulatedPairs> {
     let mut pair_counts: HashMap<(u32, u32), u32> =
         HashMap::with_capacity(history.commits.len().saturating_mul(4));
@@ -154,8 +182,8 @@ fn accumulate_pairs(
                 // when i != j and all IDs in a commit are distinct paths.
                 debug_assert!(a < b, "canonical pair invariant: a({a}) < b({b})");
 
-                // Check MAX_PAIRS before inserting a new entry.
-                if !pair_counts.contains_key(&(a, b)) && pair_counts.len() >= MAX_PAIRS {
+                // Check max_pairs limit before inserting a new entry.
+                if !pair_counts.contains_key(&(a, b)) && pair_counts.len() >= max_pairs {
                     return Err(SearchError::IndexCorrupted(
                         "co-change pair count exceeds safety limit".into(),
                     ));

--- a/crates/rskim-search/src/cochange/builder_tests.rs
+++ b/crates/rskim-search/src/cochange/builder_tests.rs
@@ -161,7 +161,9 @@ fn test_coupling_max_files_skip_exceeds() {
     let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
 
     // Create a commit with COUPLING_MAX_FILES + 1 files
-    let paths: Vec<String> = (0..=COUPLING_MAX_FILES).map(|i| format!("f{i}.rs")).collect();
+    let paths: Vec<String> = (0..=COUPLING_MAX_FILES)
+        .map(|i| format!("f{i}.rs"))
+        .collect();
     let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
     let history = make_history(vec![path_strs.clone()]);
     let path_map = make_path_map(&path_strs);
@@ -181,7 +183,9 @@ fn test_coupling_max_files_exactly_at_limit_processed() {
     let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
 
     // Exactly COUPLING_MAX_FILES files — should be processed
-    let paths: Vec<String> = (0..COUPLING_MAX_FILES).map(|i| format!("f{i}.rs")).collect();
+    let paths: Vec<String> = (0..COUPLING_MAX_FILES)
+        .map(|i| format!("f{i}.rs"))
+        .collect();
     let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
     let history = make_history(vec![path_strs.clone()]);
     let path_map = make_path_map(&path_strs);
@@ -242,7 +246,9 @@ fn test_commits_processed_counts_all_commits() {
     let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
 
     // 3 commits, one is too large to produce pairs but still counted
-    let paths: Vec<String> = (0..=COUPLING_MAX_FILES).map(|i| format!("f{i}.rs")).collect();
+    let paths: Vec<String> = (0..=COUPLING_MAX_FILES)
+        .map(|i| format!("f{i}.rs"))
+        .collect();
     let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
     let history = make_history(vec![
         vec!["a.rs", "b.rs"],
@@ -251,7 +257,9 @@ fn test_commits_processed_counts_all_commits() {
     ]);
     let mut path_map = make_path_map(&["a.rs", "b.rs", "c.rs"]);
     for (i, p) in path_strs.iter().enumerate() {
-        path_map.entry(PathBuf::from(p)).or_insert(FileId(i as u32 + 100));
+        path_map
+            .entry(PathBuf::from(p))
+            .or_insert(FileId(i as u32 + 100));
     }
 
     let stats = builder.build(&history, &path_map).unwrap();
@@ -289,10 +297,7 @@ fn test_build_then_read_roundtrip() {
     let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
 
     // Two commits: (a,b) and (a,b,c)
-    let history = make_history(vec![
-        vec!["a.rs", "b.rs"],
-        vec!["a.rs", "b.rs", "c.rs"],
-    ]);
+    let history = make_history(vec![vec!["a.rs", "b.rs"], vec!["a.rs", "b.rs", "c.rs"]]);
     let path_map = make_path_map(&["a.rs", "b.rs", "c.rs"]);
 
     let stats = builder.build(&history, &path_map).unwrap();
@@ -333,5 +338,8 @@ fn test_duplicate_paths_in_commit_deduplicated() {
     use crate::cochange::CochangeMatrixReader;
     let reader = CochangeMatrixReader::open(tmp.path()).unwrap();
     let count = reader.pair_count(FileId(0), FileId(1)).unwrap();
-    assert_eq!(count, 1, "co-change count should be 1, not inflated by duplicates");
+    assert_eq!(
+        count, 1,
+        "co-change count should be 1, not inflated by duplicates"
+    );
 }

--- a/crates/rskim-search/src/cochange/builder_tests.rs
+++ b/crates/rskim-search/src/cochange/builder_tests.rs
@@ -1,0 +1,314 @@
+//! Tests for CochangeMatrixBuilder.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::{COUPLING_MAX_FILES, CochangeMatrixBuilder};
+use crate::{CommitInfo, FileChangeInfo, FileId, HistoryResult, TemporalMetadata};
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+fn make_history(commits: Vec<Vec<&str>>) -> HistoryResult {
+    let commit_list = commits
+        .into_iter()
+        .enumerate()
+        .map(|(i, paths)| CommitInfo {
+            hash: format!("{i:040x}"),
+            timestamp: i as i64,
+            author: "test".to_string(),
+            message: "test commit".to_string(),
+            changed_files: paths
+                .into_iter()
+                .map(|p| FileChangeInfo {
+                    path: PathBuf::from(p),
+                    additions: 1,
+                    deletions: 0,
+                })
+                .collect(),
+        })
+        .collect();
+    HistoryResult {
+        commits: commit_list,
+        metadata: TemporalMetadata {
+            is_shallow: false,
+            commit_count: 0,
+        },
+    }
+}
+
+fn make_path_map(paths: &[&str]) -> HashMap<PathBuf, FileId> {
+    paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (PathBuf::from(p), FileId(i as u32)))
+        .collect()
+}
+
+// -----------------------------------------------------------------------
+// Constructor validation
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_constructor_nonexistent_dir_fails() {
+    let dir = PathBuf::from("/nonexistent/path/that/does/not/exist");
+    let result = CochangeMatrixBuilder::new(dir);
+    assert!(result.is_err(), "should fail on nonexistent directory");
+}
+
+#[test]
+fn test_constructor_existing_dir_succeeds() {
+    let tmp = TempDir::new().unwrap();
+    let result = CochangeMatrixBuilder::new(tmp.path().to_path_buf());
+    assert!(result.is_ok(), "should succeed with existing directory");
+}
+
+// -----------------------------------------------------------------------
+// Empty history
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_empty_history_writes_matrix_with_zero_stats() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    let history = make_history(vec![]);
+    let path_map = make_path_map(&[]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(stats.pair_count, 0);
+    assert_eq!(stats.file_count, 0);
+    assert_eq!(stats.commits_processed, 0);
+    assert_eq!(stats.commits_skipped_too_large, 0);
+    assert_eq!(stats.unknown_paths_skipped, 0);
+
+    // File must exist
+    assert!(tmp.path().join("cochange.skcc").exists());
+}
+
+// -----------------------------------------------------------------------
+// Single commit / two files
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_single_commit_two_files_creates_one_pair() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    let history = make_history(vec![vec!["a.rs", "b.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs"]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(stats.pair_count, 1);
+    assert_eq!(stats.file_count, 2);
+    assert_eq!(stats.commits_processed, 1);
+    assert_eq!(stats.commits_skipped_too_large, 0);
+    assert_eq!(stats.unknown_paths_skipped, 0);
+}
+
+// -----------------------------------------------------------------------
+// Self-pairs excluded
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_single_file_commit_produces_no_pairs() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    let history = make_history(vec![vec!["a.rs"]]);
+    let path_map = make_path_map(&["a.rs"]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(stats.pair_count, 0, "a single file has no pairs");
+}
+
+// -----------------------------------------------------------------------
+// Canonical pair ordering (min, max)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_canonical_pair_ordering() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    // Reverse order to verify normalization
+    let history = make_history(vec![vec!["b.rs", "a.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs"]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    // Still one canonical pair regardless of file order in commit
+    assert_eq!(stats.pair_count, 1);
+
+    // Verify the pair exists via reader
+    use crate::cochange::CochangeMatrixReader;
+    let reader = CochangeMatrixReader::open(tmp.path()).unwrap();
+    let count = reader.pair_count(FileId(0), FileId(1)).unwrap();
+    assert_eq!(count, 1);
+}
+
+// -----------------------------------------------------------------------
+// COUPLING_MAX_FILES threshold
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_coupling_max_files_skip_exceeds() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+
+    // Create a commit with COUPLING_MAX_FILES + 1 files
+    let paths: Vec<String> = (0..=COUPLING_MAX_FILES).map(|i| format!("f{i}.rs")).collect();
+    let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+    let history = make_history(vec![path_strs.clone()]);
+    let path_map = make_path_map(&path_strs);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(
+        stats.commits_skipped_too_large, 1,
+        "commit with > COUPLING_MAX_FILES files should be skipped"
+    );
+    assert_eq!(stats.pair_count, 0, "no pairs from skipped commit");
+}
+
+#[test]
+fn test_coupling_max_files_exactly_at_limit_processed() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+
+    // Exactly COUPLING_MAX_FILES files — should be processed
+    let paths: Vec<String> = (0..COUPLING_MAX_FILES).map(|i| format!("f{i}.rs")).collect();
+    let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+    let history = make_history(vec![path_strs.clone()]);
+    let path_map = make_path_map(&path_strs);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(
+        stats.commits_skipped_too_large, 0,
+        "commit with exactly COUPLING_MAX_FILES files should be processed"
+    );
+    // n files → n*(n-1)/2 pairs
+    let expected_pairs = (COUPLING_MAX_FILES * (COUPLING_MAX_FILES - 1)) / 2;
+    assert_eq!(stats.pair_count as usize, expected_pairs);
+}
+
+#[test]
+fn test_coupling_max_files_below_limit_processed() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+
+    let paths: Vec<String> = (0..3).map(|i| format!("f{i}.rs")).collect();
+    let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+    let history = make_history(vec![path_strs.clone()]);
+    let path_map = make_path_map(&path_strs);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(stats.commits_skipped_too_large, 0);
+    assert_eq!(stats.pair_count, 3, "3 files → 3 pairs");
+}
+
+// -----------------------------------------------------------------------
+// Unknown paths
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_unknown_paths_skipped_counted() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    // "c.rs" is not in path_map
+    let history = make_history(vec![vec!["a.rs", "b.rs", "c.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs"]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(stats.unknown_paths_skipped, 1);
+    // a.rs and b.rs still form a valid pair
+    assert_eq!(stats.pair_count, 1);
+}
+
+// -----------------------------------------------------------------------
+// Commits processed counter
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_commits_processed_counts_all_commits() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+
+    // 3 commits, one is too large to produce pairs but still counted
+    let paths: Vec<String> = (0..=COUPLING_MAX_FILES).map(|i| format!("f{i}.rs")).collect();
+    let path_strs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+    let history = make_history(vec![
+        vec!["a.rs", "b.rs"],
+        path_strs.clone(),
+        vec!["a.rs", "c.rs"],
+    ]);
+    let mut path_map = make_path_map(&["a.rs", "b.rs", "c.rs"]);
+    for (i, p) in path_strs.iter().enumerate() {
+        path_map.entry(PathBuf::from(p)).or_insert(FileId(i as u32 + 100));
+    }
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    assert_eq!(stats.commits_processed, 3, "all 3 commits counted");
+    assert_eq!(stats.commits_skipped_too_large, 1);
+}
+
+// -----------------------------------------------------------------------
+// Atomic write produces file
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_atomic_write_produces_file() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    let history = make_history(vec![vec!["a.rs", "b.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs"]);
+
+    builder.build(&history, &path_map).unwrap();
+
+    assert!(
+        tmp.path().join("cochange.skcc").exists(),
+        "cochange.skcc must be written"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Build-then-read roundtrip
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_build_then_read_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+
+    // Two commits: (a,b) and (a,b,c)
+    let history = make_history(vec![
+        vec!["a.rs", "b.rs"],
+        vec!["a.rs", "b.rs", "c.rs"],
+    ]);
+    let path_map = make_path_map(&["a.rs", "b.rs", "c.rs"]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    // a-b co-changed in both commits
+    assert_eq!(stats.pair_count, 3); // (a,b), (a,c), (b,c)
+
+    use crate::cochange::CochangeMatrixReader;
+    let reader = CochangeMatrixReader::open(tmp.path()).unwrap();
+
+    let ab = reader.pair_count(FileId(0), FileId(1)).unwrap();
+    assert_eq!(ab, 2, "a and b co-changed in 2 commits");
+
+    let ac = reader.pair_count(FileId(0), FileId(2)).unwrap();
+    assert_eq!(ac, 1, "a and c co-changed in 1 commit");
+
+    let bc = reader.pair_count(FileId(1), FileId(2)).unwrap();
+    assert_eq!(bc, 1, "b and c co-changed in 1 commit");
+}

--- a/crates/rskim-search/src/cochange/builder_tests.rs
+++ b/crates/rskim-search/src/cochange/builder_tests.rs
@@ -2,53 +2,13 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use tempfile::TempDir;
 
 use super::{COUPLING_MAX_FILES, CochangeMatrixBuilder};
-use crate::{CommitInfo, FileChangeInfo, FileId, HistoryResult, TemporalMetadata};
-
-// -----------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------
-
-fn make_history(commits: Vec<Vec<&str>>) -> HistoryResult {
-    let commit_list = commits
-        .into_iter()
-        .enumerate()
-        .map(|(i, paths)| CommitInfo {
-            hash: format!("{i:040x}"),
-            timestamp: i as i64,
-            author: "test".to_string(),
-            message: "test commit".to_string(),
-            changed_files: paths
-                .into_iter()
-                .map(|p| FileChangeInfo {
-                    path: PathBuf::from(p),
-                    additions: 1,
-                    deletions: 0,
-                })
-                .collect(),
-        })
-        .collect();
-    HistoryResult {
-        commits: commit_list,
-        metadata: TemporalMetadata {
-            is_shallow: false,
-            commit_count: 0,
-        },
-    }
-}
-
-fn make_path_map(paths: &[&str]) -> HashMap<PathBuf, FileId> {
-    paths
-        .iter()
-        .enumerate()
-        .map(|(i, p)| (PathBuf::from(p), FileId(i as u32)))
-        .collect()
-}
+use crate::FileId;
+use crate::cochange::test_helpers::{make_history, make_path_map};
 
 // -----------------------------------------------------------------------
 // Constructor validation
@@ -341,5 +301,29 @@ fn test_duplicate_paths_in_commit_deduplicated() {
     assert_eq!(
         count, 1,
         "co-change count should be 1, not inflated by duplicates"
+    );
+}
+
+// -----------------------------------------------------------------------
+// MAX_PAIRS safety cap → IndexCorrupted
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_max_pairs_safety_cap_returns_index_corrupted() {
+    // Use a tiny max_pairs limit (2) so we can trigger the cap with 3 files
+    // in a single commit — 3 files produce 3 distinct pairs: (0,1),(0,2),(1,2).
+    // The first two pairs fill the cap; the third triggers the error.
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    let history = make_history(vec![vec!["a.rs", "b.rs", "c.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs", "c.rs"]);
+
+    let result = builder.build_with_max_pairs(&history, &path_map, 2);
+    assert!(result.is_err(), "should fail when pair count exceeds limit");
+    let err = result.err().unwrap();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("safety limit") || msg.contains("IndexCorrupted") || msg.contains("pair"),
+        "error should describe the safety cap: {msg}"
     );
 }

--- a/crates/rskim-search/src/cochange/builder_tests.rs
+++ b/crates/rskim-search/src/cochange/builder_tests.rs
@@ -312,3 +312,26 @@ fn test_build_then_read_roundtrip() {
     let bc = reader.pair_count(FileId(1), FileId(2)).unwrap();
     assert_eq!(bc, 1, "b and c co-changed in 1 commit");
 }
+
+// -----------------------------------------------------------------------
+// Duplicate paths within a commit
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_duplicate_paths_in_commit_deduplicated() {
+    let tmp = TempDir::new().unwrap();
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    // Same path appears twice in one commit — must not create self-pairs.
+    let history = make_history(vec![vec!["a.rs", "b.rs", "a.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs"]);
+
+    let stats = builder.build(&history, &path_map).unwrap();
+
+    // Only one canonical pair (a, b) should exist, with count 1.
+    assert_eq!(stats.pair_count, 1, "duplicate paths must be deduplicated");
+
+    use crate::cochange::CochangeMatrixReader;
+    let reader = CochangeMatrixReader::open(tmp.path()).unwrap();
+    let count = reader.pair_count(FileId(0), FileId(1)).unwrap();
+    assert_eq!(count, 1, "co-change count should be 1, not inflated by duplicates");
+}

--- a/crates/rskim-search/src/cochange/builder_tests.rs
+++ b/crates/rskim-search/src/cochange/builder_tests.rs
@@ -323,7 +323,7 @@ fn test_max_pairs_safety_cap_returns_index_corrupted() {
     let err = result.err().unwrap();
     let msg = format!("{err}");
     assert!(
-        msg.contains("safety limit") || msg.contains("IndexCorrupted") || msg.contains("pair"),
+        msg.contains("safety limit") || msg.contains("pair"),
         "error should describe the safety cap: {msg}"
     );
 }

--- a/crates/rskim-search/src/cochange/format.rs
+++ b/crates/rskim-search/src/cochange/format.rs
@@ -113,11 +113,7 @@ pub(crate) struct PairEntry {
 ///
 /// Returns [`SearchError::IndexCorrupted`] if the range would overflow `usize`
 /// or exceeds `data.len()`, rather than panicking.
-fn read_array<const N: usize>(
-    data: &[u8],
-    start: usize,
-    context: &'static str,
-) -> Result<[u8; N]> {
+fn read_array<const N: usize>(data: &[u8], start: usize, context: &'static str) -> Result<[u8; N]> {
     let end = start
         .checked_add(N)
         .ok_or_else(|| SearchError::IndexCorrupted(format!("{context}: offset overflow")))?;
@@ -256,11 +252,7 @@ pub(crate) fn decode_pair(data: &[u8]) -> Result<PairEntry> {
 ///
 /// Returns `Ok(Some(count))` if found, `Ok(None)` if absent, or
 /// [`SearchError::IndexCorrupted`] if the slice is malformed.
-pub(crate) fn lookup_pair(
-    pairs_data: &[u8],
-    file_a: u32,
-    file_b: u32,
-) -> Result<Option<u32>> {
+pub(crate) fn lookup_pair(pairs_data: &[u8], file_a: u32, file_b: u32) -> Result<Option<u32>> {
     if !pairs_data.len().is_multiple_of(PAIR_ENTRY_SIZE) {
         return Err(SearchError::IndexCorrupted(format!(
             "pairs_data length {} is not a multiple of PAIR_ENTRY_SIZE {}; likely corrupt",

--- a/crates/rskim-search/src/cochange/format.rs
+++ b/crates/rskim-search/src/cochange/format.rs
@@ -1,0 +1,305 @@
+//! Pure binary codec for the co-change matrix format (`.skcc`).
+//!
+//! # File layout
+//!
+//! ```text
+//! [SkccHeader: 18 bytes]
+//! [FileCommitEntry × file_count:  8 bytes each, sorted by file_id]
+//! [PairEntry       × pair_count: 12 bytes each, sorted by (file_a, file_b)]
+//! ```
+//!
+//! # Encoding
+//!
+//! All multi-byte integers are little-endian. The header checksum covers the
+//! `FileCommitEntry` array bytes concatenated with the `PairEntry` array bytes.
+//!
+//! # Invariants upheld by this module
+//!
+//! - **No `std::fs` or `std::io::Write`** — every function operates on `&[u8]`
+//!   or returns owned byte arrays. All I/O happens in `builder.rs` / `reader.rs`.
+//! - **No `unwrap()` / `expect()` / `panic!()`** outside `#[cfg(test)]`.
+
+use crate::{Result, SearchError};
+
+/// Magic bytes at the start of every `.skcc` file.
+pub(crate) const SKCC_MAGIC: &[u8; 4] = b"SKCC";
+
+/// Current on-disk format version. Increment on any breaking change.
+pub(crate) const FORMAT_VERSION: u16 = 1;
+
+/// Size in bytes of [`SkccHeader`] on disk.
+///
+/// Layout: magic (4) + version (2) + pair_count (4) + file_count (4) + checksum (4) = 18 bytes.
+pub(crate) const HEADER_SIZE: usize = 18;
+
+/// Size in bytes of a single [`FileCommitEntry`] on disk.
+///
+/// Layout: file_id (4) + commit_count (4) = 8 bytes.
+pub(crate) const FILE_COMMIT_ENTRY_SIZE: usize = 8;
+
+/// Size in bytes of a single [`PairEntry`] on disk.
+///
+/// Layout: file_a (4) + file_b (4) + count (4) = 12 bytes.
+pub(crate) const PAIR_ENTRY_SIZE: usize = 12;
+
+// ============================================================================
+// On-disk structs
+// ============================================================================
+
+/// Fixed-size header at the start of every `.skcc` file.
+///
+/// Layout (18 bytes, all integers little-endian):
+/// ```text
+/// [0..4]   magic       4 bytes
+/// [4..6]   version     2 bytes
+/// [6..10]  pair_count  4 bytes
+/// [10..14] file_count  4 bytes
+/// [14..18] checksum    4 bytes (CRC32 of file_commit + pair bytes)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SkccHeader {
+    /// Must equal [`SKCC_MAGIC`].
+    pub magic: [u8; 4],
+    /// Must equal [`FORMAT_VERSION`].
+    pub version: u16,
+    /// Number of co-change pair entries.
+    pub pair_count: u32,
+    /// Number of file-commit-count entries.
+    pub file_count: u32,
+    /// CRC32 of the `FileCommitEntry` array bytes ++ `PairEntry` array bytes.
+    pub checksum: u32,
+}
+
+/// Per-file commit count entry, sorted by `file_id` ascending.
+///
+/// Layout (8 bytes, all integers little-endian):
+/// ```text
+/// [0..4] file_id      4 bytes
+/// [4..8] commit_count 4 bytes
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FileCommitEntry {
+    /// The [`crate::FileId`] inner value.
+    pub file_id: u32,
+    /// Number of commits in which this file appeared.
+    pub commit_count: u32,
+}
+
+/// A single co-change pair entry, sorted by `(file_a, file_b)` ascending.
+///
+/// Invariant: `file_a < file_b` (canonical ordering enforced by builder).
+///
+/// Layout (12 bytes, all integers little-endian):
+/// ```text
+/// [0..4]  file_a 4 bytes
+/// [4..8]  file_b 4 bytes
+/// [8..12] count  4 bytes
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PairEntry {
+    /// Lower file ID in the pair.
+    pub file_a: u32,
+    /// Higher file ID in the pair.
+    pub file_b: u32,
+    /// Number of commits in which both files appeared together.
+    pub count: u32,
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/// Extract a fixed-size byte array from `data[start..start+N]`.
+///
+/// Returns [`SearchError::IndexCorrupted`] if the range would overflow `usize`
+/// or exceeds `data.len()`, rather than panicking.
+fn read_array<const N: usize>(
+    data: &[u8],
+    start: usize,
+    context: &'static str,
+) -> Result<[u8; N]> {
+    let end = start
+        .checked_add(N)
+        .ok_or_else(|| SearchError::IndexCorrupted(format!("{context}: offset overflow")))?;
+    data.get(start..end)
+        .and_then(|s| s.try_into().ok())
+        .ok_or_else(|| {
+            SearchError::IndexCorrupted(format!(
+                "{context}: need {N} bytes at offset {start}, got {}",
+                data.len()
+            ))
+        })
+}
+
+// ============================================================================
+// Header encode / decode
+// ============================================================================
+
+/// Encode a [`SkccHeader`] into its 18-byte on-disk representation.
+pub(crate) fn encode_header(h: &SkccHeader) -> [u8; HEADER_SIZE] {
+    let mut buf = [0u8; HEADER_SIZE];
+    buf[0..4].copy_from_slice(&h.magic);
+    buf[4..6].copy_from_slice(&h.version.to_le_bytes());
+    buf[6..10].copy_from_slice(&h.pair_count.to_le_bytes());
+    buf[10..14].copy_from_slice(&h.file_count.to_le_bytes());
+    buf[14..18].copy_from_slice(&h.checksum.to_le_bytes());
+    buf
+}
+
+/// Decode a [`SkccHeader`] from a byte slice.
+///
+/// # Errors
+///
+/// Returns [`SearchError::IndexCorrupted`] if the slice is too short, the
+/// magic bytes do not match, or the version is not [`FORMAT_VERSION`].
+pub(crate) fn decode_header(data: &[u8]) -> Result<SkccHeader> {
+    if data.len() < HEADER_SIZE {
+        return Err(SearchError::IndexCorrupted(format!(
+            "header truncated: need {HEADER_SIZE} bytes, got {}",
+            data.len()
+        )));
+    }
+    let magic: [u8; 4] = read_array(data, 0, "header: magic")?;
+    if &magic != SKCC_MAGIC {
+        return Err(SearchError::IndexCorrupted(format!(
+            "bad magic: expected {:?}, got {:?}",
+            SKCC_MAGIC, magic
+        )));
+    }
+    let version = u16::from_le_bytes(read_array(data, 4, "header: version")?);
+    if version != FORMAT_VERSION {
+        return Err(SearchError::IndexCorrupted(format!(
+            "unsupported format version: {version} (expected {FORMAT_VERSION}); \
+             please rebuild the co-change matrix"
+        )));
+    }
+    Ok(SkccHeader {
+        magic,
+        version,
+        pair_count: u32::from_le_bytes(read_array(data, 6, "header: pair_count")?),
+        file_count: u32::from_le_bytes(read_array(data, 10, "header: file_count")?),
+        checksum: u32::from_le_bytes(read_array(data, 14, "header: checksum")?),
+    })
+}
+
+// ============================================================================
+// FileCommitEntry encode / decode
+// ============================================================================
+
+/// Encode a [`FileCommitEntry`] into its 8-byte on-disk representation.
+pub(crate) fn encode_file_commit(e: &FileCommitEntry) -> [u8; FILE_COMMIT_ENTRY_SIZE] {
+    let mut buf = [0u8; FILE_COMMIT_ENTRY_SIZE];
+    buf[0..4].copy_from_slice(&e.file_id.to_le_bytes());
+    buf[4..8].copy_from_slice(&e.commit_count.to_le_bytes());
+    buf
+}
+
+/// Decode a [`FileCommitEntry`] from an 8-byte slice.
+///
+/// # Errors
+///
+/// Returns [`SearchError::IndexCorrupted`] if the slice is too short.
+pub(crate) fn decode_file_commit(data: &[u8]) -> Result<FileCommitEntry> {
+    if data.len() < FILE_COMMIT_ENTRY_SIZE {
+        return Err(SearchError::IndexCorrupted(format!(
+            "file_commit truncated: need {FILE_COMMIT_ENTRY_SIZE} bytes, got {}",
+            data.len()
+        )));
+    }
+    Ok(FileCommitEntry {
+        file_id: u32::from_le_bytes(read_array(data, 0, "file_commit: file_id")?),
+        commit_count: u32::from_le_bytes(read_array(data, 4, "file_commit: commit_count")?),
+    })
+}
+
+// ============================================================================
+// PairEntry encode / decode
+// ============================================================================
+
+/// Encode a [`PairEntry`] into its 12-byte on-disk representation.
+pub(crate) fn encode_pair(p: &PairEntry) -> [u8; PAIR_ENTRY_SIZE] {
+    let mut buf = [0u8; PAIR_ENTRY_SIZE];
+    buf[0..4].copy_from_slice(&p.file_a.to_le_bytes());
+    buf[4..8].copy_from_slice(&p.file_b.to_le_bytes());
+    buf[8..12].copy_from_slice(&p.count.to_le_bytes());
+    buf
+}
+
+/// Decode a [`PairEntry`] from a 12-byte slice.
+///
+/// # Errors
+///
+/// Returns [`SearchError::IndexCorrupted`] if the slice is too short.
+pub(crate) fn decode_pair(data: &[u8]) -> Result<PairEntry> {
+    if data.len() < PAIR_ENTRY_SIZE {
+        return Err(SearchError::IndexCorrupted(format!(
+            "pair_entry truncated: need {PAIR_ENTRY_SIZE} bytes, got {}",
+            data.len()
+        )));
+    }
+    Ok(PairEntry {
+        file_a: u32::from_le_bytes(read_array(data, 0, "pair_entry: file_a")?),
+        file_b: u32::from_le_bytes(read_array(data, 4, "pair_entry: file_b")?),
+        count: u32::from_le_bytes(read_array(data, 8, "pair_entry: count")?),
+    })
+}
+
+// ============================================================================
+// Binary search over sorted pair entries
+// ============================================================================
+
+/// Binary-search `pairs_data` for the pair `(file_a, file_b)`.
+///
+/// `pairs_data` must be a byte slice whose length is a multiple of
+/// [`PAIR_ENTRY_SIZE`] and whose entries are sorted ascending by
+/// `(file_a, file_b)`.
+///
+/// Returns `Ok(Some(count))` if found, `Ok(None)` if absent, or
+/// [`SearchError::IndexCorrupted`] if the slice is malformed.
+pub(crate) fn lookup_pair(
+    pairs_data: &[u8],
+    file_a: u32,
+    file_b: u32,
+) -> Result<Option<u32>> {
+    if !pairs_data.len().is_multiple_of(PAIR_ENTRY_SIZE) {
+        return Err(SearchError::IndexCorrupted(format!(
+            "pairs_data length {} is not a multiple of PAIR_ENTRY_SIZE {}; likely corrupt",
+            pairs_data.len(),
+            PAIR_ENTRY_SIZE
+        )));
+    }
+    let n = pairs_data.len() / PAIR_ENTRY_SIZE;
+    let mut lo = 0usize;
+    let mut hi = n;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let offset = mid * PAIR_ENTRY_SIZE;
+        let entry = decode_pair(&pairs_data[offset..offset + PAIR_ENTRY_SIZE])?;
+        match (entry.file_a, entry.file_b).cmp(&(file_a, file_b)) {
+            std::cmp::Ordering::Equal => return Ok(Some(entry.count)),
+            std::cmp::Ordering::Less => lo = mid + 1,
+            std::cmp::Ordering::Greater => hi = mid,
+        }
+    }
+    Ok(None)
+}
+
+// ============================================================================
+// CRC32 checksum
+// ============================================================================
+
+/// Compute the CRC32 checksum of `data`.
+///
+/// The header checksum covers the `FileCommitEntry` array bytes concatenated
+/// with the `PairEntry` array bytes.
+pub(crate) fn compute_checksum(data: &[u8]) -> u32 {
+    crc32fast::hash(data)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[path = "format_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/cochange/format_tests.rs
+++ b/crates/rskim-search/src/cochange/format_tests.rs
@@ -56,7 +56,10 @@ fn test_header_bad_version() {
     let result = decode_header(&encoded);
     assert!(result.is_err());
     let msg = format!("{}", result.unwrap_err());
-    assert!(msg.contains("version"), "error should mention 'version': {msg}");
+    assert!(
+        msg.contains("version"),
+        "error should mention 'version': {msg}"
+    );
 }
 
 #[test]
@@ -124,9 +127,21 @@ fn test_pair_entry_roundtrip() {
 fn test_lookup_pair_found() {
     // Build a sorted pairs slice: (1,2,10), (1,3,5), (2,4,3)
     let pairs = [
-        PairEntry { file_a: 1, file_b: 2, count: 10 },
-        PairEntry { file_a: 1, file_b: 3, count: 5 },
-        PairEntry { file_a: 2, file_b: 4, count: 3 },
+        PairEntry {
+            file_a: 1,
+            file_b: 2,
+            count: 10,
+        },
+        PairEntry {
+            file_a: 1,
+            file_b: 3,
+            count: 5,
+        },
+        PairEntry {
+            file_a: 2,
+            file_b: 4,
+            count: 3,
+        },
     ];
     let mut data = Vec::new();
     for p in &pairs {
@@ -139,8 +154,16 @@ fn test_lookup_pair_found() {
 #[test]
 fn test_lookup_pair_not_found() {
     let pairs = [
-        PairEntry { file_a: 1, file_b: 2, count: 10 },
-        PairEntry { file_a: 2, file_b: 4, count: 3 },
+        PairEntry {
+            file_a: 1,
+            file_b: 2,
+            count: 10,
+        },
+        PairEntry {
+            file_a: 2,
+            file_b: 4,
+            count: 3,
+        },
     ];
     let mut data = Vec::new();
     for p in &pairs {
@@ -167,24 +190,6 @@ fn test_lookup_pair_misaligned_slice() {
         msg.contains("multiple") || msg.contains("aligned") || msg.contains("corrupt"),
         "error should mention alignment: {msg}"
     );
-}
-
-// -----------------------------------------------------------------------
-// read_array overflow
-// -----------------------------------------------------------------------
-
-#[test]
-fn test_read_array_overflow() {
-    // Try to read 4 bytes starting at usize::MAX - 2, should overflow checked_add
-    let data = vec![0u8; 8];
-    // We can't directly call read_array (it's private), so we test it indirectly
-    // via decode_header with a slice that's exactly HEADER_SIZE but with bad content.
-    // Use decode_pair with a slice too short as indirect coverage.
-    let short = vec![0u8; PAIR_ENTRY_SIZE - 1];
-    let result = decode_pair(&short);
-    assert!(result.is_err());
-    // Ensure data not used warning doesn't fire
-    let _ = data;
 }
 
 // -----------------------------------------------------------------------

--- a/crates/rskim-search/src/cochange/format_tests.rs
+++ b/crates/rskim-search/src/cochange/format_tests.rs
@@ -1,0 +1,215 @@
+//! Tests for the co-change binary format codec (format.rs).
+
+#![allow(clippy::unwrap_used)]
+
+use super::*;
+
+// -----------------------------------------------------------------------
+// Header roundtrip
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_header_roundtrip() {
+    let h = SkccHeader {
+        magic: *SKCC_MAGIC,
+        version: FORMAT_VERSION,
+        pair_count: 42,
+        file_count: 10,
+        checksum: 0xDEAD_BEEF,
+    };
+    let encoded = encode_header(&h);
+    assert_eq!(encoded.len(), HEADER_SIZE);
+    let decoded = decode_header(&encoded).unwrap();
+    assert_eq!(decoded.magic, h.magic);
+    assert_eq!(decoded.version, h.version);
+    assert_eq!(decoded.pair_count, h.pair_count);
+    assert_eq!(decoded.file_count, h.file_count);
+    assert_eq!(decoded.checksum, h.checksum);
+}
+
+#[test]
+fn test_header_bad_magic() {
+    let h = SkccHeader {
+        magic: *b"ABCD",
+        version: FORMAT_VERSION,
+        pair_count: 0,
+        file_count: 0,
+        checksum: 0,
+    };
+    let encoded = encode_header(&h);
+    let result = decode_header(&encoded);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("magic"), "error should mention 'magic': {msg}");
+}
+
+#[test]
+fn test_header_bad_version() {
+    let h = SkccHeader {
+        magic: *SKCC_MAGIC,
+        version: FORMAT_VERSION + 1,
+        pair_count: 0,
+        file_count: 0,
+        checksum: 0,
+    };
+    let encoded = encode_header(&h);
+    let result = decode_header(&encoded);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(msg.contains("version"), "error should mention 'version': {msg}");
+}
+
+#[test]
+fn test_header_truncated() {
+    let h = SkccHeader {
+        magic: *SKCC_MAGIC,
+        version: FORMAT_VERSION,
+        pair_count: 1,
+        file_count: 1,
+        checksum: 0,
+    };
+    let encoded = encode_header(&h);
+    // Truncate to 10 bytes (less than HEADER_SIZE = 18)
+    let truncated = &encoded[..10];
+    let result = decode_header(truncated);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("truncated") || msg.contains("bytes"),
+        "error should describe truncation: {msg}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// FileCommitEntry roundtrip
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_file_commit_entry_roundtrip() {
+    let e = FileCommitEntry {
+        file_id: 7,
+        commit_count: 42,
+    };
+    let encoded = encode_file_commit(&e);
+    assert_eq!(encoded.len(), FILE_COMMIT_ENTRY_SIZE);
+    let decoded = decode_file_commit(&encoded).unwrap();
+    assert_eq!(decoded.file_id, e.file_id);
+    assert_eq!(decoded.commit_count, e.commit_count);
+}
+
+// -----------------------------------------------------------------------
+// PairEntry roundtrip
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_pair_entry_roundtrip() {
+    let p = PairEntry {
+        file_a: 3,
+        file_b: 5,
+        count: 17,
+    };
+    let encoded = encode_pair(&p);
+    assert_eq!(encoded.len(), PAIR_ENTRY_SIZE);
+    let decoded = decode_pair(&encoded).unwrap();
+    assert_eq!(decoded.file_a, p.file_a);
+    assert_eq!(decoded.file_b, p.file_b);
+    assert_eq!(decoded.count, p.count);
+}
+
+// -----------------------------------------------------------------------
+// lookup_pair
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_lookup_pair_found() {
+    // Build a sorted pairs slice: (1,2,10), (1,3,5), (2,4,3)
+    let pairs = [
+        PairEntry { file_a: 1, file_b: 2, count: 10 },
+        PairEntry { file_a: 1, file_b: 3, count: 5 },
+        PairEntry { file_a: 2, file_b: 4, count: 3 },
+    ];
+    let mut data = Vec::new();
+    for p in &pairs {
+        data.extend_from_slice(&encode_pair(p));
+    }
+    let result = lookup_pair(&data, 1, 3).unwrap();
+    assert_eq!(result, Some(5));
+}
+
+#[test]
+fn test_lookup_pair_not_found() {
+    let pairs = [
+        PairEntry { file_a: 1, file_b: 2, count: 10 },
+        PairEntry { file_a: 2, file_b: 4, count: 3 },
+    ];
+    let mut data = Vec::new();
+    for p in &pairs {
+        data.extend_from_slice(&encode_pair(p));
+    }
+    let result = lookup_pair(&data, 1, 3).unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_lookup_pair_empty_slice() {
+    let result = lookup_pair(&[], 0, 1).unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_lookup_pair_misaligned_slice() {
+    // 5 bytes is not a multiple of PAIR_ENTRY_SIZE (12)
+    let data = vec![0u8; 5];
+    let result = lookup_pair(&data, 0, 1);
+    assert!(result.is_err());
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("multiple") || msg.contains("aligned") || msg.contains("corrupt"),
+        "error should mention alignment: {msg}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// read_array overflow
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_read_array_overflow() {
+    // Try to read 4 bytes starting at usize::MAX - 2, should overflow checked_add
+    let data = vec![0u8; 8];
+    // We can't directly call read_array (it's private), so we test it indirectly
+    // via decode_header with a slice that's exactly HEADER_SIZE but with bad content.
+    // Use decode_pair with a slice too short as indirect coverage.
+    let short = vec![0u8; PAIR_ENTRY_SIZE - 1];
+    let result = decode_pair(&short);
+    assert!(result.is_err());
+    // Ensure data not used warning doesn't fire
+    let _ = data;
+}
+
+// -----------------------------------------------------------------------
+// Checksum determinism
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_checksum_determinism() {
+    let data = b"hello world";
+    let c1 = compute_checksum(data);
+    let c2 = compute_checksum(data);
+    assert_eq!(c1, c2);
+}
+
+#[test]
+fn test_checksum_different_data() {
+    let c1 = compute_checksum(b"hello");
+    let c2 = compute_checksum(b"world");
+    assert_ne!(c1, c2);
+}
+
+#[test]
+fn test_checksum_empty() {
+    // Empty data should not panic and should return a deterministic value.
+    let c1 = compute_checksum(b"");
+    let c2 = compute_checksum(b"");
+    assert_eq!(c1, c2);
+}

--- a/crates/rskim-search/src/cochange/mod.rs
+++ b/crates/rskim-search/src/cochange/mod.rs
@@ -24,6 +24,8 @@
 pub(crate) mod builder;
 pub(crate) mod format;
 pub(crate) mod reader;
+#[cfg(test)]
+pub(crate) mod test_helpers;
 
 pub use builder::CochangeMatrixBuilder;
 pub use reader::CochangeMatrixReader;

--- a/crates/rskim-search/src/cochange/mod.rs
+++ b/crates/rskim-search/src/cochange/mod.rs
@@ -1,0 +1,29 @@
+//! Co-change matrix: binary persistence of file co-change counts derived from
+//! git history, with Jaccard similarity and top-K retrieval.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use std::collections::HashMap;
+//! use std::path::PathBuf;
+//! use rskim_search::cochange::{CochangeMatrixBuilder, CochangeMatrixReader};
+//! use rskim_search::FileId;
+//!
+//! // Build phase (once per index refresh)
+//! let dir = PathBuf::from("/tmp/my_index");
+//! let builder = CochangeMatrixBuilder::new(dir.clone()).unwrap();
+//! let path_map: HashMap<PathBuf, FileId> = HashMap::new(); // populate from manifest
+//! let stats = builder.build(&history_result, &path_map).unwrap();
+//!
+//! // Query phase
+//! let reader = CochangeMatrixReader::open(&dir).unwrap();
+//! let j = reader.jaccard(FileId(0), FileId(1)).unwrap();
+//! let partners = reader.pairs_for_file(FileId(0)).unwrap();
+//! ```
+
+pub(crate) mod builder;
+pub(crate) mod format;
+pub(crate) mod reader;
+
+pub use builder::CochangeMatrixBuilder;
+pub use reader::CochangeMatrixReader;

--- a/crates/rskim-search/src/cochange/reader.rs
+++ b/crates/rskim-search/src/cochange/reader.rs
@@ -29,8 +29,8 @@ use std::path::Path;
 use memmap2::Mmap;
 
 use super::format::{
-    FILE_COMMIT_ENTRY_SIZE, HEADER_SIZE, PAIR_ENTRY_SIZE, SkccHeader, compute_checksum,
-    decode_file_commit, decode_header, lookup_pair,
+    FILE_COMMIT_ENTRY_SIZE, HEADER_SIZE, PAIR_ENTRY_SIZE, compute_checksum, decode_file_commit,
+    decode_header, lookup_pair,
 };
 use crate::{FileId, Result, SearchError};
 
@@ -40,14 +40,21 @@ use crate::{FileId, Result, SearchError};
 
 /// Memory-mapped, read-only query layer for a co-change matrix.
 pub struct CochangeMatrixReader {
-    /// Decoded header (copied out of mmap for cheap access).
-    header: SkccHeader,
     // SAFETY: read-only after construction; see module-level SAFETY note.
     mmap: Mmap,
+    /// Byte offset where the file-commit section begins (always `HEADER_SIZE`).
+    fc_start: usize,
+    /// Byte offset where the file-commit section ends / pair section begins.
+    /// Computed once in `open()` with checked arithmetic and cached here so
+    /// that `file_commit_slice` and `pairs_slice` never repeat multiplication
+    /// that could overflow on 32-bit targets.
+    fc_end: usize,
+    /// Byte offset where the pair section ends (equals total file size).
+    pairs_end: usize,
 }
 
 // CochangeMatrixReader is automatically Send + Sync because all fields
-// (SkccHeader: Copy, Mmap: Send+Sync) satisfy the auto-trait bounds.
+// (Mmap: Send+Sync, usize: Send+Sync) satisfy the auto-trait bounds.
 
 impl CochangeMatrixReader {
     /// Open an existing co-change matrix from `dir`.
@@ -59,6 +66,7 @@ impl CochangeMatrixReader {
     ///
     /// - [`SearchError::Io`] if `cochange.skcc` cannot be opened.
     /// - [`SearchError::IndexCorrupted`] if validation fails.
+    #[must_use = "dropping the reader immediately means no queries can be made"]
     pub fn open(dir: &Path) -> Result<Self> {
         let path = dir.join("cochange.skcc");
         let file = std::fs::File::open(&path)?;
@@ -79,10 +87,18 @@ impl CochangeMatrixReader {
             .ok_or_else(|| {
                 SearchError::IndexCorrupted("pair_count * PAIR_ENTRY_SIZE overflow".into())
             })?;
-        let expected_size = HEADER_SIZE
+        // Cache validated offsets: HEADER_SIZE → fc_end → pairs_end.
+        // These are computed once here with checked arithmetic and stored as
+        // struct fields so that `file_commit_slice` and `pairs_slice` never
+        // need to repeat potentially-overflowing multiplication.
+        let fc_start = HEADER_SIZE;
+        let fc_end = fc_start
             .checked_add(fc_bytes)
-            .and_then(|s| s.checked_add(pair_bytes))
-            .ok_or_else(|| SearchError::IndexCorrupted("expected_size overflow".into()))?;
+            .ok_or_else(|| SearchError::IndexCorrupted("fc_end overflow".into()))?;
+        let pairs_end = fc_end
+            .checked_add(pair_bytes)
+            .ok_or_else(|| SearchError::IndexCorrupted("pairs_end overflow".into()))?;
+        let expected_size = pairs_end;
 
         if mmap.len() != expected_size {
             return Err(SearchError::IndexCorrupted(format!(
@@ -101,7 +117,12 @@ impl CochangeMatrixReader {
             )));
         }
 
-        Ok(Self { header, mmap })
+        Ok(Self {
+            mmap,
+            fc_start,
+            fc_end,
+            pairs_end,
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -116,6 +137,7 @@ impl CochangeMatrixReader {
     /// # Errors
     ///
     /// Returns [`SearchError::IndexCorrupted`] if the pair data is malformed.
+    #[must_use = "ignoring the co-change count discards the query result"]
     pub fn pair_count(&self, a: FileId, b: FileId) -> Result<u32> {
         if a == b {
             return Ok(0);
@@ -134,6 +156,7 @@ impl CochangeMatrixReader {
     /// # Errors
     ///
     /// Returns [`SearchError::IndexCorrupted`] if the underlying data is malformed.
+    #[must_use = "ignoring the Jaccard similarity discards the query result"]
     pub fn jaccard(&self, a: FileId, b: FileId) -> Result<f64> {
         if a == b {
             return Ok(0.0);
@@ -154,7 +177,15 @@ impl CochangeMatrixReader {
     /// Return all co-change partners for `file_id`, sorted by co-change count
     /// descending.
     ///
-    /// Performs a linear scan over all pair entries (O(pair_count)).
+    /// # Complexity
+    ///
+    /// **O(pair_count)** — performs a full linear scan over all pair entries.
+    /// At the `MAX_PAIRS` cap of 2,000,000 pairs this reads up to ~24 MB per
+    /// call.  Pairs are stored sorted by `(file_a, file_b)`, so `file_a`
+    /// matches form a contiguous range — a future optimisation could use
+    /// binary search on the `file_a` dimension to reduce this to
+    /// O(log(pair_count) + k) where k is the number of matching pairs.
+    ///
     /// Returns an empty Vec for unknown `file_id` values.
     ///
     /// # Errors
@@ -214,17 +245,17 @@ impl CochangeMatrixReader {
     // -----------------------------------------------------------------------
 
     /// Slice of file-commit entries within the mmap.
+    ///
+    /// Uses offsets cached at `open()` time — no arithmetic at call site.
     fn file_commit_slice(&self) -> &[u8] {
-        let fc_start = HEADER_SIZE;
-        let fc_end = fc_start + (self.header.file_count as usize) * FILE_COMMIT_ENTRY_SIZE;
-        &self.mmap[fc_start..fc_end]
+        &self.mmap[self.fc_start..self.fc_end]
     }
 
     /// Slice of pair entries within the mmap.
+    ///
+    /// Uses offsets cached at `open()` time — no arithmetic at call site.
     fn pairs_slice(&self) -> &[u8] {
-        let fc_end = HEADER_SIZE + (self.header.file_count as usize) * FILE_COMMIT_ENTRY_SIZE;
-        let pairs_end = fc_end + (self.header.pair_count as usize) * PAIR_ENTRY_SIZE;
-        &self.mmap[fc_end..pairs_end]
+        &self.mmap[self.fc_end..self.pairs_end]
     }
 }
 

--- a/crates/rskim-search/src/cochange/reader.rs
+++ b/crates/rskim-search/src/cochange/reader.rs
@@ -46,9 +46,8 @@ pub struct CochangeMatrixReader {
     mmap: Mmap,
 }
 
-// SAFETY: Mmap is Send + Sync; all fields are immutable after construction.
-unsafe impl Send for CochangeMatrixReader {}
-unsafe impl Sync for CochangeMatrixReader {}
+// CochangeMatrixReader is automatically Send + Sync because all fields
+// (SkccHeader: Copy, Mmap: Send+Sync) satisfy the auto-trait bounds.
 
 impl CochangeMatrixReader {
     /// Open an existing co-change matrix from `dir`.
@@ -241,7 +240,7 @@ impl CochangeMatrixReader {
 /// Return `(min(a,b), max(a,b))` as `(u32, u32)`.
 #[inline]
 fn canonicalize(a: FileId, b: FileId) -> (u32, u32) {
-    if a.0 <= b.0 { (a.0, b.0) } else { (b.0, a.0) }
+    (a.0.min(b.0), a.0.max(b.0))
 }
 
 // ============================================================================

--- a/crates/rskim-search/src/cochange/reader.rs
+++ b/crates/rskim-search/src/cochange/reader.rs
@@ -1,0 +1,253 @@
+//! [`CochangeMatrixReader`] — memory-mapped, read-only query layer for the
+//! co-change matrix.
+//!
+//! # Memory layout
+//!
+//! The `.skcc` file is memory-mapped in its entirety. The layout is:
+//!
+//! ```text
+//! [SkccHeader: 18 bytes]
+//! [FileCommitEntry × file_count:  8 bytes each, sorted by file_id]
+//! [PairEntry       × pair_count: 12 bytes each, sorted by (file_a, file_b)]
+//! ```
+//!
+//! # Send + Sync
+//!
+//! `CochangeMatrixReader` is `Send + Sync` because:
+//! - `Mmap` is `Send + Sync` on all platforms supported by `memmap2`.
+//! - All fields are read-only after construction.
+//! - There is no interior mutation.
+//!
+//! # SAFETY
+//!
+//! The mmap is created read-only.  If another process truncates or overwrites
+//! `cochange.skcc` concurrently, behaviour is undefined — this is an inherent
+//! constraint of mmap-based indexes.
+
+use std::path::Path;
+
+use memmap2::Mmap;
+
+use super::format::{
+    FILE_COMMIT_ENTRY_SIZE, HEADER_SIZE, PAIR_ENTRY_SIZE, SkccHeader, compute_checksum,
+    decode_file_commit, decode_header, lookup_pair,
+};
+use crate::{FileId, Result, SearchError};
+
+// ============================================================================
+// Reader struct
+// ============================================================================
+
+/// Memory-mapped, read-only query layer for a co-change matrix.
+pub struct CochangeMatrixReader {
+    /// Decoded header (copied out of mmap for cheap access).
+    header: SkccHeader,
+    // SAFETY: read-only after construction; see module-level SAFETY note.
+    mmap: Mmap,
+}
+
+// SAFETY: Mmap is Send + Sync; all fields are immutable after construction.
+unsafe impl Send for CochangeMatrixReader {}
+unsafe impl Sync for CochangeMatrixReader {}
+
+impl CochangeMatrixReader {
+    /// Open an existing co-change matrix from `dir`.
+    ///
+    /// Validates magic bytes, format version, file size, and CRC32 checksum
+    /// before returning.
+    ///
+    /// # Errors
+    ///
+    /// - [`SearchError::Io`] if `cochange.skcc` cannot be opened.
+    /// - [`SearchError::IndexCorrupted`] if validation fails.
+    pub fn open(dir: &Path) -> Result<Self> {
+        let path = dir.join("cochange.skcc");
+        let file = std::fs::File::open(&path)?;
+
+        // SAFETY: The file is not modified after mapping. See module-level note.
+        let mmap = unsafe { Mmap::map(&file) }?;
+
+        let header = decode_header(&mmap)?;
+
+        // Validate size consistency.
+        let fc_bytes = (header.file_count as usize)
+            .checked_mul(FILE_COMMIT_ENTRY_SIZE)
+            .ok_or_else(|| {
+                SearchError::IndexCorrupted(
+                    "file_count * FILE_COMMIT_ENTRY_SIZE overflow".into(),
+                )
+            })?;
+        let pair_bytes = (header.pair_count as usize)
+            .checked_mul(PAIR_ENTRY_SIZE)
+            .ok_or_else(|| {
+                SearchError::IndexCorrupted("pair_count * PAIR_ENTRY_SIZE overflow".into())
+            })?;
+        let expected_size = HEADER_SIZE
+            .checked_add(fc_bytes)
+            .and_then(|s| s.checked_add(pair_bytes))
+            .ok_or_else(|| SearchError::IndexCorrupted("expected_size overflow".into()))?;
+
+        if mmap.len() != expected_size {
+            return Err(SearchError::IndexCorrupted(format!(
+                "skcc size mismatch: expected {expected_size}, got {}",
+                mmap.len()
+            )));
+        }
+
+        // Verify CRC32 over file_commit ++ pair bytes.
+        let payload = &mmap[HEADER_SIZE..expected_size];
+        let actual_checksum = compute_checksum(payload);
+        if actual_checksum != header.checksum {
+            return Err(SearchError::IndexCorrupted(format!(
+                "checksum mismatch: expected {:#010x}, got {:#010x}",
+                header.checksum, actual_checksum
+            )));
+        }
+
+        Ok(Self { header, mmap })
+    }
+
+    // -----------------------------------------------------------------------
+    // Public query API
+    // -----------------------------------------------------------------------
+
+    /// Return the co-change count for the pair `(a, b)`.
+    ///
+    /// Canonicalises the pair to `(min, max)` before lookup, so the caller
+    /// can pass IDs in either order. Returns `0` for absent pairs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::IndexCorrupted`] if the pair data is malformed.
+    pub fn pair_count(&self, a: FileId, b: FileId) -> Result<u32> {
+        if a == b {
+            return Ok(0);
+        }
+        let (lo, hi) = canonicalize(a, b);
+        let pairs_data = self.pairs_slice();
+        lookup_pair(pairs_data, lo, hi).map(|opt| opt.unwrap_or(0))
+    }
+
+    /// Compute Jaccard similarity between files `a` and `b`.
+    ///
+    /// `Jaccard(a, b) = count_ab / (count_a + count_b - count_ab)`
+    ///
+    /// Returns `0.0` for self-pairs, absent pairs, and zero denominators.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::IndexCorrupted`] if the underlying data is malformed.
+    pub fn jaccard(&self, a: FileId, b: FileId) -> Result<f64> {
+        if a == b {
+            return Ok(0.0);
+        }
+        let count_ab = self.pair_count(a, b)?;
+        if count_ab == 0 {
+            return Ok(0.0);
+        }
+        let count_a = self.file_commits(a)?;
+        let count_b = self.file_commits(b)?;
+        let denominator =
+            u64::from(count_a) + u64::from(count_b) - u64::from(count_ab);
+        if denominator == 0 {
+            return Ok(0.0);
+        }
+        Ok(f64::from(count_ab) / denominator as f64)
+    }
+
+    /// Return all co-change partners for `file_id`, sorted by co-change count
+    /// descending.
+    ///
+    /// Performs a linear scan over all pair entries (O(pair_count)).
+    /// Returns an empty Vec for unknown `file_id` values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::IndexCorrupted`] if the pair data is malformed.
+    pub fn pairs_for_file(&self, file_id: FileId) -> Result<Vec<(FileId, u32)>> {
+        let id = file_id.0;
+        let pairs_data = self.pairs_slice();
+        let n = pairs_data.len() / PAIR_ENTRY_SIZE;
+        let mut results: Vec<(FileId, u32)> = Vec::new();
+
+        for i in 0..n {
+            let offset = i * PAIR_ENTRY_SIZE;
+            let entry = super::format::decode_pair(&pairs_data[offset..offset + PAIR_ENTRY_SIZE])?;
+            if entry.file_a == id {
+                results.push((FileId(entry.file_b), entry.count));
+            } else if entry.file_b == id {
+                results.push((FileId(entry.file_a), entry.count));
+            }
+        }
+
+        // Sort by count descending; tie-break by FileId ascending for determinism.
+        results.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        Ok(results)
+    }
+
+    /// Return the number of commits in which `file_id` appeared.
+    ///
+    /// Returns `0` for unknown `file_id` values (not present in the matrix).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::IndexCorrupted`] if the file-commit data is malformed.
+    pub fn file_commits(&self, file_id: FileId) -> Result<u32> {
+        let id = file_id.0;
+        let fc_data = self.file_commit_slice();
+
+        // Binary search over FileCommitEntry sorted by file_id.
+        let n = fc_data.len() / FILE_COMMIT_ENTRY_SIZE;
+        let mut lo = 0usize;
+        let mut hi = n;
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            let offset = mid * FILE_COMMIT_ENTRY_SIZE;
+            let entry =
+                decode_file_commit(&fc_data[offset..offset + FILE_COMMIT_ENTRY_SIZE])?;
+            match entry.file_id.cmp(&id) {
+                std::cmp::Ordering::Equal => return Ok(entry.commit_count),
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+            }
+        }
+        Ok(0)
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /// Slice of file-commit entries within the mmap.
+    fn file_commit_slice(&self) -> &[u8] {
+        let fc_start = HEADER_SIZE;
+        let fc_end = fc_start + (self.header.file_count as usize) * FILE_COMMIT_ENTRY_SIZE;
+        &self.mmap[fc_start..fc_end]
+    }
+
+    /// Slice of pair entries within the mmap.
+    fn pairs_slice(&self) -> &[u8] {
+        let fc_end =
+            HEADER_SIZE + (self.header.file_count as usize) * FILE_COMMIT_ENTRY_SIZE;
+        let pairs_end = fc_end + (self.header.pair_count as usize) * PAIR_ENTRY_SIZE;
+        &self.mmap[fc_end..pairs_end]
+    }
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/// Return `(min(a,b), max(a,b))` as `(u32, u32)`.
+#[inline]
+fn canonicalize(a: FileId, b: FileId) -> (u32, u32) {
+    if a.0 <= b.0 { (a.0, b.0) } else { (b.0, a.0) }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[path = "reader_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/cochange/reader.rs
+++ b/crates/rskim-search/src/cochange/reader.rs
@@ -87,10 +87,6 @@ impl CochangeMatrixReader {
             .ok_or_else(|| {
                 SearchError::IndexCorrupted("pair_count * PAIR_ENTRY_SIZE overflow".into())
             })?;
-        // Cache validated offsets: HEADER_SIZE → fc_end → pairs_end.
-        // These are computed once here with checked arithmetic and stored as
-        // struct fields so that `file_commit_slice` and `pairs_slice` never
-        // need to repeat potentially-overflowing multiplication.
         let fc_start = HEADER_SIZE;
         let fc_end = fc_start
             .checked_add(fc_bytes)
@@ -98,17 +94,16 @@ impl CochangeMatrixReader {
         let pairs_end = fc_end
             .checked_add(pair_bytes)
             .ok_or_else(|| SearchError::IndexCorrupted("pairs_end overflow".into()))?;
-        let expected_size = pairs_end;
 
-        if mmap.len() != expected_size {
+        if mmap.len() != pairs_end {
             return Err(SearchError::IndexCorrupted(format!(
-                "skcc size mismatch: expected {expected_size}, got {}",
+                "skcc size mismatch: expected {pairs_end}, got {}",
                 mmap.len()
             )));
         }
 
         // Verify CRC32 over file_commit ++ pair bytes.
-        let payload = &mmap[HEADER_SIZE..expected_size];
+        let payload = &mmap[HEADER_SIZE..pairs_end];
         let actual_checksum = compute_checksum(payload);
         if actual_checksum != header.checksum {
             return Err(SearchError::IndexCorrupted(format!(

--- a/crates/rskim-search/src/cochange/reader.rs
+++ b/crates/rskim-search/src/cochange/reader.rs
@@ -72,9 +72,7 @@ impl CochangeMatrixReader {
         let fc_bytes = (header.file_count as usize)
             .checked_mul(FILE_COMMIT_ENTRY_SIZE)
             .ok_or_else(|| {
-                SearchError::IndexCorrupted(
-                    "file_count * FILE_COMMIT_ENTRY_SIZE overflow".into(),
-                )
+                SearchError::IndexCorrupted("file_count * FILE_COMMIT_ENTRY_SIZE overflow".into())
             })?;
         let pair_bytes = (header.pair_count as usize)
             .checked_mul(PAIR_ENTRY_SIZE)
@@ -146,8 +144,7 @@ impl CochangeMatrixReader {
         }
         let count_a = self.file_commits(a)?;
         let count_b = self.file_commits(b)?;
-        let denominator =
-            u64::from(count_a) + u64::from(count_b) - u64::from(count_ab);
+        let denominator = u64::from(count_a) + u64::from(count_b) - u64::from(count_ab);
         if denominator == 0 {
             return Ok(0.0);
         }
@@ -202,8 +199,7 @@ impl CochangeMatrixReader {
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
             let offset = mid * FILE_COMMIT_ENTRY_SIZE;
-            let entry =
-                decode_file_commit(&fc_data[offset..offset + FILE_COMMIT_ENTRY_SIZE])?;
+            let entry = decode_file_commit(&fc_data[offset..offset + FILE_COMMIT_ENTRY_SIZE])?;
             match entry.file_id.cmp(&id) {
                 std::cmp::Ordering::Equal => return Ok(entry.commit_count),
                 std::cmp::Ordering::Less => lo = mid + 1,
@@ -226,8 +222,7 @@ impl CochangeMatrixReader {
 
     /// Slice of pair entries within the mmap.
     fn pairs_slice(&self) -> &[u8] {
-        let fc_end =
-            HEADER_SIZE + (self.header.file_count as usize) * FILE_COMMIT_ENTRY_SIZE;
+        let fc_end = HEADER_SIZE + (self.header.file_count as usize) * FILE_COMMIT_ENTRY_SIZE;
         let pairs_end = fc_end + (self.header.pair_count as usize) * PAIR_ENTRY_SIZE;
         &self.mmap[fc_end..pairs_end]
     }

--- a/crates/rskim-search/src/cochange/reader_tests.rs
+++ b/crates/rskim-search/src/cochange/reader_tests.rs
@@ -2,55 +2,14 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use tempfile::TempDir;
 
 use super::CochangeMatrixReader;
-use crate::{CommitInfo, FileChangeInfo, FileId, HistoryResult, TemporalMetadata};
-
+use crate::FileId;
 use crate::cochange::CochangeMatrixBuilder;
-
-// -----------------------------------------------------------------------
-// Helpers
-// -----------------------------------------------------------------------
-
-fn make_history(commits: Vec<Vec<&str>>) -> HistoryResult {
-    let commit_list = commits
-        .into_iter()
-        .enumerate()
-        .map(|(i, paths)| CommitInfo {
-            hash: format!("{i:040x}"),
-            timestamp: i as i64,
-            author: "test".to_string(),
-            message: "test commit".to_string(),
-            changed_files: paths
-                .into_iter()
-                .map(|p| FileChangeInfo {
-                    path: PathBuf::from(p),
-                    additions: 1,
-                    deletions: 0,
-                })
-                .collect(),
-        })
-        .collect();
-    HistoryResult {
-        commits: commit_list,
-        metadata: TemporalMetadata {
-            is_shallow: false,
-            commit_count: 0,
-        },
-    }
-}
-
-fn make_path_map(paths: &[&str]) -> HashMap<PathBuf, FileId> {
-    paths
-        .iter()
-        .enumerate()
-        .map(|(i, p)| (PathBuf::from(p), FileId(i as u32)))
-        .collect()
-}
+use crate::cochange::test_helpers::{make_history, make_path_map};
 
 fn build_matrix(tmp: &TempDir, commits: Vec<Vec<&str>>, paths: &[&str]) -> CochangeMatrixReader {
     let history = make_history(commits);
@@ -312,4 +271,66 @@ fn test_crc32_mismatch_detected() {
         msg.contains("checksum") || msg.contains("corrupt"),
         "error should mention checksum: {msg}"
     );
+}
+
+// -----------------------------------------------------------------------
+// Jaccard perfect coupling (1.0)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_jaccard_perfect_coupling() {
+    // a and b co-change in every commit; neither appears alone.
+    // Jaccard = 3 / (3 + 3 - 3) = 3/3 = 1.0
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(
+        &tmp,
+        vec![
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "b.rs"],
+        ],
+        &["a.rs", "b.rs"],
+    );
+
+    let j = reader.jaccard(FileId(0), FileId(1)).unwrap();
+    assert!(
+        (j - 1.0_f64).abs() < 1e-9,
+        "Jaccard should be 1.0 for perfectly coupled files, got {j:.9}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// pairs_for_file — file appears only as the higher ID
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_pairs_for_file_higher_id() {
+    // Setup: three files a(0), b(1), c(2).
+    // Commits: (a,c) and (b,c).
+    // Canonical pairs stored: (0,2) and (1,2).
+    // c has FileId(2) — it always appears as file_b (higher ID) in both pairs.
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(
+        &tmp,
+        vec![vec!["a.rs", "c.rs"], vec!["b.rs", "c.rs"]],
+        &["a.rs", "b.rs", "c.rs"],
+    );
+
+    // Querying FileId(2) exercises the `entry.file_b == id` branch.
+    let pairs = reader.pairs_for_file(FileId(2)).unwrap();
+    assert_eq!(pairs.len(), 2, "c.rs co-changes with both a.rs and b.rs");
+
+    // Both partners should be present; counts are 1 each.
+    let partner_ids: Vec<u32> = pairs.iter().map(|(fid, _)| fid.0).collect();
+    assert!(
+        partner_ids.contains(&0),
+        "a.rs (FileId(0)) should be a partner of c.rs"
+    );
+    assert!(
+        partner_ids.contains(&1),
+        "b.rs (FileId(1)) should be a partner of c.rs"
+    );
+    for (_, count) in &pairs {
+        assert_eq!(*count, 1, "each partnership has count 1");
+    }
 }

--- a/crates/rskim-search/src/cochange/reader_tests.rs
+++ b/crates/rskim-search/src/cochange/reader_tests.rs
@@ -1,0 +1,315 @@
+//! Tests for CochangeMatrixReader.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use super::CochangeMatrixReader;
+use crate::{CommitInfo, FileChangeInfo, FileId, HistoryResult, TemporalMetadata};
+
+use crate::cochange::CochangeMatrixBuilder;
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+fn make_history(commits: Vec<Vec<&str>>) -> HistoryResult {
+    let commit_list = commits
+        .into_iter()
+        .enumerate()
+        .map(|(i, paths)| CommitInfo {
+            hash: format!("{i:040x}"),
+            timestamp: i as i64,
+            author: "test".to_string(),
+            message: "test commit".to_string(),
+            changed_files: paths
+                .into_iter()
+                .map(|p| FileChangeInfo {
+                    path: PathBuf::from(p),
+                    additions: 1,
+                    deletions: 0,
+                })
+                .collect(),
+        })
+        .collect();
+    HistoryResult {
+        commits: commit_list,
+        metadata: TemporalMetadata {
+            is_shallow: false,
+            commit_count: 0,
+        },
+    }
+}
+
+fn make_path_map(paths: &[&str]) -> HashMap<PathBuf, FileId> {
+    paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (PathBuf::from(p), FileId(i as u32)))
+        .collect()
+}
+
+fn build_matrix(tmp: &TempDir, commits: Vec<Vec<&str>>, paths: &[&str]) -> CochangeMatrixReader {
+    let history = make_history(commits);
+    let path_map = make_path_map(paths);
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    builder.build(&history, &path_map).unwrap();
+    CochangeMatrixReader::open(tmp.path()).unwrap()
+}
+
+// -----------------------------------------------------------------------
+// Open errors
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_open_nonexistent_dir_fails() {
+    let result = CochangeMatrixReader::open(&PathBuf::from("/nonexistent/path"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_open_corrupt_file_fails() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("cochange.skcc");
+    std::fs::write(&path, b"garbage data not a valid skcc file").unwrap();
+    let result = CochangeMatrixReader::open(tmp.path());
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("magic") || msg.contains("corrupt") || msg.contains("truncated"),
+        "error should describe corruption: {msg}"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Empty matrix
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_empty_matrix_pair_count_zero() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(&tmp, vec![], &[]);
+
+    // No pairs for any IDs
+    assert_eq!(reader.pair_count(FileId(0), FileId(1)).unwrap(), 0);
+}
+
+// -----------------------------------------------------------------------
+// pair_count
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_pair_count_correct() {
+    let tmp = TempDir::new().unwrap();
+    // a and b co-change in 3 commits
+    let reader = build_matrix(
+        &tmp,
+        vec![
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "b.rs"],
+        ],
+        &["a.rs", "b.rs"],
+    );
+
+    assert_eq!(reader.pair_count(FileId(0), FileId(1)).unwrap(), 3);
+}
+
+#[test]
+fn test_pair_count_canonical_order_transparent_to_caller() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(
+        &tmp,
+        vec![vec!["a.rs", "b.rs"]],
+        &["a.rs", "b.rs"],
+    );
+
+    // Regardless of which order the caller passes the IDs, result is the same.
+    assert_eq!(reader.pair_count(FileId(0), FileId(1)).unwrap(), 1);
+    assert_eq!(reader.pair_count(FileId(1), FileId(0)).unwrap(), 1);
+}
+
+#[test]
+fn test_pair_count_absent_pair_returns_zero() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(
+        &tmp,
+        vec![vec!["a.rs", "b.rs"]],
+        &["a.rs", "b.rs", "c.rs"],
+    );
+
+    // c.rs never co-changed with anyone
+    assert_eq!(reader.pair_count(FileId(0), FileId(2)).unwrap(), 0);
+}
+
+// -----------------------------------------------------------------------
+// Jaccard similarity
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_jaccard_known_values() {
+    // a appears in 4 commits, b appears in 4 commits, they co-change in 2.
+    // Jaccard = 2 / (4 + 4 - 2) = 2/6 ≈ 0.333
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(
+        &tmp,
+        vec![
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs"],
+            vec!["a.rs"],
+            vec!["b.rs"],
+            vec!["b.rs"],
+        ],
+        &["a.rs", "b.rs"],
+    );
+
+    let j = reader.jaccard(FileId(0), FileId(1)).unwrap();
+    let expected = 2.0 / 6.0;
+    assert!(
+        (j - expected).abs() < 1e-9,
+        "Jaccard should be ~{expected:.4}, got {j:.4}"
+    );
+}
+
+#[test]
+fn test_jaccard_self_pair_returns_zero() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(&tmp, vec![vec!["a.rs", "b.rs"]], &["a.rs", "b.rs"]);
+
+    // Self-pair: file_id A with itself
+    let j = reader.jaccard(FileId(0), FileId(0)).unwrap();
+    assert_eq!(j, 0.0, "self-pair Jaccard should be 0.0");
+}
+
+#[test]
+fn test_jaccard_absent_pair_returns_zero() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(&tmp, vec![vec!["a.rs", "b.rs"]], &["a.rs", "b.rs", "c.rs"]);
+
+    let j = reader.jaccard(FileId(0), FileId(2)).unwrap();
+    assert_eq!(j, 0.0, "absent pair Jaccard should be 0.0");
+}
+
+#[test]
+fn test_jaccard_zero_denominator_returns_zero() {
+    // Both files appear in 0 commits each (empty matrix with unknown file IDs)
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(&tmp, vec![], &["a.rs", "b.rs"]);
+
+    let j = reader.jaccard(FileId(0), FileId(1)).unwrap();
+    assert_eq!(j, 0.0, "zero denominator Jaccard should be 0.0");
+}
+
+// -----------------------------------------------------------------------
+// file_commits
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_file_commits_correct() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(
+        &tmp,
+        vec![
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs"],
+            vec!["a.rs"],
+        ],
+        &["a.rs", "b.rs"],
+    );
+
+    assert_eq!(reader.file_commits(FileId(0)).unwrap(), 3, "a.rs in 3 commits");
+    assert_eq!(reader.file_commits(FileId(1)).unwrap(), 1, "b.rs in 1 commit");
+}
+
+#[test]
+fn test_file_commits_unknown_id_returns_zero() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(&tmp, vec![vec!["a.rs"]], &["a.rs"]);
+
+    // FileId(99) was never seen
+    assert_eq!(reader.file_commits(FileId(99)).unwrap(), 0);
+}
+
+// -----------------------------------------------------------------------
+// pairs_for_file
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_pairs_for_file_sorted_by_count_desc() {
+    let tmp = TempDir::new().unwrap();
+    // a co-changes with b twice and c once
+    let reader = build_matrix(
+        &tmp,
+        vec![
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "b.rs"],
+            vec!["a.rs", "c.rs"],
+        ],
+        &["a.rs", "b.rs", "c.rs"],
+    );
+
+    let pairs = reader.pairs_for_file(FileId(0)).unwrap();
+    assert_eq!(pairs.len(), 2, "a.rs co-changes with 2 files");
+
+    // First result should be the highest count (b.rs with count 2)
+    assert_eq!(pairs[0].0, FileId(1), "highest count partner should be first");
+    assert_eq!(pairs[0].1, 2);
+
+    assert_eq!(pairs[1].0, FileId(2));
+    assert_eq!(pairs[1].1, 1);
+}
+
+#[test]
+fn test_pairs_for_file_unknown_file_returns_empty() {
+    let tmp = TempDir::new().unwrap();
+    let reader = build_matrix(&tmp, vec![vec!["a.rs", "b.rs"]], &["a.rs", "b.rs"]);
+
+    let pairs = reader.pairs_for_file(FileId(99)).unwrap();
+    assert!(pairs.is_empty());
+}
+
+// -----------------------------------------------------------------------
+// Send + Sync compile check
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_reader_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<CochangeMatrixReader>();
+}
+
+// -----------------------------------------------------------------------
+// CRC32 mismatch detection
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_crc32_mismatch_detected() {
+    let tmp = TempDir::new().unwrap();
+    // Build a valid matrix first
+    let builder = CochangeMatrixBuilder::new(tmp.path().to_path_buf()).unwrap();
+    let history = make_history(vec![vec!["a.rs", "b.rs"]]);
+    let path_map = make_path_map(&["a.rs", "b.rs"]);
+    builder.build(&history, &path_map).unwrap();
+
+    // Corrupt the file by flipping bytes in the data section (after the header)
+    let path = tmp.path().join("cochange.skcc");
+    let mut data = std::fs::read(&path).unwrap();
+    if data.len() > 20 {
+        data[18] ^= 0xFF; // flip first byte after header
+    }
+    std::fs::write(&path, &data).unwrap();
+
+    let result = CochangeMatrixReader::open(tmp.path());
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("checksum") || msg.contains("corrupt"),
+        "error should mention checksum: {msg}"
+    );
+}

--- a/crates/rskim-search/src/cochange/reader_tests.rs
+++ b/crates/rskim-search/src/cochange/reader_tests.rs
@@ -122,11 +122,7 @@ fn test_pair_count_correct() {
 #[test]
 fn test_pair_count_canonical_order_transparent_to_caller() {
     let tmp = TempDir::new().unwrap();
-    let reader = build_matrix(
-        &tmp,
-        vec![vec!["a.rs", "b.rs"]],
-        &["a.rs", "b.rs"],
-    );
+    let reader = build_matrix(&tmp, vec![vec!["a.rs", "b.rs"]], &["a.rs", "b.rs"]);
 
     // Regardless of which order the caller passes the IDs, result is the same.
     assert_eq!(reader.pair_count(FileId(0), FileId(1)).unwrap(), 1);
@@ -136,11 +132,7 @@ fn test_pair_count_canonical_order_transparent_to_caller() {
 #[test]
 fn test_pair_count_absent_pair_returns_zero() {
     let tmp = TempDir::new().unwrap();
-    let reader = build_matrix(
-        &tmp,
-        vec![vec!["a.rs", "b.rs"]],
-        &["a.rs", "b.rs", "c.rs"],
-    );
+    let reader = build_matrix(&tmp, vec![vec!["a.rs", "b.rs"]], &["a.rs", "b.rs", "c.rs"]);
 
     // c.rs never co-changed with anyone
     assert_eq!(reader.pair_count(FileId(0), FileId(2)).unwrap(), 0);
@@ -214,16 +206,20 @@ fn test_file_commits_correct() {
     let tmp = TempDir::new().unwrap();
     let reader = build_matrix(
         &tmp,
-        vec![
-            vec!["a.rs", "b.rs"],
-            vec!["a.rs"],
-            vec!["a.rs"],
-        ],
+        vec![vec!["a.rs", "b.rs"], vec!["a.rs"], vec!["a.rs"]],
         &["a.rs", "b.rs"],
     );
 
-    assert_eq!(reader.file_commits(FileId(0)).unwrap(), 3, "a.rs in 3 commits");
-    assert_eq!(reader.file_commits(FileId(1)).unwrap(), 1, "b.rs in 1 commit");
+    assert_eq!(
+        reader.file_commits(FileId(0)).unwrap(),
+        3,
+        "a.rs in 3 commits"
+    );
+    assert_eq!(
+        reader.file_commits(FileId(1)).unwrap(),
+        1,
+        "b.rs in 1 commit"
+    );
 }
 
 #[test]
@@ -257,7 +253,11 @@ fn test_pairs_for_file_sorted_by_count_desc() {
     assert_eq!(pairs.len(), 2, "a.rs co-changes with 2 files");
 
     // First result should be the highest count (b.rs with count 2)
-    assert_eq!(pairs[0].0, FileId(1), "highest count partner should be first");
+    assert_eq!(
+        pairs[0].0,
+        FileId(1),
+        "highest count partner should be first"
+    );
     assert_eq!(pairs[0].1, 2);
 
     assert_eq!(pairs[1].0, FileId(2));

--- a/crates/rskim-search/src/cochange/reader_tests.rs
+++ b/crates/rskim-search/src/cochange/reader_tests.rs
@@ -330,7 +330,7 @@ fn test_pairs_for_file_higher_id() {
         partner_ids.contains(&1),
         "b.rs (FileId(1)) should be a partner of c.rs"
     );
-    for (_, count) in &pairs {
-        assert_eq!(*count, 1, "each partnership has count 1");
+    for &(_, count) in &pairs {
+        assert_eq!(count, 1, "each partnership has count 1");
     }
 }

--- a/crates/rskim-search/src/cochange/test_helpers.rs
+++ b/crates/rskim-search/src/cochange/test_helpers.rs
@@ -1,0 +1,47 @@
+//! Shared test helpers for co-change module tests.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::{CommitInfo, FileChangeInfo, FileId, HistoryResult, TemporalMetadata};
+
+/// Build a [`HistoryResult`] from a list of commits, each described by the
+/// file paths they changed.
+pub(super) fn make_history(commits: Vec<Vec<&str>>) -> HistoryResult {
+    let commit_list = commits
+        .into_iter()
+        .enumerate()
+        .map(|(i, paths)| CommitInfo {
+            hash: format!("{i:040x}"),
+            timestamp: i as i64,
+            author: "test".to_string(),
+            message: "test commit".to_string(),
+            changed_files: paths
+                .into_iter()
+                .map(|p| FileChangeInfo {
+                    path: PathBuf::from(p),
+                    additions: 1,
+                    deletions: 0,
+                })
+                .collect(),
+        })
+        .collect();
+    HistoryResult {
+        commits: commit_list,
+        metadata: TemporalMetadata {
+            is_shallow: false,
+            commit_count: 0,
+        },
+    }
+}
+
+/// Build a path-to-[`FileId`] map from a slice of path strings.
+///
+/// Paths are assigned sequential IDs starting at 0.
+pub(super) fn make_path_map(paths: &[&str]) -> HashMap<PathBuf, FileId> {
+    paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (PathBuf::from(p), FileId(i as u32)))
+        .collect()
+}

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -10,6 +10,7 @@
 //!
 //! CLI/binary code in `crates/rskim/src/cmd/search/mod.rs` handles user-facing I/O.
 
+pub mod cochange;
 pub(crate) mod fields;
 pub mod index;
 pub mod lexical;
@@ -18,6 +19,7 @@ pub mod temporal;
 mod types;
 pub mod weights;
 
+pub use cochange::{CochangeMatrixBuilder, CochangeMatrixReader};
 pub use index::{NgramIndexBuilder, NgramIndexReader};
 pub use lexical::{
     BM25FConfig, FIELD_COUNT, MAX_QUERY_BYTES, QueryEngine, bm25f_score, classify_source,
@@ -29,8 +31,9 @@ pub use ngram::{
 };
 pub use temporal::{GixSource, is_fix_commit};
 pub use types::{
-    CommitInfo, FieldClassifier, FileChangeInfo, FileId, HistoryResult, IndexStats, LayerBuilder,
-    NodeInfo, Result, SearchError, SearchField, SearchLayer, SearchQuery, SearchResult,
-    TemporalFlags, TemporalMetadata, TemporalSource, byte_offset_to_line, compute_line_range,
+    CochangeStats, CommitInfo, FieldClassifier, FileChangeInfo, FileId, HistoryResult, IndexStats,
+    LayerBuilder, NodeInfo, Result, SearchError, SearchField, SearchLayer, SearchQuery,
+    SearchResult, TemporalFlags, TemporalMetadata, TemporalSource, byte_offset_to_line,
+    compute_line_range,
 };
 pub use weights::{BIGRAM_WEIGHTS, DEFAULT_WEIGHT, bigram_weight};

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -6,6 +6,8 @@
 //! - The `index` module provides on-disk persistence via memory-mapped files.
 //! - The `ngram` module handles bigram extraction (pure, no I/O).
 //! - The `temporal` module parses git history via gix for temporal scoring.
+//! - The `cochange` module builds and queries a binary co-change matrix with
+//!   Jaccard similarity from git history.
 //! - Returns Result types throughout — no panics in non-test code.
 //!
 //! CLI/binary code in `crates/rskim/src/cmd/search/mod.rs` handles user-facing I/O.

--- a/crates/rskim-search/src/types.rs
+++ b/crates/rskim-search/src/types.rs
@@ -165,6 +165,31 @@ impl SearchField {
 }
 
 // ============================================================================
+// Co-change Matrix Statistics
+// ============================================================================
+
+/// Statistics returned by [`crate::cochange::CochangeMatrixBuilder::build`].
+///
+/// Provides observability into the build process: how many pairs were
+/// accumulated, how many commits were processed, and how many were skipped
+/// due to the `COUPLING_MAX_FILES` cap or unknown path resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CochangeStats {
+    /// Number of distinct co-change pairs stored in the matrix.
+    pub pair_count: u32,
+    /// Number of distinct files referenced across all processed commits.
+    pub file_count: u32,
+    /// Number of commits iterated (regardless of path resolution success).
+    pub commits_processed: u32,
+    /// Number of commits skipped because they touched more than
+    /// `COUPLING_MAX_FILES` files.
+    pub commits_skipped_too_large: u32,
+    /// Number of file paths silently skipped because they were absent from the
+    /// path-to-[`FileId`] map supplied by the caller.
+    pub unknown_paths_skipped: u32,
+}
+
+// ============================================================================
 // Temporal Flags
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Add `cochange/` module to `rskim-search` that persists which files change together across commits as a binary `.skcc` matrix file, enabling coupling-aware search ranking without re-scanning git history on every query.
- Jaccard similarity normalization (`count_ab / (count_a + count_b - count_ab)`) provides symmetric coupling signal; the existing heatmap layer uses asymmetric confidence instead.
- Safety caps (`COUPLING_MAX_FILES=50` per commit, `MAX_PAIRS=2M` total) prevent bulk-refactor commits from polluting the coupling signal and protect against unbounded memory growth.

## Changes

**New files:**
- `src/cochange/format.rs` — pure binary codec for `.skcc` format: 18-byte header (magic, version, pair_count, file_count, CRC32), 8-byte `FileCommitEntry`, 12-byte `PairEntry`; all little-endian; no I/O
- `src/cochange/builder.rs` — `CochangeMatrixBuilder::build(&HistoryResult, &HashMap<PathBuf, FileId>)` accumulates canonical `(min, max)` pairs, sorts, serialises, and atomically writes `cochange.skcc`
- `src/cochange/reader.rs` — `CochangeMatrixReader::open(dir)` mmaps the file, validates magic/version/size/CRC32; exposes `pair_count`, `jaccard`, `pairs_for_file` (O(n) scan), `file_commits`
- `src/cochange/mod.rs` — module wiring and public re-exports
- 3 test files: 43 tests total

**Modified files:**
- `src/types.rs` — added `CochangeStats` struct for build observability
- `src/lib.rs` — `pub mod cochange`, re-exports for `CochangeMatrixBuilder`, `CochangeMatrixReader`, `CochangeStats`

## Breaking Changes

None. All new public API; existing indices unaffected.

## Reviewer Focus Areas

- **Binary format layout correctness** (`format.rs`): verify `HEADER_SIZE=18`, `FILE_COMMIT_ENTRY_SIZE=8`, `PAIR_ENTRY_SIZE=12` encode/decode symmetry and that CRC32 covers `file_commit_bytes ++ pair_bytes` in that order
- **Jaccard denominator** (`reader.rs:jaccard`): denominator is `u64` to prevent overflow when both files appear in many commits; returns `0.0` for self-pairs and zero-denominator edge cases
- **`COUPLING_MAX_FILES` semantics** (`builder.rs`): commits with `> COUPLING_MAX_FILES` files are skipped (not `>=`); exactly `COUPLING_MAX_FILES` is processed — verify test `test_coupling_max_files_exactly_at_limit_processed`
- **`MAX_PAIRS` breach** (`builder.rs`): checked before inserting a new key (not after), returning `IndexCorrupted` before allocating the entry