### PR TITLE
refactor(#164): split HeatmapConfig into HeatmapArgs + HeatmapConfig

### DIFF
--- a/crates/rskim/src/cmd/heatmap/args.rs
+++ b/crates/rskim/src/cmd/heatmap/args.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides [`parse_args`] (table-driven flag dispatch) and [`print_help`].
 
-use super::types::HeatmapConfig;
+use super::types::HeatmapArgs;
 use std::time::UNIX_EPOCH;
 
 // ============================================================================
@@ -71,10 +71,10 @@ const VALUE_FLAG_TABLE: &[ValueFlagSpec] = &[
     },
 ];
 
-/// Apply a value-taking flag to `config`. Each arm preserves exact validation
+/// Apply a value-taking flag to `args`. Each arm preserves exact validation
 /// logic and error messages from the original flag-by-flag implementation.
 fn apply_value_flag(
-    config: &mut HeatmapConfig,
+    config: &mut HeatmapArgs,
     action: &ValueFlagAction,
     val: String,
 ) -> anyhow::Result<()> {
@@ -146,16 +146,16 @@ fn apply_value_flag(
 // Public API
 // ============================================================================
 
-/// Parse CLI args into `HeatmapConfig`.
+/// Parse CLI args into `HeatmapArgs`.
 ///
 /// Follows the manual flag-parsing pattern used by `stats.rs` and `discover.rs`.
-/// Initialises `config.debug` from the process-wide debug flag so that
+/// Initialises `args.debug` from the process-wide debug flag so that
 /// `SKIM_DEBUG=1` (initialised by `main()` before dispatch) is honoured automatically.
-pub(super) fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
-    let mut config = HeatmapConfig {
+pub(super) fn parse_args(args: &[String]) -> anyhow::Result<HeatmapArgs> {
+    let mut config = HeatmapArgs {
         // Inherit SKIM_DEBUG / --debug flag set by main() before subcommand dispatch.
         debug: crate::debug::is_debug_enabled(),
-        ..HeatmapConfig::default()
+        ..HeatmapArgs::default()
     };
     let mut i = 0;
 
@@ -211,11 +211,11 @@ pub(super) fn parse_args(args: &[String]) -> anyhow::Result<HeatmapConfig> {
     Ok(config)
 }
 
-/// Apply a recognised boolean flag to `config`.
+/// Apply a recognised boolean flag to `args`.
 ///
 /// Returns `Ok(true)` if the flag was recognised and applied, `Ok(false)` if
 /// the flag is unknown (caller falls through to the unknown-flag error).
-fn apply_boolean_flag(config: &mut HeatmapConfig, flag: &str) -> anyhow::Result<bool> {
+fn apply_boolean_flag(config: &mut HeatmapArgs, flag: &str) -> anyhow::Result<bool> {
     match flag {
         "--json" => config.format_json = true,
         "--no-exclude" => config.no_exclude = true,
@@ -355,80 +355,80 @@ mod tests {
 
     #[test]
     fn test_parse_args_defaults() {
-        let config = parse_args(&[]).unwrap();
-        assert_eq!(config.top_n, 20);
-        assert!((config.coupling_threshold - 0.5).abs() < 1e-9);
-        assert_eq!(config.fix_window, 5);
-        assert!(!config.format_json);
-        assert!(!config.no_exclude);
+        let args = parse_args(&[]).unwrap();
+        assert_eq!(args.top_n, 20);
+        assert!((args.coupling_threshold - 0.5).abs() < 1e-9);
+        assert_eq!(args.fix_window, 5);
+        assert!(!args.format_json);
+        assert!(!args.no_exclude);
     }
 
     #[test]
     fn test_parse_args_json_flag() {
-        let config = parse_args(&["--json".to_string()]).unwrap();
-        assert!(config.format_json);
+        let args = parse_args(&["--json".to_string()]).unwrap();
+        assert!(args.format_json);
     }
 
     #[test]
     fn test_parse_args_top_n() {
-        let config = parse_args(&["--top".to_string(), "5".to_string()]).unwrap();
-        assert_eq!(config.top_n, 5);
+        let args = parse_args(&["--top".to_string(), "5".to_string()]).unwrap();
+        assert_eq!(args.top_n, 5);
     }
 
     #[test]
     fn test_parse_args_top_n_equals() {
-        let config = parse_args(&["--top=10".to_string()]).unwrap();
-        assert_eq!(config.top_n, 10);
+        let args = parse_args(&["--top=10".to_string()]).unwrap();
+        assert_eq!(args.top_n, 10);
     }
 
     #[test]
     fn test_parse_args_window_preset() {
-        let config = parse_args(&["--window=sprint".to_string()]).unwrap();
-        assert_eq!(config.window_preset.as_deref(), Some("sprint"));
+        let args = parse_args(&["--window=sprint".to_string()]).unwrap();
+        assert_eq!(args.window_preset.as_deref(), Some("sprint"));
     }
 
     #[test]
     fn test_parse_args_last_n() {
-        let config = parse_args(&["--last=100".to_string()]).unwrap();
-        assert_eq!(config.last_n, Some(100));
+        let args = parse_args(&["--last=100".to_string()]).unwrap();
+        assert_eq!(args.last_n, Some(100));
     }
 
     #[test]
     fn test_parse_args_no_exclude() {
-        let config = parse_args(&["--no-exclude".to_string()]).unwrap();
-        assert!(config.no_exclude);
+        let args = parse_args(&["--no-exclude".to_string()]).unwrap();
+        assert!(args.no_exclude);
     }
 
     #[test]
     fn test_parse_args_coupling_threshold() {
-        let config = parse_args(&["--coupling-threshold=0.3".to_string()]).unwrap();
-        assert!((config.coupling_threshold - 0.3).abs() < 1e-9);
+        let args = parse_args(&["--coupling-threshold=0.3".to_string()]).unwrap();
+        assert!((args.coupling_threshold - 0.3).abs() < 1e-9);
     }
 
     #[test]
     fn test_parse_args_since_epoch() {
-        let config = parse_args(&["--since=1700000000".to_string()]).unwrap();
-        assert_eq!(config.since, Some(1_700_000_000));
+        let args = parse_args(&["--since=1700000000".to_string()]).unwrap();
+        assert_eq!(args.since, Some(1_700_000_000));
     }
 
     #[test]
     fn test_parse_args_since_duration() {
-        let config = parse_args(&["--since=30d".to_string()]).unwrap();
+        let args = parse_args(&["--since=30d".to_string()]).unwrap();
         // Should be set to some epoch in the past
-        assert!(config.since.is_some());
+        assert!(args.since.is_some());
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
-        let since = config.since.unwrap();
+        let since = args.since.unwrap();
         let diff = now - since;
         assert!((29 * 86400..=31 * 86400).contains(&diff));
     }
 
     #[test]
     fn test_parse_args_path() {
-        let config = parse_args(&["--path=src/".to_string()]).unwrap();
-        assert_eq!(config.path.as_deref(), Some("src/"));
+        let args = parse_args(&["--path=src/".to_string()]).unwrap();
+        assert_eq!(args.path.as_deref(), Some("src/"));
     }
 
     #[test]
@@ -474,20 +474,20 @@ mod tests {
 
     #[test]
     fn test_parse_args_positional_files() {
-        let config = parse_args(&["src/main.rs".to_string(), "src/lib.rs".to_string()]).unwrap();
-        assert_eq!(config.files, vec!["src/main.rs", "src/lib.rs"]);
+        let args = parse_args(&["src/main.rs".to_string(), "src/lib.rs".to_string()]).unwrap();
+        assert_eq!(args.files, vec!["src/main.rs", "src/lib.rs"]);
     }
 
     #[test]
     fn test_parse_args_diff_flag() {
-        let config = parse_args(&["--diff".to_string(), "main".to_string()]).unwrap();
-        assert_eq!(config.diff_base, Some("main".to_string()));
+        let args = parse_args(&["--diff".to_string(), "main".to_string()]).unwrap();
+        assert_eq!(args.diff_base, Some("main".to_string()));
     }
 
     #[test]
     fn test_parse_args_diff_equals() {
-        let config = parse_args(&["--diff=develop".to_string()]).unwrap();
-        assert_eq!(config.diff_base, Some("develop".to_string()));
+        let args = parse_args(&["--diff=develop".to_string()]).unwrap();
+        assert_eq!(args.diff_base, Some("develop".to_string()));
     }
 
     #[test]
@@ -504,20 +504,20 @@ mod tests {
 
     #[test]
     fn test_parse_args_file_path_normalization() {
-        let config = parse_args(&["./src/main.rs".to_string()]).unwrap();
-        assert_eq!(config.files, vec!["src/main.rs"]);
+        let args = parse_args(&["./src/main.rs".to_string()]).unwrap();
+        assert_eq!(args.files, vec!["src/main.rs"]);
     }
 
     #[test]
     fn test_parse_args_top_explicit_flag() {
-        let config = parse_args(&["--top".to_string(), "5".to_string()]).unwrap();
-        assert!(config.top_explicit);
+        let args = parse_args(&["--top".to_string(), "5".to_string()]).unwrap();
+        assert!(args.top_explicit);
     }
 
     #[test]
     fn test_parse_args_top_implicit_by_default() {
-        let config = parse_args(&[]).unwrap();
-        assert!(!config.top_explicit);
+        let args = parse_args(&[]).unwrap();
+        assert!(!args.top_explicit);
     }
 
     #[test]
@@ -530,28 +530,28 @@ mod tests {
 
     #[test]
     fn test_parse_args_files_with_other_flags() {
-        let config = parse_args(&[
+        let args = parse_args(&[
             "--since".to_string(),
             "30d".to_string(),
             "src/main.rs".to_string(),
             "--json".to_string(),
         ])
         .unwrap();
-        assert_eq!(config.files, vec!["src/main.rs"]);
-        assert!(config.format_json);
-        assert!(config.since.is_some());
+        assert_eq!(args.files, vec!["src/main.rs"]);
+        assert!(args.format_json);
+        assert!(args.since.is_some());
     }
 
     #[test]
     fn test_parse_args_extra_exclude() {
-        let config = parse_args(&["--exclude=*.generated.ts".to_string()]).unwrap();
-        assert_eq!(config.extra_excludes, vec!["*.generated.ts"]);
+        let args = parse_args(&["--exclude=*.generated.ts".to_string()]).unwrap();
+        assert_eq!(args.extra_excludes, vec!["*.generated.ts"]);
     }
 
     #[test]
     fn test_parse_args_fix_window() {
-        let config = parse_args(&["--fix-window=10".to_string()]).unwrap();
-        assert_eq!(config.fix_window, 10);
+        let args = parse_args(&["--fix-window=10".to_string()]).unwrap();
+        assert_eq!(args.fix_window, 10);
     }
 
     // -----------------------------------------------------------------------
@@ -560,23 +560,20 @@ mod tests {
 
     #[test]
     fn test_parse_args_insights_flag() {
-        let config = parse_args(&["--insights".to_string()]).unwrap();
-        assert!(
-            config.insights,
-            "--insights should set config.insights=true"
-        );
+        let args = parse_args(&["--insights".to_string()]).unwrap();
+        assert!(args.insights, "--insights should set args.insights=true");
     }
 
     #[test]
     fn test_parse_args_insights_with_json() {
-        let config = parse_args(&["--insights".to_string(), "--json".to_string()]).unwrap();
-        assert!(config.insights, "--insights should be set");
-        assert!(config.format_json, "--json should be set");
+        let args = parse_args(&["--insights".to_string(), "--json".to_string()]).unwrap();
+        assert!(args.insights, "--insights should be set");
+        assert!(args.format_json, "--json should be set");
     }
 
     #[test]
     fn test_parse_args_insights_default_false() {
-        let config = parse_args(&[]).unwrap();
-        assert!(!config.insights, "insights should default to false");
+        let args = parse_args(&[]).unwrap();
+        assert!(!args.insights, "insights should default to false");
     }
 }

--- a/crates/rskim/src/cmd/heatmap/args.rs
+++ b/crates/rskim/src/cmd/heatmap/args.rs
@@ -74,17 +74,17 @@ const VALUE_FLAG_TABLE: &[ValueFlagSpec] = &[
 /// Apply a value-taking flag to `args`. Each arm preserves exact validation
 /// logic and error messages from the original flag-by-flag implementation.
 fn apply_value_flag(
-    config: &mut HeatmapArgs,
+    args: &mut HeatmapArgs,
     action: &ValueFlagAction,
     val: String,
 ) -> anyhow::Result<()> {
     match action {
         ValueFlagAction::Since => {
             let ts = parse_since_value(&val)?;
-            config.since = Some(ts);
+            args.since = Some(ts);
         }
         ValueFlagAction::Path => {
-            config.path = Some(val);
+            args.path = Some(val);
         }
         ValueFlagAction::TopN => {
             let n: usize = val
@@ -93,11 +93,11 @@ fn apply_value_flag(
             if n == 0 {
                 anyhow::bail!("--top must be at least 1");
             }
-            config.top_n = n;
-            config.top_explicit = true;
+            args.top_n = n;
+            args.top_explicit = true;
         }
         ValueFlagAction::Window => {
-            config.window_preset = Some(val);
+            args.window_preset = Some(val);
         }
         ValueFlagAction::LastN => {
             let n: usize = val
@@ -106,13 +106,13 @@ fn apply_value_flag(
             if n == 0 {
                 anyhow::bail!("--last must be at least 1");
             }
-            config.last_n = Some(n);
+            args.last_n = Some(n);
         }
         ValueFlagAction::Exclude => {
-            config.extra_excludes.push(val);
+            args.extra_excludes.push(val);
         }
         ValueFlagAction::CouplingThreshold => {
-            config.coupling_threshold = val
+            args.coupling_threshold = val
                 .parse::<f64>()
                 .map_err(|_| {
                     anyhow::anyhow!("--coupling-threshold requires a float between 0 and 1")
@@ -126,17 +126,17 @@ fn apply_value_flag(
             if n == 0 {
                 anyhow::bail!("--fix-window must be at least 1");
             }
-            config.fix_window = n;
+            args.fix_window = n;
         }
         ValueFlagAction::Format => {
             if val == "json" {
-                config.format_json = true;
+                args.format_json = true;
             } else {
                 anyhow::bail!("--format only supports 'json', got: {val}");
             }
         }
         ValueFlagAction::Diff => {
-            config.diff_base = Some(val);
+            args.diff_base = Some(val);
         }
     }
     Ok(())
@@ -151,29 +151,29 @@ fn apply_value_flag(
 /// Follows the manual flag-parsing pattern used by `stats.rs` and `discover.rs`.
 /// Initialises `args.debug` from the process-wide debug flag so that
 /// `SKIM_DEBUG=1` (initialised by `main()` before dispatch) is honoured automatically.
-pub(super) fn parse_args(args: &[String]) -> anyhow::Result<HeatmapArgs> {
-    let mut config = HeatmapArgs {
+pub(super) fn parse_args(raw: &[String]) -> anyhow::Result<HeatmapArgs> {
+    let mut args = HeatmapArgs {
         // Inherit SKIM_DEBUG / --debug flag set by main() before subcommand dispatch.
         debug: crate::debug::is_debug_enabled(),
         ..HeatmapArgs::default()
     };
     let mut i = 0;
 
-    while i < args.len() {
-        let arg = args[i].as_str();
+    while i < raw.len() {
+        let arg = raw[i].as_str();
 
         // Missing value pre-check: if this arg is a value-taking flag but there's
         // no next argument, bail with an actionable error before falling through to
         // "unknown flag".
-        if VALUE_FLAG_TABLE.iter().any(|s| s.name == arg) && i + 1 >= args.len() {
+        if VALUE_FLAG_TABLE.iter().any(|s| s.name == arg) && i + 1 >= raw.len() {
             anyhow::bail!("{arg} requires a value");
         }
 
         // Table-driven value flag dispatch
         let mut matched = false;
         for spec in VALUE_FLAG_TABLE {
-            if let Some(val) = extract_value(args, &mut i, spec.name) {
-                apply_value_flag(&mut config, &spec.action, val)?;
+            if let Some(val) = extract_value(raw, &mut i, spec.name) {
+                apply_value_flag(&mut args, &spec.action, val)?;
                 matched = true;
                 break;
             }
@@ -183,7 +183,7 @@ pub(super) fn parse_args(args: &[String]) -> anyhow::Result<HeatmapArgs> {
         }
 
         // Boolean flags
-        if apply_boolean_flag(&mut config, arg)? {
+        if apply_boolean_flag(&mut args, arg)? {
             i += 1;
             continue;
         }
@@ -192,36 +192,36 @@ pub(super) fn parse_args(args: &[String]) -> anyhow::Result<HeatmapArgs> {
             anyhow::bail!("unknown flag: {arg}");
         }
         // Positional (non-flag) argument — file target.
-        config.files.push(arg.to_string());
+        args.files.push(arg.to_string());
         i += 1;
     }
 
     // Post-parse validation
-    if config.diff_base.is_some() && !config.files.is_empty() {
+    if args.diff_base.is_some() && !args.files.is_empty() {
         anyhow::bail!("cannot combine --diff with explicit file arguments");
     }
 
     // Normalize file paths: strip leading ./
-    for f in &mut config.files {
+    for f in &mut args.files {
         if let Some(stripped) = f.strip_prefix("./") {
             *f = stripped.to_string();
         }
     }
 
-    Ok(config)
+    Ok(args)
 }
 
 /// Apply a recognised boolean flag to `args`.
 ///
 /// Returns `Ok(true)` if the flag was recognised and applied, `Ok(false)` if
 /// the flag is unknown (caller falls through to the unknown-flag error).
-fn apply_boolean_flag(config: &mut HeatmapArgs, flag: &str) -> anyhow::Result<bool> {
+fn apply_boolean_flag(args: &mut HeatmapArgs, flag: &str) -> anyhow::Result<bool> {
     match flag {
-        "--json" => config.format_json = true,
-        "--no-exclude" => config.no_exclude = true,
-        "--insights" => config.insights = true,
+        "--json" => args.format_json = true,
+        "--no-exclude" => args.no_exclude = true,
+        "--insights" => args.insights = true,
         "--debug" => {
-            config.debug = true;
+            args.debug = true;
             crate::debug::force_enable_debug();
         }
         _ => return Ok(false),

--- a/crates/rskim/src/cmd/heatmap/args.rs
+++ b/crates/rskim/src/cmd/heatmap/args.rs
@@ -9,7 +9,7 @@ use std::time::UNIX_EPOCH;
 // Table-driven value flag dispatch
 // ============================================================================
 
-/// Identifies which config field a value-taking flag maps to.
+/// Identifies which args field a value-taking flag maps to.
 enum ValueFlagAction {
     Since,
     Path,

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -190,7 +190,7 @@ fn prepare_commits(
             "time"
         };
         eprintln!("[skim:heatmap] window mode: {mode}");
-        if let Some(since) = window.since {
+        if let Some(since) = config.since {
             eprintln!(
                 "[skim:heatmap] since epoch: {since} ({})",
                 format_epoch(since)
@@ -497,7 +497,7 @@ fn compute_heatmap(
     file_metrics.sort_by_key(|f| f.stability_score);
 
     // Step 7: Build window info
-    let window_info = build_window_info(window, commits.len(), now_epoch);
+    let window_info = build_window_info(window, config.since, commits.len(), now_epoch);
 
     // Step 8: Get excluded patterns for output
     let excluded_patterns: Vec<String> = if config.no_exclude {

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -32,8 +32,8 @@ use metrics::{
     compute_fix_after_touch, compute_stability,
 };
 use output::{render_insights_json, render_insights_text, render_json, render_text};
-use types::{CommitInfo, FileMetrics, HeatmapConfig, HeatmapResult, ResolvedWindow};
-use window::{build_window_info, format_epoch, resolve_effective_config};
+use types::{CommitInfo, FileMetrics, HeatmapArgs, HeatmapConfig, HeatmapResult, ResolvedWindow};
+use window::{build_window_info, format_epoch, resolve_config};
 
 // ============================================================================
 // Entry point
@@ -49,8 +49,8 @@ pub(crate) fn run(
         return Ok(ExitCode::SUCCESS);
     }
 
-    let mut config = match parse_args(args) {
-        Ok(c) => c,
+    let mut raw_args = match parse_args(args) {
+        Ok(a) => a,
         Err(e) => {
             eprintln!("skim heatmap: {e}");
             eprintln!("Run `skim heatmap --help` for usage.");
@@ -60,15 +60,16 @@ pub(crate) fn run(
 
     let git_source = CliGitSource::new();
 
-    // Resolve --diff to concrete file list
-    if let Some(exit) = resolve_diff_files(&git_source, &mut config)? {
+    // Resolve --diff to concrete file list (borrows raw_args mutably)
+    if let Some(exit) = resolve_diff_files(&git_source, &mut raw_args)? {
         return Ok(exit);
     }
 
-    run_with_source(&git_source, &config, analytics)
+    // Move raw_args into run_with_source for resolution and execution
+    run_with_source(&git_source, raw_args, analytics)
 }
 
-/// Resolve `--diff` to a concrete file list, mutating `config.files`.
+/// Resolve `--diff` to a concrete file list, mutating `args.files`.
 ///
 /// Returns `Some(ExitCode::FAILURE)` for any early-exit condition so that `run()`
 /// can propagate it directly. Returns `Ok(None)` when resolution succeeded and the
@@ -81,9 +82,9 @@ pub(crate) fn run(
 /// with a clear message, and `prepare_commits` already handles the non-repo case.
 fn resolve_diff_files(
     git_source: &CliGitSource,
-    config: &mut HeatmapConfig,
+    args: &mut HeatmapArgs,
 ) -> anyhow::Result<Option<ExitCode>> {
-    let Some(base) = config.diff_base.take() else {
+    let Some(base) = args.diff_base.take() else {
         return Ok(None);
     };
 
@@ -105,7 +106,7 @@ fn resolve_diff_files(
                     );
                 }
             }
-            config.files = files;
+            args.files = files;
             Ok(None)
         }
         Err(e) => {
@@ -118,6 +119,8 @@ fn resolve_diff_files(
 /// Bundled output of [`prepare_commits`] — everything needed to call [`compute_heatmap`].
 struct PreparedCommits {
     commits: Vec<CommitInfo>,
+    /// Resolved, immutable configuration produced by [`resolve_config`].
+    config: HeatmapConfig,
     window: ResolvedWindow,
     now_epoch: u64,
     repo_root: String,
@@ -126,13 +129,16 @@ struct PreparedCommits {
 
 /// Execute Steps 1–4 of the heatmap pipeline (git I/O + exclusions).
 ///
+/// Consumes `args` by value — after this call `HeatmapArgs` is replaced by the
+/// resolved `HeatmapConfig` stored in `PreparedCommits`.
+///
 /// Returns `Ok(None)` for all early-exit conditions (not a git repo, no commits,
 /// all commits excluded). Callers treat `None` as a `ExitCode::FAILURE` signal.
 /// Returns `Ok(Some(PreparedCommits))` when the pipeline should proceed to
 /// metric computation.
 fn prepare_commits(
     source: &dyn GitDataSource,
-    config: &HeatmapConfig,
+    args: HeatmapArgs,
 ) -> anyhow::Result<Option<PreparedCommits>> {
     // Step 1: Validate git environment
     if !source.is_git_repo() {
@@ -157,26 +163,30 @@ fn prepare_commits(
         );
     }
 
-    if config.debug {
+    // Extract debug flag before moving args into resolve_config
+    let debug = args.debug;
+    // Extract last_n before moving args — needed for pre-resolution debug label
+    let had_last_n = args.last_n.is_some();
+
+    if debug {
         eprintln!("[skim:heatmap] repo root: {repo_root}");
     }
 
     // Capture a single clock snapshot for all window-resolution helpers so that
-    // preset_to_since_secs, resolve_effective_config, and build_window_info all
-    // use the same value (Issue 1: temporal consistency).
+    // preset_to_since_secs, resolve_config, and build_window_info all use the
+    // same value (temporal consistency).
     let now_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
 
-    // Step 2: Resolve effective config (presets and --last)
-    let (effective_config, window) =
-        resolve_effective_config(config, source, &mut warnings, now_epoch)?;
+    // Step 2: Resolve effective config (presets and --last). Consumes `args`.
+    let (config, window) = resolve_config(args, source, &mut warnings, now_epoch)?;
 
-    if config.debug {
+    if debug {
         let mode = if window.dual_mode {
             "dual"
-        } else if config.last_n.is_some() {
+        } else if had_last_n {
             "count"
         } else {
             "time"
@@ -191,7 +201,7 @@ fn prepare_commits(
     }
 
     // Step 3: Fetch commits
-    let raw_commits = match source.fetch_commits(&effective_config) {
+    let raw_commits = match source.fetch_commits(&config) {
         Ok(c) => c,
         Err(e) => {
             let msg = e.to_string();
@@ -204,7 +214,7 @@ fn prepare_commits(
         }
     };
 
-    if config.debug {
+    if debug {
         eprintln!("[skim:heatmap] raw commits fetched: {}", raw_commits.len());
     }
 
@@ -225,7 +235,7 @@ fn prepare_commits(
     // Remove commits that are now file-less after exclusion
     commits.retain(|c| !c.changed_files.is_empty());
 
-    if config.debug {
+    if debug {
         eprintln!(
             "[skim:heatmap] commits after exclusion: {} ({} excluded)",
             commits.len(),
@@ -240,6 +250,7 @@ fn prepare_commits(
 
     Ok(Some(PreparedCommits {
         commits,
+        config,
         window,
         now_epoch,
         repo_root,
@@ -249,27 +260,32 @@ fn prepare_commits(
 
 /// Orchestration with injected data source (enables testing).
 ///
+/// Takes `HeatmapArgs` by value — ownership moves into [`prepare_commits`] which
+/// consumes it via [`resolve_config`], producing the resolved `HeatmapConfig`
+/// stored in `PreparedCommits`.
+///
 /// All git I/O is routed through `source` — infra checks (repo detection, root,
 /// shallow clone, commit count) and the commit fetch all use the same trait object.
 fn run_with_source(
     source: &dyn GitDataSource,
-    config: &HeatmapConfig,
+    args: HeatmapArgs,
     analytics: &crate::analytics::AnalyticsConfig,
 ) -> anyhow::Result<ExitCode> {
     let PreparedCommits {
         commits,
+        config,
         window,
         now_epoch,
         repo_root,
         warnings,
-    } = match prepare_commits(source, config)? {
+    } = match prepare_commits(source, args)? {
         Some(p) => p,
         None => return Ok(ExitCode::FAILURE),
     };
 
     // Steps 5-9: Compute metrics and assemble result
     let start_time = std::time::Instant::now();
-    let mut result = compute_heatmap(commits, config, &window, now_epoch, repo_root, warnings);
+    let mut result = compute_heatmap(commits, &config, &window, now_epoch, repo_root, warnings);
 
     // Apply file-targeting display filter (after full metric computation)
     if !config.files.is_empty() {

--- a/crates/rskim/src/cmd/heatmap/mod.rs
+++ b/crates/rskim/src/cmd/heatmap/mod.rs
@@ -165,8 +165,6 @@ fn prepare_commits(
 
     // Extract debug flag before moving args into resolve_config
     let debug = args.debug;
-    // Extract last_n before moving args — needed for pre-resolution debug label
-    let had_last_n = args.last_n.is_some();
 
     if debug {
         eprintln!("[skim:heatmap] repo root: {repo_root}");
@@ -186,7 +184,7 @@ fn prepare_commits(
     if debug {
         let mode = if window.dual_mode {
             "dual"
-        } else if had_last_n {
+        } else if window.last_n.is_some() {
             "count"
         } else {
             "time"

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -150,11 +150,14 @@ pub(crate) struct HeatmapConfig {
 /// Separates derived window state from raw CLI input (`HeatmapArgs`), so
 /// `HeatmapArgs` remains a pure user-input struct and window metadata is
 /// never confused with CLI flags.
+///
+/// The effective `since` epoch is NOT stored here — it lives exclusively in
+/// [`HeatmapConfig::since`]. This eliminates the previously-redundant
+/// `ResolvedWindow::since` field whose invariant ("always identical to
+/// `HeatmapConfig::since`") could not be enforced by the type system. Callers
+/// that need the epoch for display pass it explicitly via [`super::window::build_window_info`].
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedWindow {
-    /// The effective `--since` epoch. Always identical to `HeatmapConfig::since`
-    /// by construction in `resolve_config` — both are set from the same resolved value.
-    pub(crate) since: Option<u64>,
     /// True when using dual default windowing (no explicit flag was set).
     pub(crate) dual_mode: bool,
     /// Epoch of the 90-day time window (populated in dual mode only).

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -1,5 +1,26 @@
 //! Data structures for the `skim heatmap` subcommand.
 //!
+//! # Lifecycle
+//!
+//! ```text
+//! CLI args  ──parse_args()──►  HeatmapArgs
+//!                                  │
+//!                      resolve_diff_files() mutates diff_base/files
+//!                                  │
+//!                         resolve_config()  (consumes HeatmapArgs)
+//!                                  │
+//!                     HeatmapConfig (resolved, immutable)
+//! ```
+//!
+//! `HeatmapArgs` is the raw parse output and is mutable until resolution.
+//! `HeatmapConfig` is the resolved, immutable form passed to all downstream
+//! functions. Three fields from `HeatmapArgs` are consumed during resolution
+//! and do NOT appear in `HeatmapConfig`:
+//!
+//! - `window_preset` — moved into [`ResolvedWindow`]
+//! - `last_n` — copied into [`ResolvedWindow`]
+//! - `diff_base` — consumed by `resolve_diff_files` via `.take()`
+//!
 //! No logic, no I/O. Pure data model.
 
 use serde::Serialize;
@@ -12,13 +33,19 @@ pub(crate) use rskim_search::{CommitInfo, FileChangeInfo};
 // CLI configuration
 // ============================================================================
 
-/// Parsed CLI flags for `skim heatmap`.
+/// Raw CLI parse output for `skim heatmap`.
 ///
-/// Contains raw user input only. Window resolution metadata (dual mode, since
-/// epochs) is separated into [`ResolvedWindow`] to avoid polluting this struct
-/// with derived state.
+/// Populated by [`super::args::parse_args`] from the raw `&[String]` argv slice.
+/// Fields map 1:1 to CLI flags — no resolution, no defaulting beyond what the
+/// flag itself implies (e.g. `top_n` defaults to 20, `coupling_threshold` to 0.5).
+///
+/// After `parse_args` returns:
+/// 1. [`super::mod::resolve_diff_files`] borrows `&mut HeatmapArgs` to fill
+///    `files` from a three-dot diff when `diff_base` is set.
+/// 2. [`super::window::resolve_config`] consumes this struct by value, applies
+///    presets and dual-window logic, and produces the immutable [`HeatmapConfig`].
 #[derive(Debug, Clone)]
-pub(crate) struct HeatmapConfig {
+pub(crate) struct HeatmapArgs {
     /// Epoch seconds — only analyze commits since this timestamp.
     pub(crate) since: Option<u64>,
     /// Scope analysis to files under this path.
@@ -38,12 +65,18 @@ pub(crate) struct HeatmapConfig {
     /// Enable debug output.
     pub(crate) debug: bool,
     /// Named window preset (e.g., "sprint", "quarter").
+    ///
+    /// Consumed by `resolve_config` — moved into [`ResolvedWindow`].
     pub(crate) window_preset: Option<String>,
     /// Limit analysis to last N commits.
+    ///
+    /// Consumed by `resolve_config` — copied into [`ResolvedWindow`].
     pub(crate) last_n: Option<usize>,
     /// Explicit file targets — scope display to these paths.
     pub(crate) files: Vec<String>,
     /// Base branch/ref for `--diff` three-dot diff.
+    ///
+    /// Consumed by `resolve_diff_files` via `.take()`.
     pub(crate) diff_base: Option<String>,
     /// True when `--top` was explicitly passed (vs. implied by file targeting).
     pub(crate) top_explicit: bool,
@@ -51,7 +84,7 @@ pub(crate) struct HeatmapConfig {
     pub(crate) insights: bool,
 }
 
-impl Default for HeatmapConfig {
+impl Default for HeatmapArgs {
     fn default() -> Self {
         Self {
             since: None,
@@ -73,10 +106,49 @@ impl Default for HeatmapConfig {
     }
 }
 
-/// Resolved window metadata produced by [`super::resolve_effective_config`].
+/// Resolved, immutable configuration for the `skim heatmap` pipeline.
 ///
-/// Separates derived window state from raw CLI input (`HeatmapConfig`), so
-/// `HeatmapConfig` remains a pure user-input struct and window metadata is
+/// Produced by [`super::window::resolve_config`] from [`HeatmapArgs`]. The three
+/// fields that are "consumed" during resolution (`window_preset`, `last_n`,
+/// `diff_base`) are intentionally absent here — they live in [`ResolvedWindow`]
+/// or are handled before resolution completes.
+///
+/// This type does not implement `Clone` or `Default` to enforce the invariant
+/// that it can only be constructed through `resolve_config` (the type-state
+/// transition), not by arbitrary callers.
+#[derive(Debug)]
+pub(crate) struct HeatmapConfig {
+    /// Resolved epoch seconds — only analyze commits since this timestamp.
+    /// Set by preset, `--last`, `--since`, or dual-default resolution.
+    pub(crate) since: Option<u64>,
+    /// Scope analysis to files under this path (passed through from args).
+    pub(crate) path: Option<String>,
+    /// Emit JSON output instead of text.
+    pub(crate) format_json: bool,
+    /// Maximum number of files to display (default 20).
+    pub(crate) top_n: usize,
+    /// Skip default exclude patterns.
+    pub(crate) no_exclude: bool,
+    /// Additional glob patterns to exclude.
+    pub(crate) extra_excludes: Vec<String>,
+    /// Coupling confidence threshold (default 0.5).
+    pub(crate) coupling_threshold: f64,
+    /// Fix-after-touch proximity window in commits (default 5).
+    pub(crate) fix_window: usize,
+    /// Enable debug output.
+    pub(crate) debug: bool,
+    /// Explicit file targets — scope display to these paths.
+    pub(crate) files: Vec<String>,
+    /// True when `--top` was explicitly passed (vs. implied by file targeting).
+    pub(crate) top_explicit: bool,
+    /// Show only threshold-filtered one-liner insights.
+    pub(crate) insights: bool,
+}
+
+/// Resolved window metadata produced by [`super::window::resolve_config`].
+///
+/// Separates derived window state from raw CLI input (`HeatmapArgs`), so
+/// `HeatmapArgs` remains a pure user-input struct and window metadata is
 /// never confused with CLI flags.
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedWindow {

--- a/crates/rskim/src/cmd/heatmap/types.rs
+++ b/crates/rskim/src/cmd/heatmap/types.rs
@@ -40,11 +40,11 @@ pub(crate) use rskim_search::{CommitInfo, FileChangeInfo};
 /// flag itself implies (e.g. `top_n` defaults to 20, `coupling_threshold` to 0.5).
 ///
 /// After `parse_args` returns:
-/// 1. [`super::mod::resolve_diff_files`] borrows `&mut HeatmapArgs` to fill
-///    `files` from a three-dot diff when `diff_base` is set.
+/// 1. `resolve_diff_files` borrows `&mut HeatmapArgs` to fill `files` from a
+///    three-dot diff when `diff_base` is set.
 /// 2. [`super::window::resolve_config`] consumes this struct by value, applies
 ///    presets and dual-window logic, and produces the immutable [`HeatmapConfig`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct HeatmapArgs {
     /// Epoch seconds — only analyze commits since this timestamp.
     pub(crate) since: Option<u64>,
@@ -152,8 +152,8 @@ pub(crate) struct HeatmapConfig {
 /// never confused with CLI flags.
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedWindow {
-    /// The effective `--since` epoch (may differ from `HeatmapConfig::since`
-    /// after preset/dual resolution).
+    /// The effective `--since` epoch. Always identical to `HeatmapConfig::since`
+    /// by construction in `resolve_config` — both are set from the same resolved value.
     pub(crate) since: Option<u64>,
     /// True when using dual default windowing (no explicit flag was set).
     pub(crate) dual_mode: bool,

--- a/crates/rskim/src/cmd/heatmap/window.rs
+++ b/crates/rskim/src/cmd/heatmap/window.rs
@@ -61,9 +61,6 @@ pub(super) fn resolve_config(
         last_n: args.last_n,
     };
 
-    // Resolved `since` epoch — set by whichever branch wins precedence.
-    let mut resolved_since: Option<u64> = None;
-
     // Count explicit time-selection flags
     let explicit_count = usize::from(args.since.is_some())
         + usize::from(window.last_n.is_some())
@@ -78,13 +75,11 @@ pub(super) fn resolve_config(
 
     if let Some(since) = args.since {
         // Already set — highest precedence
-        resolved_since = Some(since);
         window.since = Some(since);
     } else if let Some(n) = window.last_n {
         // --last N: find the timestamp of the Nth commit
         match source.fetch_commit_count_since(n) {
             Ok(Some(ts)) => {
-                resolved_since = Some(ts);
                 window.since = Some(ts);
             }
             Ok(None) => {
@@ -98,7 +93,6 @@ pub(super) fn resolve_config(
         }
     } else if let Some(ref preset) = window.window_preset {
         if let Some(since) = preset_to_since_secs(preset, now_epoch) {
-            resolved_since = Some(since);
             window.since = Some(since);
         } else {
             warnings.push(format!(
@@ -116,7 +110,6 @@ pub(super) fn resolve_config(
 
         // Use whichever captures more history (lower epoch = more history)
         let dual_resolved = time_since.min(count_since);
-        resolved_since = Some(dual_resolved);
         window.since = Some(dual_resolved);
         window.dual_mode = true;
         window.dual_time_since = Some(time_since);
@@ -127,7 +120,7 @@ pub(super) fn resolve_config(
     // (heap allocations) or copied (scalars). `window_preset`, `last_n`, and
     // `diff_base` are intentionally absent — they were consumed above.
     let config = HeatmapConfig {
-        since: resolved_since,
+        since: window.since,
         path: args.path,
         format_json: args.format_json,
         top_n: args.top_n,
@@ -421,12 +414,43 @@ mod tests {
         }
     }
 
+    /// Mock that always returns `Err` from `fetch_commit_count_since`, exercising
+    /// the graceful-degradation path in the `--last N` branch of `resolve_config`.
+    struct MockGitSourceErr;
+
+    impl super::super::git_source::GitDataSource for MockGitSourceErr {
+        fn is_git_repo(&self) -> bool {
+            true
+        }
+        fn get_repo_root(&self) -> anyhow::Result<String> {
+            Ok("/mock/repo".to_string())
+        }
+        fn detect_shallow_clone(&self) -> bool {
+            false
+        }
+        fn fetch_commit_count_since(&self, _n: usize) -> anyhow::Result<Option<u64>> {
+            Err(anyhow::anyhow!("simulated git error"))
+        }
+        fn fetch_commits(
+            &self,
+            _config: &super::super::types::HeatmapConfig,
+        ) -> anyhow::Result<Vec<super::super::types::CommitInfo>> {
+            Ok(vec![])
+        }
+    }
+
     fn base_args() -> super::super::types::HeatmapArgs {
         super::super::types::HeatmapArgs::default()
     }
 
     /// `window_preset` and `last_n` must appear in `ResolvedWindow`, not in
     /// `HeatmapConfig`. `HeatmapConfig` has neither field.
+    ///
+    /// Note: this test intentionally covers two independent fields in one pass
+    /// (`window_preset` move and `last_n` copy) because both are consumed at the
+    /// same point in `resolve_config`. A failure here implicates the
+    /// `ResolvedWindow` construction block, not a single field. If one of them
+    /// fails in isolation, add a targeted test for that field specifically.
     #[test]
     fn test_resolve_config_consumed_fields_go_to_window() {
         let source = MockGitSource {
@@ -439,10 +463,46 @@ mod tests {
 
         let (_config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
 
-        // `window_preset` moved into ResolvedWindow
+        // `window_preset` moved into ResolvedWindow (independent of last_n)
         assert_eq!(window.window_preset.as_deref(), Some("sprint"));
-        // `last_n` copied into ResolvedWindow
+        // `last_n` copied into ResolvedWindow (independent of window_preset)
         assert_eq!(window.last_n, Some(50));
+    }
+
+    /// When `fetch_commit_count_since` returns `Err` during `--last N` resolution,
+    /// `resolve_config` must degrade gracefully: `since` stays `None` (all history)
+    /// and a warning is emitted. The function must not return `Err` itself.
+    #[test]
+    fn test_resolve_config_last_n_git_error_degrades_to_all_history() {
+        let source = MockGitSourceErr;
+        let mut args = base_args();
+        args.last_n = Some(50);
+        let mut warnings = Vec::new();
+
+        let (config, window) =
+            resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        // Graceful degradation: since is None (analyze all history)
+        assert!(
+            config.since.is_none(),
+            "expected since=None (all history) on git error, got {:?}",
+            config.since
+        );
+        assert!(
+            window.since.is_none(),
+            "expected window.since=None on git error, got {:?}",
+            window.since
+        );
+        // Warning must be emitted so the user knows why the fallback occurred
+        assert!(
+            !warnings.is_empty(),
+            "expected at least one warning on git error"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("Could not resolve --last")),
+            "warning must mention 'Could not resolve --last', got: {:?}",
+            warnings
+        );
     }
 
     /// Passthrough scalar and heap fields carry over unchanged from args to config.

--- a/crates/rskim/src/cmd/heatmap/window.rs
+++ b/crates/rskim/src/cmd/heatmap/window.rs
@@ -75,25 +75,21 @@ pub(super) fn resolve_config(
     // Resolve the effective `since` epoch. The result is stored only in
     // `HeatmapConfig::since` — `ResolvedWindow` no longer carries a redundant
     // copy, eliminating a previously-unenforceable "always identical" invariant.
+    //
+    // The dual-default branch sets window.dual_* as side effects, so `since`
+    // must be `mut` here rather than a pure expression.
     let mut since: Option<u64> = None;
 
     if let Some(s) = args.since {
-        // Already set — highest precedence
         since = Some(s);
     } else if let Some(n) = window.last_n {
         // --last N: find the timestamp of the Nth commit
         match source.fetch_commit_count_since(n) {
-            Ok(Some(ts)) => {
-                since = Some(ts);
-            }
-            Ok(None) => {
-                warnings.push(format!(
-                    "Repository has fewer than {n} commits — analyzing all history."
-                ));
-            }
-            Err(e) => {
-                warnings.push(format!("Could not resolve --last {n}: {e}"));
-            }
+            Ok(Some(ts)) => since = Some(ts),
+            Ok(None) => warnings.push(format!(
+                "Repository has fewer than {n} commits — analyzing all history."
+            )),
+            Err(e) => warnings.push(format!("Could not resolve --last {n}: {e}")),
         }
     } else if let Some(ref preset) = window.window_preset {
         if let Some(s) = preset_to_since_secs(preset, now_epoch) {
@@ -106,15 +102,12 @@ pub(super) fn resolve_config(
     } else {
         // Dual default: max(last 90 days, last 200 commits)
         let time_since = now_epoch.saturating_sub(90 * 86400);
-
         let count_since = match source.fetch_commit_count_since(200) {
             Ok(Some(ts)) => ts,
             _ => time_since, // fallback to time-based if lookup fails
         };
-
-        // Use whichever captures more history (lower epoch = more history)
-        let dual_resolved = time_since.min(count_since);
-        since = Some(dual_resolved);
+        // Lower epoch = more history; pick whichever window captures more.
+        since = Some(time_since.min(count_since));
         window.dual_mode = true;
         window.dual_time_since = Some(time_since);
         window.dual_count_since = Some(count_since);
@@ -168,9 +161,7 @@ pub(super) fn build_window_info(
         "dual".to_string()
     };
 
-    let since_str = since
-        .map(format_epoch)
-        .unwrap_or_else(|| "all".to_string());
+    let since_str = since.map(format_epoch).unwrap_or_else(|| "all".to_string());
 
     let effective_strategy = if window.dual_mode {
         let time_since = window.dual_time_since.unwrap_or(0);
@@ -394,8 +385,29 @@ mod tests {
 
     /// Minimal mock GitDataSource for unit-testing `resolve_config` without
     /// spawning a real git process.
+    ///
+    /// Set `commit_count_since` to control the `Ok(Some(ts))` / `Ok(None)` path.
+    /// Set `error_mode = true` to simulate a git error (`Err`) from
+    /// `fetch_commit_count_since`, exercising the graceful-degradation path.
     struct MockGitSource {
         commit_count_since: Option<u64>,
+        error_mode: bool,
+    }
+
+    impl MockGitSource {
+        fn ok(commit_count_since: Option<u64>) -> Self {
+            Self {
+                commit_count_since,
+                error_mode: false,
+            }
+        }
+
+        fn err() -> Self {
+            Self {
+                commit_count_since: None,
+                error_mode: true,
+            }
+        }
     }
 
     impl GitDataSource for MockGitSource {
@@ -409,29 +421,11 @@ mod tests {
             false
         }
         fn fetch_commit_count_since(&self, _n: usize) -> anyhow::Result<Option<u64>> {
-            Ok(self.commit_count_since)
-        }
-        fn fetch_commits(&self, _config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>> {
-            Ok(vec![])
-        }
-    }
-
-    /// Mock that always returns `Err` from `fetch_commit_count_since`, exercising
-    /// the graceful-degradation path in the `--last N` branch of `resolve_config`.
-    struct MockGitSourceErr;
-
-    impl GitDataSource for MockGitSourceErr {
-        fn is_git_repo(&self) -> bool {
-            true
-        }
-        fn get_repo_root(&self) -> anyhow::Result<String> {
-            Ok("/mock/repo".to_string())
-        }
-        fn detect_shallow_clone(&self) -> bool {
-            false
-        }
-        fn fetch_commit_count_since(&self, _n: usize) -> anyhow::Result<Option<u64>> {
-            Err(anyhow::anyhow!("simulated git error"))
+            if self.error_mode {
+                Err(anyhow::anyhow!("simulated git error"))
+            } else {
+                Ok(self.commit_count_since)
+            }
         }
         fn fetch_commits(&self, _config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>> {
             Ok(vec![])
@@ -452,9 +446,7 @@ mod tests {
     /// fails in isolation, add a targeted test for that field specifically.
     #[test]
     fn test_resolve_config_consumed_fields_go_to_window() {
-        let source = MockGitSource {
-            commit_count_since: Some(1_700_000_000),
-        };
+        let source = MockGitSource::ok(Some(1_700_000_000));
         let mut args = base_args();
         args.window_preset = Some("sprint".to_string());
         args.last_n = Some(50);
@@ -487,7 +479,7 @@ mod tests {
     /// and a warning is emitted. The function must not return `Err` itself.
     #[test]
     fn test_resolve_config_last_n_git_error_degrades_to_all_history() {
-        let source = MockGitSourceErr;
+        let source = MockGitSource::err();
         let mut args = base_args();
         args.last_n = Some(50);
         let mut warnings = Vec::new();
@@ -517,9 +509,7 @@ mod tests {
     /// Passthrough scalar and heap fields carry over unchanged from args to config.
     #[test]
     fn test_resolve_config_passthrough_fields() {
-        let source = MockGitSource {
-            commit_count_since: None,
-        };
+        let source = MockGitSource::ok(None);
         let mut args = base_args();
         args.top_n = 42;
         args.format_json = true;
@@ -552,9 +542,7 @@ mod tests {
     /// When `--since` is set, it wins regardless of preset/last_n.
     #[test]
     fn test_resolve_config_since_takes_precedence() {
-        let source = MockGitSource {
-            commit_count_since: Some(999_999),
-        };
+        let source = MockGitSource::ok(Some(999_999));
         let mut args = base_args();
         args.since = Some(1_700_000_000);
         args.window_preset = Some("sprint".to_string());
@@ -571,9 +559,7 @@ mod tests {
     /// When no window flags are set, dual-mode default is applied.
     #[test]
     fn test_resolve_config_dual_default() {
-        let source = MockGitSource {
-            commit_count_since: Some(1_680_000_000),
-        };
+        let source = MockGitSource::ok(Some(1_680_000_000));
         let args = base_args();
         let mut warnings = Vec::new();
 
@@ -590,9 +576,7 @@ mod tests {
     /// `None` (analyze all history). The function must not return `Err`.
     #[test]
     fn test_resolve_config_last_n_ok_none_degrades_to_all_history() {
-        let source = MockGitSource {
-            commit_count_since: None, // Ok(None): fewer commits than requested
-        };
+        let source = MockGitSource::ok(None); // Ok(None): fewer commits than requested
         let mut args = base_args();
         args.last_n = Some(50);
         let mut warnings = Vec::new();
@@ -620,9 +604,7 @@ mod tests {
     /// NOW = 1_704_067_200 (2024-01-01). "sprint" = NOW − 14 × 86400 = 1_702_857_600.
     #[test]
     fn test_resolve_config_known_preset_resolves_epoch() {
-        let source = MockGitSource {
-            commit_count_since: None, // Not called in the preset branch
-        };
+        let source = MockGitSource::ok(None); // fetch_commit_count_since not called in preset branch
         let mut args = base_args();
         args.window_preset = Some("sprint".to_string());
         let mut warnings = Vec::new();
@@ -652,9 +634,7 @@ mod tests {
     /// and a warning is emitted naming the unrecognised preset.
     #[test]
     fn test_resolve_config_unknown_preset_emits_warning() {
-        let source = MockGitSource {
-            commit_count_since: None,
-        };
+        let source = MockGitSource::ok(None);
         let mut args = base_args();
         args.window_preset = Some("biweekly".to_string());
         let mut warnings = Vec::new();

--- a/crates/rskim/src/cmd/heatmap/window.rs
+++ b/crates/rskim/src/cmd/heatmap/window.rs
@@ -53,7 +53,6 @@ pub(super) fn resolve_config(
     // Move window_preset and last_n into ResolvedWindow first so we can read
     // them from `window.*` rather than from `args` after partial move.
     let mut window = ResolvedWindow {
-        since: None,
         dual_mode: false,
         dual_time_since: None,
         dual_count_since: None,
@@ -73,14 +72,19 @@ pub(super) fn resolve_config(
         );
     }
 
-    if let Some(since) = args.since {
+    // Resolve the effective `since` epoch. The result is stored only in
+    // `HeatmapConfig::since` — `ResolvedWindow` no longer carries a redundant
+    // copy, eliminating a previously-unenforceable "always identical" invariant.
+    let mut since: Option<u64> = None;
+
+    if let Some(s) = args.since {
         // Already set — highest precedence
-        window.since = Some(since);
+        since = Some(s);
     } else if let Some(n) = window.last_n {
         // --last N: find the timestamp of the Nth commit
         match source.fetch_commit_count_since(n) {
             Ok(Some(ts)) => {
-                window.since = Some(ts);
+                since = Some(ts);
             }
             Ok(None) => {
                 warnings.push(format!(
@@ -92,8 +96,8 @@ pub(super) fn resolve_config(
             }
         }
     } else if let Some(ref preset) = window.window_preset {
-        if let Some(since) = preset_to_since_secs(preset, now_epoch) {
-            window.since = Some(since);
+        if let Some(s) = preset_to_since_secs(preset, now_epoch) {
+            since = Some(s);
         } else {
             warnings.push(format!(
                 "Unknown window preset '{preset}' — valid: sprint, month, quarter, half, year, all. Analyzing all history."
@@ -110,7 +114,7 @@ pub(super) fn resolve_config(
 
         // Use whichever captures more history (lower epoch = more history)
         let dual_resolved = time_since.min(count_since);
-        window.since = Some(dual_resolved);
+        since = Some(dual_resolved);
         window.dual_mode = true;
         window.dual_time_since = Some(time_since);
         window.dual_count_since = Some(count_since);
@@ -120,7 +124,7 @@ pub(super) fn resolve_config(
     // (heap allocations) or copied (scalars). `window_preset`, `last_n`, and
     // `diff_base` are intentionally absent — they were consumed above.
     let config = HeatmapConfig {
-        since: window.since,
+        since,
         path: args.path,
         format_json: args.format_json,
         top_n: args.top_n,
@@ -142,8 +146,13 @@ pub(super) fn resolve_config(
 // ============================================================================
 
 /// Convert a [`ResolvedWindow`] + runtime context into a [`WindowInfo`] for output.
+///
+/// `since` is passed explicitly rather than read from `window` — `ResolvedWindow`
+/// no longer carries a `since` field (it was always identical to `HeatmapConfig::since`,
+/// which the type system could not enforce). Callers pass `config.since` here.
 pub(super) fn build_window_info(
     window: &ResolvedWindow,
+    since: Option<u64>,
     commits_analyzed: usize,
     now_epoch: u64,
 ) -> WindowInfo {
@@ -153,14 +162,13 @@ pub(super) fn build_window_info(
         preset.clone()
     } else if window.last_n.is_some() {
         "count".to_string()
-    } else if window.since.is_some() {
+    } else if since.is_some() {
         "time".to_string()
     } else {
         "dual".to_string()
     };
 
-    let since_str = window
-        .since
+    let since_str = since
         .map(format_epoch)
         .unwrap_or_else(|| "all".to_string());
 
@@ -228,7 +236,6 @@ mod tests {
 
     fn base_window() -> ResolvedWindow {
         ResolvedWindow {
-            since: None,
             dual_mode: false,
             dual_time_since: None,
             dual_count_since: None,
@@ -291,7 +298,7 @@ mod tests {
             ..base_window()
         };
 
-        let info = build_window_info(&window, 42, NOW);
+        let info = build_window_info(&window, None, 42, NOW);
 
         assert_eq!(info.mode, "dual");
         assert_eq!(info.commits_analyzed, 42);
@@ -308,7 +315,7 @@ mod tests {
             ..base_window()
         };
 
-        let info = build_window_info(&window, 10, NOW);
+        let info = build_window_info(&window, None, 10, NOW);
 
         assert_eq!(info.mode, "dual");
         assert_eq!(info.effective_strategy.as_deref(), Some("count"));
@@ -321,7 +328,7 @@ mod tests {
             ..base_window()
         };
 
-        let info = build_window_info(&window, 50, NOW);
+        let info = build_window_info(&window, None, 50, NOW);
 
         assert_eq!(info.mode, "quarter");
         assert!(info.effective_strategy.is_none());
@@ -334,7 +341,7 @@ mod tests {
             ..base_window()
         };
 
-        let info = build_window_info(&window, 200, NOW);
+        let info = build_window_info(&window, None, 200, NOW);
 
         assert_eq!(info.mode, "count");
         assert!(info.effective_strategy.is_none());
@@ -342,12 +349,9 @@ mod tests {
 
     #[test]
     fn test_build_window_info_time_mode() {
-        let window = ResolvedWindow {
-            since: Some(1_700_000_000),
-            ..base_window()
-        };
+        let window = base_window();
 
-        let info = build_window_info(&window, 77, NOW);
+        let info = build_window_info(&window, Some(1_700_000_000), 77, NOW);
 
         assert_eq!(info.mode, "time");
         assert_eq!(info.since, "2023-11-14"); // epoch 1_700_000_000
@@ -360,7 +364,7 @@ mod tests {
         // dual_mode=false, so effective_strategy is None (only set in the dual_mode branch).
         let window = base_window();
 
-        let info = build_window_info(&window, 0, NOW);
+        let info = build_window_info(&window, None, 0, NOW);
 
         assert_eq!(info.mode, "dual");
         assert!(info.effective_strategy.is_none());
@@ -370,7 +374,7 @@ mod tests {
     fn test_build_window_info_no_since_shows_all() {
         let window = base_window();
 
-        let info = build_window_info(&window, 0, NOW);
+        let info = build_window_info(&window, None, 0, NOW);
 
         assert_eq!(info.since, "all");
     }
@@ -379,7 +383,7 @@ mod tests {
     fn test_build_window_info_commits_analyzed_passthrough() {
         let window = base_window();
 
-        let info = build_window_info(&window, 999, NOW);
+        let info = build_window_info(&window, None, 999, NOW);
 
         assert_eq!(info.commits_analyzed, 999);
     }
@@ -456,12 +460,26 @@ mod tests {
         args.last_n = Some(50);
         let mut warnings = Vec::new();
 
-        let (_config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
 
         // `window_preset` moved into ResolvedWindow (independent of last_n)
         assert_eq!(window.window_preset.as_deref(), Some("sprint"));
         // `last_n` copied into ResolvedWindow (independent of window_preset)
         assert_eq!(window.last_n, Some(50));
+        // With both --last and --window set, --last wins (--since > --last > --window).
+        // The mock returns Some(1_700_000_000) for fetch_commit_count_since, so since
+        // resolves from the --last branch.
+        assert_eq!(
+            config.since,
+            Some(1_700_000_000),
+            "expected config.since from --last branch, got {:?}",
+            config.since
+        );
+        // Both --last and --window set → multiple-flag warning emitted
+        assert!(
+            !warnings.is_empty(),
+            "expected multiple-flag warning, got none"
+        );
     }
 
     /// When `fetch_commit_count_since` returns `Err` during `--last N` resolution,
@@ -474,18 +492,13 @@ mod tests {
         args.last_n = Some(50);
         let mut warnings = Vec::new();
 
-        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+        let (config, _window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
 
         // Graceful degradation: since is None (analyze all history)
         assert!(
             config.since.is_none(),
             "expected since=None (all history) on git error, got {:?}",
             config.since
-        );
-        assert!(
-            window.since.is_none(),
-            "expected window.since=None on git error, got {:?}",
-            window.since
         );
         // Warning must be emitted so the user knows why the fallback occurred
         assert!(
@@ -548,10 +561,9 @@ mod tests {
         args.last_n = Some(100);
         let mut warnings = Vec::new();
 
-        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+        let (config, _window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
 
         assert_eq!(config.since, Some(1_700_000_000));
-        assert_eq!(window.since, Some(1_700_000_000));
         // Multiple flags → warning emitted
         assert!(!warnings.is_empty());
     }
@@ -571,5 +583,97 @@ mod tests {
         assert!(window.dual_mode);
         assert!(window.dual_time_since.is_some());
         assert!(window.dual_count_since.is_some());
+    }
+
+    /// When `fetch_commit_count_since` returns `Ok(None)` (repo has fewer than N
+    /// commits), `resolve_config` must emit a warning and leave `config.since` as
+    /// `None` (analyze all history). The function must not return `Err`.
+    #[test]
+    fn test_resolve_config_last_n_ok_none_degrades_to_all_history() {
+        let source = MockGitSource {
+            commit_count_since: None, // Ok(None): fewer commits than requested
+        };
+        let mut args = base_args();
+        args.last_n = Some(50);
+        let mut warnings = Vec::new();
+
+        let (config, _window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        assert!(
+            config.since.is_none(),
+            "expected since=None (all history) when repo has fewer than 50 commits, got {:?}",
+            config.since
+        );
+        assert!(
+            !warnings.is_empty(),
+            "expected a warning about fewer commits, got none"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("fewer than 50 commits")),
+            "warning must mention 'fewer than 50 commits', got: {:?}",
+            warnings
+        );
+    }
+
+    /// When a known preset is supplied, `config.since` is set to the expected epoch.
+    ///
+    /// NOW = 1_704_067_200 (2024-01-01). "sprint" = NOW − 14 × 86400 = 1_702_857_600.
+    #[test]
+    fn test_resolve_config_known_preset_resolves_epoch() {
+        let source = MockGitSource {
+            commit_count_since: None, // Not called in the preset branch
+        };
+        let mut args = base_args();
+        args.window_preset = Some("sprint".to_string());
+        let mut warnings = Vec::new();
+
+        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        let expected_since = NOW - 14 * 86400; // 1_702_857_600
+        assert_eq!(
+            config.since,
+            Some(expected_since),
+            "expected config.since={expected_since} for 'sprint' preset, got {:?}",
+            config.since
+        );
+        assert_eq!(
+            window.window_preset.as_deref(),
+            Some("sprint"),
+            "preset must be preserved in ResolvedWindow for display logic"
+        );
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings for a known preset, got: {:?}",
+            warnings
+        );
+    }
+
+    /// When an unknown preset is supplied, `config.since` stays `None` (all history)
+    /// and a warning is emitted naming the unrecognised preset.
+    #[test]
+    fn test_resolve_config_unknown_preset_emits_warning() {
+        let source = MockGitSource {
+            commit_count_since: None,
+        };
+        let mut args = base_args();
+        args.window_preset = Some("biweekly".to_string());
+        let mut warnings = Vec::new();
+
+        let (config, _window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        assert!(
+            config.since.is_none(),
+            "expected since=None for unknown preset, got {:?}",
+            config.since
+        );
+        assert!(
+            !warnings.is_empty(),
+            "expected a warning about the unknown preset, got none"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("Unknown window preset")),
+            "warning must contain 'Unknown window preset', got: {:?}",
+            warnings
+        );
     }
 }

--- a/crates/rskim/src/cmd/heatmap/window.rs
+++ b/crates/rskim/src/cmd/heatmap/window.rs
@@ -223,6 +223,7 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use super::super::types::CommitInfo;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn base_window() -> ResolvedWindow {
@@ -393,7 +394,7 @@ mod tests {
         commit_count_since: Option<u64>,
     }
 
-    impl super::super::git_source::GitDataSource for MockGitSource {
+    impl GitDataSource for MockGitSource {
         fn is_git_repo(&self) -> bool {
             true
         }
@@ -406,10 +407,7 @@ mod tests {
         fn fetch_commit_count_since(&self, _n: usize) -> anyhow::Result<Option<u64>> {
             Ok(self.commit_count_since)
         }
-        fn fetch_commits(
-            &self,
-            _config: &super::super::types::HeatmapConfig,
-        ) -> anyhow::Result<Vec<super::super::types::CommitInfo>> {
+        fn fetch_commits(&self, _config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>> {
             Ok(vec![])
         }
     }
@@ -418,7 +416,7 @@ mod tests {
     /// the graceful-degradation path in the `--last N` branch of `resolve_config`.
     struct MockGitSourceErr;
 
-    impl super::super::git_source::GitDataSource for MockGitSourceErr {
+    impl GitDataSource for MockGitSourceErr {
         fn is_git_repo(&self) -> bool {
             true
         }
@@ -431,16 +429,13 @@ mod tests {
         fn fetch_commit_count_since(&self, _n: usize) -> anyhow::Result<Option<u64>> {
             Err(anyhow::anyhow!("simulated git error"))
         }
-        fn fetch_commits(
-            &self,
-            _config: &super::super::types::HeatmapConfig,
-        ) -> anyhow::Result<Vec<super::super::types::CommitInfo>> {
+        fn fetch_commits(&self, _config: &HeatmapConfig) -> anyhow::Result<Vec<CommitInfo>> {
             Ok(vec![])
         }
     }
 
-    fn base_args() -> super::super::types::HeatmapArgs {
-        super::super::types::HeatmapArgs::default()
+    fn base_args() -> HeatmapArgs {
+        HeatmapArgs::default()
     }
 
     /// `window_preset` and `last_n` must appear in `ResolvedWindow`, not in

--- a/crates/rskim/src/cmd/heatmap/window.rs
+++ b/crates/rskim/src/cmd/heatmap/window.rs
@@ -222,8 +222,8 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::*;
     use super::super::types::CommitInfo;
+    use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn base_window() -> ResolvedWindow {
@@ -474,8 +474,7 @@ mod tests {
         args.last_n = Some(50);
         let mut warnings = Vec::new();
 
-        let (config, window) =
-            resolve_config(args, &source, &mut warnings, NOW).unwrap();
+        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
 
         // Graceful degradation: since is None (analyze all history)
         assert!(
@@ -494,7 +493,9 @@ mod tests {
             "expected at least one warning on git error"
         );
         assert!(
-            warnings.iter().any(|w| w.contains("Could not resolve --last")),
+            warnings
+                .iter()
+                .any(|w| w.contains("Could not resolve --last")),
             "warning must mention 'Could not resolve --last', got: {:?}",
             warnings
         );

--- a/crates/rskim/src/cmd/heatmap/window.rs
+++ b/crates/rskim/src/cmd/heatmap/window.rs
@@ -4,7 +4,7 @@
 //! `--since` / `--last` / `--window` precedence, and display formatting.
 
 use super::git_source::GitDataSource;
-use super::types::{HeatmapConfig, ResolvedWindow, WindowInfo};
+use super::types::{HeatmapArgs, HeatmapConfig, ResolvedWindow, WindowInfo};
 
 // ============================================================================
 // Preset mapping
@@ -27,33 +27,47 @@ fn preset_to_since_secs(preset: &str, now_epoch: u64) -> Option<u64> {
 // Config resolution
 // ============================================================================
 
-/// Resolve the effective `HeatmapConfig` by applying presets and `--last`.
+/// Consume [`HeatmapArgs`] and produce a resolved, immutable [`HeatmapConfig`].
+///
+/// This is the type-state transition point: `HeatmapArgs` is mutable raw CLI
+/// parse output; `HeatmapConfig` is the resolved, immutable form that all
+/// downstream functions operate on.
 ///
 /// Precedence: `--since` > `--last` > `--window` preset > dual default.
+///
+/// Three fields from `HeatmapArgs` are consumed here and do NOT appear in
+/// `HeatmapConfig`:
+/// - `window_preset` — moved into the returned [`ResolvedWindow`]
+/// - `last_n` — copied into the returned [`ResolvedWindow`]
+/// - `diff_base` — already consumed by `resolve_diff_files` before this call
 ///
 /// Returns a tuple of:
 /// - `HeatmapConfig` with `since` set to the resolved epoch (used by `fetch_commits`)
 /// - `ResolvedWindow` carrying window metadata (mode, dual fields) for `build_window_info`
-pub(super) fn resolve_effective_config(
-    config: &HeatmapConfig,
+pub(super) fn resolve_config(
+    args: HeatmapArgs,
     source: &dyn GitDataSource,
     warnings: &mut Vec<String>,
     now_epoch: u64,
 ) -> anyhow::Result<(HeatmapConfig, ResolvedWindow)> {
-    let mut effective = config.clone();
+    // Move window_preset and last_n into ResolvedWindow first so we can read
+    // them from `window.*` rather than from `args` after partial move.
     let mut window = ResolvedWindow {
         since: None,
         dual_mode: false,
         dual_time_since: None,
         dual_count_since: None,
-        window_preset: config.window_preset.clone(),
-        last_n: config.last_n,
+        window_preset: args.window_preset,
+        last_n: args.last_n,
     };
 
+    // Resolved `since` epoch — set by whichever branch wins precedence.
+    let mut resolved_since: Option<u64> = None;
+
     // Count explicit time-selection flags
-    let explicit_count = usize::from(config.since.is_some())
-        + usize::from(config.last_n.is_some())
-        + usize::from(config.window_preset.is_some());
+    let explicit_count = usize::from(args.since.is_some())
+        + usize::from(window.last_n.is_some())
+        + usize::from(window.window_preset.is_some());
 
     if explicit_count > 1 {
         warnings.push(
@@ -62,15 +76,15 @@ pub(super) fn resolve_effective_config(
         );
     }
 
-    if let Some(since) = config.since {
+    if let Some(since) = args.since {
         // Already set — highest precedence
-        effective.since = Some(since);
+        resolved_since = Some(since);
         window.since = Some(since);
-    } else if let Some(n) = config.last_n {
+    } else if let Some(n) = window.last_n {
         // --last N: find the timestamp of the Nth commit
         match source.fetch_commit_count_since(n) {
             Ok(Some(ts)) => {
-                effective.since = Some(ts);
+                resolved_since = Some(ts);
                 window.since = Some(ts);
             }
             Ok(None) => {
@@ -82,9 +96,9 @@ pub(super) fn resolve_effective_config(
                 warnings.push(format!("Could not resolve --last {n}: {e}"));
             }
         }
-    } else if let Some(ref preset) = config.window_preset {
+    } else if let Some(ref preset) = window.window_preset {
         if let Some(since) = preset_to_since_secs(preset, now_epoch) {
-            effective.since = Some(since);
+            resolved_since = Some(since);
             window.since = Some(since);
         } else {
             warnings.push(format!(
@@ -101,15 +115,33 @@ pub(super) fn resolve_effective_config(
         };
 
         // Use whichever captures more history (lower epoch = more history)
-        let resolved_since = time_since.min(count_since);
-        effective.since = Some(resolved_since);
-        window.since = Some(resolved_since);
+        let dual_resolved = time_since.min(count_since);
+        resolved_since = Some(dual_resolved);
+        window.since = Some(dual_resolved);
         window.dual_mode = true;
         window.dual_time_since = Some(time_since);
         window.dual_count_since = Some(count_since);
     }
 
-    Ok((effective, window))
+    // Build the resolved, immutable HeatmapConfig. Fields are moved from args
+    // (heap allocations) or copied (scalars). `window_preset`, `last_n`, and
+    // `diff_base` are intentionally absent — they were consumed above.
+    let config = HeatmapConfig {
+        since: resolved_since,
+        path: args.path,
+        format_json: args.format_json,
+        top_n: args.top_n,
+        no_exclude: args.no_exclude,
+        extra_excludes: args.extra_excludes,
+        coupling_threshold: args.coupling_threshold,
+        fix_window: args.fix_window,
+        debug: args.debug,
+        files: args.files,
+        top_explicit: args.top_explicit,
+        insights: args.insights,
+    };
+
+    Ok((config, window))
 }
 
 // ============================================================================
@@ -356,5 +388,132 @@ mod tests {
         let info = build_window_info(&window, 999, NOW);
 
         assert_eq!(info.commits_analyzed, 999);
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_config — type-state transition tests
+    // -----------------------------------------------------------------------
+
+    /// Minimal mock GitDataSource for unit-testing `resolve_config` without
+    /// spawning a real git process.
+    struct MockGitSource {
+        commit_count_since: Option<u64>,
+    }
+
+    impl super::super::git_source::GitDataSource for MockGitSource {
+        fn is_git_repo(&self) -> bool {
+            true
+        }
+        fn get_repo_root(&self) -> anyhow::Result<String> {
+            Ok("/mock/repo".to_string())
+        }
+        fn detect_shallow_clone(&self) -> bool {
+            false
+        }
+        fn fetch_commit_count_since(&self, _n: usize) -> anyhow::Result<Option<u64>> {
+            Ok(self.commit_count_since)
+        }
+        fn fetch_commits(
+            &self,
+            _config: &super::super::types::HeatmapConfig,
+        ) -> anyhow::Result<Vec<super::super::types::CommitInfo>> {
+            Ok(vec![])
+        }
+    }
+
+    fn base_args() -> super::super::types::HeatmapArgs {
+        super::super::types::HeatmapArgs::default()
+    }
+
+    /// `window_preset` and `last_n` must appear in `ResolvedWindow`, not in
+    /// `HeatmapConfig`. `HeatmapConfig` has neither field.
+    #[test]
+    fn test_resolve_config_consumed_fields_go_to_window() {
+        let source = MockGitSource {
+            commit_count_since: Some(1_700_000_000),
+        };
+        let mut args = base_args();
+        args.window_preset = Some("sprint".to_string());
+        args.last_n = Some(50);
+        let mut warnings = Vec::new();
+
+        let (_config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        // `window_preset` moved into ResolvedWindow
+        assert_eq!(window.window_preset.as_deref(), Some("sprint"));
+        // `last_n` copied into ResolvedWindow
+        assert_eq!(window.last_n, Some(50));
+    }
+
+    /// Passthrough scalar and heap fields carry over unchanged from args to config.
+    #[test]
+    fn test_resolve_config_passthrough_fields() {
+        let source = MockGitSource {
+            commit_count_since: None,
+        };
+        let mut args = base_args();
+        args.top_n = 42;
+        args.format_json = true;
+        args.no_exclude = true;
+        args.coupling_threshold = 0.7;
+        args.fix_window = 10;
+        args.debug = true;
+        args.top_explicit = true;
+        args.insights = true;
+        args.path = Some("src/".to_string());
+        args.extra_excludes = vec!["*.generated.ts".to_string()];
+        args.files = vec!["src/main.rs".to_string()];
+        let mut warnings = Vec::new();
+
+        let (config, _window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        assert_eq!(config.top_n, 42);
+        assert!(config.format_json);
+        assert!(config.no_exclude);
+        assert!((config.coupling_threshold - 0.7).abs() < 1e-9);
+        assert_eq!(config.fix_window, 10);
+        assert!(config.debug);
+        assert!(config.top_explicit);
+        assert!(config.insights);
+        assert_eq!(config.path.as_deref(), Some("src/"));
+        assert_eq!(config.extra_excludes, vec!["*.generated.ts"]);
+        assert_eq!(config.files, vec!["src/main.rs"]);
+    }
+
+    /// When `--since` is set, it wins regardless of preset/last_n.
+    #[test]
+    fn test_resolve_config_since_takes_precedence() {
+        let source = MockGitSource {
+            commit_count_since: Some(999_999),
+        };
+        let mut args = base_args();
+        args.since = Some(1_700_000_000);
+        args.window_preset = Some("sprint".to_string());
+        args.last_n = Some(100);
+        let mut warnings = Vec::new();
+
+        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        assert_eq!(config.since, Some(1_700_000_000));
+        assert_eq!(window.since, Some(1_700_000_000));
+        // Multiple flags → warning emitted
+        assert!(!warnings.is_empty());
+    }
+
+    /// When no window flags are set, dual-mode default is applied.
+    #[test]
+    fn test_resolve_config_dual_default() {
+        let source = MockGitSource {
+            commit_count_since: Some(1_680_000_000),
+        };
+        let args = base_args();
+        let mut warnings = Vec::new();
+
+        let (config, window) = resolve_config(args, &source, &mut warnings, NOW).unwrap();
+
+        assert!(config.since.is_some());
+        assert!(window.dual_mode);
+        assert!(window.dual_time_since.is_some());
+        assert!(window.dual_count_since.is_some());
     }
 }


### PR DESCRIPTION
## Summary

- Introduces a type-state split for the heatmap pipeline: `HeatmapArgs` (raw CLI parse output, mutable) and `HeatmapConfig` (resolved, immutable, no `Clone`/`Default`).
- The three fields consumed during resolution (`window_preset`, `last_n`, `diff_base`) are absent from `HeatmapConfig` — the compiler enforces this at the type level.
- `resolve_effective_config` renamed to `resolve_config`, now takes `HeatmapArgs` by value, making post-move access a compile error rather than a runtime risk.

## Changes

**`types.rs`**
- Renamed `HeatmapConfig` → `HeatmapArgs` (raw, mutable, cloneable)
- Added new `HeatmapConfig` struct (12 fields, resolved, `#[derive(Debug)]` only)
- Added module-level lifecycle doc comment explaining the two-phase design

**`args.rs`**
- Updated `parse_args` return type and internal type references to `HeatmapArgs`
- Renamed test locals `config` → `args` for clarity

**`window.rs`**
- Renamed `resolve_effective_config` → `resolve_config`
- Signature change: takes `HeatmapArgs` by value (move), builds `HeatmapConfig` field-by-field at the end
- `window_preset` moved into `ResolvedWindow` before args is consumed; reads from `window.window_preset` thereafter
- Eliminates the `let mut effective = config.clone()` pattern entirely
- Added 4 unit tests with inline `MockGitSource` covering the type-state transition

**`mod.rs`**
- `PreparedCommits` gains `config: HeatmapConfig` field
- `resolve_diff_files` takes `&mut HeatmapArgs`
- `run_with_source` takes `HeatmapArgs` by value
- `prepare_commits` takes `HeatmapArgs` by value, extracts `debug`/`had_last_n` before the move for pre-resolution logging
- Post-resolution debug reads from `config.debug` (resolved type)

**`git_source.rs`** — no changes; `fetch_commits(&self, config: &HeatmapConfig)` now refers to the resolved type automatically.

## Breaking Changes

None — this is a pure internal refactor. Public API and output are byte-identical.

## Reviewer Focus Areas

- `window.rs`: verify `window_preset` move ordering (moved into `ResolvedWindow` first, read from `window.window_preset` in the preset branch)
- `mod.rs`: verify `debug` and `had_last_n` locals are extracted before the `args` move, so pre-resolution debug logging is correct
- `types.rs`: confirm `HeatmapConfig` has no `Clone`, `Default`, `window_preset`, `last_n`, or `diff_base` fields (AC-1)
- All 140 heatmap tests pass; 0 warnings from `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt -- --check`