### PR TITLE
feat(#190): Wave 3b — AST frequency analysis API (AstBigram, AstTrigram)

### DIFF
--- a/crates/rskim-core/src/ast_walk.rs
+++ b/crates/rskim-core/src/ast_walk.rs
@@ -398,11 +398,7 @@ mod tests {
 
         // No item should have depth >= max_depth.
         for item in &items {
-            assert!(
-                item.depth < 3,
-                "depth {} >= max_depth 3",
-                item.depth
-            );
+            assert!(item.depth < 3, "depth {} >= max_depth 3", item.depth);
         }
     }
 

--- a/crates/rskim-research/src/ast_extract.rs
+++ b/crates/rskim-research/src/ast_extract.rs
@@ -385,13 +385,23 @@ mod tests {
     ///
     /// Used to verify that ERROR and MISSING nodes are never inserted into the vocabulary
     /// and therefore cannot appear as parent or child in any emitted bigram.
-    fn assert_no_kind_in_bigrams(result: &AstFileResult, vocab: &NodeKindVocabulary, forbidden: &str) {
+    fn assert_no_kind_in_bigrams(
+        result: &AstFileResult,
+        vocab: &NodeKindVocabulary,
+        forbidden: &str,
+    ) {
         for &bigram in &result.bigrams {
             let (parent_id, child_id) = crate::ast_types::decode_ast_bigram(bigram);
             let parent_kind = vocab.resolve(parent_id).unwrap_or("UNKNOWN");
             let child_kind = vocab.resolve(child_id).unwrap_or("UNKNOWN");
-            assert_ne!(parent_kind, forbidden, "bigram parent should not be {forbidden}");
-            assert_ne!(child_kind, forbidden, "bigram child should not be {forbidden}");
+            assert_ne!(
+                parent_kind, forbidden,
+                "bigram parent should not be {forbidden}"
+            );
+            assert_ne!(
+                child_kind, forbidden,
+                "bigram child should not be {forbidden}"
+            );
         }
     }
 

--- a/crates/rskim-search/benches/linearize_bench.rs
+++ b/crates/rskim-search/benches/linearize_bench.rs
@@ -38,16 +38,19 @@ const RUST_FIXTURE: &str = include_str!("../../../tests/fixtures/rust/simple.rs"
 const TS_FIXTURE: &str = include_str!("../../../tests/fixtures/typescript/simple.ts");
 const PY_FIXTURE: &str = include_str!("../../../tests/fixtures/python/simple.py");
 const GO_FIXTURE: &str = "package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"hello\") }\n";
-const JAVA_FIXTURE: &str = "public class Foo { public static void main(String[] args) { System.out.println(\"hi\"); } }";
+const JAVA_FIXTURE: &str =
+    "public class Foo { public static void main(String[] args) { System.out.println(\"hi\"); } }";
 const C_FIXTURE: &str = "#include <stdio.h>\nint main() { printf(\"hi\"); return 0; }\n";
 const CPP_FIXTURE: &str = "#include <iostream>\nint main() { std::cout << \"hi\"; return 0; }\n";
 const JS_FIXTURE: &str = "function foo(x) { return x + 1; }\nconst bar = (y) => y * 2;\n";
-const CS_FIXTURE: &str = "using System;\nclass Foo { static void Main() { Console.WriteLine(\"hi\"); } }\n";
+const CS_FIXTURE: &str =
+    "using System;\nclass Foo { static void Main() { Console.WriteLine(\"hi\"); } }\n";
 const RUBY_FIXTURE: &str = "def greet(name)\n  puts \"Hello, #{name}\"\nend\n";
 const SQL_FIXTURE: &str = "SELECT id, name FROM users WHERE active = 1 ORDER BY name;\n";
 const KOTLIN_FIXTURE: &str = "fun greet(name: String): String = \"Hello, $name\"\n";
 const SWIFT_FIXTURE: &str = "func greet(name: String) -> String { return \"Hello, \\(name)\" }\n";
-const MD_FIXTURE: &str = "# Hello\n\nThis is a **paragraph** with `code`.\n\n## Section\n\nMore text.\n";
+const MD_FIXTURE: &str =
+    "# Hello\n\nThis is a **paragraph** with `code`.\n\n## Section\n\nMore text.\n";
 
 // ============================================================================
 // Group 1: Per-language linearization
@@ -92,13 +95,9 @@ fn bench_linearize_scaling(c: &mut Criterion) {
     for &n_fns in &[10usize, 50, 100, 500, 1000] {
         let source = gen_rust_fns(n_fns);
         // Benchmarks end-to-end linearize_source, including parsing overhead.
-        group.bench_with_input(
-            BenchmarkId::new("rust_fns", n_fns),
-            &source,
-            |b, src| {
-                b.iter(|| linearize_source(black_box(src.as_str()), black_box(Language::Rust)).unwrap())
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("rust_fns", n_fns), &source, |b, src| {
+            b.iter(|| linearize_source(black_box(src.as_str()), black_box(Language::Rust)).unwrap())
+        });
     }
 
     group.finish();
@@ -117,7 +116,9 @@ fn bench_linearize_depth(c: &mut Criterion) {
             BenchmarkId::new("rust_nested_depth", depth),
             &source,
             |b, src| {
-                b.iter(|| linearize_source(black_box(src.as_str()), black_box(Language::Rust)).unwrap())
+                b.iter(|| {
+                    linearize_source(black_box(src.as_str()), black_box(Language::Rust)).unwrap()
+                })
             },
         );
     }

--- a/crates/rskim-search/src/ast_index/linearize.rs
+++ b/crates/rskim-search/src/ast_index/linearize.rs
@@ -29,6 +29,8 @@ use rskim_core::{AstWalkConfig, AstWalkIter, Language, Parser};
 use crate::ast_weights::NODE_KIND_VOCABULARY;
 use crate::types::SearchError;
 
+use super::NodeKindId;
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -75,7 +77,7 @@ const MAX_FILE_SIZE_LARGE: usize = 1024 * 1024;
 pub struct LinearNode {
     /// Vocabulary ID into `NODE_KIND_VOCABULARY`. `0` is the sentinel for
     /// unknown kinds.
-    pub kind_id: u16,
+    pub kind_id: NodeKindId,
     /// 0-indexed depth from the tree root (root node is depth 0).
     pub depth: u16,
 }

--- a/crates/rskim-search/src/ast_index/linearize.rs
+++ b/crates/rskim-search/src/ast_index/linearize.rs
@@ -200,10 +200,7 @@ static LANG_MAPS: LazyLock<HashMap<Language, Vec<Option<u16>>>> = LazyLock::new(
 /// Returns `Err(SearchError::Ast)` if the tree-sitter grammar for
 /// `language` fails to load (grammar crate not compiled in, ABI mismatch,
 /// etc.). This is distinct from a parse error, which produces an empty result.
-pub fn linearize_source(
-    source: &str,
-    language: Language,
-) -> crate::types::Result<LinearizeResult> {
+pub fn linearize_source(source: &str, language: Language) -> crate::types::Result<LinearizeResult> {
     // Guard 1: oversized files return empty result (not an error).
     // SQL migrations/schema dumps can exceed 100 KiB, so SQL uses a larger
     // limit (1 MiB) consistent with rskim-research/src/ast_extract.rs.
@@ -270,7 +267,10 @@ fn linearize_tree(tree: &tree_sitter::Tree, lang_map: &[Option<u16>]) -> Lineari
         // saturating_cast is the correct pattern for converting u32 → u16.
         #[allow(clippy::cast_possible_truncation)]
         let depth = item.depth.min(u32::from(u16::MAX)) as u16;
-        nodes.push(LinearNode { kind_id: vocab_id, depth });
+        nodes.push(LinearNode {
+            kind_id: vocab_id,
+            depth,
+        });
     }
 
     LinearizeResult {

--- a/crates/rskim-search/src/ast_index/linearize_tests.rs
+++ b/crates/rskim-search/src/ast_index/linearize_tests.rs
@@ -40,7 +40,8 @@ fn resolve_kinds(result: &LinearizeResult) -> Vec<&'static str> {
 fn assert_node_count_invariant(result: &LinearizeResult) {
     let expected = result.nodes.len() as u32 + result.error_count;
     assert_eq!(
-        result.node_count, expected,
+        result.node_count,
+        expected,
         "invariant violated: node_count ({}) != nodes.len() ({}) + error_count ({})",
         result.node_count,
         result.nodes.len(),
@@ -52,7 +53,10 @@ fn assert_node_count_invariant(result: &LinearizeResult) {
 
 #[test]
 fn linear_node_is_copy() {
-    let n = LinearNode { kind_id: 42, depth: 3 };
+    let n = LinearNode {
+        kind_id: 42,
+        depth: 3,
+    };
     let copy = n;
     assert_eq!(copy.kind_id, 42);
     assert_eq!(copy.depth, 3);
@@ -83,7 +87,10 @@ fn vocabulary_is_non_empty_and_indexable_by_u16() {
     // kind_id (stored as u16) is a valid index. Exact size is an
     // implementation detail of the generated ast_weights.rs; testing it
     // causes breakage on every vocabulary regeneration.
-    assert!(!NODE_KIND_VOCABULARY.is_empty(), "NODE_KIND_VOCABULARY must not be empty");
+    assert!(
+        !NODE_KIND_VOCABULARY.is_empty(),
+        "NODE_KIND_VOCABULARY must not be empty"
+    );
     assert!(
         NODE_KIND_VOCABULARY.len() <= u16::MAX as usize,
         "vocabulary length {} exceeds u16::MAX — kind_id would overflow",
@@ -94,20 +101,36 @@ fn vocabulary_is_non_empty_and_indexable_by_u16() {
 #[test]
 fn rust_lang_map_contains_known_kinds() {
     let maps = &*LANG_MAPS;
-    let rust_map = maps.get(&Language::Rust).expect("Rust must have a lang map");
+    let rust_map = maps
+        .get(&Language::Rust)
+        .expect("Rust must have a lang map");
     // "function_item" is a core Rust grammar node — must be in the map.
     let found = rust_map.iter().any(|entry| {
-        entry.map(|idx| NODE_KIND_VOCABULARY[idx as usize] == "function_item").unwrap_or(false)
+        entry
+            .map(|idx| NODE_KIND_VOCABULARY[idx as usize] == "function_item")
+            .unwrap_or(false)
     });
-    assert!(found, "Rust lang map must map some kind_id to 'function_item'");
+    assert!(
+        found,
+        "Rust lang map must map some kind_id to 'function_item'"
+    );
 }
 
 #[test]
 fn serde_only_languages_not_in_lang_maps() {
     let maps = &*LANG_MAPS;
-    assert!(!maps.contains_key(&Language::Json), "JSON must not have a lang map");
-    assert!(!maps.contains_key(&Language::Yaml), "YAML must not have a lang map");
-    assert!(!maps.contains_key(&Language::Toml), "TOML must not have a lang map");
+    assert!(
+        !maps.contains_key(&Language::Json),
+        "JSON must not have a lang map"
+    );
+    assert!(
+        !maps.contains_key(&Language::Yaml),
+        "YAML must not have a lang map"
+    );
+    assert!(
+        !maps.contains_key(&Language::Toml),
+        "TOML must not have a lang map"
+    );
 }
 
 #[test]
@@ -139,7 +162,10 @@ fn empty_source_produces_root_only() {
 #[test]
 fn simple_fn_produces_multiple_nodes() {
     let result = parse_and_linearize("fn main() {}", Language::Rust);
-    assert!(result.nodes.len() > 1, "simple fn must produce more than one node");
+    assert!(
+        result.nodes.len() > 1,
+        "simple fn must produce more than one node"
+    );
     assert_node_count_invariant(&result);
 }
 
@@ -148,8 +174,7 @@ fn pre_order_root_comes_first() {
     let result = parse_and_linearize("fn main() {}", Language::Rust);
     // Root node is at depth 0 and must be the very first node.
     assert_eq!(
-        result.nodes[0].depth,
-        0,
+        result.nodes[0].depth, 0,
         "first node must be the root at depth 0"
     );
 }
@@ -275,9 +300,18 @@ fn oversized_file_returns_default() {
     // File larger than MAX_FILE_SIZE should return empty default result.
     let big = "fn x() {}\n".repeat(MAX_FILE_SIZE / 10 + 1);
     let result = parse_and_linearize(&big, Language::Rust);
-    assert!(result.nodes.is_empty(), "oversized file must return empty nodes");
-    assert_eq!(result.node_count, 0, "oversized file must return node_count 0");
-    assert_eq!(result.error_count, 0, "oversized file must return error_count 0");
+    assert!(
+        result.nodes.is_empty(),
+        "oversized file must return empty nodes"
+    );
+    assert_eq!(
+        result.node_count, 0,
+        "oversized file must return node_count 0"
+    );
+    assert_eq!(
+        result.error_count, 0,
+        "oversized file must return error_count 0"
+    );
 }
 
 // ── Cycle 6: Multi-language ───────────────────────────────────────────────────
@@ -400,7 +434,9 @@ fn unknown_kind_emits_sentinel_zero() {
     // We verify this contract without relying on parse output accidentally containing
     // kind_id == 0 (which would make the test vacuously pass if no such node exists).
     let maps = &*LANG_MAPS;
-    let rust_map = maps.get(&Language::Rust).expect("Rust must have a lang map");
+    let rust_map = maps
+        .get(&Language::Rust)
+        .expect("Rust must have a lang map");
 
     // Any index beyond the map length is out of bounds; grammars have 200–500 kinds.
     let out_of_bounds = rust_map.len();

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -32,8 +32,22 @@
 mod linearize;
 mod ngram;
 
+// ============================================================================
+// Shared type alias
+// ============================================================================
+
+/// Compact numeric ID for a tree-sitter node kind string.
+///
+/// Indexes into [`crate::ast_weights::NODE_KIND_VOCABULARY`]. `0` is the
+/// sentinel for unknown kinds (maps to `""`).
+///
+/// Defined here (the shared parent module) so that both `linearize` and
+/// `ngram` reference the same canonical definition rather than each working
+/// with a raw `u16`.
+pub type NodeKindId = u16;
+
 pub use linearize::{LinearNode, LinearizeResult, linearize_source};
 pub use ngram::{
-    AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, NodeKindId, ast_bigram_idf, ast_trigram_idf,
-    vocab_len, vocab_lookup, vocab_resolve,
+    AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, ast_bigram_idf, ast_trigram_idf, vocab_len,
+    vocab_lookup, vocab_resolve,
 };

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -1,19 +1,39 @@
-//! AST structural indexing: CST linearization for n-gram extraction.
+//! AST structural indexing: CST linearization and n-gram encoding for
+//! structural code search.
 //!
 //! This module converts tree-sitter CSTs into compact depth-encoded node-type
 //! sequences. Each node in the pre-order traversal is represented as a
 //! `LinearNode { kind_id, depth }` pair, enabling downstream n-gram extraction
 //! over structural AST patterns without retaining the full tree.
 //!
+//! The `ngram` sub-module provides [`AstBigram`] and [`AstTrigram`] newtypes
+//! for packing node-kind ID pairs into compact integer keys, along with
+//! vocabulary helpers and IDF weight lookup functions.
+//!
 //! # Usage
 //!
 //! ```rust,ignore
-//! use rskim_search::ast_index::{LinearNode, LinearizeResult, linearize_source};
+//! use rskim_search::ast_index::{
+//!     AstBigram, AstTrigram, LinearNode, LinearizeResult, NodeKindId,
+//!     ast_bigram_idf, ast_trigram_idf, linearize_source,
+//!     vocab_len, vocab_lookup, vocab_resolve, DEFAULT_AST_WEIGHT,
+//! };
 //! use rskim_core::Language;
 //!
 //! let result = linearize_source("fn main() {}", Language::Rust).unwrap();
 //! println!("{} nodes", result.node_count);
+//!
+//! let parent = vocab_lookup("function_item").unwrap();
+//! let child = vocab_lookup("block").unwrap();
+//! let bigram = AstBigram::encode(parent, child);
+//! let weight = ast_bigram_idf(Language::Rust, bigram);
 //! ```
 
 mod linearize;
+mod ngram;
+
 pub use linearize::{LinearNode, LinearizeResult, linearize_source};
+pub use ngram::{
+    AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, NodeKindId, ast_bigram_idf, ast_trigram_idf,
+    vocab_len, vocab_lookup, vocab_resolve,
+};

--- a/crates/rskim-search/src/ast_index/ngram.rs
+++ b/crates/rskim-search/src/ast_index/ngram.rs
@@ -1,0 +1,256 @@
+//! AST n-gram newtypes for structural code search.
+//!
+//! This module provides two newtypes — [`AstBigram`] and [`AstTrigram`] — that
+//! pack tree-sitter node-kind ID pairs (and triples) into compact integer keys,
+//! matching the encoding used by [`crate::ast_weights`].
+//!
+//! It also exposes vocabulary helpers ([`vocab_lookup`], [`vocab_resolve`],
+//! [`vocab_len`]) and IDF weight lookup functions ([`ast_bigram_idf`],
+//! [`ast_trigram_idf`]) that fall back to [`DEFAULT_AST_WEIGHT`] for unknown
+//! entries.
+//!
+//! # Encoding
+//!
+//! - **Bigram**: `(u32::from(parent) << 16) | u32::from(child)`
+//! - **Trigram**: `(u64::from(grandparent) << 32) | (u64::from(parent) << 16) | u64::from(child)`
+//!
+//! These formulas match `crates/rskim-research/src/ast_types.rs` exactly and are
+//! the same layout stored in [`crate::ast_weights::RUST_AST_BIGRAM_WEIGHTS`] (and
+//! the other per-language tables).
+
+use std::fmt;
+
+use rskim_core::Language;
+
+use crate::ast_weights::{NODE_KIND_VOCABULARY, ast_bigram_weight, ast_trigram_weight};
+
+// ============================================================================
+// Type alias
+// ============================================================================
+
+/// Compact numeric ID for a tree-sitter node kind string.
+///
+/// Indexes into [`NODE_KIND_VOCABULARY`]. `0` is the sentinel for unknown kinds
+/// (maps to `""`).
+pub type NodeKindId = u16;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Default IDF weight returned when a bigram or trigram is not found in any
+/// per-language weight table.
+///
+/// Matches [`crate::weights::DEFAULT_WEIGHT`] so that AST and lexical signals
+/// are on the same scale.
+pub const DEFAULT_AST_WEIGHT: f32 = 1.0;
+
+// ============================================================================
+// AstBigram newtype
+// ============================================================================
+
+/// A packed parent→child AST node-kind pair encoded as a `u32`.
+///
+/// Encoding: `(u32::from(parent) << 16) | u32::from(child)`.
+///
+/// The encoding matches [`crate::ast_weights::ast_bigram_weight`], so weight
+/// lookup via [`ast_bigram_idf`] is a single binary-search call with no
+/// transformation.
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AstBigram(u32);
+
+impl AstBigram {
+    /// Encode a parent–child node-kind pair into an [`AstBigram`].
+    ///
+    /// `encode(parent, child)` = `(u32::from(parent) << 16) | u32::from(child)`.
+    #[must_use]
+    #[inline]
+    pub fn encode(parent: NodeKindId, child: NodeKindId) -> Self {
+        Self((u32::from(parent) << 16) | u32::from(child))
+    }
+
+    /// Decode an [`AstBigram`] back into its `(parent, child)` component IDs.
+    #[must_use]
+    #[inline]
+    pub fn decode(self) -> (NodeKindId, NodeKindId) {
+        let parent = (self.0 >> 16) as NodeKindId;
+        let child = (self.0 & 0xFFFF) as NodeKindId;
+        (parent, child)
+    }
+
+    /// Return the raw `u32` encoding key.
+    ///
+    /// Suitable for passing directly to [`crate::ast_weights::ast_bigram_weight`].
+    #[must_use]
+    #[inline]
+    pub fn key(self) -> u32 {
+        self.0
+    }
+
+    /// Construct an [`AstBigram`] directly from a raw `u32` key.
+    ///
+    /// Intended for internal crate use where the key is already in the encoded
+    /// form (e.g. when iterating over a stored weight table).  External callers
+    /// should use [`encode`][Self::encode] to guarantee the correct encoding.
+    #[must_use]
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn from_raw(key: u32) -> Self {
+        Self(key)
+    }
+}
+
+impl fmt::Display for AstBigram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (parent, child) = self.decode();
+        fmt_kind_id(f, parent)?;
+        write!(f, " > ")?;
+        fmt_kind_id(f, child)
+    }
+}
+
+// ============================================================================
+// AstTrigram newtype
+// ============================================================================
+
+/// A packed grandparent→parent→child AST node-kind triple encoded as a `u64`.
+///
+/// Encoding: `(u64::from(grandparent) << 32) | (u64::from(parent) << 16) | u64::from(child)`.
+///
+/// The encoding matches [`crate::ast_weights::ast_trigram_weight`].
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AstTrigram(u64);
+
+impl AstTrigram {
+    /// Encode a grandparent–parent–child node-kind triple into an [`AstTrigram`].
+    ///
+    /// `encode(gp, parent, child)` = `(u64::from(gp) << 32) | (u64::from(parent) << 16) | u64::from(child)`.
+    #[must_use]
+    #[inline]
+    pub fn encode(grandparent: NodeKindId, parent: NodeKindId, child: NodeKindId) -> Self {
+        Self((u64::from(grandparent) << 32) | (u64::from(parent) << 16) | u64::from(child))
+    }
+
+    /// Decode an [`AstTrigram`] back into its `(grandparent, parent, child)` component IDs.
+    #[must_use]
+    #[inline]
+    pub fn decode(self) -> (NodeKindId, NodeKindId, NodeKindId) {
+        let grandparent = ((self.0 >> 32) & 0xFFFF) as NodeKindId;
+        let parent = ((self.0 >> 16) & 0xFFFF) as NodeKindId;
+        let child = (self.0 & 0xFFFF) as NodeKindId;
+        (grandparent, parent, child)
+    }
+
+    /// Return the raw `u64` encoding key.
+    ///
+    /// Suitable for passing directly to [`crate::ast_weights::ast_trigram_weight`].
+    #[must_use]
+    #[inline]
+    pub fn key(self) -> u64 {
+        self.0
+    }
+
+    /// Construct an [`AstTrigram`] directly from a raw `u64` key.
+    ///
+    /// Intended for internal crate use where the key is already in the encoded
+    /// form.  External callers should use [`encode`][Self::encode].
+    #[must_use]
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn from_raw(key: u64) -> Self {
+        Self(key)
+    }
+}
+
+impl fmt::Display for AstTrigram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (grandparent, parent, child) = self.decode();
+        fmt_kind_id(f, grandparent)?;
+        write!(f, " > ")?;
+        fmt_kind_id(f, parent)?;
+        write!(f, " > ")?;
+        fmt_kind_id(f, child)
+    }
+}
+
+// ============================================================================
+// Vocabulary helpers
+// ============================================================================
+
+/// Look up the [`NodeKindId`] for a node-kind string.
+///
+/// Uses binary search on the sorted [`NODE_KIND_VOCABULARY`] table.
+///
+/// Returns `Some(0)` for `""` (the sentinel for unknown kinds) and `None` for
+/// strings not present in the vocabulary.
+#[must_use]
+pub fn vocab_lookup(kind: &str) -> Option<NodeKindId> {
+    NODE_KIND_VOCABULARY
+        .binary_search(&kind)
+        .ok()
+        .map(|idx| idx as NodeKindId)
+}
+
+/// Resolve a [`NodeKindId`] back to its kind string.
+///
+/// Returns `Some("")` for ID `0` (the sentinel for unknown kinds) and `None`
+/// for IDs beyond the vocabulary length.
+#[must_use]
+pub fn vocab_resolve(id: NodeKindId) -> Option<&'static str> {
+    NODE_KIND_VOCABULARY.get(usize::from(id)).copied()
+}
+
+/// Return the total number of entries in [`NODE_KIND_VOCABULARY`].
+#[must_use]
+pub fn vocab_len() -> usize {
+    NODE_KIND_VOCABULARY.len()
+}
+
+// ============================================================================
+// Weight lookup
+// ============================================================================
+
+/// Look up the IDF weight for an [`AstBigram`] in the per-language weight table.
+///
+/// Falls back to [`DEFAULT_AST_WEIGHT`] when:
+/// - The language has no AST weight table (JSON, YAML, TOML, and other
+///   non-tree-sitter languages).
+/// - The specific bigram is not in the table.
+#[must_use]
+pub fn ast_bigram_idf(lang: Language, bigram: AstBigram) -> f32 {
+    ast_bigram_weight(lang.name(), bigram.key()).unwrap_or(DEFAULT_AST_WEIGHT)
+}
+
+/// Look up the IDF weight for an [`AstTrigram`] in the per-language weight table.
+///
+/// Falls back to [`DEFAULT_AST_WEIGHT`] when:
+/// - The language has no AST weight table (JSON, YAML, TOML, and other
+///   non-tree-sitter languages).
+/// - The specific trigram is not in the table.
+#[must_use]
+pub fn ast_trigram_idf(lang: Language, trigram: AstTrigram) -> f32 {
+    ast_trigram_weight(lang.name(), trigram.key()).unwrap_or(DEFAULT_AST_WEIGHT)
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/// Format a [`NodeKindId`] using the vocabulary.
+///
+/// - Known, non-empty string → write the string.
+/// - ID `0` (sentinel / empty string) → write `"<unknown>"`.
+/// - Out-of-bounds ID → write `"?{id}"`.
+fn fmt_kind_id(f: &mut fmt::Formatter<'_>, id: NodeKindId) -> fmt::Result {
+    match vocab_resolve(id) {
+        Some("") => write!(f, "<unknown>"),
+        Some(s) => write!(f, "{s}"),
+        None => write!(f, "?{id}"),
+    }
+}
+
+#[cfg(test)]
+#[path = "ngram_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/ast_index/ngram.rs
+++ b/crates/rskim-search/src/ast_index/ngram.rs
@@ -41,7 +41,7 @@ pub type NodeKindId = u16;
 /// Default IDF weight returned when a bigram or trigram is not found in any
 /// per-language weight table.
 ///
-/// Matches [`crate::weights::DEFAULT_WEIGHT`] so that AST and lexical signals
+/// Matches the lexical `DEFAULT_WEIGHT` so that AST and lexical signals
 /// are on the same scale.
 pub const DEFAULT_AST_WEIGHT: f32 = 1.0;
 
@@ -58,7 +58,7 @@ pub const DEFAULT_AST_WEIGHT: f32 = 1.0;
 /// transformation.
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct AstBigram(u32);
+pub struct AstBigram(pub(crate) u32);
 
 impl AstBigram {
     /// Encode a parent–child node-kind pair into an [`AstBigram`].
@@ -121,7 +121,7 @@ impl fmt::Display for AstBigram {
 /// The encoding matches [`crate::ast_weights::ast_trigram_weight`].
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct AstTrigram(u64);
+pub struct AstTrigram(pub(crate) u64);
 
 impl AstTrigram {
     /// Encode a grandparent–parent–child node-kind triple into an [`AstTrigram`].
@@ -190,7 +190,7 @@ pub fn vocab_lookup(kind: &str) -> Option<NodeKindId> {
     NODE_KIND_VOCABULARY
         .binary_search(&kind)
         .ok()
-        .map(|idx| idx as NodeKindId)
+        .and_then(|idx| u16::try_from(idx).ok())
 }
 
 /// Resolve a [`NodeKindId`] back to its kind string.

--- a/crates/rskim-search/src/ast_index/ngram.rs
+++ b/crates/rskim-search/src/ast_index/ngram.rs
@@ -24,15 +24,9 @@ use rskim_core::Language;
 
 use crate::ast_weights::{NODE_KIND_VOCABULARY, ast_bigram_weight, ast_trigram_weight};
 
-// ============================================================================
-// Type alias
-// ============================================================================
-
-/// Compact numeric ID for a tree-sitter node kind string.
-///
-/// Indexes into [`NODE_KIND_VOCABULARY`]. `0` is the sentinel for unknown kinds
-/// (maps to `""`).
-pub type NodeKindId = u16;
+// NodeKindId is defined in the parent module (ast_index/mod.rs) and imported
+// here so that both `linearize` and `ngram` share the same canonical definition.
+use super::NodeKindId;
 
 // ============================================================================
 // Constants
@@ -254,3 +248,7 @@ fn fmt_kind_id(f: &mut fmt::Formatter<'_>, id: NodeKindId) -> fmt::Result {
 #[cfg(test)]
 #[path = "ngram_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "ngram_display_tests.rs"]
+mod display_tests;

--- a/crates/rskim-search/src/ast_index/ngram_display_tests.rs
+++ b/crates/rskim-search/src/ast_index/ngram_display_tests.rs
@@ -1,0 +1,60 @@
+//! T5: Display formatting tests for AstBigram and AstTrigram.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+
+// ── T5: Display formatting ────────────────────────────────────────────────────
+
+#[test]
+fn bigram_display_known_ids() {
+    let id_ident = vocab_lookup("identifier").expect("identifier in vocab");
+    let id_fn = vocab_lookup("function_item").expect("function_item in vocab");
+    let s = AstBigram::encode(id_ident, id_fn).to_string();
+    assert!(s.contains("identifier"), "got: {s}");
+    assert!(s.contains("function_item"), "got: {s}");
+    assert!(s.contains(" > "), "must contain ' > ' separator, got: {s}");
+}
+
+#[test]
+fn bigram_display_unknown_ids_use_fallback() {
+    let s = AstBigram::encode(u16::MAX, u16::MAX).to_string();
+    assert!(
+        s.contains("?65535"),
+        "out-of-bounds ID must display as '?65535', got: {s}"
+    );
+}
+
+#[test]
+fn bigram_display_sentinel_id_zero() {
+    let s = AstBigram::encode(0, 0).to_string();
+    assert!(
+        s.contains("<unknown>"),
+        "sentinel ID 0 must display as '<unknown>', got: {s}"
+    );
+}
+
+#[test]
+fn trigram_display_known_ids() {
+    let id_ident = vocab_lookup("identifier").expect("identifier in vocab");
+    let id_fn = vocab_lookup("function_item").expect("function_item in vocab");
+    let id_src = vocab_lookup("source_file").expect("source_file in vocab");
+    let s = AstTrigram::encode(id_src, id_fn, id_ident).to_string();
+    assert!(s.contains("source_file"), "got: {s}");
+    assert!(s.contains("function_item"), "got: {s}");
+    assert!(s.contains("identifier"), "got: {s}");
+    assert_eq!(
+        s.matches(" > ").count(),
+        2,
+        "trigram must have 2 ' > ' separators, got: {s}"
+    );
+}
+
+#[test]
+fn trigram_display_unknown_ids_use_fallback() {
+    let s = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX).to_string();
+    assert!(
+        s.contains("?65535"),
+        "out-of-bounds must use '?65535' fallback, got: {s}"
+    );
+}

--- a/crates/rskim-search/src/ast_index/ngram_tests.rs
+++ b/crates/rskim-search/src/ast_index/ngram_tests.rs
@@ -291,8 +291,7 @@ fn vocab_len_nonzero_and_fits_in_u16() {
 
 #[test]
 fn bigram_idf_known_rust_entry_above_default() {
-    // First entry in RUST_AST_BIGRAM_WEIGHTS:
-    //   (0x009A0125, 11.251047) → "abstract_type"(154) -> "bounded_type"(293)
+    // First entry in RUST_AST_BIGRAM_WEIGHTS: "abstract_type" -> "bounded_type"
     let parent = vocab_lookup("abstract_type").expect("abstract_type in vocab");
     let child = vocab_lookup("bounded_type").expect("bounded_type in vocab");
     let bg = AstBigram::encode(parent, child);
@@ -300,6 +299,21 @@ fn bigram_idf_known_rust_entry_above_default() {
     assert!(
         w > DEFAULT_AST_WEIGHT,
         "known Rust bigram must have weight > DEFAULT_AST_WEIGHT ({DEFAULT_AST_WEIGHT}), got {w}"
+    );
+}
+
+// ── T9b: ast_bigram_idf returns weight > DEFAULT for known TypeScript bigram ───
+
+#[test]
+fn bigram_idf_known_typescript_entry_above_default() {
+    // First entry in TYPESCRIPT_AST_BIGRAM_WEIGHTS: "abstract_class_declaration" -> "abstract"
+    let parent = vocab_lookup("abstract_class_declaration").expect("abstract_class_declaration in vocab");
+    let child = vocab_lookup("abstract").expect("abstract in vocab");
+    let bg = AstBigram::encode(parent, child);
+    let w = ast_bigram_idf(Language::TypeScript, bg);
+    assert!(
+        w > DEFAULT_AST_WEIGHT,
+        "known TypeScript bigram must have weight > DEFAULT_AST_WEIGHT ({DEFAULT_AST_WEIGHT}), got {w}"
     );
 }
 
@@ -334,8 +348,7 @@ fn bigram_idf_non_treesitter_languages_return_default() {
 
 #[test]
 fn trigram_idf_known_rust_entry_above_default() {
-    // First entry in RUST_AST_TRIGRAM_WEIGHTS:
-    //   (0x0000009A01250035, 11.251047) → "abstract_type"(154) -> "bounded_type"(293) -> "+"(53)
+    // First entry in RUST_AST_TRIGRAM_WEIGHTS: "abstract_type" -> "bounded_type" -> "+"
     let gp = vocab_lookup("abstract_type").expect("abstract_type in vocab");
     let parent = vocab_lookup("bounded_type").expect("bounded_type in vocab");
     let child = vocab_lookup("+").expect("'+' in vocab");
@@ -392,7 +405,44 @@ fn bigram_from_raw_consistent_with_encode() {
     assert_eq!(AstBigram::from_raw(bg.key()), bg);
 }
 
-// ── T14: DEFAULT_AST_WEIGHT constant value ────────────────────────────────────
+// ── T14: Ordering semantics ───────────────────────────────────────────────────
+
+/// Bigrams are parent-major: a higher parent always sorts after a lower parent,
+/// regardless of the child component.
+#[test]
+fn bigram_ordering_is_parent_major() {
+    let low_parent = AstBigram::encode(1, u16::MAX); // parent=1, child=MAX
+    let high_parent = AstBigram::encode(2, 0); // parent=2, child=0
+    assert!(
+        high_parent > low_parent,
+        "bigrams must sort parent-major: encode(2,0) > encode(1, MAX)"
+    );
+}
+
+/// Trigrams are grandparent-major: a higher grandparent always sorts last,
+/// then parent, then child.
+#[test]
+fn trigram_ordering_is_grandparent_major() {
+    let low_gp = AstTrigram::encode(1, u16::MAX, u16::MAX); // gp=1, rest=MAX
+    let high_gp = AstTrigram::encode(2, 0, 0); // gp=2, rest=0
+    assert!(
+        high_gp > low_gp,
+        "trigrams must sort grandparent-major: encode(2,0,0) > encode(1,MAX,MAX)"
+    );
+}
+
+/// Within the same parent, bigrams sort by child.
+#[test]
+fn bigram_ordering_child_tiebreak() {
+    let small_child = AstBigram::encode(5, 1);
+    let large_child = AstBigram::encode(5, 100);
+    assert!(
+        large_child > small_child,
+        "bigrams with equal parent must sort by child"
+    );
+}
+
+// ── T16: DEFAULT_AST_WEIGHT constant value ────────────────────────────────────
 
 #[test]
 fn default_ast_weight_is_one() {

--- a/crates/rskim-search/src/ast_index/ngram_tests.rs
+++ b/crates/rskim-search/src/ast_index/ngram_tests.rs
@@ -210,8 +210,7 @@ fn vocab_resolve_and_lookup_are_inverses() {
         "function_item",
         "source_file",
     ] {
-        let id = vocab_lookup(kind)
-            .unwrap_or_else(|| panic!("{kind} must be in vocabulary"));
+        let id = vocab_lookup(kind).unwrap_or_else(|| panic!("{kind} must be in vocabulary"));
         assert_eq!(
             vocab_resolve(id),
             Some(kind),
@@ -252,8 +251,8 @@ fn bigram_idf_known_rust_entry_above_default() {
 #[test]
 fn bigram_idf_known_typescript_entry_above_default() {
     // First entry in TYPESCRIPT_AST_BIGRAM_WEIGHTS: "abstract_class_declaration" -> "abstract"
-    let parent = vocab_lookup("abstract_class_declaration")
-        .expect("abstract_class_declaration in vocab");
+    let parent =
+        vocab_lookup("abstract_class_declaration").expect("abstract_class_declaration in vocab");
     let child = vocab_lookup("abstract").expect("abstract in vocab");
     let bg = AstBigram::encode(parent, child);
     let w = ast_bigram_idf(Language::TypeScript, bg);
@@ -342,13 +341,6 @@ fn bigram_encoding_consistent_with_weight_table() {
         expected_key,
         "encode() must produce the same key as stored in RUST_AST_BIGRAM_WEIGHTS[0]"
     );
-}
-
-#[test]
-fn bigram_from_raw_consistent_with_encode() {
-    // from_raw(encode(a,b).key()) must equal encode(a,b).
-    let bg = AstBigram::encode(154, 293);
-    assert_eq!(AstBigram::from_raw(bg.key()), bg);
 }
 
 // ── T15: Ordering semantics ───────────────────────────────────────────────────

--- a/crates/rskim-search/src/ast_index/ngram_tests.rs
+++ b/crates/rskim-search/src/ast_index/ngram_tests.rs
@@ -1,0 +1,492 @@
+//! Tests for AST n-gram newtypes and vocabulary/weight helpers.
+//!
+//! Test cycles:
+//!   T1  AstBigram encode/decode roundtrip
+//!   T2  AstTrigram encode/decode roundtrip
+//!   T3  key() matches encoding formula
+//!   T4  from_raw() roundtrip
+//!   T5  Display formatting
+//!   T6  vocab_lookup
+//!   T7  vocab_resolve
+//!   T8  vocab_len
+//!   T9  ast_bigram_idf returns weight > DEFAULT for known Rust bigram
+//!   T10 ast_bigram_idf fallback for unknown bigram
+//!   T11 ast_bigram_idf fallback for non-tree-sitter languages
+//!   T12 ast_trigram_idf parallel tests
+//!   T13 Encoding consistency with weight table entries
+//!   T14 DEFAULT_AST_WEIGHT constant value
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use rskim_core::Language;
+
+use super::*;
+use crate::ast_weights::RUST_AST_BIGRAM_WEIGHTS;
+
+// ── T1: AstBigram encode/decode roundtrip ────────────────────────────────────
+
+#[test]
+fn bigram_roundtrip_zero() {
+    let bg = AstBigram::encode(0, 0);
+    assert_eq!(bg.decode(), (0, 0));
+}
+
+#[test]
+fn bigram_roundtrip_one() {
+    let bg = AstBigram::encode(1, 1);
+    assert_eq!(bg.decode(), (1, 1));
+}
+
+#[test]
+fn bigram_roundtrip_max() {
+    let bg = AstBigram::encode(u16::MAX, u16::MAX);
+    assert_eq!(bg.decode(), (u16::MAX, u16::MAX));
+}
+
+#[test]
+fn bigram_roundtrip_asymmetric() {
+    let bg = AstBigram::encode(0, u16::MAX);
+    assert_eq!(bg.decode(), (0, u16::MAX));
+
+    let bg2 = AstBigram::encode(u16::MAX, 0);
+    assert_eq!(bg2.decode(), (u16::MAX, 0));
+}
+
+#[test]
+fn bigram_roundtrip_typical_ids() {
+    // Typical vocab IDs in range [1, 1740]
+    for parent in [1u16, 42, 154, 293, 500, 1000, 1740] {
+        for child in [1u16, 10, 154, 293, 800, 1740] {
+            let bg = AstBigram::encode(parent, child);
+            assert_eq!(
+                bg.decode(),
+                (parent, child),
+                "roundtrip failed for ({parent},{child})"
+            );
+        }
+    }
+}
+
+// ── T2: AstTrigram encode/decode roundtrip ────────────────────────────────────
+
+#[test]
+fn trigram_roundtrip_zero() {
+    let tg = AstTrigram::encode(0, 0, 0);
+    assert_eq!(tg.decode(), (0, 0, 0));
+}
+
+#[test]
+fn trigram_roundtrip_max() {
+    let tg = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX);
+    assert_eq!(tg.decode(), (u16::MAX, u16::MAX, u16::MAX));
+}
+
+#[test]
+fn trigram_roundtrip_asymmetric() {
+    let tg = AstTrigram::encode(0, 0, u16::MAX);
+    assert_eq!(tg.decode(), (0, 0, u16::MAX));
+
+    let tg2 = AstTrigram::encode(u16::MAX, 0, 0);
+    assert_eq!(tg2.decode(), (u16::MAX, 0, 0));
+
+    let tg3 = AstTrigram::encode(0, u16::MAX, 0);
+    assert_eq!(tg3.decode(), (0, u16::MAX, 0));
+}
+
+#[test]
+fn trigram_roundtrip_typical_ids() {
+    for gp in [1u16, 42, 154] {
+        for parent in [1u16, 293, 500] {
+            for child in [53u16, 100, 800] {
+                let tg = AstTrigram::encode(gp, parent, child);
+                assert_eq!(
+                    tg.decode(),
+                    (gp, parent, child),
+                    "roundtrip failed for ({gp},{parent},{child})"
+                );
+            }
+        }
+    }
+}
+
+// ── T3: key() matches encoding formula ───────────────────────────────────────
+
+#[test]
+fn bigram_key_matches_formula() {
+    assert_eq!(
+        AstBigram::encode(1, 2).key(),
+        (1u32 << 16) | 2u32,
+        "bigram key formula mismatch"
+    );
+}
+
+#[test]
+fn bigram_key_formula_boundary_values() {
+    assert_eq!(AstBigram::encode(0, 0).key(), 0u32);
+    assert_eq!(
+        AstBigram::encode(u16::MAX, u16::MAX).key(),
+        (u32::from(u16::MAX) << 16) | u32::from(u16::MAX)
+    );
+    assert_eq!(AstBigram::encode(0, u16::MAX).key(), u32::from(u16::MAX));
+    assert_eq!(
+        AstBigram::encode(u16::MAX, 0).key(),
+        u32::from(u16::MAX) << 16
+    );
+}
+
+#[test]
+fn trigram_key_matches_formula() {
+    assert_eq!(
+        AstTrigram::encode(1, 2, 3).key(),
+        (1u64 << 32) | (2u64 << 16) | 3u64,
+        "trigram key formula mismatch"
+    );
+}
+
+#[test]
+fn trigram_key_formula_boundary_values() {
+    assert_eq!(AstTrigram::encode(0, 0, 0).key(), 0u64);
+    assert_eq!(
+        AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX).key(),
+        (u64::from(u16::MAX) << 32) | (u64::from(u16::MAX) << 16) | u64::from(u16::MAX)
+    );
+}
+
+// ── T4: from_raw() roundtrip ──────────────────────────────────────────────────
+
+#[test]
+fn bigram_from_raw_roundtrip() {
+    let original = AstBigram::encode(42, 99);
+    let reconstructed = AstBigram::from_raw(original.key());
+    assert_eq!(reconstructed, original);
+}
+
+#[test]
+fn bigram_from_raw_zero() {
+    assert_eq!(AstBigram::from_raw(0), AstBigram::encode(0, 0));
+}
+
+#[test]
+fn trigram_from_raw_roundtrip() {
+    let original = AstTrigram::encode(10, 20, 30);
+    let reconstructed = AstTrigram::from_raw(original.key());
+    assert_eq!(reconstructed, original);
+}
+
+#[test]
+fn trigram_from_raw_zero() {
+    assert_eq!(AstTrigram::from_raw(0), AstTrigram::encode(0, 0, 0));
+}
+
+// ── T5: Display formatting ────────────────────────────────────────────────────
+
+#[test]
+fn bigram_display_known_ids() {
+    // "identifier" and "function_item" are known Rust vocab entries.
+    let id_identifier = vocab_lookup("identifier").expect("identifier must be in vocab");
+    let id_fn_item = vocab_lookup("function_item").expect("function_item must be in vocab");
+
+    let bg = AstBigram::encode(id_identifier, id_fn_item);
+    let s = bg.to_string();
+    assert!(
+        s.contains("identifier"),
+        "Display must contain 'identifier', got: {s}"
+    );
+    assert!(
+        s.contains("function_item"),
+        "Display must contain 'function_item', got: {s}"
+    );
+    assert!(
+        s.contains(" > "),
+        "Display must contain ' > ' separator, got: {s}"
+    );
+}
+
+#[test]
+fn bigram_display_unknown_ids_use_fallback() {
+    // u16::MAX is far beyond vocabulary length — both IDs are out-of-bounds.
+    let bg = AstBigram::encode(u16::MAX, u16::MAX);
+    let s = bg.to_string();
+    // Both sides should use the "?{id}" fallback.
+    assert!(
+        s.contains(&format!("?{}", u16::MAX)),
+        "out-of-bounds ID must display as '?65535', got: {s}"
+    );
+}
+
+#[test]
+fn bigram_display_sentinel_id_zero() {
+    // ID 0 maps to "" (sentinel). Display should render it as "<unknown>".
+    let bg = AstBigram::encode(0, 0);
+    let s = bg.to_string();
+    assert!(
+        s.contains("<unknown>"),
+        "sentinel ID 0 must display as '<unknown>', got: {s}"
+    );
+}
+
+#[test]
+fn trigram_display_known_ids() {
+    let id_identifier = vocab_lookup("identifier").expect("identifier in vocab");
+    let id_fn_item = vocab_lookup("function_item").expect("function_item in vocab");
+    let id_source = vocab_lookup("source_file").expect("source_file in vocab");
+
+    let tg = AstTrigram::encode(id_source, id_fn_item, id_identifier);
+    let s = tg.to_string();
+    assert!(s.contains("source_file"), "got: {s}");
+    assert!(s.contains("function_item"), "got: {s}");
+    assert!(s.contains("identifier"), "got: {s}");
+    // Two " > " separators expected
+    let sep_count = s.matches(" > ").count();
+    assert_eq!(
+        sep_count, 2,
+        "trigram Display must have 2 ' > ' separators, got: {s}"
+    );
+}
+
+#[test]
+fn trigram_display_unknown_ids_use_fallback() {
+    let tg = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX);
+    let s = tg.to_string();
+    assert!(
+        s.contains(&format!("?{}", u16::MAX)),
+        "out-of-bounds ID must use '?65535' fallback, got: {s}"
+    );
+}
+
+// ── T6: vocab_lookup ──────────────────────────────────────────────────────────
+
+#[test]
+fn vocab_lookup_identifier_found() {
+    assert!(
+        vocab_lookup("identifier").is_some(),
+        "'identifier' must be in vocabulary"
+    );
+}
+
+#[test]
+fn vocab_lookup_function_item_found() {
+    assert!(
+        vocab_lookup("function_item").is_some(),
+        "'function_item' must be in vocabulary"
+    );
+}
+
+#[test]
+fn vocab_lookup_nonexistent_returns_none() {
+    assert_eq!(
+        vocab_lookup("NONEXISTENT_KIND_XYZ"),
+        None,
+        "nonsense kind must not be in vocabulary"
+    );
+}
+
+#[test]
+fn vocab_lookup_sentinel_empty_string() {
+    // ID 0 is the sentinel "" entry.
+    assert_eq!(
+        vocab_lookup(""),
+        Some(0),
+        "empty string must resolve to ID 0"
+    );
+}
+
+// ── T7: vocab_resolve ─────────────────────────────────────────────────────────
+
+#[test]
+fn vocab_resolve_zero_is_sentinel() {
+    assert_eq!(
+        vocab_resolve(0),
+        Some(""),
+        "ID 0 must resolve to empty string sentinel"
+    );
+}
+
+#[test]
+fn vocab_resolve_roundtrip() {
+    let id = vocab_lookup("identifier").expect("identifier in vocab");
+    assert_eq!(
+        vocab_resolve(id),
+        Some("identifier"),
+        "vocab_resolve(vocab_lookup('identifier')) must equal 'identifier'"
+    );
+}
+
+#[test]
+fn vocab_resolve_out_of_bounds_returns_none() {
+    assert_eq!(
+        vocab_resolve(u16::MAX),
+        None,
+        "ID u16::MAX must be out of bounds and return None"
+    );
+}
+
+#[test]
+fn vocab_resolve_and_lookup_are_inverses() {
+    // Spot-check several known kinds.
+    for kind in [
+        "abstract_type",
+        "bounded_type",
+        "function_item",
+        "source_file",
+    ] {
+        if let Some(id) = vocab_lookup(kind) {
+            assert_eq!(
+                vocab_resolve(id),
+                Some(kind),
+                "vocab_resolve(vocab_lookup({kind:?})) must equal {kind:?}"
+            );
+        }
+    }
+}
+
+// ── T8: vocab_len ─────────────────────────────────────────────────────────────
+
+#[test]
+fn vocab_len_is_nonzero() {
+    assert!(vocab_len() > 0, "vocabulary must not be empty");
+}
+
+#[test]
+fn vocab_len_fits_in_u16() {
+    assert!(
+        vocab_len() < u16::MAX as usize,
+        "vocabulary length {} must fit in u16 (< {})",
+        vocab_len(),
+        u16::MAX
+    );
+}
+
+// ── T9: ast_bigram_idf returns weight > DEFAULT for known Rust bigram ─────────
+
+#[test]
+fn bigram_idf_known_rust_entry_above_default() {
+    // First entry in RUST_AST_BIGRAM_WEIGHTS:
+    //   (0x009A0125, 11.251047) → "abstract_type"(154) -> "bounded_type"(293)
+    let parent = vocab_lookup("abstract_type").expect("abstract_type in vocab");
+    let child = vocab_lookup("bounded_type").expect("bounded_type in vocab");
+    let bg = AstBigram::encode(parent, child);
+    let w = ast_bigram_idf(Language::Rust, bg);
+    assert!(
+        w > DEFAULT_AST_WEIGHT,
+        "known Rust bigram must have weight > DEFAULT_AST_WEIGHT ({DEFAULT_AST_WEIGHT}), got {w}"
+    );
+}
+
+// ── T10: ast_bigram_idf fallback for unknown bigram ───────────────────────────
+
+#[test]
+fn bigram_idf_unknown_bigram_returns_default() {
+    let bg = AstBigram::encode(u16::MAX, u16::MAX);
+    assert_eq!(
+        ast_bigram_idf(Language::Rust, bg),
+        DEFAULT_AST_WEIGHT,
+        "unknown bigram must return DEFAULT_AST_WEIGHT"
+    );
+}
+
+// ── T11: ast_bigram_idf fallback for non-tree-sitter languages ────────────────
+
+#[test]
+fn bigram_idf_json_returns_default() {
+    let bg = AstBigram::encode(1, 2);
+    assert_eq!(
+        ast_bigram_idf(Language::Json, bg),
+        DEFAULT_AST_WEIGHT,
+        "JSON has no AST weight table — must return DEFAULT_AST_WEIGHT"
+    );
+}
+
+#[test]
+fn bigram_idf_yaml_returns_default() {
+    let bg = AstBigram::encode(1, 2);
+    assert_eq!(
+        ast_bigram_idf(Language::Yaml, bg),
+        DEFAULT_AST_WEIGHT,
+        "YAML has no AST weight table — must return DEFAULT_AST_WEIGHT"
+    );
+}
+
+#[test]
+fn bigram_idf_toml_returns_default() {
+    let bg = AstBigram::encode(1, 2);
+    assert_eq!(
+        ast_bigram_idf(Language::Toml, bg),
+        DEFAULT_AST_WEIGHT,
+        "TOML has no AST weight table — must return DEFAULT_AST_WEIGHT"
+    );
+}
+
+// ── T12: ast_trigram_idf parallel tests ──────────────────────────────────────
+
+#[test]
+fn trigram_idf_known_rust_entry_above_default() {
+    // First entry in RUST_AST_TRIGRAM_WEIGHTS:
+    //   (0x0000009A01250035, 11.251047) → "abstract_type"(154) -> "bounded_type"(293) -> "+"(53)
+    let gp = vocab_lookup("abstract_type").expect("abstract_type in vocab");
+    let parent = vocab_lookup("bounded_type").expect("bounded_type in vocab");
+    let child = vocab_lookup("+").expect("'+' in vocab");
+    let tg = AstTrigram::encode(gp, parent, child);
+    let w = ast_trigram_idf(Language::Rust, tg);
+    assert!(
+        w > DEFAULT_AST_WEIGHT,
+        "known Rust trigram must have weight > DEFAULT_AST_WEIGHT ({DEFAULT_AST_WEIGHT}), got {w}"
+    );
+}
+
+#[test]
+fn trigram_idf_unknown_trigram_returns_default() {
+    let tg = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX);
+    assert_eq!(
+        ast_trigram_idf(Language::Rust, tg),
+        DEFAULT_AST_WEIGHT,
+        "unknown trigram must return DEFAULT_AST_WEIGHT"
+    );
+}
+
+#[test]
+fn trigram_idf_json_returns_default() {
+    let tg = AstTrigram::encode(1, 2, 3);
+    assert_eq!(ast_trigram_idf(Language::Json, tg), DEFAULT_AST_WEIGHT);
+}
+
+#[test]
+fn trigram_idf_yaml_returns_default() {
+    let tg = AstTrigram::encode(1, 2, 3);
+    assert_eq!(ast_trigram_idf(Language::Yaml, tg), DEFAULT_AST_WEIGHT);
+}
+
+#[test]
+fn trigram_idf_toml_returns_default() {
+    let tg = AstTrigram::encode(1, 2, 3);
+    assert_eq!(ast_trigram_idf(Language::Toml, tg), DEFAULT_AST_WEIGHT);
+}
+
+// ── T13: Encoding consistency with weight table entries ───────────────────────
+
+#[test]
+fn bigram_encoding_consistent_with_weight_table() {
+    // Verify that our encode() produces the same u32 key as stored in the table.
+    let (expected_key, _weight) = RUST_AST_BIGRAM_WEIGHTS[0];
+    let parent_id = (expected_key >> 16) as u16;
+    let child_id = (expected_key & 0xFFFF) as u16;
+    assert_eq!(
+        AstBigram::encode(parent_id, child_id).key(),
+        expected_key,
+        "encode() must produce the same key as stored in RUST_AST_BIGRAM_WEIGHTS[0]"
+    );
+}
+
+#[test]
+fn bigram_from_raw_consistent_with_encode() {
+    // from_raw(encode(a,b).key()) must equal encode(a,b).
+    let bg = AstBigram::encode(154, 293);
+    assert_eq!(AstBigram::from_raw(bg.key()), bg);
+}
+
+// ── T14: DEFAULT_AST_WEIGHT constant value ────────────────────────────────────
+
+#[test]
+fn default_ast_weight_is_one() {
+    assert_eq!(DEFAULT_AST_WEIGHT, 1.0_f32);
+}

--- a/crates/rskim-search/src/ast_index/ngram_tests.rs
+++ b/crates/rskim-search/src/ast_index/ngram_tests.rs
@@ -152,61 +152,6 @@ fn trigram_from_raw_roundtrip() {
     assert_eq!(AstTrigram::from_raw(tg.key()), tg);
 }
 
-// ── T5: Display formatting ────────────────────────────────────────────────────
-
-#[test]
-fn bigram_display_known_ids() {
-    let id_ident = vocab_lookup("identifier").expect("identifier in vocab");
-    let id_fn = vocab_lookup("function_item").expect("function_item in vocab");
-    let s = AstBigram::encode(id_ident, id_fn).to_string();
-    assert!(s.contains("identifier"), "got: {s}");
-    assert!(s.contains("function_item"), "got: {s}");
-    assert!(s.contains(" > "), "must contain ' > ' separator, got: {s}");
-}
-
-#[test]
-fn bigram_display_unknown_ids_use_fallback() {
-    let s = AstBigram::encode(u16::MAX, u16::MAX).to_string();
-    assert!(
-        s.contains("?65535"),
-        "out-of-bounds ID must display as '?65535', got: {s}"
-    );
-}
-
-#[test]
-fn bigram_display_sentinel_id_zero() {
-    let s = AstBigram::encode(0, 0).to_string();
-    assert!(
-        s.contains("<unknown>"),
-        "sentinel ID 0 must display as '<unknown>', got: {s}"
-    );
-}
-
-#[test]
-fn trigram_display_known_ids() {
-    let id_ident = vocab_lookup("identifier").expect("identifier in vocab");
-    let id_fn = vocab_lookup("function_item").expect("function_item in vocab");
-    let id_src = vocab_lookup("source_file").expect("source_file in vocab");
-    let s = AstTrigram::encode(id_src, id_fn, id_ident).to_string();
-    assert!(s.contains("source_file"), "got: {s}");
-    assert!(s.contains("function_item"), "got: {s}");
-    assert!(s.contains("identifier"), "got: {s}");
-    assert_eq!(
-        s.matches(" > ").count(),
-        2,
-        "trigram must have 2 ' > ' separators, got: {s}"
-    );
-}
-
-#[test]
-fn trigram_display_unknown_ids_use_fallback() {
-    let s = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX).to_string();
-    assert!(
-        s.contains("?65535"),
-        "out-of-bounds must use '?65535' fallback, got: {s}"
-    );
-}
-
 // ── T6: vocab_lookup ──────────────────────────────────────────────────────────
 
 #[test]
@@ -265,13 +210,13 @@ fn vocab_resolve_and_lookup_are_inverses() {
         "function_item",
         "source_file",
     ] {
-        if let Some(id) = vocab_lookup(kind) {
-            assert_eq!(
-                vocab_resolve(id),
-                Some(kind),
-                "roundtrip failed for {kind:?}"
-            );
-        }
+        let id = vocab_lookup(kind)
+            .unwrap_or_else(|| panic!("{kind} must be in vocabulary"));
+        assert_eq!(
+            vocab_resolve(id),
+            Some(kind),
+            "roundtrip failed for {kind:?}"
+        );
     }
 }
 
@@ -302,12 +247,13 @@ fn bigram_idf_known_rust_entry_above_default() {
     );
 }
 
-// ── T9b: ast_bigram_idf returns weight > DEFAULT for known TypeScript bigram ───
+// ── T10: ast_bigram_idf returns weight > DEFAULT for known TypeScript bigram ───
 
 #[test]
 fn bigram_idf_known_typescript_entry_above_default() {
     // First entry in TYPESCRIPT_AST_BIGRAM_WEIGHTS: "abstract_class_declaration" -> "abstract"
-    let parent = vocab_lookup("abstract_class_declaration").expect("abstract_class_declaration in vocab");
+    let parent = vocab_lookup("abstract_class_declaration")
+        .expect("abstract_class_declaration in vocab");
     let child = vocab_lookup("abstract").expect("abstract in vocab");
     let bg = AstBigram::encode(parent, child);
     let w = ast_bigram_idf(Language::TypeScript, bg);
@@ -317,7 +263,7 @@ fn bigram_idf_known_typescript_entry_above_default() {
     );
 }
 
-// ── T10: ast_bigram_idf fallback for unknown bigram ───────────────────────────
+// ── T11: ast_bigram_idf fallback for unknown bigram ───────────────────────────
 
 #[test]
 fn bigram_idf_unknown_bigram_returns_default() {
@@ -329,7 +275,7 @@ fn bigram_idf_unknown_bigram_returns_default() {
     );
 }
 
-// ── T11: ast_bigram_idf fallback for non-tree-sitter languages ────────────────
+// ── T12: ast_bigram_idf fallback for non-tree-sitter languages ────────────────
 
 #[test]
 fn bigram_idf_non_treesitter_languages_return_default() {
@@ -344,7 +290,7 @@ fn bigram_idf_non_treesitter_languages_return_default() {
     }
 }
 
-// ── T12: ast_trigram_idf parallel tests ──────────────────────────────────────
+// ── T13: ast_trigram_idf parallel tests ──────────────────────────────────────
 
 #[test]
 fn trigram_idf_known_rust_entry_above_default() {
@@ -383,14 +329,14 @@ fn trigram_idf_non_treesitter_languages_return_default() {
     }
 }
 
-// ── T13: Encoding consistency with weight table entries ───────────────────────
+// ── T14: Encoding consistency with weight table entries ───────────────────────
 
 #[test]
 fn bigram_encoding_consistent_with_weight_table() {
     // Verify that our encode() produces the same u32 key as stored in the table.
     let (expected_key, _weight) = RUST_AST_BIGRAM_WEIGHTS[0];
-    let parent_id = (expected_key >> 16) as u16;
-    let child_id = (expected_key & 0xFFFF) as u16;
+    let parent_id = u16::try_from(expected_key >> 16).expect("parent fits in u16");
+    let child_id = u16::try_from(expected_key & 0xFFFF).expect("child fits in u16");
     assert_eq!(
         AstBigram::encode(parent_id, child_id).key(),
         expected_key,
@@ -405,7 +351,7 @@ fn bigram_from_raw_consistent_with_encode() {
     assert_eq!(AstBigram::from_raw(bg.key()), bg);
 }
 
-// ── T14: Ordering semantics ───────────────────────────────────────────────────
+// ── T15: Ordering semantics ───────────────────────────────────────────────────
 
 /// Bigrams are parent-major: a higher parent always sorts after a lower parent,
 /// regardless of the child component.

--- a/crates/rskim-search/src/ast_index/ngram_tests.rs
+++ b/crates/rskim-search/src/ast_index/ngram_tests.rs
@@ -1,20 +1,4 @@
 //! Tests for AST n-gram newtypes and vocabulary/weight helpers.
-//!
-//! Test cycles:
-//!   T1  AstBigram encode/decode roundtrip
-//!   T2  AstTrigram encode/decode roundtrip
-//!   T3  key() matches encoding formula
-//!   T4  from_raw() roundtrip
-//!   T5  Display formatting
-//!   T6  vocab_lookup
-//!   T7  vocab_resolve
-//!   T8  vocab_len
-//!   T9  ast_bigram_idf returns weight > DEFAULT for known Rust bigram
-//!   T10 ast_bigram_idf fallback for unknown bigram
-//!   T11 ast_bigram_idf fallback for non-tree-sitter languages
-//!   T12 ast_trigram_idf parallel tests
-//!   T13 Encoding consistency with weight table entries
-//!   T14 DEFAULT_AST_WEIGHT constant value
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -156,69 +140,42 @@ fn trigram_key_formula_boundary_values() {
 
 #[test]
 fn bigram_from_raw_roundtrip() {
-    let original = AstBigram::encode(42, 99);
-    let reconstructed = AstBigram::from_raw(original.key());
-    assert_eq!(reconstructed, original);
-}
-
-#[test]
-fn bigram_from_raw_zero() {
     assert_eq!(AstBigram::from_raw(0), AstBigram::encode(0, 0));
+    let bg = AstBigram::encode(42, 99);
+    assert_eq!(AstBigram::from_raw(bg.key()), bg);
 }
 
 #[test]
 fn trigram_from_raw_roundtrip() {
-    let original = AstTrigram::encode(10, 20, 30);
-    let reconstructed = AstTrigram::from_raw(original.key());
-    assert_eq!(reconstructed, original);
-}
-
-#[test]
-fn trigram_from_raw_zero() {
     assert_eq!(AstTrigram::from_raw(0), AstTrigram::encode(0, 0, 0));
+    let tg = AstTrigram::encode(10, 20, 30);
+    assert_eq!(AstTrigram::from_raw(tg.key()), tg);
 }
 
 // ── T5: Display formatting ────────────────────────────────────────────────────
 
 #[test]
 fn bigram_display_known_ids() {
-    // "identifier" and "function_item" are known Rust vocab entries.
-    let id_identifier = vocab_lookup("identifier").expect("identifier must be in vocab");
-    let id_fn_item = vocab_lookup("function_item").expect("function_item must be in vocab");
-
-    let bg = AstBigram::encode(id_identifier, id_fn_item);
-    let s = bg.to_string();
-    assert!(
-        s.contains("identifier"),
-        "Display must contain 'identifier', got: {s}"
-    );
-    assert!(
-        s.contains("function_item"),
-        "Display must contain 'function_item', got: {s}"
-    );
-    assert!(
-        s.contains(" > "),
-        "Display must contain ' > ' separator, got: {s}"
-    );
+    let id_ident = vocab_lookup("identifier").expect("identifier in vocab");
+    let id_fn = vocab_lookup("function_item").expect("function_item in vocab");
+    let s = AstBigram::encode(id_ident, id_fn).to_string();
+    assert!(s.contains("identifier"), "got: {s}");
+    assert!(s.contains("function_item"), "got: {s}");
+    assert!(s.contains(" > "), "must contain ' > ' separator, got: {s}");
 }
 
 #[test]
 fn bigram_display_unknown_ids_use_fallback() {
-    // u16::MAX is far beyond vocabulary length — both IDs are out-of-bounds.
-    let bg = AstBigram::encode(u16::MAX, u16::MAX);
-    let s = bg.to_string();
-    // Both sides should use the "?{id}" fallback.
+    let s = AstBigram::encode(u16::MAX, u16::MAX).to_string();
     assert!(
-        s.contains(&format!("?{}", u16::MAX)),
+        s.contains("?65535"),
         "out-of-bounds ID must display as '?65535', got: {s}"
     );
 }
 
 #[test]
 fn bigram_display_sentinel_id_zero() {
-    // ID 0 maps to "" (sentinel). Display should render it as "<unknown>".
-    let bg = AstBigram::encode(0, 0);
-    let s = bg.to_string();
+    let s = AstBigram::encode(0, 0).to_string();
     assert!(
         s.contains("<unknown>"),
         "sentinel ID 0 must display as '<unknown>', got: {s}"
@@ -227,45 +184,37 @@ fn bigram_display_sentinel_id_zero() {
 
 #[test]
 fn trigram_display_known_ids() {
-    let id_identifier = vocab_lookup("identifier").expect("identifier in vocab");
-    let id_fn_item = vocab_lookup("function_item").expect("function_item in vocab");
-    let id_source = vocab_lookup("source_file").expect("source_file in vocab");
-
-    let tg = AstTrigram::encode(id_source, id_fn_item, id_identifier);
-    let s = tg.to_string();
+    let id_ident = vocab_lookup("identifier").expect("identifier in vocab");
+    let id_fn = vocab_lookup("function_item").expect("function_item in vocab");
+    let id_src = vocab_lookup("source_file").expect("source_file in vocab");
+    let s = AstTrigram::encode(id_src, id_fn, id_ident).to_string();
     assert!(s.contains("source_file"), "got: {s}");
     assert!(s.contains("function_item"), "got: {s}");
     assert!(s.contains("identifier"), "got: {s}");
-    // Two " > " separators expected
-    let sep_count = s.matches(" > ").count();
     assert_eq!(
-        sep_count, 2,
-        "trigram Display must have 2 ' > ' separators, got: {s}"
+        s.matches(" > ").count(),
+        2,
+        "trigram must have 2 ' > ' separators, got: {s}"
     );
 }
 
 #[test]
 fn trigram_display_unknown_ids_use_fallback() {
-    let tg = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX);
-    let s = tg.to_string();
+    let s = AstTrigram::encode(u16::MAX, u16::MAX, u16::MAX).to_string();
     assert!(
-        s.contains(&format!("?{}", u16::MAX)),
-        "out-of-bounds ID must use '?65535' fallback, got: {s}"
+        s.contains("?65535"),
+        "out-of-bounds must use '?65535' fallback, got: {s}"
     );
 }
 
 // ── T6: vocab_lookup ──────────────────────────────────────────────────────────
 
 #[test]
-fn vocab_lookup_identifier_found() {
+fn vocab_lookup_known_kinds_found() {
     assert!(
         vocab_lookup("identifier").is_some(),
         "'identifier' must be in vocabulary"
     );
-}
-
-#[test]
-fn vocab_lookup_function_item_found() {
     assert!(
         vocab_lookup("function_item").is_some(),
         "'function_item' must be in vocabulary"
@@ -274,16 +223,11 @@ fn vocab_lookup_function_item_found() {
 
 #[test]
 fn vocab_lookup_nonexistent_returns_none() {
-    assert_eq!(
-        vocab_lookup("NONEXISTENT_KIND_XYZ"),
-        None,
-        "nonsense kind must not be in vocabulary"
-    );
+    assert_eq!(vocab_lookup("NONEXISTENT_KIND_XYZ"), None);
 }
 
 #[test]
 fn vocab_lookup_sentinel_empty_string() {
-    // ID 0 is the sentinel "" entry.
     assert_eq!(
         vocab_lookup(""),
         Some(0),
@@ -305,25 +249,16 @@ fn vocab_resolve_zero_is_sentinel() {
 #[test]
 fn vocab_resolve_roundtrip() {
     let id = vocab_lookup("identifier").expect("identifier in vocab");
-    assert_eq!(
-        vocab_resolve(id),
-        Some("identifier"),
-        "vocab_resolve(vocab_lookup('identifier')) must equal 'identifier'"
-    );
+    assert_eq!(vocab_resolve(id), Some("identifier"));
 }
 
 #[test]
 fn vocab_resolve_out_of_bounds_returns_none() {
-    assert_eq!(
-        vocab_resolve(u16::MAX),
-        None,
-        "ID u16::MAX must be out of bounds and return None"
-    );
+    assert_eq!(vocab_resolve(u16::MAX), None);
 }
 
 #[test]
 fn vocab_resolve_and_lookup_are_inverses() {
-    // Spot-check several known kinds.
     for kind in [
         "abstract_type",
         "bounded_type",
@@ -334,7 +269,7 @@ fn vocab_resolve_and_lookup_are_inverses() {
             assert_eq!(
                 vocab_resolve(id),
                 Some(kind),
-                "vocab_resolve(vocab_lookup({kind:?})) must equal {kind:?}"
+                "roundtrip failed for {kind:?}"
             );
         }
     }
@@ -343,17 +278,12 @@ fn vocab_resolve_and_lookup_are_inverses() {
 // ── T8: vocab_len ─────────────────────────────────────────────────────────────
 
 #[test]
-fn vocab_len_is_nonzero() {
-    assert!(vocab_len() > 0, "vocabulary must not be empty");
-}
-
-#[test]
-fn vocab_len_fits_in_u16() {
+fn vocab_len_nonzero_and_fits_in_u16() {
+    let len = vocab_len();
+    assert!(len > 0, "vocabulary must not be empty");
     assert!(
-        vocab_len() < u16::MAX as usize,
-        "vocabulary length {} must fit in u16 (< {})",
-        vocab_len(),
-        u16::MAX
+        len < u16::MAX as usize,
+        "vocabulary length {len} must fit in u16"
     );
 }
 
@@ -388,33 +318,16 @@ fn bigram_idf_unknown_bigram_returns_default() {
 // ── T11: ast_bigram_idf fallback for non-tree-sitter languages ────────────────
 
 #[test]
-fn bigram_idf_json_returns_default() {
+fn bigram_idf_non_treesitter_languages_return_default() {
     let bg = AstBigram::encode(1, 2);
-    assert_eq!(
-        ast_bigram_idf(Language::Json, bg),
-        DEFAULT_AST_WEIGHT,
-        "JSON has no AST weight table — must return DEFAULT_AST_WEIGHT"
-    );
-}
-
-#[test]
-fn bigram_idf_yaml_returns_default() {
-    let bg = AstBigram::encode(1, 2);
-    assert_eq!(
-        ast_bigram_idf(Language::Yaml, bg),
-        DEFAULT_AST_WEIGHT,
-        "YAML has no AST weight table — must return DEFAULT_AST_WEIGHT"
-    );
-}
-
-#[test]
-fn bigram_idf_toml_returns_default() {
-    let bg = AstBigram::encode(1, 2);
-    assert_eq!(
-        ast_bigram_idf(Language::Toml, bg),
-        DEFAULT_AST_WEIGHT,
-        "TOML has no AST weight table — must return DEFAULT_AST_WEIGHT"
-    );
+    for lang in [Language::Json, Language::Yaml, Language::Toml] {
+        assert_eq!(
+            ast_bigram_idf(lang, bg),
+            DEFAULT_AST_WEIGHT,
+            "{} has no AST weight table — must return DEFAULT_AST_WEIGHT",
+            lang.name()
+        );
+    }
 }
 
 // ── T12: ast_trigram_idf parallel tests ──────────────────────────────────────
@@ -445,21 +358,16 @@ fn trigram_idf_unknown_trigram_returns_default() {
 }
 
 #[test]
-fn trigram_idf_json_returns_default() {
+fn trigram_idf_non_treesitter_languages_return_default() {
     let tg = AstTrigram::encode(1, 2, 3);
-    assert_eq!(ast_trigram_idf(Language::Json, tg), DEFAULT_AST_WEIGHT);
-}
-
-#[test]
-fn trigram_idf_yaml_returns_default() {
-    let tg = AstTrigram::encode(1, 2, 3);
-    assert_eq!(ast_trigram_idf(Language::Yaml, tg), DEFAULT_AST_WEIGHT);
-}
-
-#[test]
-fn trigram_idf_toml_returns_default() {
-    let tg = AstTrigram::encode(1, 2, 3);
-    assert_eq!(ast_trigram_idf(Language::Toml, tg), DEFAULT_AST_WEIGHT);
+    for lang in [Language::Json, Language::Yaml, Language::Toml] {
+        assert_eq!(
+            ast_trigram_idf(lang, tg),
+            DEFAULT_AST_WEIGHT,
+            "{} has no AST trigram table — must return DEFAULT_AST_WEIGHT",
+            lang.name()
+        );
+    }
 }
 
 // ── T13: Encoding consistency with weight table entries ───────────────────────

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -32,7 +32,10 @@ pub mod temporal;
 mod types;
 pub mod weights;
 
-pub use ast_index::{LinearNode, LinearizeResult, linearize_source};
+pub use ast_index::{
+    AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, LinearNode, LinearizeResult, NodeKindId,
+    ast_bigram_idf, ast_trigram_idf, linearize_source, vocab_len, vocab_lookup, vocab_resolve,
+};
 pub use cochange::{CochangeMatrixBuilder, CochangeMatrixReader};
 pub use index::{NgramIndexBuilder, NgramIndexReader};
 pub use lexical::{


### PR DESCRIPTION
## Summary

- Adds `AstBigram` (u32 newtype) and `AstTrigram` (u64 newtype) for packing tree-sitter node-kind ID pairs into compact integer keys, using the same bit layout as the `ast_weights` tables
- Exposes vocabulary helpers (`vocab_lookup`, `vocab_resolve`, `vocab_len`) backed by `NODE_KIND_VOCABULARY` with O(log n) binary search
- Exposes `ast_bigram_idf` / `ast_trigram_idf` for per-language IDF weight lookup, falling back to `DEFAULT_AST_WEIGHT` (1.0) for unknown entries and non-tree-sitter languages (JSON, YAML, TOML)
- All new types re-exported from the `rskim-search` crate root

## Changes

**New files:**
- `crates/rskim-search/src/ast_index/ngram.rs` — `AstBigram`, `AstTrigram`, vocabulary helpers, weight lookup functions (~256 lines)
- `crates/rskim-search/src/ast_index/ngram_tests.rs` — 45 tests covering T1–T14 (~492 lines)

**Modified files:**
- `crates/rskim-search/src/ast_index/mod.rs` — added `mod ngram` and pub re-exports
- `crates/rskim-search/src/lib.rs` — expanded `pub use ast_index` to include new types
- Other files: `cargo fmt` formatting cleanup from Wave 3a

## Acceptance Criteria

- AC-1: `AstBigram` and `AstTrigram` are newtypes (not type aliases); `from_raw()` is `pub(crate)` — done
- AC-2: Encode/decode roundtrip verified for all u16 boundary values — done
- AC-3: `vocab_lookup`/`vocab_resolve`/`vocab_len` work correctly — done
- AC-4: Weight lookup returns >1.0 for known bigrams; 1.0 for unknown/non-TS languages — done
- AC-5: Display formatting with fallback for unknown/sentinel IDs — done
- AC-6: Doc comments on all public items, re-exported from crate root — done
- AC-7: T13 verifies encoding consistency with weight table entries — done
- AC-8: Zero regressions; 539 tests pass; zero clippy warnings — done

## Testing

```
cargo test -p rskim-search -- ast_index::ngram  # 45 tests pass
cargo test -p rskim-search                       # 539 tests pass, 0 fail
cargo clippy -p rskim-search -- -D warnings      # 0 warnings, 0 errors
cargo fmt -- --check                             # clean
```

Closes #190