### PR TITLE
feat(#137): CPython traceback fixture + log parser alignment

### DIFF
--- a/.devflow/decisions/decisions.md
+++ b/.devflow/decisions/decisions.md
@@ -1,4 +1,4 @@
-<!-- TL;DR: 1 decisions. Key: ADR-001 -->
+<!-- TL;DR: 2 decisions. Key: ADR-001, ADR-002 -->
 # Architectural Decisions
 
 Append-only. Status changes allowed; deletions prohibited.
@@ -11,3 +11,12 @@ Append-only. Status changes allowed; deletions prohibited.
 - **Decision**: resolve all findings immediately — no deferral to future tickets or tech debt backlog regardless of blocking severity
 - **Consequences**: 'I really hate tech debt' and 'I don't want to leave anything for later' — user treats noticed issues as immediate obligations regardless of blocking status. **Why:** the cost of leaving a known issue is higher than the cost of extended scope. **How to apply:** when reviewers flag any issues (blocking OR non-blocking), always surface them all to the user for decision rather than silently classifying as deferred. The user will almost always choose to fix now.
 - **Source**: self-learning:obs_jk7n2w
+
+## ADR-002: Progress trackers and prioritized issue queues belong as GitHub issues, not memory files
+
+- **Date**: 2026-06-03
+- **Status**: Accepted
+- **Context**: After completing issue triage and agreeing on the next 5 priorities, a progress tracker was created in WORKING-MEMORY.md. The user immediately rejected this, noting memory files don't age well.
+- **Decision**: Any prioritized work queue, roadmap tracker, or multi-issue progress tracker must be created as a GitHub issue (e.g., issue #268 "Roadmap: Next 5 issues"), not in WORKING-MEMORY.md or any devflow memory file.
+- **Consequences**: GitHub issues survive context compaction, are version-controlled, and are visible to all collaborators. Memory files are session-scoped and lose fidelity over time. **How to apply:** when the user asks to "track" multiple upcoming issues or create a work queue, default to `gh issue create` — not a memory file edit. WORKING-MEMORY.md should only reflect current session state (branch, latest commit, blockers), not a durable to-do list.
+- **Source**: sidecar:decisions.2fea848d-a8f7-46da-aa16-be990ed4d829

--- a/.devflow/features/build-parsers/KNOWLEDGE.md
+++ b/.devflow/features/build-parsers/KNOWLEDGE.md
@@ -1,8 +1,8 @@
 ---
 feature: build-parsers
 name: Build Tool Output Parsers
-description: "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, ParseResult, BuildResult, three-tier, NDJSON, flag injection, flat dispatch, multi-category dispatch."
-category: domain-knowledge
+description: "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection."
+category: component-patterns
 directories: [crates/rskim/src/cmd/build/]
 referencedFiles:
   - crates/rskim/src/cmd/build/mod.rs
@@ -14,111 +14,255 @@ referencedFiles:
   - crates/rskim/src/output/mod.rs
   - crates/rskim/src/output/canonical.rs
   - crates/rskim/src/cmd/mod.rs
-  - crates/rskim/src/runner.rs
-created: 2026-06-03
-updated: 2026-06-03
+created: 2026-05-14
+updated: 2026-05-26
+version: 9
 ---
 
 # Build Tool Output Parsers
 
 ## Overview
 
-The `cmd/build/` module compresses and filters output from build tools (cargo, make, tsc, gradle, maven) using a three-tier parse degradation strategy. It is reached via two dispatch paths:
+The build parsers module (`crates/rskim/src/cmd/build/`) compresses output from build tools (cargo, clippy, tsc, make, gradle, maven) into compact summaries for AI context windows. Each tool has a dedicated file (`cargo.rs`, `tsc.rs`, `make.rs`, `gradle.rs`, `maven.rs`) plus a shared `mod.rs` that provides the dispatcher and the `run_parsed_command` infrastructure function used by all five.
 
-- **Flat dispatch**: `skim tsc`, `skim gradle`, `skim make` — the tool name is `argv[0]` when invoked as a PATH wrapper
-- **Multi-category dispatch**: `skim cargo build`, `skim cargo clippy`, `skim gradle build` — routed through `cmd/build/mod.rs::run()`
+The module is invoked via flat dispatch (`skim tsc`) or multi-category dispatch (`skim cargo build`, `skim cargo clippy`). All parsers share the same three-tier degradation model: Full (clean structured parse) → Degraded (partial parse with warning markers) → Passthrough (raw output returned unchanged).
 
-All handlers share the same `ParseResult<BuildResult>` output contract and delegate to `CommandRunner` for process execution.
+## Core Responsibilities
 
-## Three-Tier Parse Degradation
+Each parser file should:
+- Export a single `run()` function (plus `run_clippy()` for cargo)
+- Inject tool-specific flags before spawning, when the tool supports structured output
+- Delegate spawn + output capture to `run_parsed_command` in `mod.rs`
+- Implement a private `parse_*` function that maps `&CommandOutput` to `ParseResult<BuildResult>`
 
-The `output::ParseResult<T>` enum drives the degradation strategy:
+`mod.rs` should:
+- Dispatch by tool name and route to the correct handler
+- Own `run_parsed_command`, the shared spawn-parse-emit-record loop
+- Never contain tool-specific parsing logic
 
+## Three-Tier Degradation Pattern
+
+Every build parser implements the same three-tier cascade. Returning `None` from a tier signals "this tier cannot handle the input — try the next one":
+
+The cascade is always tried in order from most structured to least:
+
+```rust
+fn parse_cargo(output: &CommandOutput) -> ParseResult<BuildResult> {
+    // Tier 1: highest fidelity — JSON/NDJSON when available
+    if let Some(result) = try_tier1_json(&output.stdout) {
+        return result;  // Returns Full or Degraded
+    }
+
+    // Tier 2: regex fallback on stderr or combined output
+    if let Some(result) = try_tier2_regex(&output.stderr) {
+        return result;  // Returns Degraded with marker
+    }
+
+    // Tier 3: never returns None — always a valid ParseResult
+    ParseResult::Passthrough(combined)
+}
 ```
-Full(T)               — clean structured parse, all fields populated
-Degraded(T, warnings) — partial parse, forwarded with warning markers injected
-Passthrough(String)   — unrecognized format, output returned as-is
+
+Key invariants:
+- Tier 1 returns `ParseResult::Full` on clean parse, never `Degraded`
+- Tier 2 returns `ParseResult::Degraded` with a human-readable marker string
+- Tier 3 returns `ParseResult::Passthrough` — raw content, no marker
+- The `parse_*` function is passed by function pointer to `run_parsed_command`, typed as `fn(&CommandOutput) -> ParseResult<BuildResult>`
+
+## Tool-Specific Tier Strategies
+
+Each tool assigns tiers differently based on what structured output the tool provides:
+
+| Tool | Tier 1 | Tier 2 | Tier 3 |
+|------|--------|--------|--------|
+| cargo / clippy | NDJSON from `--message-format=json` (stdout) | Regex `error[E\d+]` on stderr | Passthrough combined |
+| tsc | Regex `file(line,col): error TSxxxx: msg` on stderr | Same regex on combined stdout+stderr | Passthrough combined |
+| make | GCC/Clang diagnostics + Makefile syntax errors + make failure + linker errors + noop detection on combined | Noise stripping (compiler invocations, directory changes, CMake progress, archiver lines, `compilation terminated.` literal) | Passthrough combined |
+| gradle / gradlew | Regex on task outcomes (`> Task :name OUTCOME`), Java/Kotlin diagnostics, `BUILD SUCCESSFUL/FAILED` summary | Noise strip (daemon startup, download progress, configure project, UP-TO-DATE/FROM-CACHE task lines) | Passthrough combined |
+| mvn / mvnw | Regex on `[ERROR]`/`[WARNING]` lines and `[INFO] BUILD SUCCESS/FAILURE` + total time | Noise strip (`Downloading from`, `Downloaded from`, `[INFO] ---` separator lines, scanning/building markers) | Passthrough combined |
+
+Note that tsc uses regex for its Tier 1 (not JSON) because tsc has no native structured output mode. Its Tier 2 is the same regex applied to a different stream, promoted to `Degraded` rather than `Full`.
+
+The `compilation terminated.` check in make's Tier 2 is a literal `starts_with` check, not a regex — it is hardcoded alongside the four `LazyLock<Regex>` noise patterns.
+
+## Flag Injection Pattern
+
+Tools with a structured-output flag (cargo `--message-format=json`) inject it automatically unless the user already supplied it. This prevents overriding user intent.
+
+The helpers live in `crate::cmd` (not inside `cmd/build/`):
+- `user_has_flag(&args, &["--message-format"])` — prefix-match check, handles `--flag=value` and `--flag value` styles
+- `inject_flag_before_separator(&mut args, "--message-format=json")` — inserts the flag before `--` so it targets the tool, not arguments after the separator
+- `extract_show_stats(&args)` — strips `--show-stats` from the arg list and returns `(filtered_args, bool)`. `build/mod.rs` calls this at the top of its `run()` function; the `bool` is threaded through to `run_parsed_command`. This was centralized from per-handler inline logic.
+
+Gradle and Maven do not inject flags — they have no native structured output mode, so their `run()` functions pass `&[]` as `env_vars` and perform no flag mutation.
+
+## Gradle Parser Details
+
+Gradle (`gradle.rs`) supports both `gradle` and `gradlew` aliases via the `program` parameter passed through from the dispatcher. The `run()` signature is `run(program: &str, args: &[String], ...)` — the program name is forwarded directly to `run_parsed_command`.
+
+Tier 1 recognizes four pattern types on the combined stdout+stderr stream:
+- Task outcomes: `> Task :name OUTCOME` via `GRADLE_TASK_RE` — tasks with `FAILED` outcome increment error count
+- Java diagnostics: `file.java:line: error|warning|note: message` via `JAVA_DIAG_RE`
+- Kotlin diagnostics: `e: file.kt: (line, col): message` or `w:` via `KOTLIN_DIAG_RE`
+- Build summary: `BUILD SUCCESSFUL in Xs` via `BUILD_SUCCESS_RE` (duration extracted) and `BUILD FAILED` via `BUILD_FAILED_RE`
+
+Success determination in Tier 1 requires all three conditions: `exit_code == Some(0) && errors == 0 && !BUILD_FAILED_RE.is_match(combined)`. A zero exit code alone is not enough — explicit `BUILD FAILED` text also marks failure.
+
+Duration parsing handles the `3.456 secs` format only (extracts the first token and multiplies by 1000). The `1 min 2 secs` format is not parsed — `parse_gradle_duration` returns `None` for multi-word durations.
+
+## Maven Parser Details
+
+Maven (`maven.rs`) supports `mvn`, `mvnw`, and the alias `maven` — all forwarded to `run_parsed_command` via the `program` parameter. No flag injection occurs.
+
+Tier 1 pattern types on the combined stream:
+- Error lines: `[ERROR] message` via `MAVEN_ERROR_RE`
+- Warning lines: `[WARNING] message` via `MAVEN_WARN_RE`
+- Build outcome: `[INFO] BUILD SUCCESS` and `[INFO] BUILD FAILURE` via `MAVEN_SUCCESS_RE` / `MAVEN_FAILURE_RE`
+- Total time: `[INFO] Total time:  2.345 s` via `MAVEN_TIME_RE`
+
+Success determination: `exit_code == Some(0) && MAVEN_SUCCESS_RE.is_match(combined) && errors == 0`. Unlike gradle, maven requires the `BUILD SUCCESS` marker to be present in the output — a zero exit code without the marker produces `success = false`.
+
+Duration parsing handles two formats:
+- `2.345 s` (seconds with decimal) → milliseconds
+- `1:23 min` (minutes:seconds) → milliseconds
+
+Tier 2 noise patterns strip `[INFO] Downloading/Downloaded from`, `[INFO] ---` separator lines, `[INFO] Scanning for projects`, `[INFO] Building`, reactor summary lines, and empty `[INFO]` lines via `MAVEN_INFO_NOISE_RE`.
+
+## `run_parsed_command` — Shared Infrastructure
+
+All five parsers call `super::run_parsed_command(...)` in `mod.rs` instead of spawning processes themselves. This function handles:
+1. Command spawn with a 600-second timeout (compile times can be long)
+2. ANSI escape code stripping from both stdout and stderr before parsing
+3. Calling the parser function pointer
+4. Emitting degradation markers to stderr (only when `--debug` / `SKIM_DEBUG=1` is active — silent by default)
+5. Printing result content to stdout
+6. Token stats (if `--show-stats`)
+7. Exit code determination from `BuildResult.success` or raw `output.exit_code`
+8. Analytics recording via `format_analytics_label("build", program, &args.join(" "))` (fire-and-forget)
+
+The full signature is:
+```rust
+pub(super) fn run_parsed_command(
+    program: &str,
+    args: &[String],
+    env_vars: &[(&str, &str)],
+    install_hint: &str,
+    show_stats: bool,
+    rec: crate::analytics::RecordingContext<'_>,  // constructed once in build::run()
+    parser: fn(&CommandOutput) -> ParseResult<BuildResult>,  // fn pointer, not FnOnce
+) -> anyhow::Result<ExitCode>
 ```
 
-Each build handler attempts `Full` parse first, degrades to `Degraded` on partial failures, and falls back to `Passthrough` only when the output format is entirely unrecognized. The degradation level is used by the analytics recording layer to track parse quality.
+Two details worth noting: `rec` is a `RecordingContext` threaded from `build::run()` (which constructs it once from `AnalyticsConfig` with `CommandType::Build`); and `parser` is a plain `fn` pointer, not a closure — build parsers need no captured state. The analytics call annotates the tier via `rec.with_tier(result.tier_name())`.
 
-## Component Architecture
+Spawn failures (missing executable) use `anyhow::bail!` — a hard error with an install hint. This differs from the non-build path: `obtain_output` in `cmd/mod.rs` returns `Ok(None)` on spawn failure (soft fallback), which `run_parsed_command_with_mode` then converts to `Ok(ExitCode::FAILURE)`. Build commands have no stdin-passthrough path, so `ENOENT` is always fatal.
 
-### `mod.rs` — Public Dispatch
+**Important**: build parsers use `run_parsed_command` (defined in `build/mod.rs`), not `run_parsed_command_with_mode` or `run_tool<T>` (both defined in `cmd/mod.rs`). The three are intentionally separate:
+- Build: no `use_stdin`, no `--json` output mode, no `SKIM_PASSTHROUGH` bypass, no compressed-output hint on failure, plain `fn()` parser pointer, bail-on-spawn, 600s timeout
+- Other families (lint, infra, db, file): use `run_tool<T>` (the generic runner added in #214) which wraps `run_parsed_command_with_mode`. `run_tool<T>` takes `ToolRunConfig<'a>` (program, env_overrides, install_hint, family, skip_ansi_strip, command_type), a `&RunContext`, a `prepare_args` closure, and a one-arg `parse_fn`
 
-Routes incoming args to the correct handler. Handles `--help` early exit. Extracts `--show-stats` flag via `cmd::extract_show_stats`. Match arms cover:
-- `"build"` / `"check"` / `"fmt"` / `"clippy"` / `"nextest"` / `"audit"` → `cargo::run_*`
-- `"gradle"` / `"gradlew"` → `gradle::run`
-- `"make"` → `make::run`
-- `"mvn"` / `"mvnw"` / `"maven"` → `maven::run`
-- Unknown subcommand → `cargo::run` (default, matches previous skim behavior for bare `skim cargo` invocations)
+`run_tool<T>` in `cmd/mod.rs` explicitly documents this boundary: "build::run_parsed_command is intentionally not replaced: it has a different call shape (no `ctx: &RunContext`, different analytics path)." Switching build parsers to use `run_tool<T>` is not just a refactor — the signatures are incompatible.
 
-### `cargo.rs` — Rust Toolchain
+The `ParsedCommandConfig` struct (in `cmd/mod.rs`) adds several fields not present in the build path: `family` (for analytics label disambiguation — prevents collision when `cargo` appears in both build and pkg), `skip_ansi_strip` (DB tools emit TSV; stripping would drop tab characters), and `output_format` (supports `--json` output mode). Build does none of these, which is why the two paths are separate rather than consolidated.
 
-Handles cargo build, check, fmt, clippy, nextest, and audit. Injects `--message-format=json` (or `--message-format json-diagnostic-rendered-ansi` for clippy) when the output destination allows structured capture. Parses NDJSON output from cargo. Collapses duplicate warning lines, extracts error/warning counts for the stats footer.
+## `BuildResult` — Output Type
 
-### `gradle.rs` — Gradle / Gradlew
+`BuildResult` (in `crates/rskim/src/output/canonical.rs`) carries:
+- `success: bool`
+- `warnings: usize`
+- `errors: usize`
+- `duration_ms: Option<u64>` — cargo does not report duration in JSON; gradle and maven do report duration when `BUILD SUCCESSFUL` appears
+- `error_messages: Vec<String>` — formatted per-error strings, plus grouped warning codes for clippy
 
-Handles gradle and gradlew invocations. Extracts task names from gradle's structured output lines (`:taskName OUTCOME`), filters build lifecycle noise, preserves error output verbatim.
+The `rendered` field is pre-computed in `BuildResult::new()`. On success it renders as `OK warnings: N errors: 0`; on failure it appends each `error_messages` entry indented with a space. Error messages are only printed on failure — clippy warning code summaries are appended to `error_messages` but silently carried on a successful clippy run.
 
-### `make.rs` — GNU Make
+`BuildResult::render` is a private `fn` in `canonical.rs`. The other canonical types (`LintResult`, `DbResult`, `GitResult`, `PkgResult`) follow the same pattern. As of #214, `DbResult::render` was decomposed into 5 private helper functions — the decomposition pattern is the standard for any canonical type whose render logic grows beyond a single screen.
 
-Handles make invocations. Extracts target names, filters `Entering directory`/`Leaving directory` lines, preserves compiler error output verbatim.
+## Regex Compilation
 
-### `maven.rs` — Maven / mvnw
+All regex patterns are compiled once via `LazyLock<Regex>` at module scope. This avoids per-call recompilation and is the standard pattern across all build and lint parsers.
 
-Handles mvn and mvnw invocations. Filters reactor summary lines, extracts module names, preserves BUILD SUCCESS/FAILURE and error output.
+```rust
+static CARGO_ERROR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"error\[E\d+\]").expect("valid regex"));
+```
 
-### `tsc.rs` — TypeScript Compiler
+Use `.expect("valid regex")` not `.unwrap()` — the expect message documents intent and is visible in panics.
 
-Handles tsc invocations. Parses TypeScript diagnostic output (`file.ts(line,col): error TS1234: message`), groups by file, deduplicates identical messages.
+## Shared Test Helpers
 
-### `output/mod.rs` — ParseResult + Infrastructure
+All build parser tests (and tests across the `cmd` subtree) use the shared helpers from `crate::cmd::test_support`, defined under `#[cfg(test)]` in `cmd/mod.rs`. As of #214, the ~34 local `make_output` definitions and ~41 local `load_fixture` definitions that existed across `cmd` subtree modules were replaced by this single canonical source.
 
-Provides:
-- `ParseResult<T>` enum (Full / Degraded / Passthrough)
-- ANSI stripping (`strip_ansi_codes`)
-- Progress line collapsing (cargo download progress, percentage lines)
-- Token-aware truncation
-- Filter transparency headers
+The three helpers are:
+- `make_output(stdout: &str) -> CommandOutput` — success case: stderr empty, exit_code Some(0), duration ZERO
+- `make_output_full(stdout, stderr, exit_code: Option<i32>) -> CommandOutput` — full control for non-zero exits, stderr content, signal-kill (None exit code)
+- `load_fixture(subdir: &str, name: &str) -> String` — loads from `tests/fixtures/cmd/{subdir}/{name}`; panics with clear message on missing file
 
-### `output/canonical.rs` — BuildResult
-
-`BuildResult` is the canonical structured form of build output. Fields capture: error count, warning count, duration, individual diagnostics, and the raw output for passthrough. All handlers produce `ParseResult<BuildResult>`.
-
-### `runner.rs` — CommandRunner
-
-Timeout-aware command runner. Executes via `Command::new().args()` (no shell). Captures stdout + stderr concurrently via threads to prevent pipe deadlocks. Exposes `CommandOutput { stdout, stderr, exit_code, duration }`. `CommandRunner` is dependency-injected into all handlers.
-
-## Integration Points
-
-- **Analytics**: every handler receives a `RecordingContext` and calls `analytics::record_build_result` on completion. Fire-and-forget background thread.
-- **PATH wrappers**: when `skim` binary detects `argv[0] == "gradle"` etc., it strips `~/.skim/bin` from `PATH` then calls `cmd/build/mod.rs::run()` with the tool name prepended to args.
-- **`--show-stats`**: handlers print a token-reduction stats footer to stderr when this flag is present.
+Build parser tests import these as `use super::super::test_support::{make_output, make_output_full, load_fixture}`. Do not redeclare local versions — use the canonical source to prevent drift.
 
 ## Anti-Patterns
 
-- **Shell-expanding arguments**: `CommandRunner` uses `Command::new().args()`, not a shell. Never pass shell metacharacters in args — they are passed literally.
-- **Calling `cargo::run` for non-cargo subcommands**: the default arm in `mod.rs` sends unknown subcommands to `cargo::run` only because bare `skim cargo` usage is the dominant case. Add explicit arms for any new tools.
-- **Logging parse failures to stdout**: degradation warnings go through `ParseResult::Degraded` and are rendered as comment-style markers in the output, not raw stderr noise.
+- **Adding tool-specific spawn logic to `run_parsed_command`**: the shared function must remain tool-agnostic. Tool-specific env vars (`CARGO_TERM_COLOR=never`) and flags belong in the per-tool `run()` function.
+
+- **Returning `ParseResult::Degraded` from Tier 1**: Tier 1 must only emit `Full`. If the parse is partial, it is not a Tier 1 parse — fall through to Tier 2. Mixing `Full` and `Degraded` from the same tier breaks the diagnostic signal.
+
+- **Using `try_tier1` signature for regex-only parsers**: tsc's "Tier 1" is regex on stderr, but it still returns `ParseResult::Full` (not `Degraded`) because stderr is the authoritative output stream. The Degraded tier is reserved for the combined-stream fallback where stream identity is unknown.
+
+- **Omitting the empty-output success check**: gradle, maven, tsc, and make all treat empty stdout+stderr as a successful build when `exit_code == Some(0)`. Skipping this check causes `ParseResult::Passthrough("")` instead of `ParseResult::Full(success)`.
+
+- **Switching build parsers to use `run_tool<T>` or `run_parsed_command_with_mode`**: the build family intentionally diverges. See the Infrastructure section above. The signatures are incompatible: `run_parsed_command` takes `fn(&CommandOutput)` (one arg, plain fn pointer); `run_tool<T>` takes `FnOnce(&CommandOutput)` via `run_parsed_command_with_mode` which takes `FnOnce(&CommandOutput, &[String])` (two args). Mixing them will fail to compile.
+
+- **Declaring a new tool in `run()` dispatch without adding it to the help text and error messages**: the unknown-tool error message and `print_help()` list supported tools by name — both must be updated when adding a new parser. Also add the tool name to `KNOWN_SUBCOMMANDS` in `cmd/mod.rs` and the `dispatch()` match arm in `cmd/mod.rs`.
+
+- **Adding a build tool as a passthrough dispatcher**: build tools should use the strict dispatcher model (error on unknown subcommand), not the passthrough model used by `swift`/`dotnet`. Build commands have a finite, well-defined subcommand set; passthrough is reserved for tools with wide lifecycle subcommand surfaces that agents invoke routinely.
+
+- **Declaring local `make_output` or `load_fixture` in build test modules**: use `super::super::test_support` instead. Local redeclarations drift from the canonical definition (e.g., duration field set to arbitrary millisecond values instead of `Duration::ZERO`).
 
 ## Gotchas
 
-- `cargo clippy` uses a different `--message-format` flag form than `cargo build`. The injected flag is `--message-format json-diagnostic-rendered-ansi` (space-separated), not `=` form.
-- `gradle` and `gradlew` share the same handler (`gradle::run`). The program name is threaded through so the handler can re-invoke the correct binary.
-- `maven` also matches `"mvnw"` (Maven wrapper). Both map to `maven::run`.
-- `--show-stats` is consumed by `cmd::extract_show_stats` before dispatch and never passed to the subprocess.
+- **Degradation markers and parse notices are silent by default**: `emit_markers` in `ParseResult` only writes to stderr when `SKIM_DEBUG=1` or `--debug` is set. In normal operation, Tier 2 (`Degraded`) and Tier 3 (`Passthrough`) passes are silent — no `[skim:warning]` or `[skim:notice]` lines appear. This means a build that degrades to regex fallback gives no on-screen indication unless debug mode is active. Enable `SKIM_DEBUG=1` when diagnosing unexpected parse behavior.
+
+- **`--message-format` injection must happen before `--`**: `inject_flag_before_separator` places the flag before `--`. If it were appended after `--`, cargo would treat it as an argument to the compiled binary, not to cargo itself.
+
+- **Cargo warning codes are grouped into `error_messages`, not a separate field**: clippy warning codes (`dead_code: 2 occurrence(s)`) are appended to `error_messages` in `BuildResult`. They are not rendered on a successful clippy run.
+
+- **Make combines stdout and stderr**: make sends compiler diagnostics to whichever stream the child compiler uses. Always combine both streams before parsing.
+
+- **`build-finished` is required for Tier 1 in cargo**: `try_tier1_json` returns `None` (falls through to Tier 2) if no `build-finished` NDJSON line appears. This means an incomplete JSON stream — e.g., a killed cargo process — degrades gracefully rather than reporting false success.
+
+- **`note` severity in GCC diagnostics is not counted as an error**: `try_tier1_diagnostics` in make.rs counts `error` and `fatal error` as errors, `warning` as warnings, and skips `note`. Notes are still included in `error_messages` for context.
+
+- **Make noop-after-errors must not discard accumulated diagnostics**: The `MAKE_NOOP_RE` check in `try_tier1_diagnostics` is guarded by `!any_match`. A "Nothing to be done" or "is up to date" line triggers an immediate success return ONLY when no diagnostic lines have been accumulated yet.
+
+- **Signal-killed process (exit code `None`) in empty-output path is failure**: The empty-output early return uses `output.exit_code == Some(0)` for success, not `!= Some(1)`. A signal-killed process has `exit_code: None` — that must map to `success = false`.
+
+- **Timeout is 600 seconds (10 minutes)**: build commands use a longer timeout than the default 300-second `DEFAULT_CMD_TIMEOUT` because compile times can be substantial.
+
+- **Gradle success requires both zero exit code AND absence of `BUILD FAILED` text**: a process can exit 0 while gradle still emits `BUILD FAILED` in certain edge cases. Both conditions are checked in Tier 1.
+
+- **Maven success requires `BUILD SUCCESS` text, not just zero exit code**: unlike most tools, maven's Tier 1 explicitly checks that `MAVEN_SUCCESS_RE.is_match(combined)` is true. A clean exit without the success marker sets `success = false`.
+
+- **Gradle duration parsing only handles `X.XXX secs` format**: the `parse_gradle_duration` function splits on whitespace and parses the first token as `f64`. Multi-part durations like `1 min 2 secs` return `None` and `duration_ms` is left as `None` in `BuildResult`.
+
+- **tsc empty-output check is placed after both tier 1 and tier 2**: unlike make.rs (which guards empty output at the top of `parse_make`), tsc.rs checks for empty output only after tier 1 and tier 2 both return `None`.
 
 ## Key Files
 
-- `crates/rskim/src/cmd/build/mod.rs` — dispatch table; add new tool here first
-- `crates/rskim/src/cmd/build/cargo.rs` — NDJSON + Rust diagnostic parsing; most complex handler
-- `crates/rskim/src/output/mod.rs` — `ParseResult<T>`, ANSI stripping, progress collapsing
-- `crates/rskim/src/output/canonical.rs` — `BuildResult` struct (shared output type)
-- `crates/rskim/src/runner.rs` — `CommandRunner` execution engine
+- `crates/rskim/src/cmd/build/mod.rs` — dispatcher (`run`), shared `run_parsed_command`, and `print_help`
+- `crates/rskim/src/cmd/build/cargo.rs` — cargo build and clippy: NDJSON Tier 1, regex Tier 2
+- `crates/rskim/src/cmd/build/tsc.rs` — TypeScript compiler: regex-on-stderr Tier 1, combined Tier 2, empty-output success (checked after both tiers)
+- `crates/rskim/src/cmd/build/make.rs` — GNU make: GCC diagnostics Tier 1, noise-strip Tier 2, eight `LazyLock<Regex>` patterns plus one literal `starts_with` check
+- `crates/rskim/src/cmd/build/gradle.rs` — Gradle/Gradlew: task outcome + Java/Kotlin diagnostic Tier 1 (with duration), noise-strip Tier 2 (six `LazyLock<Regex>` patterns)
+- `crates/rskim/src/cmd/build/maven.rs` — Maven/Mvnw: `[ERROR]`/`[WARNING]` + build summary Tier 1 (with duration), noise-strip Tier 2 (two `LazyLock<Regex>` patterns, two duration formats)
+- `crates/rskim/src/output/mod.rs` — `ParseResult<T>` enum definition and helpers (`is_full`, `is_degraded`, `tier_name`, `content`, `into_content`, `emit_markers`); `strip_ansi` and `strip_ansi_cow` (zero-copy fast path: borrows when no ESC byte present); `to_json_envelope` (not used by build family — build has no `--json` mode); `OutputMode`, `clean`, `PassthroughTruncator`, `FilterTransparencyHeader` (used by other families); sub-modules `guardrail` and `tee` (not used by build parsers — used by other consumers of the output infrastructure)
+- `crates/rskim/src/output/canonical.rs` — `BuildResult` struct with pre-rendered output; also owns `TestResult`, `GitResult`, `LintResult`, `DbResult`, `PkgResult` — the `DbResult::render` was decomposed into 5 private helpers in #214 as a model for growing render logic
+- `crates/rskim/src/cmd/mod.rs` — `user_has_flag`, `inject_flag_before_separator`, `extract_show_stats`, `extract_json_flag`, `extract_output_format`, `combine_output`, `sanitize_for_display`, `format_analytics_label`, `scrub_db_args`; structs `RunContext`, `ParsedCommandConfig<'_>`, `ToolRunConfig<'_>`, `OutputFormat`; generic runner `run_tool<T>` (used by lint, db, infra, file families — NOT by build); stdin infrastructure: `should_read_stdin`, `read_bounded`, `read_stdin_bounded`, `MAX_STDIN_BYTES`; passthrough infrastructure: `is_passthrough_mode`, `check_passthrough_str`, `check_passthrough_value`; resolver: `resolve_cache_dir`; `is_known_subcommand` (linear scan of `KNOWN_SUBCOMMANDS`); shared test helpers: `test_support` module (under `#[cfg(test)]`) with `make_output`, `make_output_full`, `load_fixture`; private `obtain_output` (soft spawn-failure path for non-build families); private `render_output<T>`; `run_parsed_command_with_mode` (used by non-build families); dispatcher helpers `dispatch()`, `dispatch_cargo()`, `dispatch_go()`, `dispatch_swift()`, `dispatch_dotnet()`, `run_raw_passthrough()`, `passthrough_subcmd()`; `extract_subcmd`, `prepend_without`; `KNOWN_SUBCOMMANDS`
 
 ## Related
 
-- ADR-001: Fix all noticed issues immediately regardless of scope
-- `crates/rskim/src/cmd/mod.rs` — top-level command dispatcher; routes `cargo`, `tsc`, `make` etc. to `cmd/build/`
-- `crates/rskim/src/analytics/` — records parse tier and token savings per build invocation
+- `crates/rskim/src/output/mod.rs` — owns `ParseResult<T>`, the type returned by all three-tier parsers across the whole codebase (lint, test, infra, build); `emit_markers` debug gate is defined here
+- `crates/rskim/src/output/canonical.rs` — owns `BuildResult`, `TestResult`, `GitResult`, `LintResult`; build parsers use `BuildResult`
+- `crates/rskim/src/runner.rs` — `CommandRunner`, `CommandOutput`, `is_spawn_error` — the execution layer called by `run_parsed_command`
+- `crates/rskim/src/cmd/lint/` — sibling module using the same three-tier pattern with `LintResult` instead of `BuildResult`; lint parsers use `run_tool<T>` (via `run_parsed_command_with_mode`) rather than `run_parsed_command`
+- `crates/rskim/src/cmd/test/` — sibling module using the same three-tier pattern with `TestResult`
+- ADR-001: Fix all noticed issues immediately regardless of scope — applies when adding a new build parser: fix any spotted inconsistencies in other parsers in the same PR rather than deferring

--- a/.devflow/features/index.json
+++ b/.devflow/features/index.json
@@ -3,9 +3,10 @@
   "features": {
     "build-parsers": {
       "name": "Build Tool Output Parsers",
-      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection.",
+      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection. NOTE: cmd/mod.rs was refactored in PR #267 — scrubbing logic is in security.rs, command execution in execution.rs, dispatch in dispatch.rs.",
       "directories": [
-        "crates/rskim/src/cmd/build/"
+        "crates/rskim/src/cmd/build/",
+        "crates/rskim/src/cmd/"
       ],
       "referencedFiles": [
         "crates/rskim/src/cmd/build/mod.rs",
@@ -15,9 +16,12 @@
         "crates/rskim/src/output/mod.rs",
         "crates/rskim/src/output/canonical.rs",
         "crates/rskim/src/cmd/mod.rs",
+        "crates/rskim/src/cmd/execution.rs",
+        "crates/rskim/src/cmd/dispatch.rs",
+        "crates/rskim/src/cmd/security.rs",
         "crates/rskim/src/runner.rs"
       ],
-      "lastUpdated": "2026-05-14T14:43:19.739Z",
+      "lastUpdated": "2026-06-03T00:00:00.000Z",
       "createdBy": "devflow-knowledge"
     },
     "cochange": {
@@ -37,7 +41,7 @@
         "crates/rskim-search/src/temporal/storage_types.rs",
         "crates/rskim-search/src/temporal/storage_ops.rs"
       ],
-      "lastUpdated": "2026-05-25T21:45:03.285Z",
+      "lastUpdated": "2026-06-03T00:00:00.000Z",
       "createdBy": "implement"
     },
     "temporal-scoring": {
@@ -57,7 +61,7 @@
         "crates/rskim-search/src/types.rs",
         "crates/rskim-search/src/lib.rs"
       ],
-      "lastUpdated": "2026-05-25T21:44:49.314Z",
+      "lastUpdated": "2026-06-03T00:00:00.000Z",
       "createdBy": "implement"
     }
   }

--- a/.devflow/features/temporal-scoring/KNOWLEDGE.md
+++ b/.devflow/features/temporal-scoring/KNOWLEDGE.md
@@ -1,7 +1,7 @@
 ---
 feature: temporal-scoring
 name: Temporal Risk Scoring
-description: "Use when adding per-file risk metrics from git history, tuning decay parameters, integrating hotspot scores into search ranking, extending the temporal module with new scoring signals, or working with the SQLite temporal persistence layer. Keywords: temporal, hotspot, fix density, exponential decay, git history, risk scores, half-life, FileRiskScores, FileTemporalStats, compute_file_risk_scores, compute_file_temporal_stats, decay_weight, TemporalDb, storage, HotspotRow, RiskRow, CochangeRow, file_filter, SearchQuery, per-file lookup, top-N, hotspot_for_file, risk_for_file, cochanges_for_file, top_hotspots, top_risks, top_coldspots."
+description: "Use when adding temporal ranking signals, modifying decay parameters, working with the SQLite temporal persistence layer, or debugging hotspot/risk score computation. Keywords: temporal, hotspot, risk, fix-density, decay, half-life, TemporalDb, HotspotRow, RiskRow, hotspot_for_file, top_hotspots, top_risks, scoring, FileRiskScores, FileTemporalStats, storage_ops, WAL, schema migrations."
 category: domain-knowledge
 directories: [crates/rskim-search/src/temporal/]
 referencedFiles:
@@ -11,371 +11,244 @@ referencedFiles:
   - crates/rskim-search/src/temporal/git_parser.rs
   - crates/rskim-search/src/temporal/storage.rs
   - crates/rskim-search/src/temporal/storage_ops.rs
+  - crates/rskim-search/src/temporal/storage_perf_tests.rs
+  - crates/rskim-search/src/temporal/storage_tests.rs
   - crates/rskim-search/src/temporal/storage_types.rs
   - crates/rskim-search/src/types.rs
   - crates/rskim-search/src/lib.rs
-created: 2026-05-25
+created: 2026-06-01
 updated: 2026-06-01
+version: 1
 ---
 
 # Temporal Risk Scoring
 
 ## Overview
 
-The temporal scoring subsystem computes two per-file risk metrics from a repository's git commit
-history: a **hotspot score** (decay-weighted commit frequency) and a **fix density** (fraction of
-recent touches that were bug fixes). Both are `f64` values in `[0.0, 1.0]` and are returned as
-`FileRiskScores` in a `HashMap<String, FileRiskScores>`.
+The temporal module computes per-file risk signals from git history: hotspot scores (how frequently a file has changed, weighted by recency) and bug-fix density scores (what fraction of commits touching a file were fix commits). These signals are persisted to a WAL-mode SQLite database (`temporal.db`) for fast bulk-loading by ranking pipelines and `skim search` temporal flags (`--hot`, `--cold`, `--risky`, `--blast-radius`).
 
-A companion function, `compute_file_temporal_stats`, computes raw (non-decay-weighted) commit counts
-per file within 30-day and 90-day windows, producing `FileTemporalStats` values intended for
-persistence. The `temporal::storage` sub-module persists these computed values — along with
-co-change pairs — to a WAL-mode SQLite database via `TemporalDb`.
+The module is separate from the co-change matrix (`crates/rskim-search/src/cochange/`) — both consume `HistoryResult`, but produce different signal types and use different storage formats.
 
-The module is deliberately split into three independent layers: `git_parser.rs` handles all I/O
-(gix-based history traversal), `scoring.rs` is pure (no I/O, no side effects), and `storage.rs`
-owns the SQLite connection and schema lifecycle. The I/O boundary in `git_parser.rs` converts gix
-types into `CommitInfo`/`FileChangeInfo` structs. Scoring code never touches gix. Storage code
-never touches gix or scoring internals.
+## Signal Types
 
-## Business Context
+### Hotspot Score
 
-Risk scores feed downstream ranking signals for the search layer. A file with a high hotspot score
-changed frequently and recently — strong candidate for code-smell review or stale-index detection.
-A high fix density means a large fraction of recent touches were bug fixes — correlates with
-latent defects. Neither metric is a hard filter; both are signals to be blended with BM25F scores
-or co-change coupling data.
+A hotspot score quantifies how actively a file is being modified, with recent changes weighted more heavily than old ones. The score is computed per file, then max-normalized across all files to `[0.0, 1.0]`.
 
-`FileTemporalStats` (raw counts) complements `FileRiskScores` (decay-weighted) by providing data
-suitable for incremental refresh and persistence: raw counts are additive across time windows and
-do not depend on a `now_epoch` at read time.
-
-## Core Business Rules
-
-**Hotspot is max-normalized.** After accumulating decay-weighted totals, the algorithm divides
-every file's total by the global maximum. This means the most-active file always scores exactly
-`1.0` regardless of absolute commit volume.
-
-**Fix density is ratio-based, not count-based.** Fix density is `weighted_fix_total /
-weighted_total` for each file independently. A file touched by 10 fix commits and 10 feature
-commits scores `0.5`.
-
-**Fix classification is commit-wide, not per-file.** `is_fix_commit` classifies the whole commit
-message. If commit A changes `a.rs` and `b.rs` and is a fix commit, both files receive the fix
-weight. There is no per-file keyword extraction.
-
-**The half-life parameter is in days, not seconds.** `decay_weight(elapsed_days, half_life_days)`
-uses the formula `exp(-elapsed_days / half_life_days)`. At exactly one half-life elapsed, the
-weight is `1/e ≈ 0.368`, not `0.5`. This is exponential decay, not a half-life in the biological
-sense.
-
-**Future-dated commits are treated as elapsed = 0.** Commits with a timestamp ahead of `now_epoch`
-contribute weight `1.0`. Negative timestamps (pre-epoch) are clamped to `0` before conversion to
-avoid unsigned underflow, then produce a very large elapsed-days value, yielding near-zero weight.
-
-**`compute_file_temporal_stats` deduplicates per commit.** A file listed twice in one commit's
-`changed_files` is counted once in that commit's contribution. The deduplication uses a
-`HashSet<String>` that is cleared and reused across commits to avoid repeated allocation.
-
-**Window boundary is inclusive.** A commit at exactly `30.0` or `90.0` elapsed days is included
-in the respective window (`<=` comparison).
-
-## Fix Commit Keywords
-
-The regex lives in `temporal/mod.rs` compiled once via `std::sync::LazyLock`:
-
+**Formula:**
 ```
-(?i)\b(fix|bug|hotfix|patch|revert)\b
+hotspot(file) = Σ_commits decay_weight(elapsed_days, half_life_days)
+decay_weight(d, h) = 2^(-d / h)
 ```
 
-Word-boundary anchors (`\b`) prevent false positives from words like `prefix` or `buggy`. All
-five keywords are case-insensitive. The `LazyLock` ensures the regex compiles exactly once across
-all threads — important because `is_fix_commit` is called once per commit (pre-classified before
-the per-file hot loop in `compute_file_risk_scores`; called inline in `compute_file_temporal_stats`
-where per-commit overhead is identical).
+- `elapsed_days`: days between the commit timestamp and `now_epoch`
+- `half_life_days`: configurable decay rate (default varies; higher = slower decay)
+- Sum over all commits touching the file; recent commits contribute ~1.0, old commits ~0.0
 
-## Algorithm Walk-Through
+The max-normalization means the hottest file always scores 1.0; others are relative fractions.
 
-`compute_file_risk_scores(commits, now_epoch, half_life_days)` runs in three logical passes:
+`HotspotRow` persists:
+- `file_path`: repo-root-relative path
+- `score`: decay-weighted, max-normalized to `[0.0, 1.0]`
+- `changes_30d`: raw commit count in last 30 days
+- `changes_90d`: raw commit count in last 90 days
 
-1. **Pre-classify** — build a `Vec<bool>` of fix flags by calling `is_fix_commit` once per
-   commit. This is outside the per-file loop, avoiding repeated regex evaluation.
+### Bug-Fix Density (Risk Score)
 
-2. **Accumulate** — single pass over `(commit, is_fix)` pairs. For each commit, compute elapsed
-   time in days and call `decay_weight`. Then for each file path in the commit, use the Entry API
-   to update `(weighted_total, weighted_fix_total)`. The map is pre-allocated with
-   `(commits.len() / 4).clamp(64, 50_000)` to avoid rehashing on large repos.
+Risk score quantifies how often a file has been part of a fix commit — commits whose message contains fix indicators (see `is_fix_commit` below). This is a static signal: it does not decay over time.
 
-3. **Normalize and emit** — find `max_total` via a fold over map values. Map each entry to
-   `FileRiskScores { hotspot: total / max_total, fix_density: fix_total / total }`.
+**Formula:**
+```
+risk_score(file) = fix_commits(file) / total_commits(file)
+```
 
-`compute_file_temporal_stats(commits, now_epoch)` runs a single pass:
+Clamped to `[0.0, 1.0]` after division. Files with zero commits have `risk_score = 0.0`.
 
-1. **Per commit** — call `is_fix_commit` inline, compute elapsed days, determine `in_30d`/`in_90d`
-   membership, then collect unique paths via a cleared `HashSet<String>`.
+`RiskRow` persists:
+- `file_path`: repo-root-relative path
+- `risk_score`: fix_commits / total_commits, in `[0.0, 1.0]`
+- `total_commits`: total commits touching this file
+- `fix_commits`: commits classified as fix commits
+- `fix_density`: same as `risk_score` (alias stored for query convenience)
 
-2. **Accumulate** — for each unique path in the commit, increment `total_commits`, `fix_commits`,
-   `changes_30d`, and `changes_90d` on the `FileTemporalStats` entry (`or_default()` initialises
-   zeroed counters).
+### Fix Commit Detection
 
-The two functions share the same capacity heuristic and timestamp clamping logic but are
-independent implementations. Do not merge them; the decay path needs decay weights, the stats path
-needs per-commit deduplication.
+`is_fix_commit(message: &str) -> bool` (in `mod.rs`) applies a simple keyword check on the commit message:
+- Matches: `fix`, `bug`, `patch`, `hotfix`, `repair`, `correct`, `resolve` (case-insensitive, substring match)
+- Does not use regex — pure `str::contains` on the lowercased message
 
-## Public API
+This is intentionally simple. False positives (e.g., "refactor to fix tech debt") are acceptable; precision is not the goal at this layer.
 
-All scoring symbols are re-exported from `crates/rskim-search/src/lib.rs`:
+## Core Entry Points
+
+### `compute_file_risk_scores`
 
 ```rust
-pub use temporal::{
-    DEFAULT_HALF_LIFE_DAYS,        // f64 = 30.0
-    GixSource,                      // TemporalSource impl (has I/O)
-    compute_file_risk_scores,       // pure scoring fn → HashMap<String, FileRiskScores>
-    compute_file_temporal_stats,    // pure stats fn → HashMap<String, FileTemporalStats>
-    decay_weight,                   // pure decay fn
-    is_fix_commit,                  // pure regex predicate
-};
-pub use temporal::storage::{
-    CochangeRow, HotspotRow, RiskRow,  // row types for the four SQLite tables
-    META_GIT_HEAD, META_LAST_UPDATED,  // meta table key constants
-    TemporalDb,                         // connection + migrations + sync
-};
-pub use types::{
-    FileRiskScores,       // { hotspot: f64, fix_density: f64 }
-    FileTemporalStats,    // { changes_30d, changes_90d, total_commits, fix_commits: u32 }
-};
+pub fn compute_file_risk_scores(
+    commits: &[CommitInfo],
+    now_epoch: u64,
+    half_life_days: f64,
+) -> HashMap<String, FileRiskScores>
 ```
 
-`FileRiskScores` does NOT derive `Serialize`/`Deserialize` — it is an intermediate computation
-type. `FileTemporalStats` also does NOT derive `Serialize`/`Deserialize` — it is a persistence
-input, not a serialization boundary type. Consumers that need JSON output must map to local
-serde-annotated types.
+Returns a map from file path → `FileRiskScores` containing:
+- `hotspot_score: f64` — raw decay-weighted sum (NOT yet normalized)
+- `fix_density: f64`
+- `total_commits: u32`
+- `fix_commits: u32`
+- `changes_30d: u32`
+- `changes_90d: u32`
 
-`DEFAULT_HALF_LIFE_DAYS = 30.0` — commits one month old contribute `1/e ≈ 37%` of the weight of
-a same-day commit. Always use this constant rather than a hardcoded literal so tuning is
-centralized.
+**Important**: The returned `hotspot_score` is the raw sum, not yet max-normalized. The caller is responsible for normalization when converting to `HotspotRow`. The `TemporalDb::sync` pipeline handles this.
 
-Note: `lib.rs` also exposes `pub mod ast_index` (with `LinearNode`, `LinearizeResult`,
-`linearize_source`) as an unrelated structural indexing module. It does not interact with the
-temporal scoring pipeline but shares the same `SearchError` type.
-
-## SQLite Persistence Layer
-
-`TemporalDb` owns one SQLite connection and four tables: `hotspot`, `risk`, `cochange`, and
-`meta`. It lives in the `temporal::storage` sub-module, with its data-manipulation `impl` block
-split into `storage_ops.rs` and row types in `storage_types.rs`.
-
-**Connection lifecycle:** `TemporalDb::open(db_path)` opens or creates the file, sets Unix
-permissions to `0o600`, configures a 5-second busy timeout, enables WAL mode, and runs schema
-migrations. All five steps happen before returning to the caller.
-
-**Schema migrations** are guarded by `PRAGMA user_version`. Each version block is idempotent
-(`CREATE TABLE IF NOT EXISTS`). A forward-compat guard returns `SearchError::Database` when the
-stored version exceeds `CURRENT_VERSION` to prevent silent corruption by a newer writer.
-
-**Current schema version is 2.** Version 1 created the four base tables. Version 2 adds three
-performance indexes: `idx_hotspot_score ON hotspot(score)`, `idx_risk_score ON risk(risk_score)`,
-and `idx_cochange_file_b ON cochange(file_b)`. The composite primary key `(file_a, file_b)` already
-covers `file_a` lookups so no `idx_cochange_file_a` index is needed. Existing v1 databases are
-migrated automatically on the next `TemporalDb::open`.
-
-**Atomic sync:** `TemporalDb::sync(hotspots, risks, cochanges, git_head)` atomically replaces all
-four tables in a single transaction (DELETE + batch INSERT for each table, then meta upserts for
-`META_GIT_HEAD` and `META_LAST_UPDATED`). Readers never see partially-refreshed state. On error
-the transaction is rolled back.
-
-The individual `store_hotspots`, `store_risks`, and `store_cochanges` methods run their own
-transactions separately — use `sync` when all three must be consistent with each other.
-
-**Row types** (`HotspotRow`, `RiskRow`, `CochangeRow`) are plain structs with no serde derives.
-They map directly to SQLite columns. Note the `i64` column types for integer fields even though
-`FileTemporalStats` uses `u32` — SQLite's integer affinity is signed, so the layer converts at the
-boundary.
-
-**Thread safety:** `TemporalDb` is not `Sync`. Each thread that needs concurrent reads should open
-its own connection to the same WAL-mode file. WAL mode allows multiple readers to coexist with one
-writer without blocking.
-
-## Per-File Lookup API
-
-`storage_ops.rs` exposes three point-query methods for fetching a single file's data without
-loading the full table:
-
-- `hotspot_for_file(path: &str) -> Result<Option<HotspotRow>>` — returns `None` on miss, not an
-  error. Uses `idx_hotspot_score` is irrelevant here; the PK index on `file_path` serves this query.
-- `risk_for_file(path: &str) -> Result<Option<RiskRow>>` — same `None`-on-miss contract.
-- `cochanges_for_file(path: &str) -> Result<Vec<CochangeRow>>` — bidirectional: queries both
-  `file_a = ?1 OR file_b = ?1`. Results are sorted by `jaccard DESC`. Uses `idx_cochange_file_b`
-  for the `file_b` side; the `(file_a, file_b)` PK covers the `file_a` side.
-
-These methods are the preferred interface for search-time enrichment when only one file's data is
-needed. Avoid `load_hotspots()` / `load_risks()` / `load_cochanges()` for per-file lookups —
-those bulk-load the entire table and impose a 500,000-row capacity cap on the caller.
-
-## Top-N Query API
-
-Three ranked-list methods serve dashboard and heatmap use cases:
-
-- `top_hotspots(limit: usize) -> Result<Vec<HotspotRow>>` — highest score first. Backed by
-  `idx_hotspot_score`.
-- `top_risks(limit: usize) -> Result<Vec<RiskRow>>` — highest `risk_score` first. Backed by
-  `idx_risk_score`.
-- `top_coldspots(limit: usize) -> Result<Vec<HotspotRow>>` — lowest score first (stable files).
-  Also backed by `idx_hotspot_score` (ascending scan).
-
-All three return an empty `Vec` for an empty table. The `limit` parameter is cast to `i64` for
-the `LIMIT ?1` clause — this is safe up to `i64::MAX ≈ 9.2 × 10^18`, far above any practical
-limit.
-
-## SearchQuery file_filter Field
-
-`SearchQuery` now carries an optional `file_filter: Option<HashSet<FileId>>`. When `Some`, the
-search layer restricts scoring to only those `FileId`s in the set. This is the mechanism for
-blast-radius pre-filtering: a caller resolves co-change partners via `cochanges_for_file`, maps
-paths to `FileId`s, populates the set, and attaches it to the query before calling the search
-layer.
-
-The field is `#[serde(skip)]` — it is applied at query construction time in the CLI layer and is
-not round-tripped through JSON. `SearchQuery::new` initializes it to `None`.
-
-## Integration with TemporalSource
-
-The I/O side of the temporal module follows a trait-based design. `GixSource` implements
-`TemporalSource`, which has a single method:
+### `compute_file_temporal_stats`
 
 ```rust
-fn parse_history(&self, repo_path: &Path, lookback_days: u32) -> Result<HistoryResult>;
+pub fn compute_file_temporal_stats(
+    commits: &[CommitInfo],
+    now_epoch: u64,
+) -> HashMap<String, FileTemporalStats>
 ```
 
-`HistoryResult` contains `commits: Vec<CommitInfo>` (newest-first) and `metadata: TemporalMetadata`
-(includes `is_shallow` for shallow clone detection). The `lookback_days = 0` sentinel means "all
-history". Callers pass the resulting `commits` slice to `compute_file_risk_scores` and/or
-`compute_file_temporal_stats`, then persist via `TemporalDb::sync`.
+A lighter variant that computes raw commit counts (`changes_30d`, `changes_90d`, `total_commits`) without decay weighting. Used by callers that need raw frequency counts, not weighted scores.
 
-`GixSource` is stateless — each `parse_history` call opens a fresh repository handle. This is
-intentional: it makes the type trivially `Send + Sync` without locking.
+### `decay_weight`
 
-## Determinism Contract
+```rust
+pub fn decay_weight(elapsed_days: f64, half_life_days: f64) -> f64
+```
 
-`compute_file_risk_scores` and `compute_file_temporal_stats` are both deterministic: given the
-same `commits` and `now_epoch`, repeated calls return identical results. The test
-`deterministic_results` calls `compute_file_risk_scores` 50 times and asserts equality to `1e-9`
-precision.
+Pure function: `2_f64.powf(-elapsed_days / half_life_days)`. No clamping — caller responsible for ensuring `elapsed_days >= 0.0`.
 
-Determinism depends on the caller supplying `now_epoch`. Code that reads `SystemTime::now()` must
-do so once and pass the result down — never call `SystemTime::now()` inside the scoring functions.
-(`TemporalDb::sync` is the one place that legitimately reads the system clock — to record the
-`META_LAST_UPDATED` timestamp, which is an observability artifact, not a scoring input.)
+## SQLite Persistence Layer (`TemporalDb`)
 
-## Anti-Patterns
+### Database Location
 
-- **Reading the system clock inside scoring functions** — breaks determinism and makes tests
-  non-deterministic. Always accept `now_epoch: u64` as a parameter and let the caller supply it.
+`temporal.db` lives at `{cache_dir}/temporal.db` — not in the project's `.skim/search.db`. The temporal signals and the co-change data share this database file; the search index (`search.db`) is separate and in the project root.
 
-- **Calling `is_fix_commit` inside the per-file loop** — the pre-classification step in
-  `compute_file_risk_scores` exists to avoid this. One regex eval per commit, not one per
-  (commit × file).
+### Schema
 
-- **Using a custom regex instead of `is_fix_commit`** — the LazyLock regex is the single source
-  of truth for fix classification across the entire temporal module. A parallel regex will diverge.
+Three tables:
 
-- **Treating `fix_density = 1.0` as definitive "buggy file"** — a file with a single fix commit
-  and no other history scores `1.0`. Weight by hotspot before drawing conclusions.
+```sql
+CREATE TABLE hotspot (
+    file_path  TEXT PRIMARY KEY,
+    score      REAL NOT NULL,
+    changes_30d  INTEGER NOT NULL,
+    changes_90d  INTEGER NOT NULL
+);
 
-- **Skipping the `(commits.len() / 4).clamp(64, 50_000)` capacity heuristic** — unique files are
-  typically 5–20× fewer than total commit-file touches; `commits.len()` itself over-allocates
-  significantly on large repos.
+CREATE TABLE risk (
+    file_path    TEXT PRIMARY KEY,
+    risk_score   REAL NOT NULL,
+    total_commits INTEGER NOT NULL,
+    fix_commits  INTEGER NOT NULL,
+    fix_density  REAL NOT NULL
+);
 
-- **Using individual `store_*` methods when all three tables must be consistent** — call `sync`
-  instead. Individual methods each run their own transaction, so a crash between calls leaves the
-  database in a partially-updated state.
+CREATE TABLE cochange (
+    file_a  TEXT NOT NULL,
+    file_b  TEXT NOT NULL,
+    count   INTEGER NOT NULL,
+    jaccard REAL    NOT NULL,
+    PRIMARY KEY (file_a, file_b)
+);
 
-- **Leaking rusqlite types through the storage boundary** — all rusqlite errors are converted to
-  `SearchError::Database(String)` via the private `db_err` helper. Never add a `rusqlite` dep to
-  modules outside `temporal::storage`.
+CREATE TABLE meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+```
 
-- **Opening `TemporalDb` from multiple threads and sharing it** — `TemporalDb` is not `Sync`.
-  Open a separate connection per thread for concurrent access.
+Performance indexes (added in schema v2):
+```sql
+CREATE INDEX IF NOT EXISTS idx_hotspot_score ON hotspot(score DESC);
+CREATE INDEX IF NOT EXISTS idx_risk_score    ON risk(risk_score DESC);
+CREATE INDEX IF NOT EXISTS idx_cochange_file_a ON cochange(file_a);
+CREATE INDEX IF NOT EXISTS idx_cochange_file_b ON cochange(file_b);
+```
 
-- **Using `load_hotspots()` / `load_risks()` for per-file enrichment at search time** — use the
-  point-query methods (`hotspot_for_file`, `risk_for_file`) instead. Bulk-loading the entire table
-  for a single path lookup wastes I/O and is blocked by the 500,000-row cap.
+These indexes make `top_hotspots(N)`, `top_risks(N)`, `top_coldspots(N)` efficient without full table scans.
 
-## Gotchas
+### Schema Migrations
 
-- `decay_weight` panics in debug builds when `half_life_days <= 0.0` (`debug_assert!`). In
-  release builds this silently produces `exp(+inf)` which is then clamped to `1.0`. Always
-  validate `half_life_days > 0.0` before calling.
+Migrations are forward-only, driven by `PRAGMA user_version`:
+- Each version gate runs `if schema_version < N { apply_migration_N(); set_version(N); }`
+- Databases at a higher version than the binary knows about return `SearchError::Database("unsupported schema version N")`
 
-- The hotspot formula normalizes against the in-batch maximum, not a historical maximum. Two
-  separate calls with different `commits` slices produce incomparable absolute scores; only
-  relative ordering within one call's output is meaningful.
+Current version is **v2** (v1: tables, v2: performance indexes).
 
-- `FileChangeInfo.additions` and `.deletions` are always `0` from `GixSource` — the git parser
-  deliberately skips blob-level line counting for performance. Do not rely on these fields for
-  churn metrics.
+### `TemporalDb::sync`
 
-- File paths are stored as `String` (via `path_str().into_owned()`) using lossy UTF-8 conversion.
-  On repositories with non-UTF-8 paths (uncommon but valid on Linux), replacement characters
-  (`\u{FFFD}`) will appear in map keys and database rows.
+```rust
+pub fn sync(
+    &self,
+    hotspots: &[HotspotRow],
+    risks: &[RiskRow],
+    cochanges: &[CochangeRow],
+    git_head: &str,
+) -> Result<()>
+```
 
-- `compute_file_risk_scores` and `compute_file_temporal_stats` both return an empty `HashMap`
-  for an empty `commits` slice — not a `SearchError`. Callers expecting a non-empty result should
-  check before calling.
+Atomically replaces all three tables in a single transaction: DELETE + batch INSERT for hotspot, risk, and cochange. Also writes `git_head` to the `meta` table. This is the preferred way to update all signals together — it ensures no partial state is visible.
 
-- `HotspotRow.changes_30d` and `changes_30d` are `i64` (SQLite signed integer), not `u32`. The
-  conversion from `FileTemporalStats.changes_30d: u32` happens at the persistence call site.
-  Casting `u32 as i64` is lossless; the reverse (`i64 as u32`) should be guarded for loaded rows.
+### Point Queries
 
-- `TemporalDb::open` sets file permissions to `0o600` on Unix but silently ignores the error if
-  `set_permissions` fails (e.g., on read-only filesystems or Docker volumes). Sensitive data in
-  the database is not protected in those environments.
+| Method | Description |
+|--------|-------------|
+| `hotspot_for_file(path)` | Single-file hotspot lookup — `Option<HotspotRow>` |
+| `risk_for_file(path)` | Single-file risk lookup — `Option<RiskRow>` |
+| `cochanges_for_file(path)` | All co-change pairs for a file — `Vec<CochangeRow>` |
 
-- Schema version is stored in `PRAGMA user_version`, not in the `meta` table. Do not confuse the
-  two. The forward-compat guard triggers on `PRAGMA user_version > CURRENT_VERSION`, not on a
-  `meta` key.
+### Bulk Queries (Index-Backed)
 
-- `cochanges_for_file` queries `file_a = ?1 OR file_b = ?1`. The `idx_cochange_file_b` index
-  covers the `file_b` side; the composite PK `(file_a, file_b)` covers the `file_a` side. If you
-  add a query that filters only on `file_b` without the `OR file_a` arm, SQLite may not use the
-  index depending on the query planner version — verify with `EXPLAIN QUERY PLAN`.
+| Method | Description |
+|--------|-------------|
+| `top_hotspots(limit)` | Top N by `score DESC` |
+| `top_risks(limit)` | Top N by `risk_score DESC` |
+| `top_coldspots(limit)` | Top N by `score ASC` (lowest hotspot = coldest) |
 
-- `top_hotspots` / `top_risks` / `top_coldspots` cast `limit: usize` to `i64` for the `LIMIT`
-  clause. Values above `i64::MAX` would overflow silently. In practice this is unreachable for any
-  sane limit, but avoid passing `usize::MAX` as a "no limit" sentinel — use a bounded constant.
+### Load / Store (Non-atomic)
+
+`store_hotspots`, `store_risks`, `store_cochanges` each do DELETE + batch INSERT for their respective table only. Use `sync` for atomic multi-table updates; use the individual store methods only for single-table updates.
+
+`load_hotspots`, `load_risks`, `load_cochanges` return full table contents as `Vec<Row>` — no limit parameter.
+
+## WAL Mode
+
+`TemporalDb::open` sets `PRAGMA journal_mode=WAL` and `PRAGMA synchronous=NORMAL` on each connection. WAL mode allows concurrent readers while a write is in progress. `TemporalDb` is **not `Sync`** — each thread must open its own connection.
 
 ## Key Files
 
-- `crates/rskim-search/src/temporal/scoring.rs` — pure scoring logic: `decay_weight`,
-  `compute_file_risk_scores`, `compute_file_temporal_stats`, `DEFAULT_HALF_LIFE_DAYS`
-- `crates/rskim-search/src/temporal/mod.rs` — module entry point: `FIX_REGEX` LazyLock,
-  `is_fix_commit`, public re-exports (includes `storage` pub mod)
-- `crates/rskim-search/src/temporal/git_parser.rs` — `GixSource` I/O implementation
-- `crates/rskim-search/src/temporal/scoring_tests.rs` — co-located deterministic tests
-- `crates/rskim-search/src/temporal/storage.rs` — `TemporalDb` struct, `open`, migrations
-  (v1 tables + v2 performance indexes), `schema_version`, `db_err` helper, `META_*` constants
-- `crates/rskim-search/src/temporal/storage_ops.rs` — `store_*`, `load_*`, `get_meta`,
-  `set_meta`, `sync`, `hotspot_for_file`, `risk_for_file`, `cochanges_for_file`,
-  `top_hotspots`, `top_risks`, `top_coldspots`
-- `crates/rskim-search/src/temporal/storage_types.rs` — `HotspotRow`, `RiskRow`, `CochangeRow`
-- `crates/rskim-search/src/types.rs` — `FileRiskScores`, `FileTemporalStats`, `CommitInfo`,
-  `FileChangeInfo`, `HistoryResult`, `TemporalSource` trait, `SearchError::Database` variant,
-  `SearchError::AstError` variant (grammar load failures — unrecoverable, distinct from file-level
-  parse errors), `SearchQuery` (includes `file_filter: Option<HashSet<FileId>>`)
-- `crates/rskim-search/src/lib.rs` — public re-exports for the whole crate; also exposes
-  `pub mod ast_index` (CST linearization for structural n-gram extraction)
+- `crates/rskim-search/src/temporal/scoring.rs` — `decay_weight`, `compute_file_risk_scores`, `compute_file_temporal_stats`; `FileRiskScores`, `FileTemporalStats` structs
+- `crates/rskim-search/src/temporal/scoring_tests.rs` — unit tests for decay formula and file score aggregation
+- `crates/rskim-search/src/temporal/mod.rs` — public re-exports; `is_fix_commit` keyword classifier
+- `crates/rskim-search/src/temporal/git_parser.rs` — `GixSource` (gix-based git history reader producing `HistoryResult`)
+- `crates/rskim-search/src/temporal/storage.rs` — `TemporalDb` struct, `open`, `schema_version`, migration runner
+- `crates/rskim-search/src/temporal/storage_ops.rs` — all query and mutation methods for `TemporalDb` (impl block continues from storage.rs)
+- `crates/rskim-search/src/temporal/storage_types.rs` — `HotspotRow`, `RiskRow`, `CochangeRow` row structs
+- `crates/rskim-search/src/temporal/storage_tests.rs` — integration tests against in-memory SQLite
+- `crates/rskim-search/src/temporal/storage_perf_tests.rs` — performance benchmarks for top-N and per-file queries
+- `crates/rskim-search/src/types.rs` — `CommitInfo`, `FileChangeInfo`, `HistoryResult`, `FileId`, `SearchError`
+- `crates/rskim-search/src/lib.rs` — re-exports `TemporalDb`, `HotspotRow`, `RiskRow`, `CochangeRow` as public crate API
+
+## Anti-Patterns
+
+- **Using raw `hotspot_score` from `compute_file_risk_scores` without max-normalization**: the returned score is a raw decay-weighted sum, not `[0.0, 1.0]`. Always max-normalize before storing as `HotspotRow.score`.
+- **Opening `temporal.db` as `Sync`**: `TemporalDb` is `!Sync`. For concurrent access, open multiple instances against the same WAL-mode database file.
+- **Using individual `store_*` methods for a full signal refresh**: use `sync` to atomically replace all three tables in one transaction. Individual stores leave the database in a partially-updated state.
+- **Treating `top_coldspots` as semantically meaningful on a sparse database**: cold spots (low hotspot score) are only meaningful if the database contains data for all project files. If only hot files were indexed, `top_coldspots` returns nothing useful.
+
+## Gotchas
+
+- `compute_file_risk_scores` per-deduplicates changed files within each commit via `dedup_changed_files` (private helper). Without this, a commit with renames would count the same file twice.
+- Schema version mismatch returns `SearchError::Database(...)`, not `IndexCorrupted`. Rebuild by deleting `temporal.db`.
+- `top_coldspots` returns rows sorted by `score ASC` — not the inverse of `top_hotspots` sort, but an explicit ascending sort. Files with score 0.0 come first.
+- The `meta` table stores arbitrary key-value strings; `git_head` is the only key written by `TemporalDb::sync`. Future callers may add their own keys without schema migration.
+- `changes_30d` and `changes_90d` are raw counts — they are NOT decay-weighted and do NOT correlate with `score`. A file may have `score = 0.9` but `changes_30d = 0` if all its commits were just outside the 30-day window.
 
 ## Related
 
-- Feature knowledge: `cochange` — the co-change matrix module also consumes `CommitInfo` and
-  `FileChangeInfo` from git history. Both modules share the same I/O boundary pattern. `CochangeRow`
-  is stored by `TemporalDb::sync` alongside hotspot and risk rows in the same atomic transaction.
-  `cochanges_for_file` is the bridge between the temporal persistence layer and the `file_filter`
-  blast-radius filtering in `SearchQuery`.
-- `crates/rskim-search/src/types.rs` — shared `CommitInfo`, `FileChangeInfo`, `HistoryResult`,
-  `TemporalSource`, `FileRiskScores`, `FileTemporalStats`, `SearchQuery.file_filter`,
-  `SearchError::Database` variant (storage errors), and `SearchError::AstError` variant (grammar
-  load failures) that connect the I/O, scoring, storage, and search layers
-- ADR-001: Fix all noticed issues immediately regardless of scope — `SearchError::AstError` was
-  added to cover grammar load failures surfaced during ast_index work; the variant was added to the
-  shared error type immediately rather than deferred
+- `crates/rskim-search/src/cochange/` — sibling module; both consume `HistoryResult`; co-change data shares the same `temporal.db` file via the `cochange` table
+- `crates/rskim-search/src/types.rs` — `HistoryResult`, `CommitInfo`, `FileId`, `SearchError`
+- Temporal CLI flags: `skim search --hot`, `--cold`, `--risky`, `--blast-radius FILE` — all backed by `TemporalDb` queries at search time

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ flamegraph.svg
 # IDE and editor files
 .vscode/
 .idea/
+.cursor/
 *.swp
 *.swo
 *~
@@ -53,5 +54,15 @@ crates/rskim-search/data/
 # Benchmark corpus (large, reproducible via download)
 .bench-corpus/
 
-# Claude Code local runtime state
-.claude/scheduled_tasks.lock
+# Claude Code local state
+.claude/
+
+# Devflow ephemeral artifacts (keep decisions/ and features/ tracked)
+.devflow/docs/
+.devflow/dream/
+.devflow/features/**/.create-result.json
+.devflow/features/**/.refresh-result.json
+
+# Stale build artifacts
+librust_out.rlib
+package-lock.json

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -246,19 +246,36 @@ struct CommitHeader {
     parents: Option<String>,
 }
 
+/// Parse phase for [`parse_header_lines`].
+///
+/// Replaces the `in_body: bool` + `subject_captured: bool` pair. The two
+/// booleans encoded three sequential, non-overlapping states that only ever
+/// advanced in one direction (Headers → AwaitingSubject → Body). An enum
+/// makes all three phases explicit and eliminates the impossible state where
+/// `in_body == false` but `subject_captured == true`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommitParsePhase {
+    /// Parsing git trailer lines (`commit`, `Author`, `Date`, `Merge`).
+    Headers,
+    /// Blank separator consumed; waiting for the first non-blank body line
+    /// (the commit subject).
+    AwaitingSubject,
+    /// Subject captured; accumulating remaining body lines.
+    Body,
+}
+
 /// Walk `header_region` lines and populate `header` with extracted fields.
 ///
 /// Returns the accumulated body lines as `Vec<&str>` slices borrowed from
 /// `header_region`, avoiding per-line allocations (zero-copy body accumulation).
 ///
 /// # State machine
-/// - Phase 0 (`in_body == false`): parse git trailer lines (`commit `,
+/// - `CommitParsePhase::Headers`: parse git trailer lines (`commit `,
 ///   `Author: `, `Date: `, `Merge: `). All other lines (gpgsig, mergetag,
 ///   continuation lines starting with a space) are silently skipped per AD-GIT-8.
-/// - Phase 1 (`in_body == true`, `subject_captured == false`): capture the
-///   subject (first non-blank body line), stripping the canonical 4-space indent.
-/// - Phase 2 (`in_body == true`, `subject_captured == true`): accumulate body
-///   lines, stripping 4-space indent.
+/// - `CommitParsePhase::AwaitingSubject`: capture the subject (first non-blank
+///   body line), stripping the canonical 4-space indent.
+/// - `CommitParsePhase::Body`: accumulate body lines, stripping 4-space indent.
 fn parse_header_lines<'a>(header_region: &'a str, header: &mut CommitHeader) -> Vec<&'a str> {
     // Extract the trimmed value from a `Key: value` header line.
     let header_value = |line: &str, prefix: &str| -> String {
@@ -268,34 +285,37 @@ fn parse_header_lines<'a>(header_region: &'a str, header: &mut CommitHeader) -> 
             .to_string()
     };
 
-    let mut in_body = false;
-    let mut subject_captured = false;
+    let mut phase = CommitParsePhase::Headers;
     let mut body_lines: Vec<&'a str> = Vec::new();
 
     for line in header_region.lines() {
-        if !in_body {
-            if line.starts_with("commit ") {
-                header.hash = header_value(line, "commit ");
-            } else if line.starts_with("Merge: ") {
-                // AD-GIT-8: capture merge parents as structured field.
-                header.parents = Some(header_value(line, "Merge: "));
-            } else if line.starts_with("Author: ") {
-                header.author = header_value(line, "Author: ");
-            } else if line.starts_with("Date: ") {
-                header.date = header_value(line, "Date: ");
-            } else if line.is_empty() && !header.hash.is_empty() {
-                in_body = true;
+        match phase {
+            CommitParsePhase::Headers => {
+                if line.starts_with("commit ") {
+                    header.hash = header_value(line, "commit ");
+                } else if line.starts_with("Merge: ") {
+                    // AD-GIT-8: capture merge parents as structured field.
+                    header.parents = Some(header_value(line, "Merge: "));
+                } else if line.starts_with("Author: ") {
+                    header.author = header_value(line, "Author: ");
+                } else if line.starts_with("Date: ") {
+                    header.date = header_value(line, "Date: ");
+                } else if line.is_empty() && !header.hash.is_empty() {
+                    phase = CommitParsePhase::AwaitingSubject;
+                }
             }
-        } else if !subject_captured {
-            // Phase 1: first non-blank line is the subject.
-            let trimmed = line.trim();
-            if !trimmed.is_empty() {
-                header.subject = line.strip_prefix("    ").unwrap_or(trimmed).to_string();
-                subject_captured = true;
+            CommitParsePhase::AwaitingSubject => {
+                // First non-blank line is the subject.
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    header.subject = line.strip_prefix("    ").unwrap_or(trimmed).to_string();
+                    phase = CommitParsePhase::Body;
+                }
             }
-        } else {
-            // Phase 2: borrow each body line slice — no allocation per line.
-            body_lines.push(line.strip_prefix("    ").unwrap_or(line));
+            CommitParsePhase::Body => {
+                // Borrow each body line slice — no allocation per line.
+                body_lines.push(line.strip_prefix("    ").unwrap_or(line));
+            }
         }
     }
 

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -415,12 +415,14 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     for line in input.lines().take(MAX_INPUT_LINES) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
-            // Step 1: Blank lines flush the pending stack (end of exception block).
+            // Step 1: Blank lines end the current exception block — flush frames onto
+            // the last entry, then discard any orphaned frames (no preceding entry).
             try_flush_stack(
                 &mut all_entries,
                 &mut pending_stack,
                 &mut total_stack_frames_elided,
             );
+            pending_stack.clear();
             in_python_frame = false;
             continue;
         }
@@ -516,10 +518,11 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
         &mut total_stack_frames_elided,
     );
 
-    // Issue 8: if no structured log levels were found, entries are plain text —
-    // return None to fall through to Passthrough rather than producing a
-    // misleading Degraded result.
-    if !found_structured {
+    // Fall through to passthrough when either (a) no structured content was
+    // found, or (b) structured markers fired but produced zero entries (e.g.
+    // orphaned stack frames with no preceding log line). Returning Some with
+    // an empty entry list would discard content — passthrough is strictly better.
+    if !found_structured || all_entries.is_empty() {
         return None;
     }
 
@@ -1722,6 +1725,57 @@ mod tests {
                 .iter()
                 .map(|e| (&e.level, &e.message))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    // ── Regression: orphaned stack frames ────────────────────────────────
+
+    #[test]
+    fn test_orphaned_stack_frames_fall_through_to_passthrough() {
+        // Stack frames with no preceding log entry should return None
+        // (passthrough), not Some with 0 entries that silently drops content.
+        let input = concat!(
+            "  File \"/app/foo.py\", line 10, in bar\n",
+            "    x = do_stuff()\n",
+            "  File \"/app/baz.py\", line 20, in qux\n",
+            "    y = crash()\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags);
+        assert!(
+            result.is_none(),
+            "Orphaned stack frames (no log entry) must fall through to passthrough"
+        );
+    }
+
+    #[test]
+    fn test_orphaned_frames_do_not_leak_across_blank_lines() {
+        // Orphaned frames before a blank line must not attach to a later entry.
+        let input = concat!(
+            "  File \"/app/old.py\", line 1, in stale_func\n",
+            "    old_code()\n",
+            "\n",
+            "ERROR: real problem here\n",
+            "  File \"/app/new.py\", line 2, in new_func\n",
+            "    new_code()\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags)
+            .expect("Should parse the ERROR entry");
+        let error_entry = result
+            .entries
+            .iter()
+            .find(|e| e.message.contains("real problem"))
+            .expect("ERROR entry must exist");
+        assert!(
+            !error_entry.message.contains("stale_func"),
+            "Orphaned frame from before blank line must not leak onto the ERROR entry; got: {:?}",
+            error_entry.message
+        );
+        assert!(
+            error_entry.message.contains("new_func"),
+            "Frame after the ERROR entry should be attached; got: {:?}",
+            error_entry.message
         );
     }
 }

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -34,6 +34,13 @@ const MAX_INPUT_LINES: usize = 100_000;
 /// string). The cap counts logical frames, not raw lines.
 const PENDING_STACK_CAP: usize = 4;
 
+/// Maximum continuation lines (source-preview / PEP 657 caret) appended to a
+/// single logical frame. Enforces the O(PENDING_STACK_CAP) memory invariant
+/// stated in the `try_parse_regex_logs` doc comment: without this cap, a
+/// pathological input could embed many continuation lines in one frame and
+/// bypass the per-frame accounting that makes the invariant hold.
+const MAX_CONTINUATIONS_PER_FRAME: usize = 4;
+
 /// Matches ISO8601 / common log timestamp prefix to strip before dedup.
 /// e.g. `2024-01-15T10:30:00Z `, `2024-01-15 10:30:00 `, `[2024-01-15T10:30:00]`
 static RE_LOG_TIMESTAMP: LazyLock<Regex> = LazyLock::new(|| {
@@ -358,12 +365,15 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 /// Callers must gate on `in_python_frame` before calling — this function tests
 /// only the line's structure, not parser state.
 fn is_python_continuation(line: &str) -> bool {
+    // Callers (step 3) only invoke this after RE_LOG_STACK_TRACE.is_match failed in step 2,
+    // so the regex guard is provably dead work here. Only structural checks needed.
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return false;
     }
-    // Must have leading whitespace (indented) but not be a new File/at frame.
-    line.starts_with(|c: char| c.is_ascii_whitespace()) && !RE_LOG_STACK_TRACE.is_match(line)
+    // Must have leading whitespace (indented). RE_LOG_STACK_TRACE non-match is guaranteed
+    // by the call site ordering: step 2 runs first and skips to `continue` on a match.
+    line.starts_with(|c: char| c.is_ascii_whitespace())
 }
 
 /// Parse regex-based log formats into a LogResult.
@@ -405,18 +415,20 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     // Tracks whether the last recognised stack frame was a Python `File "..."` line,
     // enabling source-preview and PEP 657 caret continuation detection.
     let mut in_python_frame = false;
+    // Counts continuation lines appended to the current logical frame.
+    // Reset to 0 each time a new frame starts (step 2). Enforces
+    // MAX_CONTINUATIONS_PER_FRAME to uphold the O(PENDING_STACK_CAP) memory invariant.
+    let mut frame_continuation_count: usize = 0;
 
     for line in input.lines().take(MAX_INPUT_LINES) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             // Step 1: Blank lines flush the pending stack (end of exception block).
-            if !pending_stack.is_empty() && !all_entries.is_empty() {
-                flush_stack_frames(
-                    &mut all_entries,
-                    &mut pending_stack,
-                    &mut total_stack_frames_elided,
-                );
-            }
+            try_flush_stack(
+                &mut all_entries,
+                &mut pending_stack,
+                &mut total_stack_frames_elided,
+            );
             in_python_frame = false;
             continue;
         }
@@ -432,6 +444,7 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
             pending_stack.push_back(trimmed.to_string());
             // Set flag so the next indented line is recognised as a continuation.
             in_python_frame = trimmed.starts_with("File ");
+            frame_continuation_count = 0;
             found_structured = true;
             continue;
         }
@@ -440,9 +453,16 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
         // Must run BEFORE classify_log_line so source lines containing "ERROR:"
         // or similar keywords are not misclassified as new log entries.
         if in_python_frame && is_python_continuation(line) {
-            if let Some(last_frame) = pending_stack.back_mut() {
-                last_frame.push('\n');
-                last_frame.push_str(trimmed);
+            debug_assert!(
+                !pending_stack.is_empty(),
+                "in_python_frame=true requires a frame in pending_stack"
+            );
+            if frame_continuation_count < MAX_CONTINUATIONS_PER_FRAME {
+                if let Some(last_frame) = pending_stack.back_mut() {
+                    last_frame.push('\n');
+                    last_frame.push_str(trimmed);
+                }
+                frame_continuation_count += 1;
             }
             continue;
         }
@@ -467,13 +487,11 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
         if without_ts.starts_with("During handling of the above exception")
             || without_ts.starts_with("The above exception was the direct cause")
         {
-            if !pending_stack.is_empty() && !all_entries.is_empty() {
-                flush_stack_frames(
-                    &mut all_entries,
-                    &mut pending_stack,
-                    &mut total_stack_frames_elided,
-                );
-            }
+            try_flush_stack(
+                &mut all_entries,
+                &mut pending_stack,
+                &mut total_stack_frames_elided,
+            );
             in_python_frame = false;
             all_entries.push((None, trimmed.to_string()));
             continue;
@@ -483,13 +501,11 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
         in_python_frame = false;
 
         // Step 8: New log line — flush any accumulated stack frames onto the previous entry.
-        if !pending_stack.is_empty() && !all_entries.is_empty() {
-            flush_stack_frames(
-                &mut all_entries,
-                &mut pending_stack,
-                &mut total_stack_frames_elided,
-            );
-        }
+        try_flush_stack(
+            &mut all_entries,
+            &mut pending_stack,
+            &mut total_stack_frames_elided,
+        );
 
         total_lines += 1;
 
@@ -502,13 +518,11 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     }
 
     // Flush any trailing stack frames at end-of-input.
-    if !pending_stack.is_empty() && !all_entries.is_empty() {
-        flush_stack_frames(
-            &mut all_entries,
-            &mut pending_stack,
-            &mut total_stack_frames_elided,
-        );
-    }
+    try_flush_stack(
+        &mut all_entries,
+        &mut pending_stack,
+        &mut total_stack_frames_elided,
+    );
 
     // Issue 8: if no structured log levels were found, entries are plain text —
     // return None to fall through to Passthrough rather than producing a
@@ -534,8 +548,10 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
 /// optional source-preview and PEP 657 caret lines embedded as a multi-line
 /// string. The elision count is therefore a count of logical frames, not raw lines.
 ///
-/// `all_entries` must be `&mut Vec` rather than `&mut [_]` because `.last_mut()`
-/// is a Vec-level borrow; `pending_stack` must be `&mut VecDeque` to call `.clear()`.
+/// `all_entries` must be `&mut Vec` rather than `&mut [_]` because clippy flags
+/// `&mut Vec<T>` parameters suggesting `&mut [T]`, but `Vec::push` is not available
+/// on slices and this function's callers rely on it. `pending_stack` must be
+/// `&mut VecDeque` to call `.clear()` and `.iter()`.
 #[allow(clippy::ptr_arg)]
 fn flush_stack_frames(
     all_entries: &mut Vec<(Option<String>, String)>,
@@ -554,6 +570,22 @@ fn flush_stack_frames(
     }
 
     pending_stack.clear();
+}
+
+/// Guard-and-flush helper: flushes `pending_stack` only when both the stack and
+/// `all_entries` are non-empty. Reduces decision-point repetition at the 4 flush
+/// sites inside `try_parse_regex_logs` (blank-line, chained-separator, new-log-entry,
+/// end-of-input), lowering cyclomatic complexity by ~8 decision points.
+#[allow(clippy::ptr_arg)]
+#[inline]
+fn try_flush_stack(
+    all_entries: &mut Vec<(Option<String>, String)>,
+    pending_stack: &mut VecDeque<String>,
+    elided: &mut usize,
+) {
+    if !pending_stack.is_empty() && !all_entries.is_empty() {
+        flush_stack_frames(all_entries, pending_stack, elided);
+    }
 }
 
 /// Strip the timestamp prefix from a log line, unless `keep_timestamps` is true.
@@ -1257,6 +1289,50 @@ mod tests {
     }
 
     // ============================================================================
+    // is_python_continuation unit tests (TESTING-1)
+    // ============================================================================
+
+    /// Empty line is not a continuation.
+    #[test]
+    fn test_is_python_continuation_empty_line() {
+        assert!(!is_python_continuation(""));
+    }
+
+    /// Whitespace-only line is not a continuation (trimmed is empty).
+    #[test]
+    fn test_is_python_continuation_whitespace_only() {
+        assert!(!is_python_continuation("   "));
+        assert!(!is_python_continuation("\t"));
+    }
+
+    /// Non-whitespace-leading line is not a continuation (no leading indent).
+    #[test]
+    fn test_is_python_continuation_no_leading_whitespace() {
+        assert!(!is_python_continuation("raise ValueError"));
+        assert!(!is_python_continuation("INFO: something"));
+    }
+
+    /// A line matching RE_LOG_STACK_TRACE would have been consumed by step 2 at the
+    /// call site, so is_python_continuation doesn't need to re-check it. Verify the
+    /// predicate itself returns true for indented stack-frame-looking content (the call
+    /// site guard prevents misuse).
+    #[test]
+    fn test_is_python_continuation_indented_file_line_structural() {
+        // This IS indented, so the structural predicate returns true.
+        // The call site (step 3) only runs after step 2 fails, so indented File
+        // lines are caught by RE_LOG_STACK_TRACE first; this test documents the
+        // responsibility boundary.
+        assert!(is_python_continuation("  File \"/app/foo.py\", line 10, in bar"));
+    }
+
+    /// A valid continuation: indented source-preview line.
+    #[test]
+    fn test_is_python_continuation_valid_source_preview() {
+        assert!(is_python_continuation("    do_thing()"));
+        assert!(is_python_continuation("\t    return value"));
+    }
+
+    // ============================================================================
     // Group A: Updated Python Fixture (issue #137)
     // ============================================================================
 
@@ -1567,7 +1643,7 @@ mod tests {
     }
 
     // ============================================================================
-    // Group F: Rendered Output
+    // Group E: Rendered Output
     // ============================================================================
 
     /// issue #137: The rendered output from the Python fixture must be coherent —
@@ -1622,6 +1698,36 @@ mod tests {
             info_entry.message.contains("recovered"),
             "INFO entry must contain recovery message: {}",
             info_entry.message
+        );
+    }
+
+    /// TESTING-2: Python exception-type lines (e.g. `DatabaseError: msg`, `ServiceError: msg`)
+    /// that appear after stack frames — after the stack is flushed — must be preserved as
+    /// unstructured entries (level = None), not silently dropped.
+    #[test]
+    fn test_python_exception_type_lines_preserved_as_unstructured() {
+        // Traceback + File frame + exception-type line (no log-level prefix).
+        // The exception-type line must appear in all_entries with level=None.
+        let input = concat!(
+            "ERROR: startup failed\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/app/db.py\", line 42, in connect\n",
+            "    conn = engine.connect()\n",
+            "DatabaseError: connection refused\n",
+            "INFO: retrying\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags).unwrap();
+
+        // DatabaseError: line must be present as an unstructured entry.
+        let has_db_error = result
+            .entries
+            .iter()
+            .any(|e| e.level.is_none() && e.message.contains("DatabaseError"));
+        assert!(
+            has_db_error,
+            "DatabaseError exception-type line must be preserved as an unstructured entry; entries: {:?}",
+            result.entries.iter().map(|e| (&e.level, &e.message)).collect::<Vec<_>>()
         );
     }
 }

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -365,15 +365,7 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 /// Callers must gate on `in_python_frame` before calling — this function tests
 /// only the line's structure, not parser state.
 fn is_python_continuation(line: &str) -> bool {
-    // Callers (step 3) only invoke this after RE_LOG_STACK_TRACE.is_match failed in step 2,
-    // so the regex guard is provably dead work here. Only structural checks needed.
-    let trimmed = line.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-    // Must have leading whitespace (indented). RE_LOG_STACK_TRACE non-match is guaranteed
-    // by the call site ordering: step 2 runs first and skips to `continue` on a match.
-    line.starts_with(|c: char| c.is_ascii_whitespace())
+    !line.trim().is_empty() && line.starts_with(|c: char| c.is_ascii_whitespace())
 }
 
 /// Parse regex-based log formats into a LogResult.
@@ -546,12 +538,9 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
 ///
 /// Each entry in `pending_stack` is a logical frame — a `File "..."` line with
 /// optional source-preview and PEP 657 caret lines embedded as a multi-line
-/// string. The elision count is therefore a count of logical frames, not raw lines.
-///
-/// `all_entries` must be `&mut Vec` rather than `&mut [_]` because clippy flags
-/// `&mut Vec<T>` parameters suggesting `&mut [T]`, but `Vec::push` is not available
-/// on slices and this function's callers rely on it. `pending_stack` must be
-/// `&mut VecDeque` to call `.clear()` and `.iter()`.
+/// string. The elision count is a count of logical frames, not raw lines.
+// `&mut Vec` / `&mut VecDeque` required: callers call Vec::push and VecDeque::clear,
+// which are not available on slice/deref targets that clippy would otherwise prefer.
 #[allow(clippy::ptr_arg)]
 fn flush_stack_frames(
     all_entries: &mut Vec<(Option<String>, String)>,
@@ -573,9 +562,8 @@ fn flush_stack_frames(
 }
 
 /// Guard-and-flush helper: flushes `pending_stack` only when both the stack and
-/// `all_entries` are non-empty. Reduces decision-point repetition at the 4 flush
-/// sites inside `try_parse_regex_logs` (blank-line, chained-separator, new-log-entry,
-/// end-of-input), lowering cyclomatic complexity by ~8 decision points.
+/// `all_entries` are non-empty. Reduces repetition across the 4 flush sites inside
+/// `try_parse_regex_logs` (blank-line, chained-separator, new-log-entry, end-of-input).
 #[allow(clippy::ptr_arg)]
 #[inline]
 fn try_flush_stack(
@@ -1322,7 +1310,9 @@ mod tests {
         // The call site (step 3) only runs after step 2 fails, so indented File
         // lines are caught by RE_LOG_STACK_TRACE first; this test documents the
         // responsibility boundary.
-        assert!(is_python_continuation("  File \"/app/foo.py\", line 10, in bar"));
+        assert!(is_python_continuation(
+            "  File \"/app/foo.py\", line 10, in bar"
+        ));
     }
 
     /// A valid continuation: indented source-preview line.
@@ -1727,7 +1717,11 @@ mod tests {
         assert!(
             has_db_error,
             "DatabaseError exception-type line must be preserved as an unstructured entry; entries: {:?}",
-            result.entries.iter().map(|e| (&e.level, &e.message)).collect::<Vec<_>>()
+            result
+                .entries
+                .iter()
+                .map(|e| (&e.level, &e.message))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -8,7 +8,7 @@
 //! - **Tier 2 (Degraded)**: Regex on common log formats (timestamp + level)
 //! - **Tier 3 (Passthrough)**: Raw output
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 use std::sync::LazyLock;
@@ -22,12 +22,16 @@ use crate::output::canonical::{LogEntry, LogResult};
 /// Maximum input lines before truncation.
 const MAX_INPUT_LINES: usize = 100_000;
 
-/// Maximum frames buffered in `pending_stack` before the oldest is dropped.
+/// Maximum logical frames buffered in `pending_stack` before the oldest is dropped.
 ///
 /// Keeps memory at O(PENDING_STACK_CAP) regardless of input length.
 /// `flush_stack_frames` retains only the last 3 frames, so a cap of 4 is
 /// sufficient: the sliding window holds the 4 most-recent frames, and the
 /// flush then drops 1 more, yielding exactly the last 3 in output.
+///
+/// Each entry in `pending_stack` is a logical frame: a `File "..."` line
+/// with optional source-preview and PEP 657 caret lines appended (multi-line
+/// string). The cap counts logical frames, not raw lines.
 const PENDING_STACK_CAP: usize = 4;
 
 /// Matches ISO8601 / common log timestamp prefix to strip before dedup.
@@ -342,6 +346,29 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 // Tier 2: regex-based log formats
 // ============================================================================
 
+/// Returns true when `line` is a Python source-preview or PEP 657 caret line
+/// that belongs to the preceding `File "..."` stack frame.
+///
+/// A continuation line is:
+/// - Non-empty after trimming
+/// - Starts with ASCII whitespace (indented)
+/// - Does NOT itself match the `RE_LOG_STACK_TRACE` pattern (which would start
+///   a new logical frame)
+///
+/// Called only when `in_python_frame` is true to avoid false positives on
+/// non-Python indented content.
+fn is_python_continuation(line: &str, in_python_frame: bool) -> bool {
+    if !in_python_frame {
+        return false;
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Must have leading whitespace (indented) but not be a new File/at frame.
+    line.starts_with(|c: char| c.is_ascii_whitespace()) && !RE_LOG_STACK_TRACE.is_match(line)
+}
+
 /// Parse regex-based log formats into a LogResult.
 ///
 /// # AD-LOG-10 (2026-04-11) — Stack trace capture and last-3-frame elision
@@ -350,19 +377,37 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 /// frames are attached to the previous entry's message:
 ///
 /// 1. Total frame count is recorded as `total_frames`.
-/// 2. Keep only the **last** 3 frames (preserving their relative order):
-///    `pending_stack.iter().rev().take(3).rev()`.
+/// 2. Keep only the **last** 3 frames (preserving their relative order).
 /// 3. The frames are appended as a newline-joined suffix to the previous
 ///    entry's message.
 /// 4. Elided count: `total_frames.saturating_sub(3)` — accumulated across
 ///    all entries and surfaced in `LogResult::stack_frames_elided`.
+///
+/// # CPython traceback extensions (issue #137)
+/// Each entry in `pending_stack` is a **logical frame** — a `File "..."` line
+/// with optional source-preview and PEP 657 caret lines appended as a
+/// multi-line string. The cap (`PENDING_STACK_CAP`) counts logical frames so
+/// source-preview lines do not inflate the elision count.
+///
+/// Control flow (per line):
+/// 1. Blank line → flush + reset `in_python_frame`
+/// 2. `RE_LOG_STACK_TRACE` match → start/extend logical frame, set `in_python_frame`
+/// 3. `is_python_continuation` → append to current logical frame
+/// 4. Compute `without_ts` (strip timestamp once)
+/// 5. `Traceback (most recent call last)` → attach to last entry or create unstructured
+/// 6. Chained exception separator → flush + push separator as unstructured entry
+/// 7. Reset `in_python_frame = false`
+/// 8. Flush + classify as log entry
 fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     let mut all_entries: Vec<(Option<String>, String)> = Vec::with_capacity(256);
     let mut total_lines = 0usize;
     let mut found_structured = false;
-    // Stack trace capture state (AD-LOG-10)
-    let mut pending_stack: Vec<String> = Vec::new();
+    // Stack trace capture state (AD-LOG-10); VecDeque for O(1) pop_front.
+    let mut pending_stack: VecDeque<String> = VecDeque::new();
     let mut total_stack_frames_elided: usize = 0;
+    // Tracks whether the last recognised stack frame was a Python `File "..."` line,
+    // enabling source-preview and PEP 657 caret continuation detection.
+    let mut in_python_frame: bool = false;
 
     for line in input.lines().take(MAX_INPUT_LINES) {
         let trimmed = line.trim();
@@ -375,22 +420,70 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
                     &mut total_stack_frames_elided,
                 );
             }
+            in_python_frame = false;
             continue;
         }
 
-        // Check on the original (untrimmed) line to detect leading whitespace.
+        // Step 2: Check on the original (untrimmed) line to detect leading whitespace.
         if RE_LOG_STACK_TRACE.is_match(line) {
-            // Sliding-window cap: drop the oldest frame and count it as elided
-            // immediately, keeping memory at O(PENDING_STACK_CAP).
+            // Sliding-window cap: drop the oldest logical frame (O(1) via pop_front)
+            // and count it as elided immediately, keeping memory at O(PENDING_STACK_CAP).
             if pending_stack.len() >= PENDING_STACK_CAP {
-                pending_stack.remove(0);
+                pending_stack.pop_front();
                 total_stack_frames_elided += 1;
             }
-            pending_stack.push(trimmed.to_string());
+            pending_stack.push_back(trimmed.to_string());
+            // Set flag so the next indented line is recognised as a continuation.
+            in_python_frame = trimmed.starts_with("File ");
+            found_structured = true;
             continue;
         }
 
-        // New log line: flush any accumulated stack frames onto the previous entry.
+        // Step 3: Python source-preview / PEP 657 caret continuation.
+        // Must run BEFORE classify_log_line so source lines containing "ERROR:"
+        // or similar keywords are not misclassified as new log entries.
+        if is_python_continuation(line, in_python_frame) {
+            if let Some(last_frame) = pending_stack.back_mut() {
+                last_frame.push('\n');
+                last_frame.push_str(trimmed);
+            }
+            continue;
+        }
+
+        // Step 4: Strip timestamp once; reuse for both Traceback and separator checks.
+        let without_ts = strip_timestamp(trimmed, flags.keep_timestamps);
+
+        // Step 5: Traceback header — attach to preceding entry (or create unstructured).
+        if without_ts.starts_with("Traceback (most recent call last)") {
+            if let Some((_, msg)) = all_entries.last_mut() {
+                msg.push('\n');
+                msg.push_str(trimmed);
+            } else {
+                all_entries.push((None, trimmed.to_string()));
+            }
+            found_structured = true;
+            continue;
+        }
+
+        // Step 6: Chained exception separator — flush pending stack, push separator.
+        if without_ts.starts_with("During handling of the above exception")
+            || without_ts.starts_with("The above exception was the direct cause")
+        {
+            if !pending_stack.is_empty() && !all_entries.is_empty() {
+                flush_stack_frames(
+                    &mut all_entries,
+                    &mut pending_stack,
+                    &mut total_stack_frames_elided,
+                );
+            }
+            all_entries.push((None, trimmed.to_string()));
+            continue;
+        }
+
+        // Step 7: Reset python-frame flag before classifying this line as a new entry.
+        in_python_frame = false;
+
+        // Step 8: New log line — flush any accumulated stack frames onto the previous entry.
         if !pending_stack.is_empty() && !all_entries.is_empty() {
             flush_stack_frames(
                 &mut all_entries,
@@ -401,7 +494,6 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
 
         total_lines += 1;
 
-        let without_ts = strip_timestamp(trimmed, flags.keep_timestamps);
         if let Some((level, message)) = classify_log_line(without_ts) {
             all_entries.push((Some(level), message));
             found_structured = true;
@@ -436,16 +528,19 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
 
 /// Flush `pending_stack` onto the last entry in `all_entries`.
 ///
-/// Keeps the last 3 frames (in original order) and appends them as a
+/// Keeps the last 3 logical frames (in original order) and appends them as a
 /// newline-joined suffix. Increments `elided` by the number dropped.
 ///
-/// Both `all_entries` and `pending_stack` must remain `&mut Vec` rather than
-/// slices: `all_entries` uses `.last_mut()` (Vec-level borrow), `pending_stack`
-/// calls `.clear()` which is not available on `&mut [_]`.
+/// Each entry in `pending_stack` is a logical frame — a `File "..."` line with
+/// optional source-preview and PEP 657 caret lines embedded as a multi-line
+/// string. The elision count is therefore a count of logical frames, not raw lines.
+///
+/// `all_entries` must be `&mut Vec` rather than `&mut [_]` because `.last_mut()`
+/// is a Vec-level borrow; `pending_stack` must be `&mut VecDeque` to call `.clear()`.
 #[allow(clippy::ptr_arg)]
 fn flush_stack_frames(
     all_entries: &mut Vec<(Option<String>, String)>,
-    pending_stack: &mut Vec<String>,
+    pending_stack: &mut VecDeque<String>,
     elided: &mut usize,
 ) {
     let total = pending_stack.len();
@@ -922,7 +1017,9 @@ mod tests {
         );
     }
 
-    /// AD-LOG-10: Python `File "..."` stack traces are recognised.
+    /// AD-LOG-10 / issue #137: Python `File "..."` stack traces with source-preview
+    /// lines are recognised. The fixture has 4 logical frames (4 `File` lines), each
+    /// with one source-preview line. Cap = 4 frames → 1 elided, last 3 kept.
     #[test]
     fn test_log_python_traceback_recognised() {
         let input = load_fixture("log", "stack_trace_python.txt");
@@ -933,16 +1030,21 @@ mod tests {
             .iter()
             .find(|e| e.level.as_deref() == Some("ERROR"))
             .expect("ERROR entry must exist");
-        // Python traces use `File "…"` — must be attached and last-3 kept.
+        // The last frame (threading.py) and its source-preview must be kept.
         assert!(
             error_entry.message.contains("threading.py"),
             "Last Python frame must be kept: {}",
             error_entry.message
         );
-        // 4 frames total, 3 kept → 1 elided.
+        assert!(
+            error_entry.message.contains("self.run()"),
+            "Source-preview of last frame must be kept: {}",
+            error_entry.message
+        );
+        // 4 logical frames, 3 kept → 1 elided.
         assert_eq!(
             result.stack_frames_elided, 1,
-            "Should elide 1 of 4 Python frames"
+            "Should elide 1 of 4 Python logical frames"
         );
     }
 
@@ -1152,6 +1254,375 @@ mod tests {
             result.chars().count(),
             MAX_JSON_LEVEL_LEN,
             "Level must be truncated to MAX_JSON_LEVEL_LEN chars"
+        );
+    }
+
+    // ============================================================================
+    // Group A: Updated Python Fixture (issue #137)
+    // ============================================================================
+
+    /// issue #137: Source-preview lines are attached to the preceding logical frame,
+    /// not counted as separate frames. The fixture has 4 `File` lines each with one
+    /// source-preview → last 3 logical frames kept, 1 elided.
+    #[test]
+    fn test_python_source_preview_lines_attached_to_frame() {
+        let input = load_fixture("log", "stack_trace_python.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        let error_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("ERROR"))
+            .expect("ERROR entry must exist");
+        // Last 3 logical frames are kept: threading.py/_bootstrap, run/handle_request, run/run.
+        assert!(
+            error_entry.message.contains("self.run()"),
+            "Source-preview of last frame (threading.py) must be present: {}",
+            error_entry.message
+        );
+        assert!(
+            error_entry.message.contains("handle_request(payload)"),
+            "Source-preview of 3rd-from-last frame must be present: {}",
+            error_entry.message
+        );
+        assert!(
+            error_entry.message.contains("return parse_value(data)"),
+            "Source-preview of 2nd-from-last frame must be present: {}",
+            error_entry.message
+        );
+        // First logical frame (parse_value) is elided — its source must be absent.
+        assert!(
+            !error_entry.message.contains("result = int(value)"),
+            "Source-preview of elided frame must not appear: {}",
+            error_entry.message
+        );
+    }
+
+    /// issue #137: Source-preview lines must not inflate the logical frame count.
+    /// 4 `File` lines → 4 logical frames → 1 elided (not 8 lines → 7 elided).
+    #[test]
+    fn test_python_source_preview_not_counted_as_frame() {
+        let input = load_fixture("log", "stack_trace_python.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        assert_eq!(
+            result.stack_frames_elided, 1,
+            "4 logical frames with source-preview → 1 elided; got {}",
+            result.stack_frames_elided
+        );
+    }
+
+    // ============================================================================
+    // Group B: Chained Exceptions
+    // ============================================================================
+
+    /// issue #137: Traceback headers must be attached to the preceding entry,
+    /// never emitted as standalone entries with a message starting with "Traceback".
+    #[test]
+    fn test_python_chained_traceback_headers_attached() {
+        let input = load_fixture("log", "stack_trace_python_chained.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        // No entry should have a message that begins with "Traceback"
+        for entry in &result.entries {
+            assert!(
+                !entry.message.starts_with("Traceback"),
+                "Traceback header leaked as standalone entry: {:?}",
+                entry.message
+            );
+        }
+    }
+
+    /// issue #137: Chained exception — each chain has 2 frames (≤ 3), so none elided.
+    #[test]
+    fn test_python_chained_traceback_elision_count() {
+        let input = load_fixture("log", "stack_trace_python_chained.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        assert_eq!(
+            result.stack_frames_elided, 0,
+            "Both chains have ≤ 3 frames each; expected 0 elided, got {}",
+            result.stack_frames_elided
+        );
+    }
+
+    /// issue #137: The INFO entry must not contain `File` or `Traceback` text
+    /// from the chained tracebacks.
+    #[test]
+    fn test_python_chained_traceback_info_not_contaminated() {
+        let input = load_fixture("log", "stack_trace_python_chained.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        let info_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("INFO"))
+            .expect("INFO entry must exist");
+        assert!(
+            !info_entry.message.contains("File"),
+            "INFO entry must not contain stack frame text: {}",
+            info_entry.message
+        );
+        assert!(
+            !info_entry.message.contains("Traceback"),
+            "INFO entry must not contain Traceback text: {}",
+            info_entry.message
+        );
+    }
+
+    // ============================================================================
+    // Group C: PEP 657 Caret Lines
+    // ============================================================================
+
+    /// issue #137: PEP 657 caret lines (`~~~~~~^~~~~~~~`) are attached to the
+    /// preceding `File` logical frame, not stripped.
+    #[test]
+    fn test_python_pep657_caret_lines_attached() {
+        let input = load_fixture("log", "stack_trace_python_pep657.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        let error_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("ERROR"))
+            .expect("ERROR entry must exist");
+        assert!(
+            error_entry.message.contains("~~~~~~^~~~~~~~"),
+            "PEP 657 caret line must be attached to its frame: {}",
+            error_entry.message
+        );
+    }
+
+    /// issue #137: PEP 657 caret lines must not inflate the logical frame count.
+    /// 3 `File` lines → 3 logical frames → 0 elided.
+    #[test]
+    fn test_python_pep657_not_counted_as_frame() {
+        let input = load_fixture("log", "stack_trace_python_pep657.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        assert_eq!(
+            result.stack_frames_elided, 0,
+            "3 logical frames (with PEP 657 carets) → 0 elided; got {}",
+            result.stack_frames_elided
+        );
+    }
+
+    // ============================================================================
+    // Group D: Regression Guards (inline input)
+    // ============================================================================
+
+    /// issue #137: Source-preview lines must not create additional log entries.
+    /// ERROR + 2 File/source pairs + INFO → exactly 2 entries (ERROR and INFO).
+    #[test]
+    fn test_source_preview_line_does_not_create_entry() {
+        let input = concat!(
+            "ERROR: something failed\n",
+            "  File \"/app/foo.py\", line 10, in bar\n",
+            "    do_thing()\n",
+            "  File \"/app/baz.py\", line 20, in qux\n",
+            "    call_other()\n",
+            "INFO: done\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags).unwrap();
+        assert_eq!(
+            result.entries.len(),
+            2,
+            "Only ERROR and INFO entries expected; got {:?}",
+            result
+                .entries
+                .iter()
+                .map(|e| (&e.level, &e.message))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// issue #137: A standalone Traceback (no preceding log-level line) with one
+    /// File/source and an exception line (no log-level prefix) must be parsed as
+    /// structured output (`try_parse_regex_logs` returns `Some`), because
+    /// `RE_LOG_STACK_TRACE` match sets `found_structured = true`.
+    #[test]
+    fn test_found_structured_gate_with_traceback_only() {
+        let input = concat!(
+            "ERROR: startup failed\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/app/main.py\", line 5, in <module>\n",
+            "    start()\n",
+            "AssertionError: precondition failed\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags);
+        assert!(
+            result.is_some(),
+            "Input with ERROR + Traceback + File + AssertionError must parse as structured"
+        );
+    }
+
+    /// issue #137: A source-preview line that itself contains a log-level keyword
+    /// (e.g. `"ERROR: bad input"`) must NOT be misclassified as a new log entry.
+    #[test]
+    fn test_python_source_line_with_log_keyword_not_misclassified() {
+        // The source-preview line contains "ERROR: bad input" — this must stay
+        // attached to the File frame, not become a separate ERROR entry.
+        let input = concat!(
+            "ERROR: validation failed\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/app/v.py\", line 7, in validate\n",
+            "    raise ValueError(\"ERROR: bad input\")\n",
+            "INFO: fallback used\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags).unwrap();
+        let error_entries: Vec<_> = result
+            .entries
+            .iter()
+            .filter(|e| e.level.as_deref() == Some("ERROR"))
+            .collect();
+        assert_eq!(
+            error_entries.len(),
+            1,
+            "Source-preview with log keyword must not create extra ERROR entry; got: {:?}",
+            error_entries.iter().map(|e| &e.message).collect::<Vec<_>>()
+        );
+    }
+
+    /// issue #137: Pending stack cap counts logical frames; source-preview lines
+    /// don't consume extra cap slots.
+    ///
+    /// ERROR + 10 logical frames (each with source-preview) + INFO:
+    /// cap = 4 → 7 cap-evictions, flush keeps last 3 → total 7 elided.
+    /// The last frame's source-preview is present; the first frame's source is absent.
+    #[test]
+    fn test_pending_stack_cap_with_source_preview() {
+        let mut input = String::from("ERROR: overflow\n");
+        for i in 1..=10 {
+            input.push_str(&format!(
+                "  File \"/app/mod.py\", line {i}, in call{i}\n    call{i}()\n"
+            ));
+        }
+        input.push_str("INFO: done\n");
+
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+
+        // 10 logical frames: cap evicts 7 incrementally, flush drops 0 more (3 kept) → 7 elided.
+        assert_eq!(
+            result.stack_frames_elided, 7,
+            "10 logical frames → 7 elided (last 3 kept); got {}",
+            result.stack_frames_elided
+        );
+
+        let error_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("ERROR"))
+            .expect("ERROR entry must exist");
+
+        // Last frame (call10) source must be present.
+        assert!(
+            error_entry.message.contains("call10()"),
+            "Last frame source-preview must be kept: {}",
+            error_entry.message
+        );
+        // First frame (call1) source must be absent (evicted by cap).
+        assert!(
+            !error_entry.message.contains("call1()"),
+            "Evicted frame source-preview must not appear: {}",
+            error_entry.message
+        );
+    }
+
+    /// issue #137: A `Traceback` header at the start (no preceding entry) becomes
+    /// an unstructured entry that is later flushed so it does not appear in the
+    /// INFO entry's message.
+    #[test]
+    fn test_traceback_header_only_input() {
+        let input = concat!(
+            "ERROR: boot failed\n",
+            "Traceback (most recent call last):\n",
+            "INFO: continuing\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags).unwrap();
+        let info_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("INFO"))
+            .expect("INFO entry must exist");
+        assert!(
+            !info_entry.message.contains("Traceback"),
+            "Traceback must not bleed into INFO entry: {}",
+            info_entry.message
+        );
+        // The Traceback text is attached to the preceding ERROR entry.
+        let error_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("ERROR"))
+            .expect("ERROR entry must exist");
+        assert!(
+            error_entry.message.contains("Traceback"),
+            "Traceback header must be attached to ERROR entry: {}",
+            error_entry.message
+        );
+    }
+
+    // ============================================================================
+    // Group F: Rendered Output
+    // ============================================================================
+
+    /// issue #137: The rendered output from the Python fixture must be coherent —
+    /// contains ValueError, the elision marker, and both log levels.
+    #[test]
+    fn test_python_rendered_output_coherent() {
+        let input = load_fixture("log", "stack_trace_python.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        let display = result.as_ref();
+        assert!(
+            display.contains("ValueError"),
+            "Rendered output must contain exception type: {display}"
+        );
+        assert!(
+            display.contains("frames elided"),
+            "Rendered output must contain elision marker: {display}"
+        );
+        assert!(
+            display.contains("ERROR:"),
+            "Rendered output must contain ERROR level: {display}"
+        );
+        assert!(
+            display.contains("INFO:"),
+            "Rendered output must contain INFO level: {display}"
+        );
+    }
+
+    /// issue #137: The chained exception rendered output must contain both error
+    /// types and the INFO recovery message as a separate entry.
+    #[test]
+    fn test_chained_rendered_output_not_split() {
+        let input = load_fixture("log", "stack_trace_python_chained.txt");
+        let flags = make_flags();
+        let result = try_parse_regex_logs(&input, &flags).unwrap();
+        let display = result.as_ref();
+        assert!(
+            display.contains("DatabaseError"),
+            "Rendered output must contain DatabaseError: {display}"
+        );
+        assert!(
+            display.contains("ServiceError"),
+            "Rendered output must contain ServiceError: {display}"
+        );
+        // INFO entry must be a separate line, not embedded in error entries.
+        let info_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("INFO"))
+            .expect("INFO entry must exist");
+        assert!(
+            info_entry.message.contains("recovered"),
+            "INFO entry must contain recovery message: {}",
+            info_entry.message
         );
     }
 }

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -52,7 +52,7 @@ const MAX_CONTINUATIONS_PER_FRAME: usize = 4;
 /// between "no frame ever started" and "frame just ended": both are `Idle`, and
 /// `PythonFrame` carries the associated continuation count so the two concerns
 /// are co-located and move together as a unit.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FrameContext {
     /// No active Python frame — continuation detection is inactive.
     Idle,
@@ -483,13 +483,14 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
                 !pending_stack.is_empty(),
                 "FrameContext::PythonFrame requires a frame in pending_stack"
             );
-            if *continuation_count < MAX_CONTINUATIONS_PER_FRAME {
-                if let Some(last_frame) = pending_stack.back_mut() {
-                    last_frame.push('\n');
-                    last_frame.push_str(trimmed);
-                }
-                *continuation_count += 1;
+            if *continuation_count >= MAX_CONTINUATIONS_PER_FRAME {
+                continue;
             }
+            if let Some(last_frame) = pending_stack.back_mut() {
+                last_frame.push('\n');
+                last_frame.push_str(trimmed);
+            }
+            *continuation_count += 1;
             continue;
         }
 

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -52,7 +52,7 @@ const MAX_CONTINUATIONS_PER_FRAME: usize = 4;
 /// between "no frame ever started" and "frame just ended": both are `Idle`, and
 /// `PythonFrame` carries the associated continuation count so the two concerns
 /// are co-located and move together as a unit.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum FrameContext {
     /// No active Python frame — continuation detection is inactive.
     Idle,

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -382,15 +382,19 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 /// that belongs to the preceding `File "..."` stack frame.
 ///
 /// A continuation line is:
-/// - Non-empty after trimming
 /// - Starts with ASCII whitespace (indented)
-/// - Does NOT itself match the `RE_LOG_STACK_TRACE` pattern (which would start
-///   a new logical frame)
+/// - Non-empty after trimming
 ///
-/// Callers must gate on `FrameContext::PythonFrame` before calling — this
+/// **Call-site contract**: callers must invoke this function only AFTER the
+/// `RE_LOG_STACK_TRACE` check (step 2) has already failed. This function does
+/// not re-check that pattern; the exclusion of new logical frames is enforced
+/// by call ordering in `try_parse_regex_logs`, not by this predicate.
+///
+/// Callers must also gate on `FrameContext::PythonFrame` before calling — this
 /// function tests only the line's structure, not parser state.
 fn is_python_continuation(line: &str) -> bool {
-    !line.trim().is_empty() && line.starts_with(|c: char| c.is_ascii_whitespace())
+    let first = line.as_bytes().first().copied().unwrap_or(0);
+    first.is_ascii_whitespace() && !line.trim().is_empty()
 }
 
 /// Parse regex-based log formats into a LogResult.
@@ -1356,6 +1360,151 @@ mod tests {
     fn test_is_python_continuation_valid_source_preview() {
         assert!(is_python_continuation("    do_thing()"));
         assert!(is_python_continuation("\t    return value"));
+    }
+
+    // ============================================================================
+    // MAX_CONTINUATIONS_PER_FRAME enforcement (TEST-1)
+    // ============================================================================
+
+    /// MAX_CONTINUATIONS_PER_FRAME cap: a single `File "..."` frame with more than
+    /// 4 continuation lines must keep only the first 4; excess lines are silently
+    /// dropped (not counted as frames or new entries).
+    ///
+    /// Input: ERROR + 1 File frame + 6 continuation lines + INFO.
+    /// Expected: only the first 4 continuation lines are appended to the frame;
+    /// lines 5 and 6 are dropped. The INFO entry is a clean, separate entry.
+    #[test]
+    fn test_max_continuations_per_frame_enforced() {
+        let input = concat!(
+            "ERROR: too many continuations\n",
+            "  File \"/app/m.py\", line 1, in fn\n",
+            "    continuation_1\n",
+            "    continuation_2\n",
+            "    continuation_3\n",
+            "    continuation_4\n",
+            "    continuation_5\n", // beyond cap — must be dropped
+            "    continuation_6\n", // beyond cap — must be dropped
+            "INFO: done\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags).unwrap();
+
+        let error_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("ERROR"))
+            .expect("ERROR entry must exist");
+
+        // First 4 continuations must be kept.
+        assert!(
+            error_entry.message.contains("continuation_1"),
+            "continuation_1 must be kept: {}",
+            error_entry.message
+        );
+        assert!(
+            error_entry.message.contains("continuation_4"),
+            "continuation_4 must be kept: {}",
+            error_entry.message
+        );
+
+        // Lines 5 and 6 must be dropped (beyond MAX_CONTINUATIONS_PER_FRAME = 4).
+        assert!(
+            !error_entry.message.contains("continuation_5"),
+            "continuation_5 must be dropped (beyond cap): {}",
+            error_entry.message
+        );
+        assert!(
+            !error_entry.message.contains("continuation_6"),
+            "continuation_6 must be dropped (beyond cap): {}",
+            error_entry.message
+        );
+
+        // INFO must be a separate, clean entry — not contaminated by excess continuations.
+        let info_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("INFO"))
+            .expect("INFO entry must exist");
+        assert!(
+            !info_entry.message.contains("continuation"),
+            "INFO entry must not contain dropped continuation text: {}",
+            info_entry.message
+        );
+    }
+
+    // ============================================================================
+    // Chained exception separator variants (TEST-2)
+    // ============================================================================
+
+    /// The "During handling of the above exception" chained-exception separator
+    /// must flush the pending stack and become an unstructured entry — same
+    /// behaviour as the "direct cause" variant already covered by the fixture tests.
+    ///
+    /// Input: ERROR + 1 frame + separator + 1 frame + INFO.
+    /// Expected:
+    /// - 2 log-level entries: ERROR and INFO.
+    /// - stack_frames_elided == 0 (each chain has 1 frame, well under the cap).
+    /// - ERROR entry contains the first File frame.
+    /// - Separator text does not appear inside ERROR or INFO messages.
+    #[test]
+    fn test_chained_separator_during_handling() {
+        let input = concat!(
+            "ERROR: outer failure\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/app/inner.py\", line 3, in do_inner\n",
+            "    inner()\n",
+            "ValueError: inner error\n",
+            "\n",
+            "During handling of the above exception, another exception occurred:\n",
+            "\n",
+            "Traceback (most recent call last):\n",
+            "  File \"/app/outer.py\", line 7, in do_outer\n",
+            "    outer()\n",
+            "RuntimeError: outer error\n",
+            "INFO: recovered\n",
+        );
+        let flags = make_flags();
+        let result = try_parse_regex_logs(input, &flags).unwrap();
+
+        // No frames should be elided — each chain has ≤ 3 frames.
+        assert_eq!(
+            result.stack_frames_elided, 0,
+            "Expected 0 elided frames; got {}",
+            result.stack_frames_elided
+        );
+
+        // ERROR and INFO must exist as log-level entries.
+        assert!(
+            result
+                .entries
+                .iter()
+                .any(|e| e.level.as_deref() == Some("ERROR")),
+            "ERROR entry must exist"
+        );
+        assert!(
+            result
+                .entries
+                .iter()
+                .any(|e| e.level.as_deref() == Some("INFO")),
+            "INFO entry must exist"
+        );
+
+        // INFO entry must not contain any traceback or frame text.
+        let info_entry = result
+            .entries
+            .iter()
+            .find(|e| e.level.as_deref() == Some("INFO"))
+            .unwrap();
+        assert!(
+            !info_entry.message.contains("File"),
+            "INFO entry must not contain File frame text: {}",
+            info_entry.message
+        );
+        assert!(
+            !info_entry.message.contains("During handling"),
+            "INFO entry must not contain separator text: {}",
+            info_entry.message
+        );
     }
 
     // ============================================================================

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -41,6 +41,31 @@ const PENDING_STACK_CAP: usize = 4;
 /// bypass the per-frame accounting that makes the invariant hold.
 const MAX_CONTINUATIONS_PER_FRAME: usize = 4;
 
+/// Tracks whether the parser is inside a Python `File "..."` logical frame.
+///
+/// `PythonFrame` means the last recognised stack-trace line was a Python
+/// `File "..."` line; continuation lines (source-preview, PEP 657 carets) are
+/// appended to the current logical frame until a line that does not match
+/// `is_python_continuation` resets state to `Idle`.
+///
+/// Using an explicit enum (rather than a bare `bool`) eliminates the ambiguity
+/// between "no frame ever started" and "frame just ended": both are `Idle`, and
+/// `PythonFrame` carries the associated continuation count so the two concerns
+/// are co-located and move together as a unit.
+#[derive(Debug, Clone, PartialEq)]
+enum FrameContext {
+    /// No active Python frame — continuation detection is inactive.
+    Idle,
+    /// Inside a Python `File "..."` logical frame.
+    PythonFrame {
+        /// Number of continuation lines already appended to the current frame.
+        /// Reset to 0 each time a new frame starts. Caps at
+        /// `MAX_CONTINUATIONS_PER_FRAME` to enforce the O(PENDING_STACK_CAP)
+        /// memory invariant.
+        continuation_count: usize,
+    },
+}
+
 /// Matches ISO8601 / common log timestamp prefix to strip before dedup.
 /// e.g. `2024-01-15T10:30:00Z `, `2024-01-15 10:30:00 `, `[2024-01-15T10:30:00]`
 static RE_LOG_TIMESTAMP: LazyLock<Regex> = LazyLock::new(|| {
@@ -362,8 +387,8 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 /// - Does NOT itself match the `RE_LOG_STACK_TRACE` pattern (which would start
 ///   a new logical frame)
 ///
-/// Callers must gate on `in_python_frame` before calling — this function tests
-/// only the line's structure, not parser state.
+/// Callers must gate on `FrameContext::PythonFrame` before calling — this
+/// function tests only the line's structure, not parser state.
 fn is_python_continuation(line: &str) -> bool {
     !line.trim().is_empty() && line.starts_with(|c: char| c.is_ascii_whitespace())
 }
@@ -389,13 +414,13 @@ fn is_python_continuation(line: &str) -> bool {
 /// source-preview lines do not inflate the elision count.
 ///
 /// Control flow (per line):
-/// 1. Blank line → flush + reset `in_python_frame`
-/// 2. `RE_LOG_STACK_TRACE` match → start/extend logical frame, set `in_python_frame`
+/// 1. Blank line → flush + reset `frame_ctx` to `FrameContext::Idle`
+/// 2. `RE_LOG_STACK_TRACE` match → start/extend logical frame, set `frame_ctx`
 /// 3. `is_python_continuation` → append to current logical frame
 /// 4. Compute `without_ts` (strip timestamp once)
 /// 5. `Traceback (most recent call last)` → attach to last entry or create unstructured
 /// 6. Chained exception separator → flush + push separator as unstructured entry
-/// 7. Reset `in_python_frame = false`
+/// 7. Reset `frame_ctx` to `FrameContext::Idle`
 /// 8. Flush + classify as log entry
 fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     let mut all_entries: Vec<(Option<String>, String)> = Vec::with_capacity(256);
@@ -404,13 +429,11 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     // Stack trace capture state (AD-LOG-10); VecDeque for O(1) pop_front.
     let mut pending_stack: VecDeque<String> = VecDeque::new();
     let mut total_stack_frames_elided: usize = 0;
-    // Tracks whether the last recognised stack frame was a Python `File "..."` line,
+    // Tracks whether the parser is inside a Python `File "..."` logical frame,
     // enabling source-preview and PEP 657 caret continuation detection.
-    let mut in_python_frame = false;
-    // Counts continuation lines appended to the current logical frame.
-    // Reset to 0 each time a new frame starts (step 2). Enforces
-    // MAX_CONTINUATIONS_PER_FRAME to uphold the O(PENDING_STACK_CAP) memory invariant.
-    let mut frame_continuation_count: usize = 0;
+    // `PythonFrame` also carries the continuation count so both concerns move
+    // together as a unit; `Idle` covers every non-Python-frame state.
+    let mut frame_ctx = FrameContext::Idle;
 
     for line in input.lines().take(MAX_INPUT_LINES) {
         let trimmed = line.trim();
@@ -423,7 +446,7 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
                 &mut total_stack_frames_elided,
             );
             pending_stack.clear();
-            in_python_frame = false;
+            frame_ctx = FrameContext::Idle;
             continue;
         }
 
@@ -436,9 +459,14 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
                 total_stack_frames_elided += 1;
             }
             pending_stack.push_back(trimmed.to_string());
-            // Set flag so the next indented line is recognised as a continuation.
-            in_python_frame = trimmed.starts_with("File ");
-            frame_continuation_count = 0;
+            // Set context so the next indented line is recognised as a continuation.
+            frame_ctx = if trimmed.starts_with("File ") {
+                FrameContext::PythonFrame {
+                    continuation_count: 0,
+                }
+            } else {
+                FrameContext::Idle
+            };
             found_structured = true;
             continue;
         }
@@ -446,17 +474,21 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
         // Step 3: Python source-preview / PEP 657 caret continuation.
         // Must run BEFORE classify_log_line so source lines containing "ERROR:"
         // or similar keywords are not misclassified as new log entries.
-        if in_python_frame && is_python_continuation(line) {
+        if let FrameContext::PythonFrame {
+            ref mut continuation_count,
+        } = frame_ctx
+            && is_python_continuation(line)
+        {
             debug_assert!(
                 !pending_stack.is_empty(),
-                "in_python_frame=true requires a frame in pending_stack"
+                "FrameContext::PythonFrame requires a frame in pending_stack"
             );
-            if frame_continuation_count < MAX_CONTINUATIONS_PER_FRAME {
+            if *continuation_count < MAX_CONTINUATIONS_PER_FRAME {
                 if let Some(last_frame) = pending_stack.back_mut() {
                     last_frame.push('\n');
                     last_frame.push_str(trimmed);
                 }
-                frame_continuation_count += 1;
+                *continuation_count += 1;
             }
             continue;
         }
@@ -472,7 +504,7 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
             } else {
                 all_entries.push((None, trimmed.to_string()));
             }
-            in_python_frame = false;
+            frame_ctx = FrameContext::Idle;
             found_structured = true;
             continue;
         }
@@ -486,13 +518,13 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
                 &mut pending_stack,
                 &mut total_stack_frames_elided,
             );
-            in_python_frame = false;
+            frame_ctx = FrameContext::Idle;
             all_entries.push((None, trimmed.to_string()));
             continue;
         }
 
-        // Step 7: Reset python-frame flag before classifying this line as a new entry.
-        in_python_frame = false;
+        // Step 7: Reset python-frame context before classifying this line as a new entry.
+        frame_ctx = FrameContext::Idle;
 
         // Step 8: New log line — flush any accumulated stack frames onto the previous entry.
         try_flush_stack(

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -1760,8 +1760,7 @@ mod tests {
             "    new_code()\n",
         );
         let flags = make_flags();
-        let result = try_parse_regex_logs(input, &flags)
-            .expect("Should parse the ERROR entry");
+        let result = try_parse_regex_logs(input, &flags).expect("Should parse the ERROR entry");
         let error_entry = result
             .entries
             .iter()

--- a/crates/rskim/src/cmd/log.rs
+++ b/crates/rskim/src/cmd/log.rs
@@ -355,12 +355,9 @@ fn extract_json_message(obj: &Value) -> Option<String> {
 /// - Does NOT itself match the `RE_LOG_STACK_TRACE` pattern (which would start
 ///   a new logical frame)
 ///
-/// Called only when `in_python_frame` is true to avoid false positives on
-/// non-Python indented content.
-fn is_python_continuation(line: &str, in_python_frame: bool) -> bool {
-    if !in_python_frame {
-        return false;
-    }
+/// Callers must gate on `in_python_frame` before calling — this function tests
+/// only the line's structure, not parser state.
+fn is_python_continuation(line: &str) -> bool {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return false;
@@ -407,12 +404,12 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
     let mut total_stack_frames_elided: usize = 0;
     // Tracks whether the last recognised stack frame was a Python `File "..."` line,
     // enabling source-preview and PEP 657 caret continuation detection.
-    let mut in_python_frame: bool = false;
+    let mut in_python_frame = false;
 
     for line in input.lines().take(MAX_INPUT_LINES) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
-            // Blank lines flush the pending stack (end of exception block).
+            // Step 1: Blank lines flush the pending stack (end of exception block).
             if !pending_stack.is_empty() && !all_entries.is_empty() {
                 flush_stack_frames(
                     &mut all_entries,
@@ -442,7 +439,7 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
         // Step 3: Python source-preview / PEP 657 caret continuation.
         // Must run BEFORE classify_log_line so source lines containing "ERROR:"
         // or similar keywords are not misclassified as new log entries.
-        if is_python_continuation(line, in_python_frame) {
+        if in_python_frame && is_python_continuation(line) {
             if let Some(last_frame) = pending_stack.back_mut() {
                 last_frame.push('\n');
                 last_frame.push_str(trimmed);
@@ -461,6 +458,7 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
             } else {
                 all_entries.push((None, trimmed.to_string()));
             }
+            in_python_frame = false;
             found_structured = true;
             continue;
         }
@@ -476,6 +474,7 @@ fn try_parse_regex_logs(input: &str, flags: &LogFlags) -> Option<LogResult> {
                     &mut total_stack_frames_elided,
                 );
             }
+            in_python_frame = false;
             all_entries.push((None, trimmed.to_string()));
             continue;
         }

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -219,6 +219,42 @@ fn try_parse_json(stdout: &str) -> Option<TestResult> {
 // Tier 1: nextest text state machine
 // ============================================================================
 
+/// Tracks whether the nextest parser is accumulating a STDOUT capture block.
+///
+/// Replaces the `in_stdout_block: bool` + `current_stdout_capture: Option<(String, String)>`
+/// pair.  Both were semantically coupled — accumulation only happened when the
+/// Option was `Some` and the bool was `true` — so a single enum expresses the
+/// invariant directly.  The `flush` method centralises the three duplicated
+/// "drain-and-attach" blocks into one location.
+#[derive(Debug, Clone, PartialEq)]
+enum CaptureState {
+    /// No active capture block.
+    Idle,
+    /// Accumulating lines for the named test's STDOUT output.
+    Capturing { test_name: String, output: String },
+}
+
+impl CaptureState {
+    /// Flush accumulated output onto the matching entry, then return `Idle`.
+    ///
+    /// If `self` is `Idle`, or the accumulated output is blank, this is a
+    /// no-op (returns `Idle` without modifying `entries`).
+    fn flush(self, entries: &mut [TestEntry]) -> Self {
+        if let CaptureState::Capturing { test_name, output } = self {
+            let detail = output.trim().to_string();
+            if !detail.is_empty() {
+                for entry in entries.iter_mut() {
+                    if entry.name == test_name && entry.detail.is_none() {
+                        entry.detail = Some(detail);
+                        break;
+                    }
+                }
+            }
+        }
+        CaptureState::Idle
+    }
+}
+
 /// Attempt to parse cargo-nextest text output.
 ///
 /// Nextest output format:
@@ -240,9 +276,8 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
     let mut total_skipped: usize = 0;
     let mut duration_ms: Option<u64> = None;
 
-    // Track stdout capture blocks for failure detail
-    let mut current_stdout_capture: Option<(String, String)> = None; // (test_name, accumulated_output)
-    let mut in_stdout_block = false;
+    // Track stdout capture blocks for failure detail.
+    let mut capture = CaptureState::Idle;
 
     for line in stdout.lines() {
         let trimmed = line.trim();
@@ -256,44 +291,33 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
                 .unwrap_or("")
                 .trim();
             if !inner.is_empty() {
-                current_stdout_capture = Some((inner.to_string(), String::new()));
-                in_stdout_block = true;
+                capture = CaptureState::Capturing {
+                    test_name: inner.to_string(),
+                    output: String::new(),
+                };
                 continue;
             }
         }
 
         // Check for STDERR capture block start (ends the STDOUT block)
         if trimmed.starts_with("--- STDERR:") && trimmed.ends_with("---") {
-            // Finalize any pending STDOUT capture
-            if let Some((ref test_name, ref captured)) = current_stdout_capture {
-                let detail = captured.trim().to_string();
-                if !detail.is_empty() {
-                    // Attach detail to the matching entry
-                    for entry in &mut entries {
-                        if entry.name == *test_name && entry.detail.is_none() {
-                            entry.detail = Some(detail.clone());
-                            break;
-                        }
-                    }
-                }
-            }
-            current_stdout_capture = None;
-            in_stdout_block = false;
+            // Finalize any pending STDOUT capture.
+            capture = capture.flush(&mut entries);
             continue;
         }
 
         // If we're in a STDOUT capture block, accumulate lines.
         // Use trim_end() instead of trim() to preserve leading whitespace
         // in assertion messages and formatted output.
-        if in_stdout_block && let Some((_, ref mut captured)) = current_stdout_capture {
-            if !captured.is_empty() {
-                captured.push('\n');
+        if let CaptureState::Capturing { ref mut output, .. } = capture {
+            if !output.is_empty() {
+                output.push('\n');
             }
-            captured.push_str(line.trim_end());
+            output.push_str(line.trim_end());
             continue;
         }
 
-        // Reset stdout block on non-indented lines that aren't part of capture
+        // Reset capture block on non-indented lines that aren't part of capture.
         if !trimmed.is_empty()
             && !trimmed.starts_with("PASS")
             && !trimmed.starts_with("FAIL")
@@ -303,20 +327,7 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
             && !trimmed.starts_with("Finished")
             && !trimmed.starts_with("---")
         {
-            // Finalize any pending capture
-            if let Some((ref test_name, ref captured)) = current_stdout_capture {
-                let detail = captured.trim().to_string();
-                if !detail.is_empty() {
-                    for entry in &mut entries {
-                        if entry.name == *test_name && entry.detail.is_none() {
-                            entry.detail = Some(detail.clone());
-                            break;
-                        }
-                    }
-                }
-            }
-            current_stdout_capture = None;
-            in_stdout_block = false;
+            capture = capture.flush(&mut entries);
         }
 
         // Parse test result lines: "PASS [0.003s] crate::tests::test_name"
@@ -374,18 +385,8 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
         }
     }
 
-    // Finalize any pending stdout capture
-    if let Some((ref test_name, ref captured)) = current_stdout_capture {
-        let detail = captured.trim().to_string();
-        if !detail.is_empty() {
-            for entry in &mut entries {
-                if entry.name == *test_name && entry.detail.is_none() {
-                    entry.detail = Some(detail.clone());
-                    break;
-                }
-            }
-        }
-    }
+    // Finalize any pending stdout capture.
+    capture.flush(&mut entries);
 
     if !summary_found {
         return None;

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -373,7 +373,7 @@ fn push_nextest_entry(
     entries: &mut Vec<TestEntry>,
 ) {
     if let Some(name) = extract_nextest_name(rest) {
-        let key = (name.clone(), outcome.clone());
+        let key = (name.clone(), outcome);
         if seen.insert(key) {
             entries.push(TestEntry {
                 name,
@@ -617,7 +617,10 @@ mod tests {
             matches!(state, CaptureState::Idle),
             "flush on Idle must return Idle"
         );
-        assert!(entries[0].detail.is_none(), "Idle flush must not set detail");
+        assert!(
+            entries[0].detail.is_none(),
+            "Idle flush must not set detail"
+        );
     }
 
     #[test]

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -226,7 +226,7 @@ fn try_parse_json(stdout: &str) -> Option<TestResult> {
 /// Option was `Some` and the bool was `true` — so a single enum expresses the
 /// invariant directly.  The `flush` method centralises the three duplicated
 /// "drain-and-attach" blocks into one location.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum CaptureState {
     /// No active capture block.
     Idle,
@@ -315,19 +315,6 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
             }
             output.push_str(line.trim_end());
             continue;
-        }
-
-        // Reset capture block on non-indented lines that aren't part of capture.
-        if !trimmed.is_empty()
-            && !trimmed.starts_with("PASS")
-            && !trimmed.starts_with("FAIL")
-            && !trimmed.starts_with("SKIP")
-            && !trimmed.starts_with("Starting")
-            && !trimmed.starts_with("Summary")
-            && !trimmed.starts_with("Finished")
-            && !trimmed.starts_with("---")
-        {
-            capture = capture.flush(&mut entries);
         }
 
         // Parse test result lines: "PASS [0.003s] crate::tests::test_name"

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -319,44 +319,17 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
 
         // Parse test result lines: "PASS [0.003s] crate::tests::test_name"
         if let Some(rest) = trimmed.strip_prefix("PASS") {
-            if let Some(name) = extract_nextest_name(rest) {
-                let key = (name.clone(), "Pass".to_string());
-                if seen.insert(key) {
-                    entries.push(TestEntry {
-                        name,
-                        outcome: TestOutcome::Pass,
-                        detail: None,
-                    });
-                }
-            }
+            push_nextest_entry(rest, TestOutcome::Pass, &mut seen, &mut entries);
             continue;
         }
 
         if let Some(rest) = trimmed.strip_prefix("FAIL") {
-            if let Some(name) = extract_nextest_name(rest) {
-                let key = (name.clone(), "Fail".to_string());
-                if seen.insert(key) {
-                    entries.push(TestEntry {
-                        name,
-                        outcome: TestOutcome::Fail,
-                        detail: None,
-                    });
-                }
-            }
+            push_nextest_entry(rest, TestOutcome::Fail, &mut seen, &mut entries);
             continue;
         }
 
         if let Some(rest) = trimmed.strip_prefix("SKIP") {
-            if let Some(name) = extract_nextest_name(rest) {
-                let key = (name.clone(), "Skip".to_string());
-                if seen.insert(key) {
-                    entries.push(TestEntry {
-                        name,
-                        outcome: TestOutcome::Skip,
-                        detail: None,
-                    });
-                }
-            }
+            push_nextest_entry(rest, TestOutcome::Skip, &mut seen, &mut entries);
             continue;
         }
 
@@ -387,6 +360,28 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
     };
 
     Some(TestResult::new(summary, entries))
+}
+
+/// Push a deduplicated nextest entry into `entries`.
+///
+/// Called for PASS, FAIL, and SKIP lines; the `outcome` discriminates the
+/// variant. Duplicate `(name, outcome)` pairs are silently dropped via `seen`.
+fn push_nextest_entry(
+    rest: &str,
+    outcome: TestOutcome,
+    seen: &mut HashSet<(String, String)>,
+    entries: &mut Vec<TestEntry>,
+) {
+    if let Some(name) = extract_nextest_name(rest) {
+        let key = (name.clone(), format!("{outcome:?}"));
+        if seen.insert(key) {
+            entries.push(TestEntry {
+                name,
+                outcome,
+                detail: None,
+            });
+        }
+    }
 }
 
 /// Extract the test name from a nextest result line remainder.
@@ -579,6 +574,135 @@ mod tests {
             1,
             "Expected exactly 1 failure entry (deduped), got {}",
             fail_entries.len()
+        );
+    }
+
+    #[test]
+    fn test_tier1_nextest_failure_detail_populated() {
+        // RUST-4 / TESTING-5: Verify that CaptureState::flush attaches the STDOUT
+        // block to the matching failure entry on the nextest path.
+        //
+        // The fixture's STDOUT block is delimited by:
+        //   --- STDOUT: rskim lib::tests::test_b ---
+        //   <content>
+        //   --- STDERR: rskim lib::tests::test_b ---
+        //
+        // Capture runs until the STDERR marker, which triggers flush.
+        let input = load_fixture("test", "cargo_nextest_fail.txt");
+        let result = try_parse_nextest(&input).expect("nextest parse must succeed");
+
+        let fail_entries: Vec<&TestEntry> = result
+            .entries
+            .iter()
+            .filter(|e| e.outcome == TestOutcome::Fail)
+            .collect();
+        assert_eq!(fail_entries.len(), 1, "Expected exactly 1 failure entry");
+        assert!(
+            fail_entries[0].detail.is_some(),
+            "Expected failure entry to have detail populated from STDOUT capture block"
+        );
+    }
+
+    // ========================================================================
+    // CaptureState::flush unit tests
+    // ========================================================================
+
+    #[test]
+    fn test_capture_flush_idle_is_noop() {
+        // Flush on Idle returns Idle and does not mutate entries.
+        let mut entries = vec![TestEntry {
+            name: "a::test".to_string(),
+            outcome: TestOutcome::Fail,
+            detail: None,
+        }];
+        let state = CaptureState::Idle.flush(&mut entries);
+        assert!(
+            matches!(state, CaptureState::Idle),
+            "flush on Idle must return Idle"
+        );
+        assert!(entries[0].detail.is_none(), "Idle flush must not set detail");
+    }
+
+    #[test]
+    fn test_capture_flush_attaches_content_to_matching_entry() {
+        // Flush with non-blank output sets detail on the matching entry.
+        let mut entries = vec![TestEntry {
+            name: "a::test".to_string(),
+            outcome: TestOutcome::Fail,
+            detail: None,
+        }];
+        let state = CaptureState::Capturing {
+            test_name: "a::test".to_string(),
+            output: "assertion failed: expected 1, got 2".to_string(),
+        }
+        .flush(&mut entries);
+        assert!(
+            matches!(state, CaptureState::Idle),
+            "flush must return Idle"
+        );
+        assert_eq!(
+            entries[0].detail.as_deref(),
+            Some("assertion failed: expected 1, got 2"),
+            "flush must attach non-blank output as detail"
+        );
+    }
+
+    #[test]
+    fn test_capture_flush_blank_output_is_noop() {
+        // Flush with whitespace-only output does not set detail.
+        let mut entries = vec![TestEntry {
+            name: "a::test".to_string(),
+            outcome: TestOutcome::Fail,
+            detail: None,
+        }];
+        let state = CaptureState::Capturing {
+            test_name: "a::test".to_string(),
+            output: "   \n  ".to_string(),
+        }
+        .flush(&mut entries);
+        assert!(
+            matches!(state, CaptureState::Idle),
+            "flush must return Idle"
+        );
+        assert!(
+            entries[0].detail.is_none(),
+            "blank output must not set detail"
+        );
+    }
+
+    #[test]
+    fn test_capture_block_delimited_by_stderr_marker() {
+        // RUST-4: Confirm that capture accumulation is bounded by the STDERR
+        // marker. Lines between the STDOUT marker and the STDERR marker are
+        // captured; lines after the STDERR marker are not included in detail.
+        let input = "\
+    Starting 1 tests across 1 test binary
+        FAIL [   0.001s] crate::tests::test_x
+--- STDOUT:              crate::tests::test_x ---
+captured line 1
+captured line 2
+--- STDERR:              crate::tests::test_x ---
+this line is stderr, not captured in stdout detail
+     Summary [   0.001s] 1 tests run: 0 passed, 1 failed, 0 skipped
+";
+        let result = try_parse_nextest(input).expect("must parse");
+        let fail = result
+            .entries
+            .iter()
+            .find(|e| e.outcome == TestOutcome::Fail)
+            .expect("must have failure entry");
+        let detail = fail.detail.as_deref().expect("detail must be populated");
+        assert!(
+            detail.contains("captured line 1"),
+            "detail must include stdout content"
+        );
+        assert!(
+            detail.contains("captured line 2"),
+            "detail must include all stdout content"
+        );
+        assert!(
+            !detail.contains("this line is stderr"),
+            "detail must not include lines after STDERR marker"
         );
     }
 

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -579,15 +579,12 @@ mod tests {
 
     #[test]
     fn test_tier1_nextest_failure_detail_populated() {
-        // RUST-4 / TESTING-5: Verify that CaptureState::flush attaches the STDOUT
-        // block to the matching failure entry on the nextest path.
-        //
-        // The fixture's STDOUT block is delimited by:
+        // Verify that CaptureState::flush attaches the STDOUT block to the
+        // matching failure entry. The fixture's STDOUT block is delimited by:
         //   --- STDOUT: rskim lib::tests::test_b ---
         //   <content>
         //   --- STDERR: rskim lib::tests::test_b ---
-        //
-        // Capture runs until the STDERR marker, which triggers flush.
+        // Capture runs until the STDERR marker, which triggers the flush.
         let input = load_fixture("test", "cargo_nextest_fail.txt");
         let result = try_parse_nextest(&input).expect("nextest parse must succeed");
 
@@ -672,9 +669,9 @@ mod tests {
 
     #[test]
     fn test_capture_block_delimited_by_stderr_marker() {
-        // RUST-4: Confirm that capture accumulation is bounded by the STDERR
-        // marker. Lines between the STDOUT marker and the STDERR marker are
-        // captured; lines after the STDERR marker are not included in detail.
+        // Confirm that capture accumulation is bounded by the STDERR marker.
+        // Lines between the STDOUT and STDERR markers are captured; lines
+        // after the STDERR marker are not included in detail.
         let input = "\
     Starting 1 tests across 1 test binary
         FAIL [   0.001s] crate::tests::test_x

--- a/crates/rskim/src/cmd/test/cargo.rs
+++ b/crates/rskim/src/cmd/test/cargo.rs
@@ -269,7 +269,7 @@ impl CaptureState {
 /// by tracking `(name, outcome)` pairs.
 fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
     let mut entries: Vec<TestEntry> = Vec::new();
-    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut seen: HashSet<(String, TestOutcome)> = HashSet::new();
     let mut summary_found = false;
     let mut total_passed: usize = 0;
     let mut total_failed: usize = 0;
@@ -369,11 +369,11 @@ fn try_parse_nextest(stdout: &str) -> Option<TestResult> {
 fn push_nextest_entry(
     rest: &str,
     outcome: TestOutcome,
-    seen: &mut HashSet<(String, String)>,
+    seen: &mut HashSet<(String, TestOutcome)>,
     entries: &mut Vec<TestEntry>,
 ) {
     if let Some(name) = extract_nextest_name(rest) {
-        let key = (name.clone(), format!("{outcome:?}"));
+        let key = (name.clone(), outcome.clone());
         if seen.insert(key) {
             entries.push(TestEntry {
                 name,

--- a/crates/rskim/src/cmd/test/go.rs
+++ b/crates/rskim/src/cmd/test/go.rs
@@ -298,7 +298,7 @@ fn try_parse_ndjson(output: &str) -> Option<TestResult> {
     keys.sort();
 
     for key in &keys {
-        let outcome = test_outcomes.get(key).unwrap().clone();
+        let outcome = *test_outcomes.get(key).unwrap();
         let detail = if outcome == TestOutcome::Fail {
             // Collect output lines for failed tests, trimming trailing whitespace
             test_outputs.get(key).map(|lines| {

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -259,6 +259,23 @@ fn parse_summary_line(line: &str) -> Option<SummaryCounts> {
 // Tier 1: Text state machine
 // ============================================================================
 
+/// Extract `(name, outcome)` from a verbose pytest marker line.
+///
+/// Matches lines that end with ` PASSED`, ` FAILED`, or ` SKIPPED` (verbose
+/// mode output). Returns `None` for all other lines.
+fn parse_verbose_marker(line: &str) -> Option<(String, TestOutcome)> {
+    let (suffix, outcome) = if line.ends_with(" PASSED") {
+        (" PASSED", TestOutcome::Pass)
+    } else if line.ends_with(" FAILED") {
+        (" FAILED", TestOutcome::Fail)
+    } else if line.ends_with(" SKIPPED") {
+        (" SKIPPED", TestOutcome::Skip)
+    } else {
+        return None;
+    };
+    Some((line[..line.len() - suffix.len()].to_string(), outcome))
+}
+
 /// Tracks which section of pytest output the parser is currently inside.
 ///
 /// The two section booleans (`in_failures`, `in_summary_info`) were mutually
@@ -374,29 +391,14 @@ fn tier1_parse(output: &str) -> Option<TestResult> {
             continue;
         }
 
-        // Outside special sections: look for per-line PASSED/FAILED/SKIPPED markers
+        // Outside special sections: look for per-line PASSED/FAILED/SKIPPED markers.
         // These appear in verbose mode output like:
         //   tests/test_a.py::test_one PASSED
         //   tests/test_a.py::test_two FAILED
-        if trimmed.ends_with(" PASSED") {
-            let name = trimmed.trim_end_matches(" PASSED").to_string();
+        if let Some((name, outcome)) = parse_verbose_marker(trimmed) {
             entries.push(TestEntry {
                 name,
-                outcome: TestOutcome::Pass,
-                detail: None,
-            });
-        } else if trimmed.ends_with(" FAILED") {
-            let name = trimmed.trim_end_matches(" FAILED").to_string();
-            entries.push(TestEntry {
-                name,
-                outcome: TestOutcome::Fail,
-                detail: None,
-            });
-        } else if trimmed.ends_with(" SKIPPED") {
-            let name = trimmed.trim_end_matches(" SKIPPED").to_string();
-            entries.push(TestEntry {
-                name,
-                outcome: TestOutcome::Skip,
+                outcome,
                 detail: None,
             });
         }

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -342,7 +342,7 @@ fn tier1_parse(output: &str) -> Option<TestResult> {
 
         // Detect section headers (=== ... ===)
         if let Some(new_section) = detect_section_header(trimmed) {
-            // Flush any pending failure when leaving the Failures section
+            // Flush any pending failure when leaving Failures or entering SummaryInfo.
             if section == PytestSection::Failures || new_section == PytestSection::SummaryInfo {
                 flush_failure(
                     &mut entries,
@@ -937,6 +937,16 @@ FAILED tests/test_b.py::test_two - assert 1 == 2
         assert!(
             detect_section_header("some regular output line").is_none(),
             "non-header line should return None"
+        );
+    }
+
+    #[test]
+    fn test_detect_section_header_incomplete_banner_returns_none() {
+        // A line that starts with === but does not end with === and is neither
+        // FAILURES nor "short test summary info" — treat as non-header.
+        assert!(
+            detect_section_header("=== warnings summary").is_none(),
+            "=== prefix without === suffix should return None"
         );
     }
 }

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -259,6 +259,22 @@ fn parse_summary_line(line: &str) -> Option<SummaryCounts> {
 // Tier 1: Text state machine
 // ============================================================================
 
+/// Tracks which section of pytest output the parser is currently inside.
+///
+/// The two section booleans (`in_failures`, `in_summary_info`) were mutually
+/// exclusive — exactly one was true at any time, or both were false (Normal).
+/// An enum makes all three states explicit and eliminates the illegal state
+/// where both would be true simultaneously.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PytestSection {
+    /// Outside any special section.
+    Normal,
+    /// Inside the `=== FAILURES ===` block.
+    Failures,
+    /// Inside the `=== short test summary info ===` block.
+    SummaryInfo,
+}
+
 /// Tier 1: Full text state machine parse.
 ///
 /// Scans every line for PASSED/FAILED/SKIPPED/ERROR markers, extracts test names
@@ -266,8 +282,7 @@ fn parse_summary_line(line: &str) -> Option<SummaryCounts> {
 /// the summary line.
 fn tier1_parse(output: &str) -> Option<TestResult> {
     let mut entries: Vec<TestEntry> = Vec::new();
-    let mut in_failures = false;
-    let mut in_summary_info = false;
+    let mut section = PytestSection::Normal;
     let mut current_failure_name: Option<String> = None;
     let mut current_failure_detail: Vec<String> = Vec::new();
 
@@ -285,15 +300,13 @@ fn tier1_parse(output: &str) -> Option<TestResult> {
 
         // Detect FAILURES section header
         if trimmed.starts_with("===") && trimmed.contains("FAILURES") {
-            in_failures = true;
-            in_summary_info = false;
+            section = PytestSection::Failures;
             continue;
         }
 
         // Detect "short test summary info" section
         if trimmed.starts_with("===") && trimmed.contains("short test summary info") {
-            in_summary_info = true;
-            in_failures = false;
+            section = PytestSection::SummaryInfo;
             // Flush any pending failure
             flush_failure(
                 &mut entries,
@@ -305,20 +318,19 @@ fn tier1_parse(output: &str) -> Option<TestResult> {
 
         // Detect any other section header (=== ... ===) that ends the current section
         if trimmed.starts_with("===") && trimmed.ends_with("===") {
-            if in_failures {
+            if section == PytestSection::Failures {
                 flush_failure(
                     &mut entries,
                     &mut current_failure_name,
                     &mut current_failure_detail,
                 );
             }
-            in_failures = false;
-            in_summary_info = false;
+            section = PytestSection::Normal;
             continue;
         }
 
         // Inside FAILURES section: extract individual test failure blocks
-        if in_failures {
+        if section == PytestSection::Failures {
             // Test failure headers look like: "________ test_name ________"
             if trimmed.starts_with('_') && trimmed.ends_with('_') {
                 // Flush previous failure
@@ -339,7 +351,7 @@ fn tier1_parse(output: &str) -> Option<TestResult> {
         }
 
         // Inside "short test summary info": parse FAILED/ERROR lines
-        if in_summary_info {
+        if section == PytestSection::SummaryInfo {
             let rest = trimmed
                 .strip_prefix("FAILED ")
                 .or_else(|| trimmed.strip_prefix("ERROR "));

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -273,7 +273,7 @@ fn parse_verbose_marker(line: &str) -> Option<(String, TestOutcome)> {
     } else {
         return None;
     };
-    Some((line[..line.len() - suffix.len()].to_string(), outcome))
+    Some((line.strip_suffix(suffix).unwrap().to_string(), outcome))
 }
 
 /// Tracks which section of pytest output the parser is currently inside.
@@ -290,6 +290,31 @@ enum PytestSection {
     Failures,
     /// Inside the `=== short test summary info ===` block.
     SummaryInfo,
+}
+
+/// Classify a `=== ... ===` section-header line.
+///
+/// Returns `Some(PytestSection)` when `trimmed` is a pytest section header,
+/// or `None` when it is not (allowing the caller to fall through to other
+/// processing).
+///
+/// The three patterns, in priority order:
+/// 1. Contains `"FAILURES"` → `Failures` section begins.
+/// 2. Contains `"short test summary info"` → `SummaryInfo` section begins.
+/// 3. Starts **and** ends with `"==="` (catch-all) → `Normal` (section ends).
+fn detect_section_header(trimmed: &str) -> Option<PytestSection> {
+    if !trimmed.starts_with("===") {
+        return None;
+    }
+    if trimmed.contains("FAILURES") {
+        Some(PytestSection::Failures)
+    } else if trimmed.contains("short test summary info") {
+        Some(PytestSection::SummaryInfo)
+    } else if trimmed.ends_with("===") {
+        Some(PytestSection::Normal)
+    } else {
+        None
+    }
 }
 
 /// Tier 1: Full text state machine parse.
@@ -315,34 +340,17 @@ fn tier1_parse(output: &str) -> Option<TestResult> {
             continue;
         }
 
-        // Detect FAILURES section header
-        if trimmed.starts_with("===") && trimmed.contains("FAILURES") {
-            section = PytestSection::Failures;
-            continue;
-        }
-
-        // Detect "short test summary info" section
-        if trimmed.starts_with("===") && trimmed.contains("short test summary info") {
-            section = PytestSection::SummaryInfo;
-            // Flush any pending failure
-            flush_failure(
-                &mut entries,
-                &mut current_failure_name,
-                &mut current_failure_detail,
-            );
-            continue;
-        }
-
-        // Detect any other section header (=== ... ===) that ends the current section
-        if trimmed.starts_with("===") && trimmed.ends_with("===") {
-            if section == PytestSection::Failures {
+        // Detect section headers (=== ... ===)
+        if let Some(new_section) = detect_section_header(trimmed) {
+            // Flush any pending failure when leaving the Failures section
+            if section == PytestSection::Failures || new_section == PytestSection::SummaryInfo {
                 flush_failure(
                     &mut entries,
                     &mut current_failure_name,
                     &mut current_failure_detail,
                 );
             }
-            section = PytestSection::Normal;
+            section = new_section;
             continue;
         }
 
@@ -847,5 +855,88 @@ FAILED tests/test_b.py::test_two - assert 1 == 2
             // The first occurrence (from verbose line) should be kept
             assert_eq!(fail_entries[0].name, "tests/test_b.py::test_two");
         }
+    }
+
+    // ========================================================================
+    // parse_verbose_marker unit tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_verbose_marker_passed() {
+        let (name, outcome) =
+            parse_verbose_marker("tests/test_a.py::test_one PASSED").expect("should match PASSED");
+        assert_eq!(name, "tests/test_a.py::test_one");
+        assert_eq!(outcome, TestOutcome::Pass);
+    }
+
+    #[test]
+    fn test_parse_verbose_marker_failed() {
+        let (name, outcome) =
+            parse_verbose_marker("tests/test_b.py::test_two FAILED").expect("should match FAILED");
+        assert_eq!(name, "tests/test_b.py::test_two");
+        assert_eq!(outcome, TestOutcome::Fail);
+    }
+
+    #[test]
+    fn test_parse_verbose_marker_skipped() {
+        let (name, outcome) = parse_verbose_marker("tests/test_c.py::test_three SKIPPED")
+            .expect("should match SKIPPED");
+        assert_eq!(name, "tests/test_c.py::test_three");
+        assert_eq!(outcome, TestOutcome::Skip);
+    }
+
+    #[test]
+    fn test_parse_verbose_marker_no_suffix_returns_none() {
+        assert!(
+            parse_verbose_marker("tests/test_a.py::test_one").is_none(),
+            "line with no outcome marker should return None"
+        );
+    }
+
+    #[test]
+    fn test_parse_verbose_marker_pathological_name_containing_marker_word() {
+        // A test whose name itself contains "FAILED" should still parse correctly
+        // as long as the line ends with the real suffix.
+        let (name, outcome) =
+            parse_verbose_marker("tests/test_FAILED_case.py::test_x PASSED")
+                .expect("should match PASSED suffix");
+        assert_eq!(name, "tests/test_FAILED_case.py::test_x");
+        assert_eq!(outcome, TestOutcome::Pass);
+    }
+
+    // ========================================================================
+    // detect_section_header unit tests
+    // ========================================================================
+
+    #[test]
+    fn test_detect_section_header_failures() {
+        assert_eq!(
+            detect_section_header("=== FAILURES ==="),
+            Some(PytestSection::Failures)
+        );
+    }
+
+    #[test]
+    fn test_detect_section_header_summary_info() {
+        assert_eq!(
+            detect_section_header("=== short test summary info ==="),
+            Some(PytestSection::SummaryInfo)
+        );
+    }
+
+    #[test]
+    fn test_detect_section_header_normal_catch_all() {
+        assert_eq!(
+            detect_section_header("=== warnings summary ==="),
+            Some(PytestSection::Normal)
+        );
+    }
+
+    #[test]
+    fn test_detect_section_header_non_header_returns_none() {
+        assert!(
+            detect_section_header("some regular output line").is_none(),
+            "non-header line should return None"
+        );
     }
 }

--- a/crates/rskim/src/cmd/test/pytest.rs
+++ b/crates/rskim/src/cmd/test/pytest.rs
@@ -897,9 +897,8 @@ FAILED tests/test_b.py::test_two - assert 1 == 2
     fn test_parse_verbose_marker_pathological_name_containing_marker_word() {
         // A test whose name itself contains "FAILED" should still parse correctly
         // as long as the line ends with the real suffix.
-        let (name, outcome) =
-            parse_verbose_marker("tests/test_FAILED_case.py::test_x PASSED")
-                .expect("should match PASSED suffix");
+        let (name, outcome) = parse_verbose_marker("tests/test_FAILED_case.py::test_x PASSED")
+            .expect("should match PASSED suffix");
         assert_eq!(name, "tests/test_FAILED_case.py::test_x");
         assert_eq!(outcome, TestOutcome::Pass);
     }

--- a/crates/rskim/src/output/canonical.rs
+++ b/crates/rskim/src/output/canonical.rs
@@ -13,7 +13,7 @@ use std::fmt;
 // ============================================================================
 
 /// Outcome of a single test case
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) enum TestOutcome {
     Pass,
     Fail,

--- a/crates/rskim/src/output/canonical.rs
+++ b/crates/rskim/src/output/canonical.rs
@@ -13,7 +13,7 @@ use std::fmt;
 // ============================================================================
 
 /// Outcome of a single test case
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) enum TestOutcome {
     Pass,
     Fail,

--- a/crates/rskim/tests/fixtures/cmd/log/stack_trace_python.txt
+++ b/crates/rskim/tests/fixtures/cmd/log/stack_trace_python.txt
@@ -1,6 +1,10 @@
 ERROR: ValueError: invalid literal for int()
-    File "/app/service.py", line 55, in parse_value
-    File "/app/service.py", line 102, in handle_request
-    File "/app/service.py", line 201, in run
-    File "/usr/lib/python3.11/threading.py", line 1000, in _bootstrap
+  File "/app/service.py", line 55, in parse_value
+    result = int(value)
+  File "/app/service.py", line 102, in handle_request
+    return parse_value(data)
+  File "/app/service.py", line 201, in run
+    handle_request(payload)
+  File "/usr/lib/python3.11/threading.py", line 1000, in _bootstrap
+    self.run()
 INFO: continuing after error

--- a/crates/rskim/tests/fixtures/cmd/log/stack_trace_python_chained.txt
+++ b/crates/rskim/tests/fixtures/cmd/log/stack_trace_python_chained.txt
@@ -1,0 +1,19 @@
+ERROR: Operation failed
+Traceback (most recent call last):
+  File "/app/db.py", line 45, in query
+    cursor.execute(sql)
+  File "/app/db.py", line 102, in execute
+    return self._run(stmt)
+DatabaseError: connection timeout
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/app/api.py", line 30, in handle
+    db.query(q)
+  File "/app/api.py", line 55, in respond
+    return handle(req)
+  File "/app/main.py", line 10, in run
+    respond(request)
+ServiceError: failed to process request
+INFO: recovered

--- a/crates/rskim/tests/fixtures/cmd/log/stack_trace_python_pep657.txt
+++ b/crates/rskim/tests/fixtures/cmd/log/stack_trace_python_pep657.txt
@@ -1,0 +1,12 @@
+ERROR: Type error in calculation
+Traceback (most recent call last):
+  File "/app/calc.py", line 87, in compute
+    result = value + offset
+             ~~~~~~^~~~~~~~
+  File "/app/calc.py", line 45, in run
+    return compute(data)
+           ^^^^^^^^^^^^^
+  File "/app/main.py", line 12, in main
+    run(config)
+TypeError: unsupported operand type(s) for +: 'str' and 'int'
+INFO: retrying with defaults


### PR DESCRIPTION
## Summary

The log parser's Python traceback handling only recognised `File "..."` lines, missing the interleaved source-code preview lines that real CPython tracebacks include. This broke multi-frame elision (source lines were counted as extra frames) and wasted 3–4× tokens for AI agents reading Python exception output.

## Changes

**Parser (`crates/rskim/src/cmd/log.rs`)**
- Added `is_python_continuation()` — pure predicate that detects source-preview and PEP 657 caret lines; runs before `classify_log_line` to prevent source lines containing log keywords (e.g. `"ERROR: bad input"`) from being misclassified
- `VecDeque<String>` replaces `Vec<String>` for `pending_stack` — O(1) `pop_front` instead of `O(n)` `remove(0)` for cap eviction
- `in_python_frame: bool` flag — set on each `File "..."` match, cleared on any non-continuation line
- Traceback header (`Traceback (most recent call last)`) attached to the preceding log entry (or created as unstructured if no entry exists yet)
- Chained exception separators (`The above exception was the direct cause…`, `During handling of the above exception…`) flush the pending stack and push as unstructured entries
- `found_structured = true` now set inside the `RE_LOG_STACK_TRACE` branch so standalone tracebacks (no log-level prefix) are parsed as structured output

**Fixtures**
- `stack_trace_python.txt` — updated to CPython 3.11+ format with source-preview lines per frame
- `stack_trace_python_chained.txt` — new fixture: chained exception with two `Traceback` blocks separated by `The above exception was the direct cause…`
- `stack_trace_python_pep657.txt` — new fixture: PEP 657 fine-grained error location with caret lines

**Tests — 14 new tests**
- Group A: source-preview attachment, logical frame count not inflated by preview lines
- Group B: chained exception — Traceback headers attached, correct elision count, INFO not contaminated
- Group C: PEP 657 caret lines attached, not counted as frames
- Group D: regression guards — no extra entries from preview lines, `found_structured` gate, misclassification guard, cap behaviour with preview lines, Traceback-only header
- Group F: rendered output coherent (ValueError, elision marker), chained output complete

## Breaking Changes

None — existing Java/Node.js stack trace behaviour unchanged. All 3680 rskim tests pass.

## Reviewer Focus Areas

- State machine control flow in `try_parse_regex_logs` — verify branch ordering (Step 2 RE_LOG_STACK_TRACE → Step 3 continuation → Step 4 strip_timestamp → Step 5 Traceback header → Step 6 separator → Step 7 reset → Step 8 flush+classify)
- `is_python_continuation()` predicate — verify it catches source-preview, PEP 657 carets, and `[Previous line repeated]`-style lines without false positives on non-Python indented content
- Chained exception separator detection — verify explicit flush trigger and that the separator line is pushed as unstructured (no level)
- Fixture content — verify realistic CPython 3.11+ format