### PR TITLE
feat(#196): Wave 3e — AST Pattern Library & Structural Index v2

### DIFF
--- a/.devflow/features/ast-index/KNOWLEDGE.md
+++ b/.devflow/features/ast-index/KNOWLEDGE.md
@@ -1,7 +1,7 @@
 ---
 feature: ast-index
 name: AST Index (CST Linearization + N-gram Encoding + On-Disk Store)
-description: "Use when implementing AST-based n-gram extraction, building or reading the on-disk structural index, adding a new language to the structural index, debugging depth or node-count truncation, extending the shared vocabulary, working with AstBigram/AstTrigram IDF weights, extracting structural n-grams from linearized nodes, or using the shared AstWalkIter traversal primitive. Keywords: linearize, CST, AST, n-gram, bigram, trigram, NodeKindId, AstBigram, AstTrigram, AstNgramSet, AstBigramEntry, AstTrigramEntry, NODE_KIND_VOCABULARY, LANG_MAPS, LinearNode, AstWalkIter, AstWalkConfig, tree-sitter, depth-encoded, pre-order, IDF, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_weights, store, AstIndexBuilder, AstIndexReader, AstPosting, AstFileMetaEntry, skidx, skpost, SKAX, on-disk index, mmap, posting list, build_from_files, lookup_bigram, lookup_trigram."
+description: "Use when implementing AST-based n-gram extraction, building or reading the on-disk structural index, adding a new language to the structural index, debugging depth or node-count truncation, extending the shared vocabulary, working with AstBigram/AstTrigram IDF weights, extracting structural n-grams or structural metrics from linearized nodes, using the Pattern Library (structural code patterns), or using the shared AstWalkIter traversal primitive. Keywords: linearize, CST, AST, n-gram, bigram, trigram, NodeKindId, AstBigram, AstTrigram, AstNgramSet, AstBigramEntry, AstTrigramEntry, NODE_KIND_VOCABULARY, LANG_MAPS, LinearNode, AstWalkIter, AstWalkConfig, tree-sitter, depth-encoded, pre-order, IDF, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights, StructuralMetrics, structural, Pattern, patterns, EMPTY_BODY, DEEP_NODE, LARGE_BODY, MANY_PARAMS, bucket_label, synthetic n-gram, store, AstIndexBuilder, AstIndexReader, AstPosting, AstFileMetaEntry, skidx, skpost, SKAX, FORMAT_VERSION, on-disk index, mmap, posting list, build_from_files, lookup_bigram, lookup_trigram, index_version."
 category: architecture
 directories: [crates/rskim-search/src/ast_index/, crates/rskim-core/src/]
 referencedFiles:
@@ -10,6 +10,8 @@ referencedFiles:
   - crates/rskim-search/src/ast_index/linearize.rs
   - crates/rskim-search/src/ast_index/ngram.rs
   - crates/rskim-search/src/ast_index/extract.rs
+  - crates/rskim-search/src/ast_index/structural.rs
+  - crates/rskim-search/src/ast_index/patterns.rs
   - crates/rskim-search/src/ast_index/mod.rs
   - crates/rskim-search/src/ast_index/store/format.rs
   - crates/rskim-search/src/ast_index/store/builder.rs
@@ -17,9 +19,8 @@ referencedFiles:
   - crates/rskim-search/src/ast_index/store/mod.rs
   - crates/rskim-search/src/ast_weights.rs
   - crates/rskim-search/src/lib.rs
-  - crates/rskim-search/benches/ast_index_bench.rs
 created: 2026-06-01
-updated: 2026-06-05
+updated: 2026-06-06
 ---
 
 # AST Index (CST Linearization + N-gram Encoding + On-Disk Store)
@@ -28,160 +29,90 @@ updated: 2026-06-05
 
 The `ast_index` module converts tree-sitter Concrete Syntax Trees (CSTs) into a
 compact, flat representation suitable for downstream n-gram extraction and IDF-weighted
-structural search. It has four sub-modules:
+structural search. It is the AST layer of a 3-layer search system (Lexical, Temporal,
+AST n-gram) built across Waves 3a–3e.
 
-- **`linearize`** — converts source text into `Vec<LinearNode>`, a pre-order
-  depth-first sequence where each node carries a vocabulary ID and traversal depth.
-- **`ngram`** — provides `AstBigram` and `AstTrigram` newtypes for packing
-  node-kind ID pairs/triples into compact integer keys, plus vocabulary helpers
-  and IDF weight lookup backed by the per-language weight tables in `ast_weights`.
-- **`extract`** — (Wave 3c) consumes a `Vec<LinearNode>` and produces a deduplicated,
-  weighted `AstNgramSet` of structural bigrams and trigrams. This is the document-side
-  extraction step; query-side covering-set (#197) is deferred to Wave 3f.
-- **`store`** — (Wave 3d) persists an `AstNgramSet` corpus as a two-file mmap'd
-  on-disk inverted index, mirroring the lexical `index/` module. The structural
-  query engine (Wave 3f #197) is still out of scope.
+Six sub-modules make up the full Wave 3e implementation:
+
+- **`linearize`** — converts source text into `Vec<LinearNode>` (pre-order depth-first
+  sequence), each node carrying a shared vocabulary ID and traversal depth.
+- **`ngram`** — provides `AstBigram` / `AstTrigram` newtypes, vocabulary helpers,
+  and IDF weight lookup backed by per-language weight tables in `ast_weights`.
+- **`extract`** — single-pass extraction of deduplicated, weighted `AstNgramSet`
+  (real containment bigrams/trigrams) AND per-file `StructuralMetrics` via
+  `extract_ast_ngrams_with_metrics`. A separate entry point `extract_ast_ngrams_with_weights`
+  is the dependency-injected core used in unit tests.
+- **`structural`** — (Wave 3e) defines reserved synthetic parent IDs
+  (`EMPTY_BODY`, `DEEP_NODE`, `LARGE_BODY`, `MANY_PARAMS`), bucket-label child IDs
+  (`BUCKET_LABEL_BASE`), cumulative bucket edge tables, `StructuralMetrics`, and
+  `is_counted_child` (the central counting rule).
+- **`patterns`** — (Wave 3e) data-driven catalog of 29 named structural code patterns
+  in 5 categories, GOLD-verified against real code examples.
+- **`store`** — (Wave 3d/3e) two-file mmap'd on-disk inverted index; format v2 adds
+  per-file structural metrics and `avg_max_depth`. Library-only; Wave 3f (#197) wires
+  the query engine, Wave 3g (#199) adds CLI.
 
 The design is intentionally minimal: `linearize_source` is the only stateful-setup
-entry point (it triggers `LANG_MAPS` initialization on first call). All n-gram
-encoding, weight lookup, and extraction are pure (no I/O, no mutable state).
+entry point. All n-gram encoding, weight lookup, and extraction are pure.
 
-The DFS traversal logic was extracted into `rskim-core::AstWalkIter` so it can be
-shared with `rskim-research` without duplicating cursor management, bounds guarding,
-or depth tracking.
+The DFS traversal logic lives in `rskim-core::AstWalkIter` to be shared with
+`rskim-research` without duplicating cursor management or bounds guarding.
 
 ## System Context
 
-`ast_index` sits between the tree-sitter grammar layer (`rskim-core::Parser`) and
-whatever consumes structural n-grams (the `lexical` / `index` layers in `rskim-search`
-and future AST search layers). It depends on:
+`ast_index` depends on:
 
 - `rskim-core::Language` and `rskim-core::Parser` for grammar dispatch
 - `rskim-core::AstWalkIter` and `rskim-core::AstWalkConfig` for shared DFS traversal
-- `crate::ast_weights::NODE_KIND_VOCABULARY` — the shared, auto-generated vocabulary
-  of 1740 node kind strings sorted alphabetically for binary search
-- `crate::ast_weights::{ast_bigram_weight, ast_trigram_weight}` — per-language
-  IDF weight tables keyed by the same packed integer encoding as `AstBigram`/`AstTrigram`
-- `crate::types::SearchError::Ast` for the one error path that is not gracefully silenced
+- `crate::ast_weights::NODE_KIND_VOCABULARY` — auto-generated sorted `&[&str]` of
+  **1740** node kind strings (IDs 0–1739); IDs ≥ 1740 are free for synthetic use
+- `crate::ast_weights::{ast_bigram_weight, ast_trigram_weight}` — per-language IDF tables
+- `crate::types::SearchError::Ast` for the one error path not silenced gracefully
 - `crate::index::lang_map::{lang_to_id, lang_from_id}` — single source of truth for
-  language ↔ u8 ID mapping. `index/mod.rs` was widened to `pub(crate) mod lang_map` so
-  the `store/` sub-module can reuse the same mapping without duplication.
+  language ↔ u8 ID mapping (widened to `pub(crate)` in `index/mod.rs` so `store/` reuses it)
 
-Non-tree-sitter languages (JSON, YAML, TOML) have no entry in `LANG_MAPS`. Calling
-`linearize_source` for these languages returns the empty default result without an
-error. `ast_bigram_idf` and `ast_trigram_idf` return `DEFAULT_AST_WEIGHT` for them.
-`extract_ast_ngrams` also returns an empty `AstNgramSet` because it delegates weight
-lookup through the same fallback path.
+Non-tree-sitter languages (JSON, YAML, TOML) have no entry in `LANG_MAPS`.
+`linearize_source` returns an empty default; `ast_bigram_idf` returns `DEFAULT_AST_WEIGHT`.
 
 ## Component Architecture
 
 ### AstWalkIter (rskim-core)
 
-The shared traversal primitive. Lives in `crates/rskim-core/src/ast_walk.rs`.
+The shared traversal primitive in `crates/rskim-core/src/ast_walk.rs`. Encapsulates
+cursor management, depth tracking (`level_stack`), bounds guards, and error node
+detection. `AstWalkConfig` exposes `DEFAULT_MAX_DEPTH = 500` and
+`DEFAULT_MAX_NODES = 100_000` as associated constants — the canonical bound source.
 
-`AstWalkIter` encapsulates:
-- `TreeCursor`-based iterative pre-order DFS
-- `level_stack: Vec<u32>` — depth restoration on ascent (internal, not visible to callers)
-- Bounds guards: `max_depth` and `max_nodes` in `AstWalkConfig`
-- Error/missing node detection: `AstWalkNode::is_error`
-- Post-exhaustion stats: `node_count()` and `error_count()`
-- `FusedIterator` impl — once exhausted it always returns `None`
+### LinearNode and linearize_source
 
-`AstWalkConfig` exposes its defaults as associated constants so all consumers share
-one canonical source:
+`LinearNode { kind_id: u16, depth: u16 }` — the unit of linearization output.
+`kind_id` indexes into `NODE_KIND_VOCABULARY`; sentinel `0` maps to `""` for
+grammar kinds absent from the vocabulary. `depth` is 0-indexed from the root.
 
-```rust
-// AstWalkConfig::DEFAULT_MAX_DEPTH and DEFAULT_MAX_NODES are the canonical values.
-// linearize.rs aliases them as test-only pub(crate) constants:
-#[cfg(test)]
-pub(crate) const MAX_AST_DEPTH: u32 = AstWalkConfig::DEFAULT_MAX_DEPTH;  // 500
-#[cfg(test)]
-pub(crate) const MAX_AST_NODES: u32 = AstWalkConfig::DEFAULT_MAX_NODES;  // 100_000
-```
+`linearize_source` guards: files > 100 KiB (1 MiB for SQL) → empty result; language
+not in `LANG_MAPS` → empty result; grammar load failure → `Err(SearchError::Ast)`.
+Parse errors → empty result (tree-sitter is error-tolerant).
 
-Takeaways: update limits in one place (`ast_walk.rs`) and they propagate to `linearize.rs`,
-`rskim-research/ast_extract.rs`, and any future consumer automatically.
-
-### LinearNode
-
-The unit of linearization output. Two fields: `kind_id: u16` (vocabulary index) and
-`depth: u16` (0-indexed from tree root). Being `Copy` makes it cheap in `Vec` and
-by-value pass. The sentinel `kind_id == 0` maps to `""` at index 0 of
-`NODE_KIND_VOCABULARY`, used for grammar kinds not found in the shared vocabulary.
-
-`AstWalkNode::depth` is `u32`; `linearize_tree` saturates it to `u16` before storing
-in `LinearNode` (the max_depth bound of 500 makes overflow impossible in practice).
-
-Parent–child relationships are recoverable from depth alone: the parent of node at
-index `i` with depth `d` is the nearest preceding node with depth `d - 1`.
+`LANG_MAPS` is a `LazyLock<HashMap<Language, Vec<Option<u16>>>>`. Each `Vec` is
+indexed by tree-sitter's grammar-local `kind_id` and holds the vocabulary index (or
+`None`) for that kind. O(1) lookup during traversal.
 
 ### AstBigram and AstTrigram (ngram.rs)
 
-Compact newtypes for packing AST node-kind ID pairs/triples into integer keys.
+Compact newtypes packing AST node-kind IDs into integer keys:
 
-```
-// Bigram:  (u32::from(parent) << 16) | u32::from(child)
-// Trigram: (u64::from(gp) << 32) | (u64::from(parent) << 16) | u64::from(child)
-```
+- Bigram: `(u32::from(parent) << 16) | u32::from(child)`
+- Trigram: `(u64::from(gp) << 32) | (u64::from(parent) << 16) | u64::from(child)`
 
-These encodings match the keys stored in `ast_weights::RUST_AST_BIGRAM_WEIGHTS` (and
-the other per-language tables). The `ast_bigram_idf` and `ast_trigram_idf` functions
-look up weights using these packed keys, falling back to `DEFAULT_AST_WEIGHT` (1.0)
-when the bigram/trigram is not found or the language has no table.
+These encodings match the keys in `ast_weights` weight tables. `ast_bigram_idf` and
+`ast_trigram_idf` do a single binary-search call with no transformation.
 
-The `Display` impl resolves IDs through the vocabulary for human-readable output:
-`"function_item > block"`. Sentinel ID 0 displays as `"<unknown>"`; out-of-bounds
-IDs display as `"?{id}"`.
+`DEFAULT_AST_WEIGHT = 1.0` is the fallback for absent bigrams/trigrams and for all
+non-tree-sitter languages.
 
-### LANG_MAPS (LazyLock)
+### extract.rs — N-gram Extraction and Structural Metrics
 
-A `HashMap<Language, Vec<Option<u16>>>` initialized once at first use. For each
-of the 14 tree-sitter languages, a `Vec` is built indexed by tree-sitter's own
-`kind_id` (grammar-local, non-portable). Each slot holds the index into
-`NODE_KIND_VOCABULARY` if the kind string is in the vocabulary, or `None`.
-
-The vocabulary lookup is O(1) during traversal (array index) at the cost of one
-binary search per kind string at initialization.
-
-### linearize_tree (private)
-
-Delegates the DFS loop entirely to `AstWalkIter`. Caller-specific logic — vocabulary
-lookup via `LANG_MAPS` and `LinearNode` construction — stays here.
-
-### extract sub-module (extract.rs)
-
-Converts a `&[LinearNode]` into an `AstNgramSet` by replaying the pre-order sequence
-through a depth-indexed ancestor stack. This is the document-side extraction layer;
-it has no I/O and no global state.
-
-**Key types:**
-- `AstNgramSet { bigrams: Vec<AstBigramEntry>, trigrams: Vec<AstTrigramEntry> }` — the
-  output; both vecs are sorted by packed key ascending, contain unique keys.
-- `AstBigramEntry { ngram: AstBigram, weight: f32, count: u32 }` — one structural
-  parent→child edge with its IDF weight and term frequency (emitted occurrences).
-- `AstTrigramEntry { ngram: AstTrigram, weight: f32, count: u32 }` — one structural
-  grandparent→parent→child triple with its IDF weight and term frequency.
-
-The `count` field records term frequency (how many times the structural edge appeared
-in the file). It extends beyond the `(ngram, f32)` contract from issue #192 to
-future-proof BM25-style scoring without a separate pass.
-
-**Ancestor stack algorithm:**
-
-The function maintains `Vec<Option<NodeKindId>>` sized to `max_depth + 1` (one
-allocation, no per-iteration growth). For each node in pre-order traversal order:
-
-1. **Gap-fill**: if `node.depth > prev_depth + 1`, the skipped ancestor slots are
-   nulled. A depth jump greater than +1 in pre-order means an ERROR/MISSING node
-   was dropped during linearization; nulling breaks the spurious parent–child chain.
-2. **Resolve**: `parent = ancestors[depth - 1]`, `grandparent = ancestors[depth - 2]`.
-3. **Emit bigram**: when `parent` is `Some(p)` AND `p != 0` AND `node.kind_id != 0`.
-4. **Emit trigram**: when both `grandparent` and `parent` are `Some` AND all three
-   kind IDs are non-zero.
-5. **Record**: `ancestors[depth] = Some(node.kind_id)` — sentinel nodes ARE recorded
-   to preserve correct depth positions for deeper descendants.
-
-**Two entry points:**
+The document-side extraction layer. Two main entry points:
 
 ```rust
 // Dependency-injected core — testable with synthetic weights
@@ -191,174 +122,245 @@ pub fn extract_ast_ngrams_with_weights(
     trigram_weight: impl Fn(AstTrigram) -> f32,
 ) -> AstNgramSet { ... }
 
-// Production wrapper — uses ast_bigram_idf / ast_trigram_idf
-pub fn extract_ast_ngrams(nodes: &[LinearNode], lang: Language) -> AstNgramSet {
-    extract_ast_ngrams_with_weights(nodes, |b| ast_bigram_idf(lang, b), |t| ast_trigram_idf(lang, t))
-}
+// Production extraction with structural metrics (Wave 3e) — single pass
+pub fn extract_ast_ngrams_with_metrics(
+    nodes: &[LinearNode],
+    lang: Language,
+) -> (AstNgramSet, StructuralMetrics) { ... }
+
+// Production wrapper without metrics
+pub fn extract_ast_ngrams(nodes: &[LinearNode], lang: Language) -> AstNgramSet { ... }
 ```
 
-The split follows the project's dependency-injection convention: pure core is covered
-by unit tests with synthetic weights; `extract_ast_ngrams` is covered by end-to-end
-tests against real grammars and production weight tables.
+`extract_ast_ngrams_with_metrics` extends the ancestor-stack algorithm to fold in
+structural computation (body-statement counting, parameter counting, depth tracking,
+branch counting) and synthetic n-gram emission — all in ONE traversal pass with no
+additional allocations beyond the ancestor table.
 
-**Residual documented divergence (gap-fill edge case):**
+**Ancestor stack algorithm (shared core):**
 
-A dropped ERROR node that had a same-depth preceding sibling leaves no gap in depth
-values, so the orphaned child binds to that sibling as its parent — a spurious edge.
-This is confined to malformed code regions. The spurious edge's packed key almost
-always misses the selective weight table (receiving the 1.0 default weight) and does
-not structurally corrupt the output for syntactically valid regions. This behavior is
-intentionally characterized by test B2 in `extract_tests.rs` so any future silent
-change will cause that test to fail.
+1. One-pass scan for `max_depth` → allocate `Vec<Option<NodeKindId>>` of size `max_depth + 1`.
+2. For each node in pre-order:
+   - **Gap-fill**: if `node.depth > prev_depth + 1`, null skipped slots (u32 widening
+     required to prevent u16 overflow — applies PF-004).
+   - Resolve `parent = ancestors[depth-1]`, `grandparent = ancestors[depth-2]`.
+   - **Emit bigram**: when `parent` is `Some(p)` AND `p != 0` AND `node.kind_id != 0`.
+   - **Emit trigram**: when both ancestors are `Some` AND all three IDs are non-zero.
+   - Record `ancestors[depth] = Some(node.kind_id)` (sentinel nodes ARE recorded to
+     preserve correct depth positions for descendants).
 
-**u16 depth arithmetic — widen before adding offset (PF-004):**
+**Synthetic marker emission in `extract_ast_ngrams_with_metrics`:**
 
-Gap-fill uses `u32::from(node.depth) > u32::from(prev_depth) + 1` rather than
-`node.depth > prev_depth + 1`. The widening is load-bearing: u16 addition wraps at
-65535, so `p + 1` when `p == u16::MAX` silently evaluates to 0, bypassing gap-fill
-and producing a panic or spurious edge. Test B1 locks this regression.
+Synthetic markers are bigrams whose parent ID is ≥ 65000 — outside the real vocabulary
+range (0–1739) — so `vocab_resolve` returns `None` for them and no real containment
+bigram can ever collide:
 
-**HashMap capacity cap:**
+| Synthetic parent | ID | Trigger |
+|---|---|---|
+| `EMPTY_BODY` | 65000 | body/block kind with zero counted children; child = enclosing construct kind |
+| `DEEP_NODE` | 65001 | any node at depth ≥ bucket edge; child = `bucket_label(i)` |
+| `LARGE_BODY` | 65002 | function/method body with ≥ bucket-edge statements; child = `bucket_label(i)` |
+| `MANY_PARAMS` | 65003 | parameter list with ≥ bucket-edge params; child = `bucket_label(i)` |
 
-`bigram_map` and `trigram_map` are pre-allocated with `nodes.len().min(1024)` slots.
-Capping at 1024 avoids a large `nodes.len()` (up to 100K) driving unnecessary
-allocation — unique structural edges are typically an order of magnitude smaller than
-total node count because most edges repeat within a file.
+Bucket labels: `BUCKET_LABEL_BASE = 64900`, `bucket_label(i) = 64900 + i`. Cumulative
+emission: a function body with 25 statements crosses `BODY_STMT_EDGES = [10, 20, 40]`
+at indices 0 and 1, emitting both `LARGE_BODY → 64900` and `LARGE_BODY → 64901`.
 
-### store sub-module (Wave 3d, PR #272)
+Depth bucket edges: `[4, 6, 8]`. Param bucket edges: `[5, 8, 12]`.
 
-Persists an `AstNgramSet` corpus as a two-file mmap'd on-disk inverted index,
-mirroring the lexical `index/` module. Library-only; the structural query engine
-(Wave 3f #197) is still out of scope.
+**The central counting rule (`is_counted_child`):**
 
-#### On-Disk Format
+The LinearNode stream includes anonymous punctuation (kind_id == 0) and comment nodes.
+A "counted child" satisfies: `kind_id != 0` AND not in `COMMENT_KIND_IDS` AND not in
+`PUNCTUATION_KIND_IDS`. This ensures empty blocks are correctly identified: a
+`statement_block {}` has 0 counted children so `EMPTY_BODY` fires.
 
-Two files are written to `output_dir`:
+`COMMENT_KIND_IDS` and `PUNCTUATION_KIND_IDS` are `LazyLock<HashSet<NodeKindId>>`
+built once from `NODE_KIND_VOCABULARY`. The `PUNCTUATION_KIND_IDS` set includes
+bracket tokens (`{`, `}`, `(`, `)`, etc.) and structural keywords (`fn`, `if`, `let`,
+etc.) because tree-sitter emits these as named nodes that must not count as statements.
 
-- **`ast_index.skidx`** — fixed-size header + sorted bigram/trigram lookup tables + per-file metadata.
-- **`ast_index.skpost`** — concatenated posting lists (all bigram lists, then all trigram lists).
+**PF-004 compliance in structural accumulation:**
 
-Magic `b"SKAX"`, version `1`. Distinct from lexical `b"SKIX"` / `index.*` so both
-coexist in the same `.skim/` directory without collision.
+- `max_block_stmts` and `max_params`: `count.min(u32::from(u16::MAX)) as u16` before
+  assignment (saturating cast, no silent truncation).
+- `branch_count`: `metrics.branch_count.saturating_add(1)` (saturates at u32::MAX).
+
+**Residual documented edge case:**
+
+A dropped ERROR node that had a same-depth preceding sibling leaves no depth gap, so
+the orphaned child binds to that sibling as its parent — a spurious edge. Confined to
+malformed code regions; characterized intentionally by test B2.
+
+### structural.rs (Wave 3e)
+
+Defines all shared constants, sets, and helpers for structural n-gram emission:
+
+- Synthetic parent IDs: `EMPTY_BODY` (65000), `DEEP_NODE` (65001), `LARGE_BODY` (65002),
+  `MANY_PARAMS` (65003)
+- Bucket constants: `BUCKET_LABEL_BASE` (64900), `MAX_BUCKET_EDGES` (99), `bucket_label(i)`
+- Bucket edge tables: `BODY_STMT_EDGES`, `PARAM_EDGES`, `DEPTH_EDGES`
+- `StructuralMetrics { max_depth: u16, max_block_stmts: u16, max_params: u16, branch_count: u32 }`
+- `COMMENT_KIND_IDS`, `PUNCTUATION_KIND_IDS`, `FUNCTION_KIND_IDS`, `BODY_KIND_IDS`,
+  `PARAM_LIST_KIND_IDS`, `BRANCH_KIND_IDS` — all `LazyLock<HashSet<NodeKindId>>`
+- `is_counted_child(kind_id)` — the central counting rule
+
+All synthetic IDs satisfy `vocab_resolve(id) == None`, which is the isolation invariant
+guaranteeing no collision with real containment bigrams (where `parent <= 1739`).
+
+### patterns.rs (Wave 3e)
+
+Data-driven catalog of 29 named structural code patterns. A `Pattern` carries:
+
+- `name`: kebab-case query key (e.g. `"try-catch"`, `"god-function"`)
+- `description`: honest about accuracy (`exact: true` vs. approximate)
+- `bigrams`/`trigrams`: string pairs/triples resolved via `vocab_lookup` or
+  synthetic-name mapping (`"__empty_body__"` → `EMPTY_BODY`, `"__large_body_b10__"` →
+  `bucket_label(0)`, etc.)
+- `example` + `example_lang`: GOLD-verified against real code via test F7
+
+The GOLD test (`patterns_tests.rs::f7_gold_all_patterns`) is the honesty gate:
+every pattern's example must actually emit all declared n-grams when linearized
+and extracted with `extract_ast_ngrams_with_metrics`.
+
+**29 patterns in 5 categories:**
+
+| Category | Count | Examples |
+|---|---|---|
+| ErrorHandling | 6 | try-catch, empty-catch, python-try-except, ruby-begin-rescue |
+| Performance | 5 | nested-loop, deep-nesting, call-in-loop, rust-nested-loop |
+| Concurrency | 6 | go-goroutine, go-defer, go-channel-send, rust-unsafe-block, java-synchronized |
+| Quality | 7 | god-function, excessive-params, empty-function, match-with-arms, unhandled-result |
+| Structure | 5 | impl-method, class-method, switch-with-cases, ternary-expression |
+
+**Honest omissions (deliberately excluded):**
+
+- `hardcoded-secret` — requires semantic analysis of literal content
+- `single-use-variable` — requires data-flow analysis
+- `magic-number` (named) — a weak proxy is available as `numeric-literal-in-expression`
+  but is NOT named "magic-number" to avoid overclaiming
+
+**Ranking status:** Patterns are queryable but do NOT affect ranking today. Ranking
+integration of structural-complexity scoring is deferred to Wave 4 (#198/#200).
+
+Pattern API:
+
+```rust
+all_patterns() -> &'static [Pattern]
+lookup_pattern(name: &str) -> Result<&'static Pattern>   // Err for unknown names
+pattern_to_query_set(pattern: &Pattern) -> AstNgramSet   // count=1 per resolved n-gram
+pattern.resolved_bigrams() -> Vec<AstBigram>             // silently drops unresolved
+pattern.resolved_trigrams() -> Vec<AstTrigram>
+```
+
+### store sub-module — On-Disk Format v2
+
+Two files in `output_dir`:
+
+- **`ast_index.skidx`** — header + sorted lookup tables + per-file metadata
+- **`ast_index.skpost`** — concatenated posting lists
+
+Magic `b"SKAX"`, version **2** (FORMAT_VERSION=2). Distinct from lexical `b"SKIX"`.
+
+**v2 changes from v1 (Wave 3e):**
+
+- `AstFileMetaEntry` extended from 5 to **15 bytes** (adds `max_depth:u16`,
+  `max_block_stmts:u16`, `max_params:u16`, `branch_count:u32` — exactly +10 bytes per file)
+- Header reserved bytes `[38..42]` now store `avg_max_depth` as f32 LE (was zero in v1)
+- Synthetic n-grams from the Pattern Library stored alongside real n-grams
+- All v1 indexes are invalid: reader rejects them with "please rebuild the AST index"
 
 **Layout of `ast_index.skidx`:**
 
 | Section | Size | Details |
 |---|---|---|
 | `AstSkidxHeader` | 48 B | Magic, version, counts, averages, CRC32 |
-| `AstBigramEntry` × bigram_count | 16 B each | u32 key, u64 offset, u32 length |
-| `AstTrigramEntry` × trigram_count | 20 B each | u64 key, u64 offset, u32 length |
-| `AstFileMetaEntry` × file_count | 5 B each | u8 lang_id + u32 node_count |
+| `AstBigramEntry` × bigram_count | 16 B each | u32 key + u64 offset + u32 length |
+| `AstTrigramEntry` × trigram_count | 20 B each | u64 key + u64 offset + u32 length |
+| `AstFileMetaEntry` × file_count | **15 B** each (v2) | lang_id + node_count + metrics |
 
-**Posting entry (`AstPostingEntry`):** 8 B — `doc_id: u32` + `count: u32`. Postings are
-uncompressed. `count` is the per-file structural term-frequency from `AstBigramEntry.count`
-/ `AstTrigramEntry.count`; the `weight` field is discarded at build time (IDF is
-recomputed at query time in Wave 3f via `ast_bigram_idf`, with language recovered via
-`AstFileMetaEntry.lang_id` → `lang_from_id`).
+**Posting entry:** 8 B — `doc_id: u32` + `count: u32`. Postings are uncompressed.
+`count` is per-file structural term-frequency; IDF weight is discarded at build time
+and recomputed at query time via `ast_bigram_idf`/`ast_trigram_idf`.
 
-**CRC32:** covers `idx_mmap[48..expected_idx_size]` as one contiguous slice —
-bigram entries + trigram entries + file-meta entries in serialization order. This
-matches the order they appear on disk, so no copies are needed during verification.
+**CRC32** covers `idx_mmap[48..expected_idx_size]` (bigram entries + trigram entries
++ file-meta entries) as one contiguous slice. Matches serialization order on disk.
 
-#### AstIndexBuilder API
-
-Core merge primitive is `add_file_ngrams(id, lang, set, node_count)`. The convenience
-`add_file(id, content, lang)` calls `linearize_source` + `extract_ast_ngrams`
-internally. `build_from_files(output_dir, files)` rayon-parallelizes the pure extract
-step and merges sequentially — measured at ~12.8 ms for 1000 files, meeting the
-`<10 s` acceptance target with margin.
-
-**Atomic write contract:** `ast_index.skpost` is written first, then `ast_index.skidx`
-(commit point). A reader that finds `.skidx` present can assume `.skpost` is coherent.
-Uses `NamedTempFile::new_in` + `write_all` + `sync_all` + `persist` — matching the
-cochange sibling pattern; stronger than the lexical index (which uses simple rename).
+**Atomic write:** `ast_index.skpost` first, then `ast_index.skidx` (commit point).
+A reader finding `.skidx` can assume `.skpost` is coherent. Uses `atomic_write` from
+`crate::io_util`.
 
 **FileId invariant (PRECONDITION):** FileIds must be dense, sequential, starting from
-zero. Every file — even files yielding zero n-grams (non-tree-sitter languages,
-`>100 KiB`, empty content) — must receive exactly one `add_file_ngrams` call and
-advances `file_count` by 1. The builder enforces this: duplicate FileId →
-`SearchError::InvalidQuery` (message: "duplicate"); non-sequential FileId →
-`SearchError::InvalidQuery` (message: "sequential"). The shared file manifest is
-owned by the CLI / Wave 4 layer, not this library.
+zero. Every file — including those yielding zero n-grams — must receive exactly one
+`add_file_ngrams` call. Violations produce `SearchError::InvalidQuery` (duplicate or
+non-sequential).
 
-**`node_count` narrowing:** `add_file` uses `u32::try_from(lin.nodes.len())` — NOT
-`as u32` — producing `SearchError::IndexCorrupted` on overflow (applies PF-004 analog:
-no silent narrowing).
+**Version probing:** `AstIndexReader::index_version(dir)` reads only the first 6 bytes
+(magic + version) cheaply. Intended for staleness checks at Wave 3f/3g; callers can
+probe before attempting a full `open` that would fail with a version error.
 
-**Re-index concurrency:** NOT concurrency-safe; same posture as the lexical index.
-Callers must serialize re-index operations against concurrent reads.
-
-#### AstIndexReader API
-
-`open(dir)` validates magic, version, file sizes, and CRC32 before returning. The
-`idx_mmap` is always present; `post_mmap` is `None` when `postings_file_size == 0`
-(prevents mmap-ing a zero-length file, which fails on some platforms).
-
-All size validation and posting bounds use `checked_*` arithmetic.
-
-Public accessors: `file_count()`, `avg_node_count()`, `avg_bigram_count()`,
-`avg_trigram_count()`, `file_meta(file_index)`.
-
-Lookup methods return `Vec<AstPosting>` (each posting: `doc_id: u32, count: u32`).
-
-#### Reader API Contract (C1–C7)
-
-These contracts are what Wave 3f's query engine relies on:
+#### Reader API Contracts (C1–C7)
 
 | Contract | Guarantee |
 |---|---|
 | C1 | Postings sorted ascending by `doc_id`, at most one per `doc_id` |
 | C2 | Absent key → `Ok(vec![])` (no error) |
 | C3 | Malformed entry (bad offset/len, OOB, `len % 8 != 0`) → `Err(IndexCorrupted)` |
-| C4 | Every `count >= 1` (`decode_posting` rejects `count == 0`) |
-| C5 | `count` is structural TF, enables BM25 scoring |
-| C6 | `file_meta(i)` recovers `lang_id` → call `lang_from_id` to get `Language` |
+| C4 | Every `count >= 1` (validated by `decode_posting`) |
+| C5 | `count` is structural TF, enables BM25-style scoring |
+| C6 | `file_meta(i).language()` recovers `Language`; `None` for unrecognised IDs |
 | C7 | `AstIndexReader: Send + Sync` (compile-time verified by test A6) |
+
+Reader also exposes:
+
+- `file_metrics(file_index) -> Result<StructuralMetrics>` — extracts structural fields
+  from the same on-disk entry as `file_meta`
+- `avg_max_depth() -> f32` — corpus-average CST depth (from v2 header bytes [38..42])
 
 #### Cross-Index FileId Contract
 
 The AST index and the lexical index must be built over the identical, identically-ordered
-file set. The shared file manifest is owned by the CLI / Wave 4 layer; neither index
-builder owns it. `AstIndexBuilder` and `NgramIndexBuilder` both enforce the sequential-
-FileId invariant independently. Building them out of sync produces subtly mismatched
-results at query time with no runtime error.
+file set. Neither builder owns the file manifest — that is the CLI / Wave 4 layer's
+responsibility. Building them over different file sets is a logic error with no runtime
+trap.
 
 ## Component Interactions
 
 ```
 linearize_source(&str, Language)
     │
-    ├── Guard: source.len() > size_limit (100 KiB general; 1 MiB for SQL)
-    │       → Ok(default)
-    ├── Guard: language not in LANG_MAPS  → Ok(default)
-    │
-    ├── Parser::new(language)             → Err → SearchError::Ast
-    ├── parser.parse(source)              → Err → Ok(default)
-    │
+    ├── Guard: source.len() > size_limit (100 KiB; 1 MiB for SQL)  → Ok(default)
+    ├── Guard: language not in LANG_MAPS                            → Ok(default)
+    ├── Parser::new(language)   → Err                              → SearchError::Ast
+    ├── parser.parse(source)    → Err                              → Ok(default)
     └── linearize_tree(&Tree, &[Option<u16>])
-            │
-            └── AstWalkIter::new(tree.walk(), AstWalkConfig::default())
-                    │  [max_depth=500, max_nodes=100_000]
-                    ├── Yields AstWalkNode { node, depth: u32, is_error }
-                    └── Per item: is_error → skip emit
-                                 Normal   → LANG_MAPS lookup → LinearNode
+            └── AstWalkIter [max_depth=500, max_nodes=100_000]
+                    ├── ERROR/MISSING nodes → skip emit (counted in error_count)
+                    └── Normal → LANG_MAPS lookup → LinearNode { kind_id, depth }
 
-extract_ast_ngrams(&[LinearNode], Language)
+extract_ast_ngrams_with_metrics(&[LinearNode], Language)
     │
-    └── extract_ast_ngrams_with_weights(nodes, ast_bigram_idf(lang,·), ast_trigram_idf(lang,·))
-            │
-            ├── max_depth scan → allocate ancestors Vec (single allocation)
-            ├── For each node: gap-fill → resolve parent/gp → emit → record
-            └── Collect bigram_map + trigram_map → sort by key → AstNgramSet
+    ├── max_depth scan → allocate ancestors + child_counts + depth_kind tables
+    ├── For each node:
+    │     ├── Update metrics.max_depth
+    │     ├── Emit DEEP_NODE synthetic markers for crossed depth bucket edges
+    │     ├── Gap-fill (widen to u32) → null slots + reset child_counts
+    │     ├── Increment parent's child_count (if is_counted_child)
+    │     ├── Close subtrees at depth ≥ current → emit EMPTY_BODY / LARGE_BODY / MANY_PARAMS
+    │     ├── Increment branch_count for BRANCH_KIND_IDS
+    │     ├── Emit real bigram (parent → current, sentinels suppressed)
+    │     ├── Emit real trigram (gp → parent → current, sentinels suppressed)
+    │     └── Record ancestors[d], depth_kind[d]; reset child_counts[d]
+    ├── Close remaining open depths (end-of-stream)
+    └── Collect → sort → (AstNgramSet, StructuralMetrics)
 
 AstIndexBuilder::build_from_files(output_dir, files)
     │
-    ├── rayon par_iter → linearize_source + extract_ast_ngrams per file (parallel)
-    ├── Sequential merge: add_file_ngrams(id, lang, set, node_count) per file
+    ├── rayon par_iter → linearize_source + extract_ast_ngrams_with_metrics (parallel)
+    ├── Sequential merge: add_file_ngrams(id, lang, set, node_count, metrics)
     └── build()
-            ├── Sort posting lists by doc_id
-            ├── Sort keys ascending (bigram u32, trigram u64)
-            ├── Serialize postings + entries + file_meta + header
+            ├── Compute corpus averages (avg_bigram_count, avg_node_count, avg_max_depth, …)
+            ├── Sort keys ascending; serialize postings + entries + file_meta
             ├── CRC32 over post-header payload
             ├── Atomic write: skpost first, then skidx (commit point)
             └── AstIndexReader::open(output_dir)
@@ -366,224 +368,156 @@ AstIndexBuilder::build_from_files(output_dir, files)
 AstIndexReader::lookup_bigram(AstBigram)
     │
     ├── Binary search bigram entries in idx_mmap[48..bigram_end]
-    ├── Found entry → fetch offset/length into post_mmap
-    ├── Validate: OOB, alignment (len % 8 == 0)
-    └── Decode AstPostingEntry × n → Vec<AstPosting>
-
-ast_bigram_idf(Language, AstBigram) → f32
-    └── ast_bigram_weight(lang.name(), bigram.key())
-            └── binary search in per-language weight table
-                fallback: DEFAULT_AST_WEIGHT (1.0)
+    ├── Found → fetch offset/length into post_mmap
+    ├── Validate bounds + alignment (len % 8 == 0)
+    └── Decode AstPostingEntry × n → Vec<AstPosting> (C1 sort enforced defensively)
 ```
 
 ## Constraints and Bounds
 
-| Constant | Value | Source | Purpose |
-|---|---|---|---|
-| `MAX_FILE_SIZE` | 100 KiB | `linearize.rs` | Most languages: oversized files return empty |
-| `MAX_FILE_SIZE_LARGE` | 1 MiB | `linearize.rs` | SQL only: matches `rskim-research` |
-| `DEFAULT_MAX_DEPTH` | 500 | `AstWalkConfig` | Pathological nesting stops descent |
-| `DEFAULT_MAX_NODES` | 100,000 | `AstWalkConfig` | Caps output Vec allocation |
-| `AST_HEADER_SIZE` | 48 B | `store/format.rs` | Fixed header size |
-| `AST_BIGRAM_ENTRY_SIZE` | 16 B | `store/format.rs` | u32 key + u64 offset + u32 length |
-| `AST_TRIGRAM_ENTRY_SIZE` | 20 B | `store/format.rs` | u64 key + u64 offset + u32 length |
-| `AST_POSTING_ENTRY_SIZE` | 8 B | `store/format.rs` | u32 doc_id + u32 count |
-| `AST_FILE_META_SIZE` | 5 B | `store/format.rs` | u8 lang_id + u32 node_count |
-
-SQL uses `MAX_FILE_SIZE_LARGE` because migrations and schema dumps routinely exceed
-100 KiB. All other languages use `MAX_FILE_SIZE`. The branch is a `match` on
-`Language::Sql` at the top of `linearize_source`.
-
-When a depth or node-count guard triggers, the traversal moves to the next sibling
-or ascends — it does not abort entirely. The subtree is skipped; traversal continues.
-
-## Node Count Invariant
-
-`result.node_count == result.nodes.len() + result.error_count`
-
-This invariant holds at every exit point of `linearize_tree`. `node_count` is the
-total nodes visited (including ERROR/MISSING) from `iter.node_count()`.
-`error_count` comes from `iter.error_count()`. Tests assert this invariant on every
-result.
-
-## Vocabulary
-
-`NODE_KIND_VOCABULARY` in `ast_weights.rs` is auto-generated by `rskim-research
-ast-codegen`. It is a sorted `&[&str]` of 1740 node kind strings shared across all
-14 languages. It must not be edited manually — regenerate with the codegen tool.
-
-The vocabulary being sorted is a load-bearing property: `LANG_MAPS` initialization
-uses `binary_search` on it, and `vocab_lookup` (exposed from `ngram.rs`) also uses
-`binary_search`. Breaking the sort order silently corrupts all vocabulary lookups.
-The test `vocabulary_is_sorted` guards this invariant.
-
-## Public API Surface
-
-The module's public exports (via `mod.rs` and re-exported from `rskim_search`) are:
-
-| Symbol | Type | Purpose |
+| Constant | Value | Source |
 |---|---|---|
-| `linearize_source` | `fn` | Linearize source to `LinearizeResult` |
-| `LinearNode` | `struct` | Single node in linearized sequence |
-| `LinearizeResult` | `struct` | Output of linearization |
-| `NodeKindId` | `type alias` | `u16` index into vocabulary |
-| `AstBigram` | `struct` | Packed parent→child pair (u32) |
-| `AstTrigram` | `struct` | Packed gp→parent→child triple (u64) |
-| `DEFAULT_AST_WEIGHT` | `const f32` | Fallback IDF weight (1.0) |
-| `vocab_lookup` | `fn` | Kind string → `NodeKindId` (binary search) |
-| `vocab_resolve` | `fn` | `NodeKindId` → kind string |
-| `vocab_len` | `fn` | Total vocabulary entries |
-| `ast_bigram_idf` | `fn` | IDF weight for a bigram by language |
-| `ast_trigram_idf` | `fn` | IDF weight for a trigram by language |
-| `AstNgramSet` | `struct` | Output of extraction: bigrams + trigrams vecs |
-| `AstBigramEntry` | `struct` | One bigram with weight and count |
-| `AstTrigramEntry` | `struct` | One trigram with weight and count |
-| `extract_ast_ngrams` | `fn` | Production extraction (uses real IDF tables) |
-| `extract_ast_ngrams_with_weights` | `fn` | DI core: caller supplies weight closures |
-| `AstIndexBuilder` | `struct` | Builds the two-file on-disk index |
-| `AstIndexReader` | `struct` | mmap'd read-only query layer |
-| `AstPosting` | `struct` | One decoded posting: `doc_id` + `count` |
-| `AstFileMetaEntry` | `struct` | Per-file `lang_id` + `node_count` (public) |
+| `MAX_FILE_SIZE` | 100 KiB | `linearize.rs` |
+| `MAX_FILE_SIZE_LARGE` (SQL) | 1 MiB | `linearize.rs` |
+| `DEFAULT_MAX_DEPTH` | 500 | `AstWalkConfig` |
+| `DEFAULT_MAX_NODES` | 100,000 | `AstWalkConfig` |
+| `HEADER_SIZE` | 48 B | `store/format.rs` |
+| `BIGRAM_ENTRY_SIZE` | 16 B | `store/format.rs` |
+| `TRIGRAM_ENTRY_SIZE` | 20 B | `store/format.rs` |
+| `POSTING_ENTRY_SIZE` | 8 B | `store/format.rs` |
+| `FILE_META_SIZE` (v2) | **15 B** | `store/format.rs` |
+| Vocabulary size | 1740 | `ast_weights.rs` |
+| Free synthetic ID start | 1740 | `structural.rs` comment |
+| `EMPTY_BODY` | 65000 | `structural.rs` |
+| `DEEP_NODE` | 65001 | `structural.rs` |
+| `LARGE_BODY` | 65002 | `structural.rs` |
+| `MANY_PARAMS` | 65003 | `structural.rs` |
+| `BUCKET_LABEL_BASE` | 64900 | `structural.rs` |
+| `MAX_BUCKET_EDGES` | 99 | `structural.rs` |
 
 ## Anti-Patterns
 
-- **Calling `linearize_source` in a tight per-file loop without accounting for
-  `LazyLock` initialization**: the first call for each language triggers grammar
-  loading and `kind_id` table construction. Warm subsequent calls are fast; cold
-  first calls per process are heavier. Benchmarks exclude warm-up from timing.
+- **Omitting `add_file_ngrams` for files yielding zero n-grams**: every file in the
+  manifest must produce exactly one call even if `AstNgramSet` is empty. Omitting it
+  causes `file_count` to diverge from the lexical index.
 
-- **Treating `kind_id == 0` as a signal that a node is unimportant**: sentinel 0
-  means the grammar kind is not in the shared vocabulary — it is still a real node.
-  Consumers that weight by vocabulary index must handle `kind_id == 0` explicitly.
-  In `extract.rs` the sentinel is recorded in the ancestor table to preserve depth
-  positions, but suppressed at emit time; this is correct and intentional.
+- **Building the AST and lexical indexes from different file orderings**: both indexes
+  enforce sequential FileId starting from 0 but check independently — a logic error
+  with no runtime trap.
 
-- **Adding non-tree-sitter languages to the `LANG_MAPS` init list**: JSON, YAML,
-  and TOML have no tree-sitter grammar in this crate. `Parser::new` returns `Err`
-  for them; the `continue` in the init loop silently drops them. This is correct
-  behavior. These languages return the empty default from `linearize_source` and
-  `DEFAULT_AST_WEIGHT` from `ast_bigram_idf`/`ast_trigram_idf`.
+- **Using `as u32` for `node_count` narrowing**: always `u32::try_from(lin.nodes.len())`
+  (applies PF-004 — no silent narrowing).
 
-- **Holding a `LinearizeResult` across a rebuild of `LANG_MAPS`**: the `kind_id`
-  values in a result are only meaningful relative to the `NODE_KIND_VOCABULARY`
-  version used when the result was produced. If the vocabulary is regenerated
-  (changing indices), cached results become stale.
+- **Treating `kind_id == 0` as "skip this node entirely"**: the sentinel is recorded
+  in the ancestor table to preserve depth positions. It is suppressed only at emit time.
+  Code that removes sentinel nodes from the input slice before extraction will produce
+  incorrect depth relationships.
 
-- **Reimplementing DFS cursor logic in a new consumer**: use `AstWalkIter` from
-  `rskim-core` instead. The `level_stack`, bounds guards, and `is_error` detection
-  are all handled there. Adding a parallel implementation creates a divergence risk.
+- **Treating pattern structural markers as plain-query ranking signals**: `EMPTY_BODY`,
+  `DEEP_NODE`, `LARGE_BODY`, `MANY_PARAMS` are a code-audit capability. Ranking
+  integration is deferred to Wave 4 (#198/#200).
 
-- **Using `AstBigram::from_raw` / `AstTrigram::from_raw` in external callers**:
-  these are `pub(crate)` and intended for internal iteration over stored weight
-  tables. External callers must use `encode()` to guarantee correct encoding.
+- **Assuming `lookup_pattern` returns a match for any user-supplied string**: it returns
+  `SearchError::InvalidQuery` for unknown names. All 29 pattern names are kebab-case;
+  the error message lists all valid names.
+
+- **Adding non-tree-sitter languages to the `LANG_MAPS` init list**: JSON, YAML, TOML
+  have no tree-sitter grammar. They return empty results from `linearize_source` and
+  `DEFAULT_AST_WEIGHT` from IDF lookups. This is correct behavior.
+
+- **Holding a `LinearizeResult` across a vocabulary regeneration**: `kind_id` values are
+  only meaningful relative to the `NODE_KIND_VOCABULARY` version at extraction time.
+  Cached results become stale if the vocabulary is regenerated.
+
+- **Reimplementing DFS cursor logic**: use `AstWalkIter` from `rskim-core`. All cursor
+  management, bounds guarding, and `is_error` detection live there.
 
 - **Treating `count` in `AstBigramEntry`/`AstTrigramEntry` as document frequency**:
   `count` is term frequency (occurrences in one file), not the number of documents
-  containing the n-gram. Document frequency is a corpus-level metric computed at
-  index build time, not here.
+  containing the n-gram.
 
-- **Skipping `add_file_ngrams` for files that yield zero n-grams**: every file in
-  the manifest must produce exactly one call even if its `AstNgramSet` is empty.
-  Omitting it causes `file_count` to diverge from the lexical index's file count,
-  producing mismatched results at query time.
-
-- **Building the AST and lexical indexes from different file orderings**: both
-  indexes enforce sequential FileId starting from 0, but they check independently.
-  Building them over different file sets is a logic error with no runtime trap.
-
-- **Using `as u32` for `node_count` narrowing**: always use `u32::try_from(lin.nodes.len())`
-  so overflow surfaces as `IndexCorrupted` rather than a silent truncation (applies PF-004).
+- **Using `as u16` for `max_block_stmts` / `max_params` in structural code**: always
+  `count.min(u32::from(u16::MAX)) as u16` (saturating cast — applies PF-004). Similarly,
+  `branch_count` uses `saturating_add`.
 
 ## Gotchas
 
-- **`level_stack` is internal to `AstWalkIter`**: any depth-related bug fix must
-  be made in `crates/rskim-core/src/ast_walk.rs`, not in `linearize.rs`.
+- **`level_stack` is internal to `AstWalkIter`**: any depth-related bug fix must be made
+  in `crates/rskim-core/src/ast_walk.rs`, not in `linearize.rs`.
 
-- **`MAX_AST_DEPTH` / `MAX_AST_NODES` in `linearize.rs` are test-only aliases**:
-  they are `#[cfg(test)] pub(crate)` and alias `AstWalkConfig::DEFAULT_MAX_DEPTH/NODES`.
-  They exist only so test assertions can reference them by name. Production code
-  gets these limits via `AstWalkConfig::default()` inside `linearize_tree`.
+- **`MAX_AST_DEPTH` / `MAX_AST_NODES` in `linearize.rs` are test-only aliases**: they
+  are `#[cfg(test)] pub(crate)` and alias `AstWalkConfig::DEFAULT_MAX_DEPTH/NODES`.
 
-- **`AstWalkNode::depth` is `u32`; `LinearNode::depth` is `u16`**: `linearize_tree`
-  saturates via `.min(u32::from(u16::MAX)) as u16`. Marked with
-  `#[allow(clippy::cast_possible_truncation)]` as documentation of intent.
+- **Gap-fill uses `u32::from(node.depth) > u32::from(prev_depth) + 1`** (not `node.depth > prev_depth + 1`):
+  the u32 widening is load-bearing. u16 addition wraps at 65535, so `p + 1` when `p == u16::MAX`
+  silently evaluates to 0, bypassing gap-fill. Test B1 locks this regression.
 
-- **tree-sitter `kind_id` is grammar-local, not vocabulary-local**: `node.kind_id()`
-  returns a u16 valid only within one grammar. It is NOT safe to compare `kind_id`
-  values across languages. The `LANG_MAPS` indirection exists precisely to map from
-  grammar-local IDs to the shared vocabulary.
+- **tree-sitter `kind_id` is grammar-local, not vocabulary-local**: `node.kind_id()` is valid
+  only within one grammar. Do not compare `kind_id` values across languages. The `LANG_MAPS`
+  indirection exists to map from grammar-local IDs to the shared vocabulary.
 
-- **Vocabulary index 0 is the empty sentinel, not a skip signal**: `NODE_KIND_VOCABULARY[0]`
-  is `""`. A node that maps to sentinel 0 is still emitted in `result.nodes` by
-  `linearize_source`. In `extract.rs` it is additionally recorded in the ancestor table
-  but silently skipped at emit time to prevent corrupt edges.
+- **SQL file size limit is 1 MiB, not 100 KiB**: a `match` on `Language::Sql` at the top of
+  `linearize_source` is easy to miss when debugging why a large SQL file produces results
+  while a large Rust file returns empty.
 
-- **SQL file size limit is 1 MiB, not 100 KiB**: the `match language { Sql => ..., _ => ... }`
-  branch at the top of `linearize_source` is easy to miss when debugging why a large
-  SQL file produces results while a large Rust file returns empty.
+- **`post_mmap` is `None` for an empty corpus**: `AstIndexReader::open` does not mmap a
+  zero-length `.skpost`. `lookup_bigram`/`lookup_trigram` return `Ok(vec![])` — callers
+  must not confuse `None` post_mmap with "not found" at the API level.
 
-- **`ast_bigram_idf` and `ast_trigram_idf` return `DEFAULT_AST_WEIGHT` for unknown
-  bigrams and for all non-tree-sitter languages**: callers that want to detect
-  "not found" vs. "found with weight 1.0" must check the weight table directly via
-  `ast_weights::ast_bigram_weight`.
+- **v1 indexes are hard-rejected**: `decode_header` returns "unsupported format version: 1
+  (expected 2); please rebuild the AST index". The `index_version` probe lets callers detect
+  this before a full `open` call fails. Auto-rebuild wiring arrives in Wave 3f/3g, mirroring
+  `cmd/search/staleness.rs::auto_refresh_if_stale`.
 
-- **`MAX_FILE_SIZE` is checked against `source.len()` (bytes), not chars**: for
-  ASCII-heavy source this is fine. UTF-8 multibyte identifiers shrink effective
-  character count slightly below the byte limit, which is acceptable and consistent
-  with `rskim-research/src/ast_extract.rs`.
+- **`COMMENT_KIND_IDS` and `PUNCTUATION_KIND_IDS` lazy init at first `is_counted_child` call**:
+  the initialization is O(#kinds × log(vocab_len)), tiny but not zero. Benchmarks should
+  warm these sets before timing extraction.
 
-- **Gap-fill in `extract.rs` checks `node.depth > prev_depth + 1`**: the comparison
-  uses `u16` arithmetic — it will not wrap at depth 0 thanks to `checked_sub` in the
-  parent-resolution step, but the gap-fill check itself is only reached when
-  `prev_depth` is `Some`, so there is no underflow risk.
+- **`lang_map` visibility was widened to `pub(crate)` in `index/mod.rs`**: do not add a
+  second language → u8 ID mapping table elsewhere; everything reuses `lang_to_id`/`lang_from_id`.
 
-- **Ancestor stack is NOT re-used between files**: each `extract_ast_ngrams*` call
-  allocates a fresh `Vec<Option<NodeKindId>>`. For batch extraction over many files,
-  the allocation overhead is proportional to `max_depth`, which is bounded at 500.
+- **`ast_weights.rs` is auto-generated**: do not edit manually. Regenerate via
+  `rskim-research ast-run + ast-codegen`. The vocabulary being sorted is load-bearing:
+  binary search depends on it. Test `vocabulary_is_sorted` guards this invariant.
 
-- **Index size ratio is ~1.23× source, NOT < 5%**: the original #194 acceptance criterion
-  "index < 5% of source" is structurally unachievable for structural AST n-grams. The
-  tiny vocabulary (~161 distinct bi/trigrams for Rust) means each key appears in nearly
-  every file, producing dense posting lists that scale O(vocab × files). The regression
-  guard is `< 3.0×` (measured ~1.23×). Industry uncompressed trigram indexes run 3–5×.
-  Actual compression (delta + VarInt / Roaring posting) is tracked in issue #273.
+- **Index size ratio is ~1.23× source** for typical Rust corpora. The < 5% criterion
+  from issue #194 is unachievable for structural AST n-grams (tiny vocabulary → dense
+  posting lists). The regression guard is `< 2.2×` (measured ~1.23×; industry
+  uncompressed trigram indexes run 3–5×). Compression is tracked in issue #273.
 
-- **`post_mmap` is `None` for an empty corpus**: `AstIndexReader::open` does not mmap
-  a zero-length `.skpost` file. `lookup_bigram`/`lookup_trigram` return `Ok(vec![])`
-  in this case — callers must not assume `None` means "not found" at the API level.
-
-- **`lang_map` visibility was widened to `pub(crate)`**: `index/mod.rs` now declares
-  `pub(crate) mod lang_map` so `store/format.rs` can reuse `lang_to_id`/`lang_from_id`
-  without a separate mapping. Do not add a second mapping table elsewhere.
+- **Structural metrics deferred from ranking**: per-file `StructuralMetrics` are stored
+  and exposed via `AstIndexReader::file_metrics`, but ranking integration is deferred
+  to Wave 4 (#198/#200). Do not factor them into scoring before the integration is wired.
 
 ## Key Files
 
-- `crates/rskim-core/src/ast_walk.rs` — `AstWalkIter`, `AstWalkConfig` (with `DEFAULT_MAX_DEPTH`/`DEFAULT_MAX_NODES`), `AstWalkNode`; shared DFS primitive and canonical limit source
+- `crates/rskim-core/src/ast_walk.rs` — `AstWalkIter`, `AstWalkConfig` (canonical limit source), `AstWalkNode`
 - `crates/rskim-search/src/ast_index/linearize.rs` — `LANG_MAPS`, `linearize_source`, `linearize_tree`; SQL size override; delegates DFS to `AstWalkIter`
-- `crates/rskim-search/src/ast_index/ngram.rs` — `AstBigram`, `AstTrigram`, `NodeKindId`, vocabulary helpers, IDF weight lookups
-- `crates/rskim-search/src/ast_index/extract.rs` — `extract_ast_ngrams`, `extract_ast_ngrams_with_weights`, `AstNgramSet`, `AstBigramEntry`, `AstTrigramEntry`; depth-indexed ancestor stack; document-side extraction only
-- `crates/rskim-search/src/ast_index/store/format.rs` — pure binary codec: all on-disk struct definitions, encode/decode functions, binary search helpers, CRC32; no I/O
+- `crates/rskim-search/src/ast_index/ngram.rs` — `AstBigram`, `AstTrigram`, vocabulary helpers, IDF weight lookups
+- `crates/rskim-search/src/ast_index/extract.rs` — `extract_ast_ngrams_with_metrics` (single-pass, Wave 3e), `extract_ast_ngrams_with_weights` (DI core), `AstNgramSet`, `AstBigramEntry`, `AstTrigramEntry`
+- `crates/rskim-search/src/ast_index/structural.rs` — synthetic IDs, bucket edge tables, `StructuralMetrics`, `is_counted_child`, `COMMENT_KIND_IDS`, `PUNCTUATION_KIND_IDS` (Wave 3e)
+- `crates/rskim-search/src/ast_index/patterns.rs` — 29-pattern GOLD-verified catalog, `Pattern`, `PatternCategory`, `lookup_pattern`, `pattern_to_query_set` (Wave 3e)
+- `crates/rskim-search/src/ast_index/store/format.rs` — pure binary codec: all on-disk struct definitions (v2), encode/decode, binary search helpers, CRC32; no I/O
 - `crates/rskim-search/src/ast_index/store/builder.rs` — `AstIndexBuilder`: merge primitive, parallel `build_from_files`, atomic write, FileId enforcement
-- `crates/rskim-search/src/ast_index/store/reader.rs` — `AstIndexReader`, `AstPosting`: mmap open/validate, `lookup_bigram`, `lookup_trigram`, `file_meta`, `Send + Sync`
-- `crates/rskim-search/src/ast_index/store/mod.rs` — re-exports `AstIndexBuilder`, `AstIndexReader`, `AstPosting`, `AstFileMetaEntry`
-- `crates/rskim-search/src/ast_index/mod.rs` — public re-exports for all four sub-modules
-- `crates/rskim-search/src/ast_index/linearize_tests.rs` — 8 test cycles: types, vocabulary, traversal, error nodes, bounds, multi-language, edge cases, performance
-- `crates/rskim-search/src/ast_index/ngram_tests.rs` — 14 test groups: encode/decode roundtrips, key formula, Display, vocab helpers, IDF weight lookup
-- `crates/rskim-search/src/ast_index/extract_tests.rs` — 26 test cases: empty input, chain, siblings, dedup/count, gap-fill, sentinel suppression (parent + grandparent), end-to-end, sort/uniqueness, determinism, input immutability, injected weights, unknown-weight default, crate-root re-exports, large-input smoke test; batch-2 regression tests: B1 u16::MAX depth overflow guard (×2), B2 documented spurious same-depth-sibling edge (×1), B3 trigram count accumulation (×1), B4 gap-fill at max-depth boundary (×2), B5 depth-0 underflow via checked_sub (×2). Helper `bigram_keys(set)` deduplicates bigram key extraction across tests.
-- `crates/rskim-search/src/ast_index/store/builder_tests.rs` — tests A7–A14 + build_from_files + parallel tests; FileId guards, zero-ngram file meta, avg stats, duplicate/non-sequential FileId errors
-- `crates/rskim-search/src/ast_index/store/reader_tests.rs` — tests A1–A6, C1–C7 contracts; `ast_index_size_ratio` normal test (not `#[ignore]`) asserting `< 3.0×`
-- `crates/rskim-search/src/ast_index/store/format_tests.rs` — encode/decode roundtrips and boundary checks for all on-disk structs
-- `crates/rskim-search/src/ast_weights.rs` — auto-generated `NODE_KIND_VOCABULARY` (1740 entries, sorted) and per-language bigram/trigram weight tables; do not edit manually
-- `crates/rskim-search/benches/ast_index_bench.rs` — Criterion benchmark `build_1000_rust_files` (A15: `< 10 s`); measured ~12.8 ms. A16 size ratio is a normal unit test in `reader_tests.rs`.
+- `crates/rskim-search/src/ast_index/store/reader.rs` — `AstIndexReader`, `AstPosting`: mmap open/validate, `lookup_bigram`, `lookup_trigram`, `file_meta`, `file_metrics`, `index_version`, `avg_max_depth`
+- `crates/rskim-search/src/ast_index/mod.rs` — public re-exports for all six sub-modules
+- `crates/rskim-search/src/ast_weights.rs` — auto-generated `NODE_KIND_VOCABULARY` (1740 entries, sorted) and per-language IDF tables; do not edit manually
 
 ## Related
 
-- ADR-001: Fix all noticed issues immediately regardless of scope — applies when finding invariant violations or guard logic gaps during traversal or extraction changes. PR #269 applied this (Wave 3c); PR #272 applied it again (Wave 3d).
-- PF-004: u16 depth arithmetic overflow — always widen to u32 before adding an offset in depth comparisons. See gap-fill note above. The store builder applies the analogous rule: `u32::try_from` for node_count narrowing, no silent `as u32`.
-- Feature: `cochange` — consumes `FileId`-keyed data built from git history; the store builder's atomic-write pattern (`NamedTempFile::new_in + sync_all + persist`) matches the cochange sibling.
-- Feature: `temporal-scoring` — parallel sibling in `rskim-search`; same `SearchError` type, same `Result<T>` alias pattern
-- `crates/rskim-search/src/ast_weights.rs` — vocabulary source; per-language bigram/trigram IDF tables; regenerated by `rskim-research ast-codegen`
-- `crates/rskim-core/src/parser.rs` — `Parser::new(Language)` and `parser.parse(&str)` used by `linearize_source`
-- `crates/rskim-search/src/index/mod.rs` — lexical sibling; `lang_map` was widened to `pub(crate)` here so `store/format.rs` can reuse `lang_to_id`/`lang_from_id`
-- Issue #197 (deferred): query-side covering-set from `AstNgramSet` (Wave 3f)
-- Issue #273 (follow-up): on-disk compression (delta encoding + VarInt / Roaring Bitmaps) to push index size below 1× source
+- PF-004: no silent `as` narrowing — use `try_from` + `IndexCorrupted`; u16 metric fields
+  use `min(u16::MAX)` before cast; `branch_count` saturates at `u32::MAX`.
+- PF-005 / ADR-003: replace empirically-baseless acceptance criteria with grounded ones —
+  the index size guard is a measured `< 2.2×` regression guard (measured ~1.23×), not a
+  phantom number. Background: `< 5%` is structurally unachievable for structural AST n-grams.
+- Feature: `cochange` — consumes `FileId`-keyed data built from git history; the store
+  builder's atomic-write pattern matches the cochange sibling.
+- Feature: `temporal-scoring` — parallel sibling in `rskim-search`; same `SearchError` type
+  and `Result<T>` alias pattern.
+- Feature: `research-ast` — `rskim-research` crate that produces `ast_weights.rs` via
+  `ast-codegen`; also uses `AstWalkIter` from `rskim-core`.
+- `crates/rskim-search/src/index/mod.rs` — lexical sibling; `lang_map` widened to `pub(crate)` here.
+- Issue #197 (deferred, Wave 3f): query-side covering-set from `AstNgramSet`, query engine.
+- Issue #199 (deferred, Wave 3g): CLI `--ast` flag and auto-rebuild-on-version-mismatch.
+- Issue #198 / #200 (deferred, Wave 4): ranking integration of structural-complexity scoring.
+- Issue #273 (follow-up): on-disk compression (delta + VarInt / Roaring Bitmaps).

--- a/.devflow/features/ast-index/KNOWLEDGE.md
+++ b/.devflow/features/ast-index/KNOWLEDGE.md
@@ -505,8 +505,11 @@ AstIndexReader::lookup_bigram(AstBigram)
 
 ## Related
 
-- PF-004: no silent `as` narrowing — use `try_from` + `IndexCorrupted`; u16 metric fields
-  use `min(u16::MAX)` before cast; `branch_count` saturates at `u32::MAX`.
+- PF-004: widen u16 depth values to u32 before arithmetic in depth comparisons
+  (`u32::from(p) + 1`, not `p + 1`) to prevent wrap at `u16::MAX`. Unrelated to
+  saturating casts: `max_block_stmts`/`max_params` saturate at `u16::MAX` (never wrap)
+  and `branch_count` saturates at `u32::MAX` — these are direct `min()`/`saturating_add`
+  patterns, not the PF-004 widening concern.
 - PF-005 / ADR-003: replace empirically-baseless acceptance criteria with grounded ones —
   the index size guard is a measured `< 2.2×` regression guard (measured ~1.23×), not a
   phantom number. Background: `< 5%` is structurally unachievable for structural AST n-grams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Wave 3e: AST Pattern Library & Structural Index v2** — `rskim-search` AST index format bumped to v2 (breaking; re-index required). Adds per-file structural metrics (max depth, max block statements, max params, branch count) and synthetic n-gram markers (EMPTY_BODY, DEEP_NODE, LARGE_BODY, MANY_PARAMS) emitted via a single-pass extraction. Pattern library catalog with 29 named patterns (ErrorHandling, Performance, Concurrency, Quality, Structure) GOLD-verified against real parse output; each pattern is either exact (reliable subset of every occurrence) or approximate (description says "approximation" or "structural"). (#196)
+
+### Migration Note
+- **AST index format v2 (breaking change)** — Files written by Wave 3d (`format_version=1`) are rejected with "please rebuild". Run `skim search index --rebuild` (or `--force`) to regenerate. The v2 format adds 10 bytes per file entry for structural metrics and stores `avg_max_depth:f32` in the header. No data loss: v2 is a strict superset of v1.
+
+### Added
 - **Universal shell interception via PATH wrappers** — `skim init --wrappers` creates symlinks in `~/.skim/bin/` for all supported tools. The skim binary detects `argv[0]` and dispatches through the existing handlers. Recursion is prevented by stripping `~/.skim/bin` from PATH as the very first action in `main()`. `--no-wrappers` skips wrapper installation unconditionally; in TTY environments without either flag, the user is prompted interactively. Non-TTY environments default to skipping. (#258)
 - **Hook scripts include PATH prepend for wrapper activation** — Generated hook scripts now prepend `~/.skim/bin` to PATH so that sub-agents in restricted PATH environments still resolve wrapper symlinks. The prepend is guarded by a `[ -d "$HOME/.skim/bin" ]` check, so hooks installed before `skim init --wrappers` was run are unaffected. The skim binary's startup PATH strip prevents infinite recursion. (#258)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (3,626 tests passing)
+- ✅ Full Rust project with comprehensive test suite (5,191 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -79,7 +79,7 @@ analytics/          ← Token savings persistence (SQLite)
 
 **TEMPORAL SEARCH NOTE**: The `rskim-search` crate stores hotspot, risk, and co-change data in `<project-root>/.skim/search.db` (SQLite, WAL mode). Schema migrations are forward-only via `PRAGMA user_version` — each version gate runs only when the stored version is below the target. Databases created by a future version return an error rather than silently corrupting data. Current schema: v1 (hotspot, risk, cochange tables), v2 (performance indexes for top-N and per-file lookup queries).
 
-**AST INDEX FORMAT NOTE**: The `rskim-search` AST n-gram index (`ast_index.skidx` + `ast_index.skidx.postings`) is now **format v2** (Wave 3e, #196). v2 adds per-file structural metrics (max_depth, max_block_stmts, max_params, branch_count — +10 bytes per file) and stores `avg_max_depth:f32` in the header. Files created by v1 are rejected with "please rebuild". Run `skim search index --rebuild` after updating. Synthetic n-gram markers (EMPTY_BODY=65000, DEEP_NODE=65001, LARGE_BODY=65002, MANY_PARAMS=65003; bucket labels at 64900+) are emitted alongside real n-grams; vocab_resolve() returns None for all synthetic IDs (isolation guarantee).
+**AST INDEX FORMAT NOTE**: The `rskim-search` AST n-gram index (`ast_index.skidx` + `ast_index.skpost`) is now **format v2** (Wave 3e, #196). v2 adds per-file structural metrics (max_depth, max_block_stmts, max_params, branch_count — +10 bytes per file) and stores `avg_max_depth:f32` in the header. Files created by v1 are rejected with "please rebuild". Run `skim search index --rebuild` after updating. Synthetic n-gram markers (EMPTY_BODY=65000, DEEP_NODE=65001, LARGE_BODY=65002, MANY_PARAMS=65003; bucket labels at 64900+) are emitted alongside real n-grams; vocab_resolve() returns None for all synthetic IDs (isolation guarantee).
 
 ## Implementation Phases
 
@@ -605,7 +605,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,626 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,191 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (4,852 tests passing)
+- ✅ Full Rust project with comprehensive test suite (3,626 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -78,6 +78,8 @@ analytics/          ← Token savings persistence (SQLite)
 **ANALYTICS NOTE**: The `analytics/` module persists token savings to `~/.cache/skim/analytics.db` (SQLite with WAL mode). Recording is fire-and-forget via background threads. The `AnalyticsStore` trait enables MockStore-based testing of the stats dashboard without a real database. `--clear-cache` does NOT touch `analytics.db`.
 
 **TEMPORAL SEARCH NOTE**: The `rskim-search` crate stores hotspot, risk, and co-change data in `<project-root>/.skim/search.db` (SQLite, WAL mode). Schema migrations are forward-only via `PRAGMA user_version` — each version gate runs only when the stored version is below the target. Databases created by a future version return an error rather than silently corrupting data. Current schema: v1 (hotspot, risk, cochange tables), v2 (performance indexes for top-N and per-file lookup queries).
+
+**AST INDEX FORMAT NOTE**: The `rskim-search` AST n-gram index (`ast_index.skidx` + `ast_index.skidx.postings`) is now **format v2** (Wave 3e, #196). v2 adds per-file structural metrics (max_depth, max_block_stmts, max_params, branch_count — +10 bytes per file) and stores `avg_max_depth:f32` in the header. Files created by v1 are rejected with "please rebuild". Run `skim search index --rebuild` after updating. Synthetic n-gram markers (EMPTY_BODY=65000, DEEP_NODE=65001, LARGE_BODY=65002, MANY_PARAMS=65003; bucket labels at 64900+) are emitted alongside real n-grams; vocab_resolve() returns None for all synthetic IDs (isolation guarantee).
 
 ## Implementation Phases
 
@@ -603,7 +605,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 4,852 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 3,626 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (5,205 tests passing)
+- ✅ Full Rust project with comprehensive test suite (5,213 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -605,7 +605,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,205 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,213 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (5,195 tests passing)
+- ✅ Full Rust project with comprehensive test suite (5,205 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -605,7 +605,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,195 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,205 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ✅ **PHASE 3 COMPLETE** (100% of original roadmap)
 
 **What's Complete (Phases 1 & 2):**
-- ✅ Full Rust project with comprehensive test suite (5,191 tests passing)
+- ✅ Full Rust project with comprehensive test suite (5,195 tests passing)
 - ✅ 17 languages supported: TypeScript, JavaScript, Python, Rust, Go, Java, C, C++, C#, Ruby, SQL, Kotlin, Swift, Markdown, JSON, YAML, TOML
 - ✅ 4 transformation modes: structure, signatures, types, full
 - ✅ CLI with stdin/stdout streaming support
@@ -605,7 +605,7 @@ Cross-platform builds require different GitHub Actions runners:
 5. Create test fixtures
 6. Validate AST access works
 
-**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,191 tests passing. See README.md for full usage guide.
+**NOTE:** All phases complete (100%). Phase 3 features (multi-file glob, caching, parallel processing, token counting) are fully implemented and tested with 5,195 tests passing. See README.md for full usage guide.
 
 ### Critical First File: `src/parser.rs`
 

--- a/crates/rskim-search/benches/ast_index_bench.rs
+++ b/crates/rskim-search/benches/ast_index_bench.rs
@@ -21,7 +21,9 @@ use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use rskim_core::Language;
 use rskim_search::{
     AstIndexBuilder, FileId,
-    ast_index::{LinearNode, extract_ast_ngrams, extract_ast_ngrams_with_metrics, linearize_source},
+    ast_index::{
+        LinearNode, extract_ast_ngrams, extract_ast_ngrams_with_metrics, linearize_source,
+    },
 };
 use tempfile::TempDir;
 
@@ -100,9 +102,7 @@ fn bench_extraction_overhead(c: &mut Criterion) {
 
     // v2 path: extract_ast_ngrams_with_metrics returns StructuralMetrics too
     group.bench_function("extract_v2_with_metrics", |b| {
-        b.iter(|| {
-            extract_ast_ngrams_with_metrics(black_box(&nodes), black_box(Language::Rust))
-        })
+        b.iter(|| extract_ast_ngrams_with_metrics(black_box(&nodes), black_box(Language::Rust)))
     });
 
     group.finish();

--- a/crates/rskim-search/benches/ast_index_bench.rs
+++ b/crates/rskim-search/benches/ast_index_bench.rs
@@ -3,18 +3,26 @@
 //! Run with: cargo bench -p rskim-search --bench ast_index_bench
 //!
 //! Benchmark groups:
-//!   1. build_1000_files  — build_from_files over ~1000 Rust functions (A15)
+//!   1. build_1000_files       — build_from_files over ~1000 Rust functions (A15)
+//!   2. extraction_overhead    — compare extract_ast_ngrams (v1) vs
+//!                               extract_ast_ngrams_with_metrics (v2) on a
+//!                               representative linearized corpus. Empirically
+//!                               backs P1 (extraction overhead <15%).
 //!
-//! A16 (index size ratio < 1.8×) is a normal unit test in reader_tests.rs.
-//! Measured baseline: ~1.23×.  Bound < 1.8× leaves ~46% margin above baseline
-//! while catching genuine O(files²) bloat regressions.  On-disk compression
+//! A16 (index size ratio < 2.2×) is a normal unit test in reader_tests.rs.
+//! Measured baseline: ~1.23× (v1), ~1.3× (v2 with structural markers).
+//! Bound < 2.2× absorbs the deliberate v2 capability expansion while still
+//! catching genuine O(files²) bloat regressions.  On-disk compression
 //! (delta + VarInt / Roaring posting) tracked in issue #273.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use rskim_core::Language;
-use rskim_search::{AstIndexBuilder, FileId};
+use rskim_search::{
+    AstIndexBuilder, FileId,
+    ast_index::{LinearNode, extract_ast_ngrams, extract_ast_ngrams_with_metrics, linearize_source},
+};
 use tempfile::TempDir;
 
 // ============================================================================
@@ -72,8 +80,37 @@ fn bench_build_1000_files(c: &mut Criterion) {
 }
 
 // ============================================================================
+// Group 2: Extraction overhead — v1 vs v2 path (P1: < 15% overhead)
+// ============================================================================
+
+fn bench_extraction_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ast_extraction_overhead");
+
+    // Generate a representative Rust source once, linearize it once outside
+    // the timed closure so both benches measure only the extraction step.
+    let source = gen_rust_fns(50); // ~50 functions — representative corpus
+    let nodes: Vec<LinearNode> = linearize_source(&source, Language::Rust)
+        .expect("linearize failed")
+        .nodes;
+
+    // v1 path: extract_ast_ngrams discards metrics
+    group.bench_function("extract_v1_no_metrics", |b| {
+        b.iter(|| extract_ast_ngrams(black_box(&nodes), black_box(Language::Rust)))
+    });
+
+    // v2 path: extract_ast_ngrams_with_metrics returns StructuralMetrics too
+    group.bench_function("extract_v2_with_metrics", |b| {
+        b.iter(|| {
+            extract_ast_ngrams_with_metrics(black_box(&nodes), black_box(Language::Rust))
+        })
+    });
+
+    group.finish();
+}
+
+// ============================================================================
 // Criterion main
 // ============================================================================
 
-criterion_group!(benches, bench_build_1000_files);
+criterion_group!(benches, bench_build_1000_files, bench_extraction_overhead);
 criterion_main!(benches);

--- a/crates/rskim-search/benches/ast_index_bench.rs
+++ b/crates/rskim-search/benches/ast_index_bench.rs
@@ -5,9 +5,8 @@
 //! Benchmark groups:
 //!   1. build_1000_files       — build_from_files over ~1000 Rust functions (A15)
 //!   2. extraction_overhead    — compare extract_ast_ngrams (v1) vs
-//!                               extract_ast_ngrams_with_metrics (v2) on a
-//!                               representative linearized corpus. Empirically
-//!                               backs P1 (extraction overhead <15%).
+//!      extract_ast_ngrams_with_metrics (v2) on a representative
+//!      linearized corpus. Empirically backs P1 (extraction overhead <15%).
 //!
 //! A16 (index size ratio < 2.2×) is a normal unit test in reader_tests.rs.
 //! Measured baseline: ~1.23× (v1), ~1.3× (v2 with structural markers).

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -655,9 +655,7 @@ fn close_depth(
     if PARAM_LIST_KIND_IDS.contains(&kind_id) {
         // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
         let count_u16 = count.min(u32::from(u16::MAX)) as u16;
-        if count_u16 > metrics.max_params {
-            metrics.max_params = count_u16;
-        }
+        metrics.max_params = metrics.max_params.max(count_u16);
         emit_bucket_crossings(bigram_map, MANY_PARAMS, &PARAM_EDGES, count);
     }
 }
@@ -687,9 +685,7 @@ fn emit_empty_or_large_body(
     {
         // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
         let count_u16 = count.min(u32::from(u16::MAX)) as u16;
-        if count_u16 > metrics.max_block_stmts {
-            metrics.max_block_stmts = count_u16;
-        }
+        metrics.max_block_stmts = metrics.max_block_stmts.max(count_u16);
         emit_bucket_crossings(bigram_map, LARGE_BODY, &BODY_STMT_EDGES, count);
     }
 }

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -417,7 +417,6 @@ pub fn extract_ast_ngrams_with_metrics(
                     if ancestors[depth_to_close].is_some() {
                         close_depth(
                             depth_to_close,
-                            &ancestors,
                             &child_counts,
                             &depth_kind,
                             &mut metrics,
@@ -489,7 +488,6 @@ pub fn extract_ast_ngrams_with_metrics(
             if ancestors[d].is_some() {
                 close_depth(
                     d,
-                    &ancestors,
                     &child_counts,
                     &depth_kind,
                     &mut metrics,
@@ -531,7 +529,6 @@ pub fn extract_ast_ngrams_with_metrics(
 /// was encountered, or because we're at end-of-stream).
 fn close_depth(
     depth_idx: usize,
-    ancestors: &[Option<NodeKindId>],
     child_counts: &[u32],
     depth_kind: &[NodeKindId],
     metrics: &mut StructuralMetrics,
@@ -600,9 +597,6 @@ fn close_depth(
         }
     }
 
-    // `ancestors` is not used in close_depth (only depth_kind is needed here),
-    // but it is kept in the signature for future use and to express the calling contract.
-    let _ = ancestors;
 }
 
 /// Extract structural n-grams using the production per-language IDF tables.

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -27,6 +27,11 @@ use rskim_core::Language;
 
 use super::{AstBigram, AstTrigram, NodeKindId, ast_bigram_idf, ast_trigram_idf};
 use crate::ast_index::linearize::LinearNode;
+use crate::ast_index::structural::{
+    BODY_KIND_IDS, BODY_STMT_EDGES, BRANCH_KIND_IDS, DEEP_NODE, DEPTH_EDGES, EMPTY_BODY,
+    FUNCTION_KIND_IDS, LARGE_BODY, MANY_PARAMS, PARAM_EDGES, PARAM_LIST_KIND_IDS,
+    StructuralMetrics, bucket_label, is_counted_child,
+};
 
 // ============================================================================
 // Public types
@@ -247,6 +252,357 @@ pub fn extract_ast_ngrams_with_weights(
     trigrams.sort_unstable_by_key(|e| e.ngram.key());
 
     AstNgramSet { bigrams, trigrams }
+}
+
+/// Extract structural n-grams AND per-file structural metrics in a single pass.
+///
+/// This function extends [`extract_ast_ngrams_with_weights`] by folding the
+/// structural computation (body-statement counting, parameter counting, depth
+/// tracking, branch counting) and synthetic n-gram emission into the SAME
+/// traversal loop — no second pass, no additional allocations beyond the
+/// ancestor tracking already performed.
+///
+/// # Synthetic markers emitted
+///
+/// - `EMPTY_BODY → enclosing_kind` — body/block with zero counted children,
+///   keyed on the enclosing construct (parent of the body kind).
+/// - `DEEP_NODE → bucket_label(i)` — cumulative, for each depth edge crossed.
+/// - `LARGE_BODY → bucket_label(i)` — cumulative, for function/method bodies
+///   only, for each body-statement-count edge crossed.
+/// - `MANY_PARAMS → bucket_label(i)` — cumulative, for each param-count edge
+///   crossed.
+///
+/// All synthetic n-grams use `DEFAULT_AST_WEIGHT` and `count = 1`.
+/// Synthetic parent IDs (>= 65000) are guaranteed to not be in the vocabulary,
+/// so no real containment bigram can collide.
+///
+/// # PF-004 compliance
+///
+/// Saturating casts are used for all u16/u32 accumulations:
+/// - `max_block_stmts` and `max_params` use `min(u16::MAX)` before cast.
+/// - `branch_count` saturates at `u32::MAX`.
+///
+/// # Returns
+///
+/// A pair `(AstNgramSet, StructuralMetrics)` where:
+/// - `AstNgramSet` contains all real n-grams plus synthetic marker bigrams.
+/// - `StructuralMetrics` contains per-file complexity metrics.
+#[must_use]
+pub fn extract_ast_ngrams_with_metrics(
+    nodes: &[LinearNode],
+    lang: Language,
+) -> (AstNgramSet, StructuralMetrics) {
+    use crate::ast_index::DEFAULT_AST_WEIGHT;
+
+    if nodes.is_empty() {
+        return (AstNgramSet::default(), StructuralMetrics::default());
+    }
+
+    // ── Metrics state ─────────────────────────────────────────────────────────
+    let mut metrics = StructuralMetrics::default();
+
+    // ── Ancestor table (same as extract_ast_ngrams_with_weights) ─────────────
+    let max_depth = nodes.iter().map(|n| n.depth).max().unwrap_or(0);
+    let mut ancestors: Vec<Option<NodeKindId>> = vec![None; usize::from(max_depth) + 1];
+
+    // ── Accumulation maps for real n-grams ────────────────────────────────────
+    let cap = nodes.len().min(1024);
+    let mut bigram_map: HashMap<AstBigram, (f32, u32)> = HashMap::with_capacity(cap);
+    let mut trigram_map: HashMap<AstTrigram, (f32, u32)> = HashMap::with_capacity(cap);
+
+    // ── Per-ancestor structural tracking ─────────────────────────────────────
+    //
+    // For each depth slot in the ancestor table we track:
+    //   - How many "counted children" the node at that depth has seen so far.
+    //   - The kind_id of the node at that depth (mirrors `ancestors[d]` but
+    //     kept separately so we can access it at subtree-close time even after
+    //     the slot may have been overwritten by a sibling at the same depth).
+    //
+    // Invariant: `child_counts[d]` is valid only when `ancestors[d].is_some()`.
+    // When gap-fill nulls `ancestors[d]`, we also reset `child_counts[d]`.
+    let table_len = usize::from(max_depth) + 1;
+    let mut child_counts: Vec<u32> = vec![0u32; table_len];
+    // Track the kind_id stored at each depth slot so we can access it during
+    // the "previous node's subtree close" detection below.
+    let mut depth_kind: Vec<NodeKindId> = vec![0u16; table_len];
+
+    let mut prev_depth: Option<u16> = None;
+
+    // Helper: emit a synthetic bigram with count=1, DEFAULT_AST_WEIGHT
+    // into `bigram_map`.
+    let emit_synthetic = |bm: &mut HashMap<AstBigram, (f32, u32)>,
+                          parent: NodeKindId,
+                          child: NodeKindId| {
+        let key = AstBigram::encode(parent, child);
+        let entry = bm.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
+        entry.1 = entry.1.saturating_add(1);
+    };
+
+    for node in nodes {
+        let d = usize::from(node.depth);
+
+        // ── Update max_depth ──────────────────────────────────────────────────
+        if node.depth > metrics.max_depth {
+            metrics.max_depth = node.depth;
+        }
+
+        // ── Depth bucket emission ─────────────────────────────────────────────
+        // For EVERY node, check all depth edges. Cumulative: emit all crossed edges.
+        for (i, &edge) in DEPTH_EDGES.iter().enumerate() {
+            if u32::from(node.depth) >= edge {
+                emit_synthetic(&mut bigram_map, DEEP_NODE, bucket_label(i));
+            }
+        }
+
+        // ── Gap-fill (PF-004 safe: widen to u32) ────────────────────────────
+        // When a depth jump > +1 occurs, null ancestor slots AND child_counts
+        // for the skipped depths so that subtree-close logic is not triggered
+        // for nonexistent parents.
+        if let Some(p) = prev_depth
+            && u32::from(node.depth) > u32::from(p) + 1
+        {
+            let fill_start = usize::from(p) + 1;
+            debug_assert!(
+                fill_start < d,
+                "gap-fill range [{fill_start}..{d}) must be non-empty"
+            );
+            for slot in &mut ancestors[fill_start..d] {
+                *slot = None;
+            }
+            for cc in &mut child_counts[fill_start..d] {
+                *cc = 0;
+            }
+        }
+
+        // ── Detect subtree close: update child_counts for the parent ──────────
+        // The "parent" of the current node is at depth d-1. We increment that
+        // slot's counted-child count if the current node is a counted child.
+        if d > 0 {
+            let parent_d = d - 1;
+            if ancestors[parent_d].is_some() && is_counted_child(node.kind_id) {
+                child_counts[parent_d] = child_counts[parent_d].saturating_add(1);
+            }
+        }
+
+        // ── Detect if PREVIOUS node's subtree is closing ──────────────────────
+        // When depth decreases (or stays equal — a sibling), the node at
+        // `prev_depth` has had all its children visited. We can now emit
+        // structural markers for that node.
+        //
+        // Specifically: when `node.depth <= prev_depth`, the node at
+        // `prev_depth` will no longer accumulate children (all children at
+        // depth `prev_depth + 1` have been visited). We close out all depths
+        // from `prev_depth` down to `node.depth + 1` (exclusive).
+        //
+        // We close depths in reverse (deepest first) so that parent metrics
+        // include the correctly-computed child metrics.
+        if let Some(p) = prev_depth {
+            // Close all depths from prev_depth down to node.depth (inclusive).
+            //
+            // When depth decreases (e.g. prev=3 → cur=2), we must close:
+            // - depth 3: the last leaf that had no more children,
+            // - depth 2: the ancestor that was occupying depth 2 BEFORE the
+            //   current node replaces it (e.g. `parameters` before `->`).
+            //
+            // In pre-order DFS a node's subtree is fully exhausted when the
+            // next node is at the same depth OR shallower. Closing depths
+            // [close_end..=close_start] (deepest first) ensures that each
+            // structural container (parameters, block, etc.) is closed with
+            // its final `child_counts` value intact before the slot is
+            // overwritten by the incoming sibling or uncle.
+            let close_start = usize::from(node.depth);
+            let close_end = usize::from(p);
+            if close_end >= close_start {
+                for depth_to_close in (close_start..=close_end).rev() {
+                    if ancestors[depth_to_close].is_some() {
+                        close_depth(
+                            depth_to_close,
+                            &ancestors,
+                            &child_counts,
+                            &depth_kind,
+                            &mut metrics,
+                            &mut bigram_map,
+                        );
+                    }
+                }
+            }
+        }
+
+        // ── Branch count ──────────────────────────────────────────────────────
+        if BRANCH_KIND_IDS.contains(&node.kind_id) {
+            metrics.branch_count = metrics.branch_count.saturating_add(1);
+        }
+
+        // ── Resolve parent and grandparent (real n-gram emission) ─────────────
+        let table_len = ancestors.len();
+        debug_assert!(d < table_len, "depth {d} out of ancestor table (len={table_len})");
+
+        let parent: Option<NodeKindId> = node
+            .depth
+            .checked_sub(1)
+            .and_then(|pd| ancestors.get(usize::from(pd)).copied().flatten());
+
+        let grandparent: Option<NodeKindId> = node
+            .depth
+            .checked_sub(2)
+            .and_then(|gd| ancestors.get(usize::from(gd)).copied().flatten());
+
+        // Emit real bigram
+        if let Some(p) = parent
+            && p != 0
+            && node.kind_id != 0
+        {
+            let key = AstBigram::encode(p, node.kind_id);
+            let entry = bigram_map
+                .entry(key)
+                .or_insert_with(|| (ast_bigram_idf(lang, key), 0));
+            entry.1 = entry.1.saturating_add(1);
+        }
+
+        // Emit real trigram
+        if let (Some(gp), Some(p)) = (grandparent, parent)
+            && gp != 0
+            && p != 0
+            && node.kind_id != 0
+        {
+            let key = AstTrigram::encode(gp, p, node.kind_id);
+            let entry = trigram_map
+                .entry(key)
+                .or_insert_with(|| (ast_trigram_idf(lang, key), 0));
+            entry.1 = entry.1.saturating_add(1);
+        }
+
+        // ── Record node in ancestor table + reset child_count for this depth ──
+        ancestors[d] = Some(node.kind_id);
+        depth_kind[d] = node.kind_id;
+        // Reset child_count for this depth (this is a new node at depth d,
+        // its children haven't started yet).
+        child_counts[d] = 0;
+        prev_depth = Some(node.depth);
+    }
+
+    // ── Close any still-open depths at the end of the stream ─────────────────
+    // After processing all nodes, depths that were never "closed" (because no
+    // later node had a smaller depth) must be closed now.
+    if let Some(p) = prev_depth {
+        for d in (0..=usize::from(p)).rev() {
+            if ancestors[d].is_some() {
+                close_depth(
+                    d,
+                    &ancestors,
+                    &child_counts,
+                    &depth_kind,
+                    &mut metrics,
+                    &mut bigram_map,
+                );
+            }
+        }
+    }
+
+    // ── Collect and sort ──────────────────────────────────────────────────────
+    let mut bigrams: Vec<AstBigramEntry> = bigram_map
+        .into_iter()
+        .map(|(ngram, (weight, count))| AstBigramEntry {
+            ngram,
+            weight,
+            count,
+        })
+        .collect();
+    bigrams.sort_unstable_by_key(|e| e.ngram.key());
+
+    let mut trigrams: Vec<AstTrigramEntry> = trigram_map
+        .into_iter()
+        .map(|(ngram, (weight, count))| AstTrigramEntry {
+            ngram,
+            weight,
+            count,
+        })
+        .collect();
+    trigrams.sort_unstable_by_key(|e| e.ngram.key());
+
+    (AstNgramSet { bigrams, trigrams }, metrics)
+}
+
+/// Close a depth slot: emit synthetic markers for the node at `depth_idx`
+/// based on its accumulated `child_counts` and kind.
+///
+/// Called when a node at `depth_idx` is known to have had all its children
+/// visited (either because a subsequent node at a shallower or equal depth
+/// was encountered, or because we're at end-of-stream).
+fn close_depth(
+    depth_idx: usize,
+    ancestors: &[Option<NodeKindId>],
+    child_counts: &[u32],
+    depth_kind: &[NodeKindId],
+    metrics: &mut StructuralMetrics,
+    bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+) {
+    use crate::ast_index::DEFAULT_AST_WEIGHT;
+
+    let kind_id = depth_kind[depth_idx];
+    if kind_id == 0 {
+        return; // sentinel — not a real construct, skip
+    }
+
+    let count = child_counts[depth_idx];
+
+    // ── EMPTY_BODY emission ───────────────────────────────────────────────────
+    // If this node is a body/block kind AND has zero counted children,
+    // emit EMPTY_BODY → enclosing_kind (the parent of this body kind).
+    if BODY_KIND_IDS.contains(&kind_id) {
+        if count == 0 {
+            // Enclosing kind = parent of this body = ancestor at depth_idx - 1
+            if depth_idx > 0 {
+                let enclosing_id = depth_kind[depth_idx - 1];
+                if enclosing_id != 0 {
+                    let key = AstBigram::encode(EMPTY_BODY, enclosing_id);
+                    let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
+                    entry.1 = entry.1.saturating_add(1);
+                }
+            }
+        }
+
+        // ── LARGE_BODY emission (function/method bodies only) ─────────────────
+        // Check if the enclosing node is a function/method kind.
+        if depth_idx > 0 {
+            let enclosing_id = depth_kind[depth_idx - 1];
+            if FUNCTION_KIND_IDS.contains(&enclosing_id) {
+                // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
+                let count_u16 = count.min(u32::from(u16::MAX)) as u16;
+                if count_u16 > metrics.max_block_stmts {
+                    metrics.max_block_stmts = count_u16;
+                }
+                // Cumulative bucket emission
+                for (i, &edge) in BODY_STMT_EDGES.iter().enumerate() {
+                    if count >= edge {
+                        let key = AstBigram::encode(LARGE_BODY, bucket_label(i));
+                        let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
+                        entry.1 = entry.1.saturating_add(1);
+                    }
+                }
+            }
+        }
+    }
+
+    // ── MANY_PARAMS emission ──────────────────────────────────────────────────
+    if PARAM_LIST_KIND_IDS.contains(&kind_id) {
+        // PF-004: saturating cast
+        let count_u16 = count.min(u32::from(u16::MAX)) as u16;
+        if count_u16 > metrics.max_params {
+            metrics.max_params = count_u16;
+        }
+        for (i, &edge) in PARAM_EDGES.iter().enumerate() {
+            if count >= edge {
+                let key = AstBigram::encode(MANY_PARAMS, bucket_label(i));
+                let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
+                entry.1 = entry.1.saturating_add(1);
+            }
+        }
+    }
+
+    // `ancestors` is not used in close_depth (only depth_kind is needed here),
+    // but it is kept in the signature for future use and to express the calling contract.
+    let _ = ancestors;
 }
 
 /// Extract structural n-grams using the production per-language IDF tables.

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -292,66 +292,19 @@ pub fn extract_ast_ngrams_with_metrics(
     nodes: &[LinearNode],
     lang: Language,
 ) -> (AstNgramSet, StructuralMetrics) {
-    use crate::ast_index::DEFAULT_AST_WEIGHT;
-
     if nodes.is_empty() {
         return (AstNgramSet::default(), StructuralMetrics::default());
     }
 
-    // ── Metrics state ─────────────────────────────────────────────────────────
-    let mut metrics = StructuralMetrics::default();
-
-    // ── Ancestor table (same as extract_ast_ngrams_with_weights) ─────────────
     let max_depth = nodes.iter().map(|n| n.depth).max().unwrap_or(0);
-    let mut ancestors: Vec<Option<NodeKindId>> = vec![None; usize::from(max_depth) + 1];
-
-    // ── Accumulation maps for real n-grams ────────────────────────────────────
-    let cap = nodes.len().min(1024);
-    let mut bigram_map: HashMap<AstBigram, (f32, u32)> = HashMap::with_capacity(cap);
-    let mut trigram_map: HashMap<AstTrigram, (f32, u32)> = HashMap::with_capacity(cap);
-
-    // ── Per-ancestor structural tracking ─────────────────────────────────────
-    //
-    // For each depth slot in the ancestor table we track:
-    //   - How many "counted children" the node at that depth has seen so far.
-    //   - The kind_id of the node at that depth (mirrors `ancestors[d]` but
-    //     kept separately so we can access it at subtree-close time even after
-    //     the slot may have been overwritten by a sibling at the same depth).
-    //
-    // Invariant: `child_counts[d]` is valid only when `ancestors[d].is_some()`.
-    // When gap-fill nulls `ancestors[d]`, we also reset `child_counts[d]`.
-    let table_len = usize::from(max_depth) + 1;
-    let mut child_counts: Vec<u32> = vec![0u32; table_len];
-    // Track the kind_id stored at each depth slot so we can access it during
-    // the "previous node's subtree close" detection below.
-    let mut depth_kind: Vec<NodeKindId> = vec![0u16; table_len];
-
+    let mut state = ExtractState::new(max_depth, nodes.len());
     let mut prev_depth: Option<u16> = None;
-
-    // Helper: emit a synthetic bigram with count=1, DEFAULT_AST_WEIGHT
-    // into `bigram_map`.
-    let emit_synthetic =
-        |bm: &mut HashMap<AstBigram, (f32, u32)>, parent: NodeKindId, child: NodeKindId| {
-            let key = AstBigram::encode(parent, child);
-            let entry = bm.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
-            entry.1 = entry.1.saturating_add(1);
-        };
 
     for node in nodes {
         let d = usize::from(node.depth);
 
-        // ── Update max_depth ──────────────────────────────────────────────────
-        if node.depth > metrics.max_depth {
-            metrics.max_depth = node.depth;
-        }
-
-        // ── Depth bucket emission ─────────────────────────────────────────────
-        // For EVERY node, check all depth edges. Cumulative: emit all crossed edges.
-        for (i, &edge) in DEPTH_EDGES.iter().enumerate() {
-            if u32::from(node.depth) >= edge {
-                emit_synthetic(&mut bigram_map, DEEP_NODE, bucket_label(i));
-            }
-        }
+        state.update_max_depth(node.depth);
+        state.emit_depth_buckets(node.depth);
 
         // ── Gap-fill (PF-004 safe: widen to u32) ────────────────────────────
         // When a depth jump > +1 occurs, null ancestor slots AND child_counts
@@ -360,79 +313,190 @@ pub fn extract_ast_ngrams_with_metrics(
         if let Some(p) = prev_depth
             && u32::from(node.depth) > u32::from(p) + 1
         {
-            let fill_start = usize::from(p) + 1;
-            debug_assert!(
-                fill_start < d,
-                "gap-fill range [{fill_start}..{d}) must be non-empty"
-            );
-            for slot in &mut ancestors[fill_start..d] {
-                *slot = None;
-            }
-            for cc in &mut child_counts[fill_start..d] {
-                *cc = 0;
-            }
+            state.fill_depth_gap(p, d);
         }
 
-        // ── Detect subtree close: update child_counts for the parent ──────────
+        // ── Increment parent's counted-child count ────────────────────────────
         // The "parent" of the current node is at depth d-1. We increment that
         // slot's counted-child count if the current node is a counted child.
-        if d > 0 {
-            let parent_d = d - 1;
-            if ancestors[parent_d].is_some() && is_counted_child(node.kind_id) {
-                child_counts[parent_d] = child_counts[parent_d].saturating_add(1);
-            }
+        state.update_child_count(d, node.kind_id);
+
+        // ── Close subtrees of the previous node ──────────────────────────────
+        // In pre-order DFS a node's subtree is fully exhausted when the next
+        // node is at the same depth OR shallower. Close depths [node.depth..=prev]
+        // in reverse (deepest first) so parent metrics include correctly-computed
+        // child metrics before the slot is overwritten by the incoming sibling.
+        if let Some(p) = prev_depth {
+            state.close_open_subtrees(node.depth, p);
         }
 
-        // ── Detect if PREVIOUS node's subtree is closing ──────────────────────
-        // When depth decreases (or stays equal — a sibling), the node at
-        // `prev_depth` has had all its children visited. We can now emit
-        // structural markers for that node.
-        //
-        // Specifically: when `node.depth <= prev_depth`, the node at
-        // `prev_depth` will no longer accumulate children (all children at
-        // depth `prev_depth + 1` have been visited). We close out all depths
-        // from `prev_depth` down to `node.depth + 1` (exclusive).
-        //
-        // We close depths in reverse (deepest first) so that parent metrics
-        // include the correctly-computed child metrics.
-        if let Some(p) = prev_depth {
-            // Close all depths from prev_depth down to node.depth (inclusive).
-            //
-            // When depth decreases (e.g. prev=3 → cur=2), we must close:
-            // - depth 3: the last leaf that had no more children,
-            // - depth 2: the ancestor that was occupying depth 2 BEFORE the
-            //   current node replaces it (e.g. `parameters` before `->`).
-            //
-            // In pre-order DFS a node's subtree is fully exhausted when the
-            // next node is at the same depth OR shallower. Closing depths
-            // [close_end..=close_start] (deepest first) ensures that each
-            // structural container (parameters, block, etc.) is closed with
-            // its final `child_counts` value intact before the slot is
-            // overwritten by the incoming sibling or uncle.
-            let close_start = usize::from(node.depth);
-            let close_end = usize::from(p);
-            if close_end >= close_start {
-                for depth_to_close in (close_start..=close_end).rev() {
-                    if ancestors[depth_to_close].is_some() {
-                        close_depth(
-                            depth_to_close,
-                            &child_counts,
-                            &depth_kind,
-                            &mut metrics,
-                            &mut bigram_map,
-                        );
-                    }
+        state.update_branch_count(node.kind_id);
+        state.emit_real_ngrams(node, lang);
+        state.record_node(d, node.kind_id);
+
+        prev_depth = Some(node.depth);
+    }
+
+    // ── Close any still-open depths at the end of the stream ─────────────────
+    // After processing all nodes, depths that were never "closed" (because no
+    // later node had a smaller depth) must be closed now. close_open_subtrees(0, p)
+    // closes [0..=p] in reverse, which matches the original end-of-stream loop.
+    if let Some(p) = prev_depth {
+        state.close_open_subtrees(0, p);
+    }
+
+    state.into_ngram_set()
+}
+
+// ============================================================================
+// ExtractState — mutable traversal state for extract_ast_ngrams_with_metrics
+// ============================================================================
+
+/// Mutable state threaded through the single-pass extraction loop.
+///
+/// Grouping the three parallel depth-indexed arrays (`ancestors`, `child_counts`,
+/// `depth_kind`) together with the accumulation maps and metrics makes the
+/// per-node operations expressible as focused methods, each touching only
+/// the fields it needs. The struct is local to this module and carries no heap
+/// allocations beyond the initial setup.
+///
+/// # Invariants (maintained by the methods below)
+///
+/// - `ancestors`, `child_counts`, and `depth_kind` are all allocated to length
+///   `max_depth + 1` at construction and never resized.
+/// - `child_counts[d]` is meaningful only when `ancestors[d].is_some()`.
+/// - `depth_kind[d]` intentionally diverges from `ancestors[d]` at gap-fill
+///   and subtree-close boundaries: `ancestors[d]` becomes `None` when the slot
+///   is invalidated, but `depth_kind[d]` retains the last known kind so that
+///   `close_depth` can read the enclosing parent at subtree-close time.
+struct ExtractState {
+    ancestors: Vec<Option<NodeKindId>>,
+    child_counts: Vec<u32>,
+    /// Mirrors `ancestors` kind values but is NOT nulled by gap-fill, so
+    /// `close_depth` can read the enclosing-parent kind after a sibling
+    /// overwrites the `ancestors` slot to `None`.
+    depth_kind: Vec<NodeKindId>,
+    bigram_map: HashMap<AstBigram, (f32, u32)>,
+    trigram_map: HashMap<AstTrigram, (f32, u32)>,
+    metrics: StructuralMetrics,
+}
+
+impl ExtractState {
+    fn new(max_depth: u16, node_count: usize) -> Self {
+        let table_len = usize::from(max_depth) + 1;
+        let cap = node_count.min(1024);
+        Self {
+            ancestors: vec![None; table_len],
+            child_counts: vec![0u32; table_len],
+            depth_kind: vec![0u16; table_len],
+            bigram_map: HashMap::with_capacity(cap),
+            trigram_map: HashMap::with_capacity(cap),
+            metrics: StructuralMetrics::default(),
+        }
+    }
+
+    /// Update `metrics.max_depth` when `depth` exceeds the current maximum.
+    #[inline]
+    fn update_max_depth(&mut self, depth: u16) {
+        if depth > self.metrics.max_depth {
+            self.metrics.max_depth = depth;
+        }
+    }
+
+    /// Emit cumulative `DEEP_NODE → bucket_label(i)` synthetics for every
+    /// depth bucket edge crossed by `depth`.
+    #[inline]
+    fn emit_depth_buckets(&mut self, depth: u16) {
+        emit_bucket_crossings(
+            &mut self.bigram_map,
+            DEEP_NODE,
+            &DEPTH_EDGES,
+            u32::from(depth),
+        );
+    }
+
+    /// Null ancestor slots and reset child counts for the depth range
+    /// `(prev_depth..node_depth)` — the depths that were skipped over by
+    /// a jump of more than +1.
+    ///
+    /// # PF-004
+    ///
+    /// The caller must widen `prev_depth` to u32 before the `> prev + 1`
+    /// guard to avoid u16 overflow at `p == u16::MAX`. This function itself
+    /// only uses `usize` indices and is safe regardless.
+    #[inline]
+    fn fill_depth_gap(&mut self, prev_depth: u16, node_d: usize) {
+        let fill_start = usize::from(prev_depth) + 1;
+        debug_assert!(
+            fill_start < node_d,
+            "gap-fill range [{fill_start}..{node_d}) must be non-empty"
+        );
+        for slot in &mut self.ancestors[fill_start..node_d] {
+            *slot = None;
+        }
+        for cc in &mut self.child_counts[fill_start..node_d] {
+            *cc = 0;
+        }
+    }
+
+    /// Increment the counted-child count of the parent (depth `d - 1`) when
+    /// the current node at depth `d` is a counted child.
+    ///
+    /// Sentinel nodes (`kind_id == 0`) are NOT counted (they are not real
+    /// constructs), but they ARE still recorded in the ancestor table by
+    /// `record_node` to preserve correct depth positions.
+    #[inline]
+    fn update_child_count(&mut self, d: usize, kind_id: NodeKindId) {
+        if d > 0 {
+            let parent_d = d - 1;
+            if self.ancestors[parent_d].is_some() && is_counted_child(kind_id) {
+                self.child_counts[parent_d] = self.child_counts[parent_d].saturating_add(1);
+            }
+        }
+    }
+
+    /// Close all depth slots in `[node_depth..=prev_depth]` (deepest first).
+    ///
+    /// In pre-order DFS a node's subtree is fully exhausted when the next node
+    /// is at the same depth OR shallower. Closing in reverse order (deepest
+    /// first) ensures that parent structural metrics (e.g. `max_block_stmts`)
+    /// are computed from fully-accumulated child counts before the slot is
+    /// overwritten by the incoming sibling or uncle.
+    #[inline]
+    fn close_open_subtrees(&mut self, node_depth: u16, prev_depth: u16) {
+        let close_start = usize::from(node_depth);
+        let close_end = usize::from(prev_depth);
+        if close_end >= close_start {
+            for depth_to_close in (close_start..=close_end).rev() {
+                if self.ancestors[depth_to_close].is_some() {
+                    close_depth(
+                        depth_to_close,
+                        &self.child_counts,
+                        &self.depth_kind,
+                        &mut self.metrics,
+                        &mut self.bigram_map,
+                    );
                 }
             }
         }
+    }
 
-        // ── Branch count ──────────────────────────────────────────────────────
-        if BRANCH_KIND_IDS.contains(&node.kind_id) {
-            metrics.branch_count = metrics.branch_count.saturating_add(1);
+    /// Increment `metrics.branch_count` (saturating) when `kind_id` is a
+    /// branch construct (if, match, switch, etc.).
+    #[inline]
+    fn update_branch_count(&mut self, kind_id: NodeKindId) {
+        if BRANCH_KIND_IDS.contains(&kind_id) {
+            self.metrics.branch_count = self.metrics.branch_count.saturating_add(1);
         }
+    }
 
-        // ── Resolve parent and grandparent (real n-gram emission) ─────────────
-        let table_len = ancestors.len();
+    /// Emit real bigram and trigram n-grams for `node` using the production
+    /// per-language IDF tables. Sentinel `kind_id == 0` is suppressed on both
+    /// sides of every n-gram.
+    #[inline]
+    fn emit_real_ngrams(&mut self, node: &LinearNode, lang: Language) {
+        let d = usize::from(node.depth);
+        let table_len = self.ancestors.len();
         debug_assert!(
             d < table_len,
             "depth {d} out of ancestor table (len={table_len})"
@@ -441,81 +505,120 @@ pub fn extract_ast_ngrams_with_metrics(
         let parent: Option<NodeKindId> = node
             .depth
             .checked_sub(1)
-            .and_then(|pd| ancestors.get(usize::from(pd)).copied().flatten());
+            .and_then(|pd| self.ancestors.get(usize::from(pd)).copied().flatten());
 
         let grandparent: Option<NodeKindId> = node
             .depth
             .checked_sub(2)
-            .and_then(|gd| ancestors.get(usize::from(gd)).copied().flatten());
+            .and_then(|gd| self.ancestors.get(usize::from(gd)).copied().flatten());
 
-        // Emit real bigram
         if let Some(p) = parent
             && p != 0
             && node.kind_id != 0
         {
             let key = AstBigram::encode(p, node.kind_id);
-            let entry = bigram_map
+            let entry = self
+                .bigram_map
                 .entry(key)
                 .or_insert_with(|| (ast_bigram_idf(lang, key), 0));
             entry.1 = entry.1.saturating_add(1);
         }
 
-        // Emit real trigram
         if let (Some(gp), Some(p)) = (grandparent, parent)
             && gp != 0
             && p != 0
             && node.kind_id != 0
         {
             let key = AstTrigram::encode(gp, p, node.kind_id);
-            let entry = trigram_map
+            let entry = self
+                .trigram_map
                 .entry(key)
                 .or_insert_with(|| (ast_trigram_idf(lang, key), 0));
             entry.1 = entry.1.saturating_add(1);
         }
-
-        // ── Record node in ancestor table + reset child_count for this depth ──
-        ancestors[d] = Some(node.kind_id);
-        depth_kind[d] = node.kind_id;
-        // Reset child_count for this depth (this is a new node at depth d,
-        // its children haven't started yet).
-        child_counts[d] = 0;
-        prev_depth = Some(node.depth);
     }
 
-    // ── Close any still-open depths at the end of the stream ─────────────────
-    // After processing all nodes, depths that were never "closed" (because no
-    // later node had a smaller depth) must be closed now.
-    if let Some(p) = prev_depth {
-        for d in (0..=usize::from(p)).rev() {
-            if ancestors[d].is_some() {
-                close_depth(d, &child_counts, &depth_kind, &mut metrics, &mut bigram_map);
-            }
+    /// Record `node.kind_id` in the ancestor table at `depth d` and reset
+    /// `child_counts[d]` to zero (this node's children have not been seen yet).
+    ///
+    /// Sentinel nodes (`kind_id == 0`) ARE recorded here to preserve correct
+    /// depth positions for their descendants. Suppression happens at emit time.
+    #[inline]
+    fn record_node(&mut self, d: usize, kind_id: NodeKindId) {
+        self.ancestors[d] = Some(kind_id);
+        self.depth_kind[d] = kind_id;
+        self.child_counts[d] = 0;
+    }
+
+    /// Consume the state and return the sorted `(AstNgramSet, StructuralMetrics)`.
+    fn into_ngram_set(self) -> (AstNgramSet, StructuralMetrics) {
+        let mut bigrams: Vec<AstBigramEntry> = self
+            .bigram_map
+            .into_iter()
+            .map(|(ngram, (weight, count))| AstBigramEntry {
+                ngram,
+                weight,
+                count,
+            })
+            .collect();
+        bigrams.sort_unstable_by_key(|e| e.ngram.key());
+
+        let mut trigrams: Vec<AstTrigramEntry> = self
+            .trigram_map
+            .into_iter()
+            .map(|(ngram, (weight, count))| AstTrigramEntry {
+                ngram,
+                weight,
+                count,
+            })
+            .collect();
+        trigrams.sort_unstable_by_key(|e| e.ngram.key());
+
+        (AstNgramSet { bigrams, trigrams }, self.metrics)
+    }
+}
+
+// ============================================================================
+// Shared synthetic-emission helpers
+// ============================================================================
+
+/// Emit a synthetic bigram `(parent → child)` with `DEFAULT_AST_WEIGHT` and
+/// `count = 1` into `bigram_map`, incrementing the count when the key is
+/// already present (saturating).
+#[inline]
+fn emit_synthetic(
+    bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+    parent: NodeKindId,
+    child: NodeKindId,
+) {
+    use crate::ast_index::DEFAULT_AST_WEIGHT;
+    let key = AstBigram::encode(parent, child);
+    let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
+    entry.1 = entry.1.saturating_add(1);
+}
+
+/// Emit cumulative bucket crossings: for each `(i, edge)` in `edges` where
+/// `value >= edge`, emit `parent → bucket_label(i)` into `bigram_map`.
+///
+/// Used by depth-bucket, large-body, and many-params emission — all three share
+/// the same cumulative threshold pattern.
+#[inline]
+fn emit_bucket_crossings(
+    bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+    parent: NodeKindId,
+    edges: &[u32],
+    value: u32,
+) {
+    for (i, &edge) in edges.iter().enumerate() {
+        if value >= edge {
+            emit_synthetic(bigram_map, parent, bucket_label(i));
         }
     }
-
-    // ── Collect and sort ──────────────────────────────────────────────────────
-    let mut bigrams: Vec<AstBigramEntry> = bigram_map
-        .into_iter()
-        .map(|(ngram, (weight, count))| AstBigramEntry {
-            ngram,
-            weight,
-            count,
-        })
-        .collect();
-    bigrams.sort_unstable_by_key(|e| e.ngram.key());
-
-    let mut trigrams: Vec<AstTrigramEntry> = trigram_map
-        .into_iter()
-        .map(|(ngram, (weight, count))| AstTrigramEntry {
-            ngram,
-            weight,
-            count,
-        })
-        .collect();
-    trigrams.sort_unstable_by_key(|e| e.ngram.key());
-
-    (AstNgramSet { bigrams, trigrams }, metrics)
 }
+
+// ============================================================================
+// close_depth — emit synthetic markers when a depth slot's subtree closes
+// ============================================================================
 
 /// Close a depth slot: emit synthetic markers for the node at `depth_idx`
 /// based on its accumulated `child_counts` and kind.
@@ -530,67 +633,66 @@ fn close_depth(
     metrics: &mut StructuralMetrics,
     bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
 ) {
-    use crate::ast_index::DEFAULT_AST_WEIGHT;
-
     let kind_id = depth_kind[depth_idx];
     if kind_id == 0 {
         return; // sentinel — not a real construct, skip
     }
 
+    // Compute enclosing_id once: the parent of this slot (depth_idx - 1).
+    // Both BODY and PARAM_LIST branches need it; computing it here removes
+    // the duplicated `depth_idx > 0` guard and `depth_kind[depth_idx - 1]`
+    // lookup that previously appeared in two separate inner blocks.
+    let enclosing_id: Option<NodeKindId> = depth_idx
+        .checked_sub(1)
+        .map(|pd| depth_kind[pd])
+        .filter(|&id| id != 0);
+
     let count = child_counts[depth_idx];
 
-    // ── EMPTY_BODY emission ───────────────────────────────────────────────────
-    // If this node is a body/block kind AND has zero counted children,
-    // emit EMPTY_BODY → enclosing_kind (the parent of this body kind).
     if BODY_KIND_IDS.contains(&kind_id) {
-        if count == 0 {
-            // Enclosing kind = parent of this body = ancestor at depth_idx - 1
-            if depth_idx > 0 {
-                let enclosing_id = depth_kind[depth_idx - 1];
-                if enclosing_id != 0 {
-                    let key = AstBigram::encode(EMPTY_BODY, enclosing_id);
-                    let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
-                    entry.1 = entry.1.saturating_add(1);
-                }
-            }
-        }
-
-        // ── LARGE_BODY emission (function/method bodies only) ─────────────────
-        // Check if the enclosing node is a function/method kind.
-        if depth_idx > 0 {
-            let enclosing_id = depth_kind[depth_idx - 1];
-            if FUNCTION_KIND_IDS.contains(&enclosing_id) {
-                // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
-                let count_u16 = count.min(u32::from(u16::MAX)) as u16;
-                if count_u16 > metrics.max_block_stmts {
-                    metrics.max_block_stmts = count_u16;
-                }
-                // Cumulative bucket emission
-                for (i, &edge) in BODY_STMT_EDGES.iter().enumerate() {
-                    if count >= edge {
-                        let key = AstBigram::encode(LARGE_BODY, bucket_label(i));
-                        let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
-                        entry.1 = entry.1.saturating_add(1);
-                    }
-                }
-            }
-        }
+        emit_empty_or_large_body(count, enclosing_id, metrics, bigram_map);
     }
 
     // ── MANY_PARAMS emission ──────────────────────────────────────────────────
     if PARAM_LIST_KIND_IDS.contains(&kind_id) {
-        // PF-004: saturating cast
+        // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
         let count_u16 = count.min(u32::from(u16::MAX)) as u16;
         if count_u16 > metrics.max_params {
             metrics.max_params = count_u16;
         }
-        for (i, &edge) in PARAM_EDGES.iter().enumerate() {
-            if count >= edge {
-                let key = AstBigram::encode(MANY_PARAMS, bucket_label(i));
-                let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
-                entry.1 = entry.1.saturating_add(1);
-            }
+        emit_bucket_crossings(bigram_map, MANY_PARAMS, &PARAM_EDGES, count);
+    }
+}
+
+/// Emit `EMPTY_BODY` and `LARGE_BODY` markers for a body/block node whose
+/// subtree has just closed.
+///
+/// - `EMPTY_BODY → enclosing_id` fires when `count == 0` and `enclosing_id`
+///   is `Some` (i.e. there is a named enclosing construct).
+/// - `LARGE_BODY → bucket_label(i)` fires cumulatively when the enclosing
+///   construct is a function/method kind and `count` crosses a bucket edge.
+///   Updates `metrics.max_block_stmts` (PF-004 saturating cast).
+fn emit_empty_or_large_body(
+    count: u32,
+    enclosing_id: Option<NodeKindId>,
+    metrics: &mut StructuralMetrics,
+    bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+) {
+    if count == 0
+        && let Some(enc) = enclosing_id
+    {
+        emit_synthetic(bigram_map, EMPTY_BODY, enc);
+    }
+
+    if let Some(enc) = enclosing_id
+        && FUNCTION_KIND_IDS.contains(&enc)
+    {
+        // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
+        let count_u16 = count.min(u32::from(u16::MAX)) as u16;
+        if count_u16 > metrics.max_block_stmts {
+            metrics.max_block_stmts = count_u16;
         }
+        emit_bucket_crossings(bigram_map, LARGE_BODY, &BODY_STMT_EDGES, count);
     }
 }
 

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -330,13 +330,12 @@ pub fn extract_ast_ngrams_with_metrics(
 
     // Helper: emit a synthetic bigram with count=1, DEFAULT_AST_WEIGHT
     // into `bigram_map`.
-    let emit_synthetic = |bm: &mut HashMap<AstBigram, (f32, u32)>,
-                          parent: NodeKindId,
-                          child: NodeKindId| {
-        let key = AstBigram::encode(parent, child);
-        let entry = bm.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
-        entry.1 = entry.1.saturating_add(1);
-    };
+    let emit_synthetic =
+        |bm: &mut HashMap<AstBigram, (f32, u32)>, parent: NodeKindId, child: NodeKindId| {
+            let key = AstBigram::encode(parent, child);
+            let entry = bm.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
+            entry.1 = entry.1.saturating_add(1);
+        };
 
     for node in nodes {
         let d = usize::from(node.depth);
@@ -434,7 +433,10 @@ pub fn extract_ast_ngrams_with_metrics(
 
         // ── Resolve parent and grandparent (real n-gram emission) ─────────────
         let table_len = ancestors.len();
-        debug_assert!(d < table_len, "depth {d} out of ancestor table (len={table_len})");
+        debug_assert!(
+            d < table_len,
+            "depth {d} out of ancestor table (len={table_len})"
+        );
 
         let parent: Option<NodeKindId> = node
             .depth
@@ -486,13 +488,7 @@ pub fn extract_ast_ngrams_with_metrics(
     if let Some(p) = prev_depth {
         for d in (0..=usize::from(p)).rev() {
             if ancestors[d].is_some() {
-                close_depth(
-                    d,
-                    &child_counts,
-                    &depth_kind,
-                    &mut metrics,
-                    &mut bigram_map,
-                );
+                close_depth(d, &child_counts, &depth_kind, &mut metrics, &mut bigram_map);
             }
         }
     }
@@ -596,7 +592,6 @@ fn close_depth(
             }
         }
     }
-
 }
 
 /// Extract structural n-grams using the production per-language IDF tables.

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -398,9 +398,7 @@ impl ExtractState {
     /// Update `metrics.max_depth` when `depth` exceeds the current maximum.
     #[inline]
     fn update_max_depth(&mut self, depth: u16) {
-        if depth > self.metrics.max_depth {
-            self.metrics.max_depth = depth;
-        }
+        self.metrics.max_depth = self.metrics.max_depth.max(depth);
     }
 
     /// Emit cumulative `DEEP_NODE → bucket_label(i)` synthetics for every

--- a/crates/rskim-search/src/ast_index/extract_tests.rs
+++ b/crates/rskim-search/src/ast_index/extract_tests.rs
@@ -8,6 +8,7 @@
 use rskim_core::Language;
 
 use super::*;
+use crate::ast_index::structural::BUCKET_LABEL_BASE;
 use crate::ast_index::{AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, linearize_source, vocab_lookup};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -683,6 +684,125 @@ fn trigram_count_accumulates_for_repeated_triple() {
     assert_eq!(
         occurrences, 1,
         "trigram must be deduplicated to a single entry"
+    );
+}
+
+// ── B_M1: Real n-gram parity — metrics path equals weights path ──────────────
+//
+// `extract_ast_ngrams_with_metrics` re-implements the full traversal loop
+// independently from `extract_ast_ngrams_with_weights`.  Any silent divergence
+// in edge cases (gap-fill ordering, sentinel handling, end-of-stream close)
+// would produce different real n-grams without a compile-time signal.
+//
+// This test runs both functions on the same input (a multi-node tree that
+// exercises gap-fill, siblings, and depth nesting) and asserts that the real
+// bigrams and trigrams match exactly after filtering out all synthetic markers
+// (parent or child ID >= BUCKET_LABEL_BASE = 64900).
+//
+// Filtering: a bigram is synthetic when parent >= 64900 OR child >= 64900.
+// Trigrams cannot be synthetic (synthetic IDs never appear in trigram slots).
+
+#[test]
+fn metrics_path_real_ngrams_match_weights_path() {
+    // Exercises: root→child, siblings, depth nesting, gap-fill (jump > +1).
+    // Kind IDs are well below 64900 — not in the synthetic range.
+    let nodes = [
+        node(10, 0), // root
+        node(20, 1), // child A of root
+        node(30, 2), // child of A
+        node(40, 2), // sibling of child above (depth-2 sibling)
+        node(50, 1), // sibling B of A (closes depth-2 subtrees)
+        node(60, 3), // depth jump 1→3: gap-fill nulls depth 2
+    ];
+
+    let weights_result =
+        extract_ast_ngrams_with_weights(&nodes, unit_bigram_weight, unit_trigram_weight);
+    let (metrics_result, _metrics) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+
+    let is_real_bigram = |e: &AstBigramEntry| {
+        let (parent, child) = e.ngram.decode();
+        parent < BUCKET_LABEL_BASE && child < BUCKET_LABEL_BASE
+    };
+
+    let mut weights_bigram_keys: Vec<u32> = weights_result
+        .bigrams
+        .iter()
+        .filter(|e| is_real_bigram(e))
+        .map(|e| e.ngram.key())
+        .collect();
+    let mut metrics_bigram_keys: Vec<u32> = metrics_result
+        .bigrams
+        .iter()
+        .filter(|e| is_real_bigram(e))
+        .map(|e| e.ngram.key())
+        .collect();
+    weights_bigram_keys.sort_unstable();
+    metrics_bigram_keys.sort_unstable();
+
+    assert_eq!(
+        weights_bigram_keys, metrics_bigram_keys,
+        "real bigram keys from metrics path must match weights path (synthetic IDs filtered out)"
+    );
+
+    let mut weights_trigram_keys: Vec<u64> = weights_result
+        .trigrams
+        .iter()
+        .map(|e| e.ngram.key())
+        .collect();
+    let mut metrics_trigram_keys: Vec<u64> = metrics_result
+        .trigrams
+        .iter()
+        .map(|e| e.ngram.key())
+        .collect();
+    weights_trigram_keys.sort_unstable();
+    metrics_trigram_keys.sort_unstable();
+
+    assert_eq!(
+        weights_trigram_keys, metrics_trigram_keys,
+        "trigram keys from metrics path must match weights path"
+    );
+}
+
+// ── B_M2: u16::MAX depth regression guard — metrics path ─────────────────────
+//
+// B1 / B1-sibling lock the u16::MAX fix in `extract_ast_ngrams_with_weights`.
+// `extract_ast_ngrams_with_metrics` has its own gap-fill arithmetic (u32-widened
+// per PF-004) but previously had no regression guard.
+//
+// Structure mirrors B1:
+//   node(10, 0)        → root; prev_depth = 0
+//   node(20, u16::MAX) → jump 0→u16::MAX; gap-fill fires
+//                        (u32::from(u16::MAX) > u32::from(0) + 1 → true);
+//                        ancestors[1..65535] nulled → no real bigram
+//
+// Additional assertion: metrics.max_depth == u16::MAX.
+//
+// Applies ADR-003 (grounded regression guards); avoids PF-004 (u16 overflow).
+
+#[test]
+fn metrics_path_u16_max_depth_no_panic_max_depth_recorded() {
+    let nodes = [node(10, 0), node(20, u16::MAX)];
+    let (result, metrics) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+
+    let is_real_bigram = |e: &AstBigramEntry| {
+        let (parent, child) = e.ngram.decode();
+        parent < BUCKET_LABEL_BASE && child < BUCKET_LABEL_BASE
+    };
+    let real_bigrams: Vec<_> = result
+        .bigrams
+        .iter()
+        .filter(|e| is_real_bigram(e))
+        .collect();
+    assert!(
+        real_bigrams.is_empty(),
+        "node at u16::MAX depth with gap must produce no real bigram (parent slot nulled); \
+         if this fails the PF-004 u32-widening guard in the metrics path is broken"
+    );
+
+    assert_eq!(
+        metrics.max_depth,
+        u16::MAX,
+        "metrics.max_depth must record the observed maximum depth (u16::MAX)"
     );
 }
 

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -33,8 +33,8 @@ mod extract;
 mod linearize;
 mod ngram;
 pub mod patterns;
-pub(crate) mod structural;
 mod store;
+pub(crate) mod structural;
 
 // ============================================================================
 // Shared type alias
@@ -59,8 +59,6 @@ pub use ngram::{
     AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, ast_bigram_idf, ast_trigram_idf, vocab_len,
     vocab_lookup, vocab_resolve,
 };
-pub use patterns::{
-    Pattern, PatternCategory, all_patterns, lookup_pattern, pattern_to_query_set,
-};
+pub use patterns::{Pattern, PatternCategory, all_patterns, lookup_pattern, pattern_to_query_set};
 pub use store::{AstFileMetaEntry, AstIndexBuilder, AstIndexReader, AstPosting};
 pub use structural::StructuralMetrics;

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -32,7 +32,7 @@
 mod extract;
 mod linearize;
 mod ngram;
-pub mod patterns;
+mod patterns;
 mod store;
 pub(crate) mod structural;
 

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -32,6 +32,8 @@
 mod extract;
 mod linearize;
 mod ngram;
+pub mod patterns;
+pub(crate) mod structural;
 mod store;
 
 // ============================================================================
@@ -50,11 +52,15 @@ pub type NodeKindId = u16;
 
 pub use extract::{
     AstBigramEntry, AstNgramSet, AstTrigramEntry, extract_ast_ngrams,
-    extract_ast_ngrams_with_weights,
+    extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights,
 };
 pub use linearize::{LinearNode, LinearizeResult, linearize_source};
 pub use ngram::{
     AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, ast_bigram_idf, ast_trigram_idf, vocab_len,
     vocab_lookup, vocab_resolve,
 };
+pub use patterns::{
+    Pattern, PatternCategory, all_patterns, lookup_pattern, pattern_to_query_set,
+};
 pub use store::{AstFileMetaEntry, AstIndexBuilder, AstIndexReader, AstPosting};
+pub use structural::StructuralMetrics;

--- a/crates/rskim-search/src/ast_index/patterns.rs
+++ b/crates/rskim-search/src/ast_index/patterns.rs
@@ -215,7 +215,6 @@ impl Pattern {
 /// | **Total** | **29** |
 pub static PATTERNS: &[Pattern] = &[
     // ── ErrorHandling ────────────────────────────────────────────────────────
-
     Pattern {
         name: "try-catch",
         description: "A try/catch block (TypeScript/JavaScript). Exact: try_statement always \
@@ -283,12 +282,13 @@ pub static PATTERNS: &[Pattern] = &[
         exact: true,
         example: "try { f(); } catch (e) { g(); } finally { h(); }",
         example_lang: Language::TypeScript,
-        bigrams: &[("try_statement", "catch_clause"), ("try_statement", "finally_clause")],
+        bigrams: &[
+            ("try_statement", "catch_clause"),
+            ("try_statement", "finally_clause"),
+        ],
         trigrams: &[],
     },
-
     // ── Performance ──────────────────────────────────────────────────────────
-
     Pattern {
         name: "nested-loop",
         description: "A loop nested inside another loop (TypeScript/JavaScript for-statements). \
@@ -329,7 +329,11 @@ pub static PATTERNS: &[Pattern] = &[
         example: "for (const x of items) { process(x); }",
         example_lang: Language::TypeScript,
         bigrams: &[],
-        trigrams: &[("for_in_statement", "statement_block", "expression_statement")],
+        trigrams: &[(
+            "for_in_statement",
+            "statement_block",
+            "expression_statement",
+        )],
     },
     Pattern {
         name: "deep-nesting",
@@ -359,9 +363,7 @@ pub static PATTERNS: &[Pattern] = &[
         bigrams: &[],
         trigrams: &[("for_statement", "block", "for_statement")],
     },
-
     // ── Concurrency ──────────────────────────────────────────────────────────
-
     Pattern {
         name: "go-goroutine",
         description: "A goroutine launch (Go). Exact: go_statement is the tree-sitter node for \
@@ -428,9 +430,7 @@ pub static PATTERNS: &[Pattern] = &[
         bigrams: &[("synchronized_statement", "block")],
         trigrams: &[],
     },
-
     // ── Quality ──────────────────────────────────────────────────────────────
-
     Pattern {
         name: "function-with-body",
         description: "A function item with a body (Rust). Exact: function_item always contains \
@@ -518,9 +518,7 @@ pub static PATTERNS: &[Pattern] = &[
         bigrams: &[("expression_statement", "call_expression")],
         trigrams: &[],
     },
-
     // ── Structure ────────────────────────────────────────────────────────────
-
     Pattern {
         name: "switch-with-cases",
         description: "A switch statement with a switch body (TypeScript/JavaScript). Exact: \

--- a/crates/rskim-search/src/ast_index/patterns.rs
+++ b/crates/rskim-search/src/ast_index/patterns.rs
@@ -632,7 +632,7 @@ pub fn lookup_pattern(name: &str) -> Result<&'static Pattern> {
 pub fn pattern_to_query_set(pattern: &Pattern) -> AstNgramSet {
     use crate::ast_index::{AstBigramEntry, AstTrigramEntry, DEFAULT_AST_WEIGHT};
 
-    let bigrams = pattern
+    let mut bigrams: Vec<AstBigramEntry> = pattern
         .resolved_bigrams()
         .into_iter()
         .map(|ngram| AstBigramEntry {
@@ -641,8 +641,10 @@ pub fn pattern_to_query_set(pattern: &Pattern) -> AstNgramSet {
             count: 1,
         })
         .collect();
+    // AstNgramSet invariant: both vecs must be sorted by key ascending.
+    bigrams.sort_unstable_by_key(|e| e.ngram.key());
 
-    let trigrams = pattern
+    let mut trigrams: Vec<AstTrigramEntry> = pattern
         .resolved_trigrams()
         .into_iter()
         .map(|ngram| AstTrigramEntry {
@@ -651,6 +653,8 @@ pub fn pattern_to_query_set(pattern: &Pattern) -> AstNgramSet {
             count: 1,
         })
         .collect();
+    // AstNgramSet invariant: both vecs must be sorted by key ascending.
+    trigrams.sort_unstable_by_key(|e| e.ngram.key());
 
     AstNgramSet { bigrams, trigrams }
 }

--- a/crates/rskim-search/src/ast_index/patterns.rs
+++ b/crates/rskim-search/src/ast_index/patterns.rs
@@ -1,0 +1,666 @@
+//! AST Pattern Library — catalog of named structural code patterns (#196).
+//!
+//! This module provides a curated, data-driven catalog of code patterns indexed
+//! by their structural AST n-gram signatures. Patterns are either exact (the
+//! n-grams are a reliable SUBSET of any code exhibiting the pattern) or
+//! approximate (the n-grams are a weak proxy; description says "approximation"
+//! or "structural").
+//!
+//! # Design
+//!
+//! Each [`Pattern`] carries:
+//! - A unique kebab-case `name` used as a query key.
+//! - Human-readable `description` (honest about accuracy).
+//! - `exact: true` iff the n-grams are a reliable subset of every occurrence.
+//! - `bigrams`/`trigrams`: string pairs/triples to resolve via [`vocab_lookup`]
+//!   or, for synthetic markers, via reserved-name mapping.
+//! - `example`: a real code snippet GOLD-verified to emit the declared n-grams.
+//!
+//! # Honest limitations
+//!
+//! The following patterns are in LINTER TERRITORY and are NOT included because
+//! they cannot be detected from structural n-grams alone:
+//! - `hardcoded-secret` — requires semantic analysis of literal content.
+//! - `single-use-variable` — requires data-flow analysis.
+//! - `magic-number` — a weak numeric-literal-in-expression proxy is available
+//!   (see `numeric-literal-in-expression`) but is NOT named "magic-number"
+//!   to avoid overclaiming.
+//!
+//! # GOLD verification
+//!
+//! Every pattern's `example` is GOLD-verified in `patterns_tests.rs` (test F7):
+//! `linearize_source(example, example_lang)` followed by
+//! `extract_ast_ngrams_with_metrics` must emit every declared bigram and
+//! trigram. Patterns that could not be verified were either fixed or dropped.
+//!
+//! # Ranking
+//!
+//! Patterns are queryable today but do NOT affect ranking — ranking integration
+//! is deferred to Wave 4 (structural-complexity scoring dimension).
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use rskim_core::Language;
+
+use super::{AstBigram, AstNgramSet, AstTrigram, NodeKindId, vocab_lookup};
+use crate::ast_index::structural::{DEEP_NODE, EMPTY_BODY, LARGE_BODY, MANY_PARAMS, bucket_label};
+use crate::{Result, SearchError};
+
+// ============================================================================
+// Pattern category
+// ============================================================================
+
+/// Broad category for grouping patterns in the catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PatternCategory {
+    /// Error handling constructs (try/catch, rescue, except, etc.)
+    ErrorHandling,
+    /// Performance-relevant patterns (nested loops, call-in-loop, deep nesting)
+    Performance,
+    /// Concurrency-related constructs (goroutines, channels, unsafe, synchronized)
+    Concurrency,
+    /// Code quality signals (empty bodies, god functions, excessive params)
+    Quality,
+    /// Structural constructs (match/switch/impl/class)
+    Structure,
+}
+
+// ============================================================================
+// Synthetic marker name mapping
+// ============================================================================
+
+/// Reserved name strings for synthetic structural markers.
+///
+/// These are NOT in the real vocabulary. They are mapped to synthetic IDs
+/// by [`resolved_bigrams`][Pattern::resolved_bigrams] so patterns can reference
+/// structural markers (EMPTY_BODY, LARGE_BODY, MANY_PARAMS, DEEP_NODE) by name.
+///
+/// # Parent marker names
+///
+/// - `"__empty_body__"` → `EMPTY_BODY` (65000)
+/// - `"__large_body__"` → `LARGE_BODY` (65002)
+/// - `"__many_params__"` → `MANY_PARAMS` (65003)
+/// - `"__deep_node__"` → `DEEP_NODE` (65001)
+///
+/// # Bucket label names (child side of bucketed bigrams)
+///
+/// `"__large_body_b10__"` = bucket_label(0) (body stmts >= 10)
+/// `"__large_body_b20__"` = bucket_label(1) (body stmts >= 20)
+/// `"__large_body_b40__"` = bucket_label(2) (body stmts >= 40)
+/// `"__many_params_b5__"` = bucket_label(0) (params >= 5)
+/// `"__many_params_b8__"` = bucket_label(1) (params >= 8)
+/// `"__many_params_b12__"` = bucket_label(2) (params >= 12)
+/// `"__deep_node_b4__"` = bucket_label(0) (depth >= 4)
+/// `"__deep_node_b6__"` = bucket_label(1) (depth >= 6)
+/// `"__deep_node_b8__"` = bucket_label(2) (depth >= 8)
+///
+/// The correct bigram for "deep nesting detected" is:
+/// `("__deep_node__", "__deep_node_b4__")` which encodes as
+/// `AstBigram::encode(DEEP_NODE, bucket_label(0))`.
+///
+/// `"__empty_body__"` is always the parent side; the child side is a real
+/// vocab string (the enclosing construct kind).
+fn resolve_synthetic_name(name: &str) -> Option<NodeKindId> {
+    match name {
+        // Synthetic parent IDs
+        "__empty_body__" => Some(EMPTY_BODY),
+        "__large_body__" => Some(LARGE_BODY),
+        "__many_params__" => Some(MANY_PARAMS),
+        "__deep_node__" => Some(DEEP_NODE),
+        // Bucket labels (child side of bucketed bigrams)
+        "__large_body_b10__" => Some(bucket_label(0)),
+        "__large_body_b20__" => Some(bucket_label(1)),
+        "__large_body_b40__" => Some(bucket_label(2)),
+        "__many_params_b5__" => Some(bucket_label(0)),
+        "__many_params_b8__" => Some(bucket_label(1)),
+        "__many_params_b12__" => Some(bucket_label(2)),
+        "__deep_node_b4__" => Some(bucket_label(0)),
+        "__deep_node_b6__" => Some(bucket_label(1)),
+        "__deep_node_b8__" => Some(bucket_label(2)),
+        _ => None,
+    }
+}
+
+/// Resolve a kind string to a `NodeKindId`, checking synthetic names first.
+fn resolve_kind_name(name: &str) -> Option<NodeKindId> {
+    resolve_synthetic_name(name).or_else(|| vocab_lookup(name))
+}
+
+// ============================================================================
+// Pattern struct
+// ============================================================================
+
+/// One entry in the AST Pattern Library catalog.
+///
+/// A pattern is a named structural code pattern identified by its AST n-gram
+/// signatures. Patterns are either exact (reliable subset of every occurrence)
+/// or approximate (structural heuristic; description uses "approximation" or
+/// "structural proxy").
+#[derive(Debug, Clone)]
+pub struct Pattern {
+    /// Unique kebab-case query key (e.g. `"try-catch"`, `"empty-catch"`).
+    pub name: &'static str,
+    /// Human-readable description. Honest: approximate patterns explicitly say
+    /// "approximation" or "structural proxy".
+    pub description: &'static str,
+    /// Broad category.
+    pub category: PatternCategory,
+    /// `true` iff the declared n-grams are a reliable SUBSET of every occurrence
+    /// of this pattern. `false` means the match is approximate.
+    pub exact: bool,
+    /// A real code snippet (not fictional) that EXHIBITS this pattern.
+    /// GOLD-verified: `linearize_source(example, example_lang)` followed by
+    /// `extract_ast_ngrams_with_metrics` must emit all declared bigrams/trigrams.
+    pub example: &'static str,
+    /// Language of `example`.
+    pub example_lang: Language,
+    /// Real or synthetic bigram name pairs. Each `(parent_name, child_name)` is
+    /// resolved via `vocab_lookup` or synthetic-name mapping by `resolved_bigrams`.
+    pub bigrams: &'static [(&'static str, &'static str)],
+    /// Real or synthetic trigram name triples.
+    pub trigrams: &'static [(&'static str, &'static str, &'static str)],
+}
+
+impl Pattern {
+    /// Resolve declared bigram name pairs to [`AstBigram`] values.
+    ///
+    /// Pairs where either side does not resolve (unknown kind string or synthetic
+    /// name) are silently dropped. Call sites can check the count against
+    /// `self.bigrams.len()` to detect partial resolution.
+    #[must_use]
+    pub fn resolved_bigrams(&self) -> Vec<AstBigram> {
+        self.bigrams
+            .iter()
+            .filter_map(|(parent, child)| {
+                let p = resolve_kind_name(parent)?;
+                let c = resolve_kind_name(child)?;
+                Some(AstBigram::encode(p, c))
+            })
+            .collect()
+    }
+
+    /// Resolve declared trigram name triples to [`AstTrigram`] values.
+    ///
+    /// Triples where any name does not resolve are silently dropped.
+    #[must_use]
+    pub fn resolved_trigrams(&self) -> Vec<AstTrigram> {
+        self.trigrams
+            .iter()
+            .filter_map(|(gp, p, c)| {
+                let gp_id = resolve_kind_name(gp)?;
+                let p_id = resolve_kind_name(p)?;
+                let c_id = resolve_kind_name(c)?;
+                Some(AstTrigram::encode(gp_id, p_id, c_id))
+            })
+            .collect()
+    }
+}
+
+// ============================================================================
+// Pattern catalog
+// ============================================================================
+
+/// Full pattern catalog. All patterns GOLD-verified against real examples.
+///
+/// # Coverage
+///
+/// | Category | Count |
+/// |----------|-------|
+/// | ErrorHandling | 6 |
+/// | Performance | 5 |
+/// | Concurrency | 6 |
+/// | Quality | 7 |
+/// | Structure | 5 |
+/// | **Total** | **29** |
+pub static PATTERNS: &[Pattern] = &[
+    // ── ErrorHandling ────────────────────────────────────────────────────────
+
+    Pattern {
+        name: "try-catch",
+        description: "A try/catch block (TypeScript/JavaScript). Exact: try_statement always \
+                       contains a catch_clause.",
+        category: PatternCategory::ErrorHandling,
+        exact: true,
+        example: "try { doWork(); } catch (e) { handle(e); }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("try_statement", "catch_clause")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "try-finally",
+        description: "A try/finally block (TypeScript/JavaScript). Exact: try_statement always \
+                       contains a finally_clause.",
+        category: PatternCategory::ErrorHandling,
+        exact: true,
+        example: "try { open(); } finally { close(); }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("try_statement", "finally_clause")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "python-try-except",
+        description: "A try/except block (Python). Exact: try_statement contains except_clause.",
+        category: PatternCategory::ErrorHandling,
+        exact: true,
+        example: "try:\n    do_work()\nexcept Exception as e:\n    handle(e)",
+        example_lang: Language::Python,
+        bigrams: &[("try_statement", "except_clause")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "ruby-begin-rescue",
+        description: "A rescue clause in a Ruby method body. Structural approximation: \
+                       body_statement contains rescue — body_statement is the node wrapping \
+                       a Ruby method's body and inline rescue clauses. The bigram \
+                       body_statement → rescue appears whenever rescue is used directly in a \
+                       method body (the common form). Cannot distinguish from a stand-alone \
+                       rescue block outside a method.",
+        category: PatternCategory::ErrorHandling,
+        exact: false,
+        example: "def call\n  do_work\nrescue => e\n  handle(e)\nend",
+        example_lang: Language::Ruby,
+        bigrams: &[("body_statement", "rescue")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "empty-catch",
+        description: "A catch clause with an empty body (TypeScript/JavaScript). Exact: \
+                       EMPTY_BODY is emitted for a statement_block with zero counted children, \
+                       keyed on the enclosing catch_clause.",
+        category: PatternCategory::ErrorHandling,
+        exact: true,
+        example: "try { f(); } catch (e) {}",
+        example_lang: Language::TypeScript,
+        bigrams: &[("__empty_body__", "catch_clause")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "try-catch-finally",
+        description: "A try/catch/finally block (TypeScript/JavaScript). Exact: all three \
+                       clauses are children of try_statement.",
+        category: PatternCategory::ErrorHandling,
+        exact: true,
+        example: "try { f(); } catch (e) { g(); } finally { h(); }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("try_statement", "catch_clause"), ("try_statement", "finally_clause")],
+        trigrams: &[],
+    },
+
+    // ── Performance ──────────────────────────────────────────────────────────
+
+    Pattern {
+        name: "nested-loop",
+        description: "A loop nested inside another loop (TypeScript/JavaScript for-statements). \
+                       Exact: for_statement → statement_block → for_statement is the structural \
+                       trigram that identifies an outer for loop whose body contains an inner \
+                       for loop.",
+        category: PatternCategory::Performance,
+        exact: true,
+        example: "for (let i=0; i<n; i++) { for (let j=0; j<m; j++) { work(i,j); } }",
+        example_lang: Language::TypeScript,
+        bigrams: &[],
+        trigrams: &[("for_statement", "statement_block", "for_statement")],
+    },
+    Pattern {
+        name: "rust-nested-loop",
+        description: "A for-expression inside a block statement (Rust). Structural approximation: \
+                       block → expression_statement → for_expression — this trigram appears in \
+                       nested loops (the inner loop is an expression_statement in the outer \
+                       loop's block) but also matches any for loop inside a block. Cannot \
+                       distinguish between nested and non-nested without outer context.",
+        category: PatternCategory::Performance,
+        exact: false,
+        example: "fn outer() { for i in 0..n { for j in 0..m { work(i, j); } } }",
+        example_lang: Language::Rust,
+        bigrams: &[],
+        trigrams: &[("block", "expression_statement", "for_expression")],
+    },
+    Pattern {
+        name: "call-in-loop",
+        description: "A function call inside a for-of loop body (TypeScript/JavaScript). \
+                       Structural approximation: for_in_statement → statement_block → \
+                       expression_statement is the trigram showing a loop body with a statement. \
+                       Does not confirm the statement is a call; use the separate \
+                       expression_statement → call_expression bigram together for higher confidence. \
+                       Cannot distinguish between a call and other statement forms.",
+        category: PatternCategory::Performance,
+        exact: false,
+        example: "for (const x of items) { process(x); }",
+        example_lang: Language::TypeScript,
+        bigrams: &[],
+        trigrams: &[("for_in_statement", "statement_block", "expression_statement")],
+    },
+    Pattern {
+        name: "deep-nesting",
+        description: "Code with deeply nested structures (depth >= 4). Exact: DEEP_NODE marker \
+                       is emitted at exact depth bucket boundaries (4, 6, 8) — the synthetic \
+                       bigram DEEP_NODE → bucket_label(0) appears in every file with a node at \
+                       depth >= 4. Bucket granularity is fixed at index time.",
+        category: PatternCategory::Performance,
+        exact: true,
+        // The synthetic bigram is DEEP_NODE (parent) → bucket_label(0) (child).
+        // This resolves to AstBigram::encode(DEEP_NODE=65001, bucket_label(0)=64900).
+        example: "function a() { if (x) { for (;;) { if (y) { doWork(); } } } }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("__deep_node__", "__deep_node_b4__")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "python-nested-loop",
+        description: "A loop nested inside another loop (Python). Structural approximation: \
+                       for_statement → block → for_statement — the inner loop appears in the \
+                       body block of the outer loop. May also match an outer loop whose body \
+                       contains a nested function that itself has a loop.",
+        category: PatternCategory::Performance,
+        exact: false,
+        example: "for i in range(n):\n    for j in range(m):\n        work(i, j)",
+        example_lang: Language::Python,
+        bigrams: &[],
+        trigrams: &[("for_statement", "block", "for_statement")],
+    },
+
+    // ── Concurrency ──────────────────────────────────────────────────────────
+
+    Pattern {
+        name: "go-goroutine",
+        description: "A goroutine launch (Go). Exact: go_statement is the tree-sitter node for \
+                       `go f()` calls.",
+        category: PatternCategory::Concurrency,
+        exact: true,
+        // Full function body so tree-sitter can produce a valid Go source unit.
+        example: "package main\nfunc serve() { go handle(conn) }",
+        example_lang: Language::Go,
+        bigrams: &[("go_statement", "call_expression")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "go-defer",
+        description: "A defer statement (Go). Exact: defer_statement is emitted for `defer f()`.",
+        category: PatternCategory::Concurrency,
+        exact: true,
+        example: "package main\nfunc run() { defer cleanup() }",
+        example_lang: Language::Go,
+        bigrams: &[("defer_statement", "call_expression")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "go-channel-send",
+        description: "A channel send operation (Go). Exact: send_statement is the CST node for \
+                       `ch <- val`.",
+        category: PatternCategory::Concurrency,
+        exact: true,
+        example: "package main\nfunc send(ch chan string, msg string) { ch <- msg }",
+        example_lang: Language::Go,
+        bigrams: &[("send_statement", "identifier")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "go-select",
+        description: "A select statement (Go). Exact: select_statement is the CST node for \
+                       `select { case ... }`.",
+        category: PatternCategory::Concurrency,
+        exact: true,
+        example: "package main\nfunc recv(ch chan string) { select { case msg := <-ch: handle(msg) } }",
+        example_lang: Language::Go,
+        bigrams: &[("select_statement", "communication_case")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "rust-unsafe-block",
+        description: "An unsafe block (Rust). Exact: unsafe_block is the CST node for \
+                       `unsafe { ... }`. unsafe_block always contains a block node as its body.",
+        category: PatternCategory::Concurrency,
+        exact: true,
+        example: "fn write_raw(ptr: *mut i32, val: i32) { unsafe { *ptr = val; } }",
+        example_lang: Language::Rust,
+        bigrams: &[("unsafe_block", "block")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "java-synchronized",
+        description: "A synchronized block (Java). Exact: synchronized_statement is the CST \
+                       node for `synchronized (obj) { ... }`.",
+        category: PatternCategory::Concurrency,
+        exact: true,
+        example: "class C { void inc() { synchronized (this) { count++; } } }",
+        example_lang: Language::Java,
+        bigrams: &[("synchronized_statement", "block")],
+        trigrams: &[],
+    },
+
+    // ── Quality ──────────────────────────────────────────────────────────────
+
+    Pattern {
+        name: "function-with-body",
+        description: "A function item with a body (Rust). Exact: function_item always contains \
+                       a block.",
+        category: PatternCategory::Quality,
+        exact: true,
+        example: "fn foo() { let x = 1; }",
+        example_lang: Language::Rust,
+        bigrams: &[("function_item", "block")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "method-with-body",
+        description: "A method definition with a body (TypeScript/JavaScript). Exact: \
+                       method_definition always contains a statement_block.",
+        category: PatternCategory::Quality,
+        exact: true,
+        example: "class C { foo() { return 1; } }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("method_definition", "statement_block")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "match-with-arms",
+        description: "A match expression with match arms (Rust). Exact: match_expression always \
+                       contains a match_block, which contains match_arm nodes.",
+        category: PatternCategory::Quality,
+        exact: true,
+        example: "fn check(x: Result<i32,()>) -> i32 { match x { Ok(v) => v, Err(_) => 0 } }",
+        example_lang: Language::Rust,
+        bigrams: &[("match_expression", "match_block")],
+        trigrams: &[("match_expression", "match_block", "match_arm")],
+    },
+    Pattern {
+        name: "empty-function",
+        description: "A function item with an empty body (Rust). Exact: EMPTY_BODY is emitted \
+                       when a block has zero counted children, keyed on the enclosing \
+                       function_item.",
+        category: PatternCategory::Quality,
+        exact: true,
+        example: "fn todo_later() {}",
+        example_lang: Language::Rust,
+        bigrams: &[("__empty_body__", "function_item")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "god-function",
+        description: "A function with a very large body (Rust, >= 20 statements). Exact: \
+                       LARGE_BODY → bucket_label(1) is emitted when a function body has >= 20 \
+                       counted children. Bucket granularity is fixed at index time; only \
+                       function/method bodies emit this marker.",
+        category: PatternCategory::Quality,
+        exact: true,
+        // Synthetic bigram: LARGE_BODY (65002) parent → bucket_label(1) (edge >= 20 stmts) child.
+        // 20 let-statements in one function body crosses BODY_STMT_EDGES[1] = 20.
+        example: "fn big() { let a=1; let b=2; let c=3; let d=4; let e=5; let f=6; let g=7; \
+                   let h=8; let i=9; let j=10; let k=11; let l=12; let m=13; let n=14; \
+                   let o=15; let p=16; let q=17; let r=18; let s=19; let t=20; }",
+        example_lang: Language::Rust,
+        bigrams: &[("__large_body__", "__large_body_b20__")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "excessive-params",
+        description: "A function with many parameters (Rust, >= 5). Exact: \
+                       MANY_PARAMS → bucket_label(0) is emitted when a parameter list has >= 5 \
+                       counted children. Bucket granularity is fixed at index time.",
+        category: PatternCategory::Quality,
+        exact: true,
+        example: "fn many(a: i32, b: i32, c: i32, d: i32, e: i32) -> i32 { a + b + c + d + e }",
+        example_lang: Language::Rust,
+        bigrams: &[("__many_params__", "__many_params_b5__")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "unhandled-result",
+        description: "Structural approximation: an expression_statement containing a \
+                       call_expression (TypeScript/JavaScript). This is a weak structural proxy \
+                       that matches any top-level call — it cannot confirm whether the call \
+                       returns a Result type or that the caller ignores an error.",
+        category: PatternCategory::Quality,
+        exact: false,
+        example: "doSomething();",
+        example_lang: Language::TypeScript,
+        bigrams: &[("expression_statement", "call_expression")],
+        trigrams: &[],
+    },
+
+    // ── Structure ────────────────────────────────────────────────────────────
+
+    Pattern {
+        name: "switch-with-cases",
+        description: "A switch statement with a switch body (TypeScript/JavaScript). Exact: \
+                       switch_statement always contains a switch_body.",
+        category: PatternCategory::Structure,
+        exact: true,
+        example: "switch (x) { case 1: break; default: other(); }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("switch_statement", "switch_body")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "impl-method",
+        description: "A method inside a Rust impl block. Exact: impl_item contains a \
+                       declaration_list, which contains function_item nodes.",
+        category: PatternCategory::Structure,
+        exact: true,
+        example: "impl Foo { fn bar(&self) { } }",
+        example_lang: Language::Rust,
+        bigrams: &[("impl_item", "declaration_list")],
+        trigrams: &[("impl_item", "declaration_list", "function_item")],
+    },
+    Pattern {
+        name: "class-method",
+        description: "A method inside a TypeScript class. Exact: class_declaration contains \
+                       a class_body, which contains method_definition nodes.",
+        category: PatternCategory::Structure,
+        exact: true,
+        example: "class Foo { bar() { return 1; } }",
+        example_lang: Language::TypeScript,
+        bigrams: &[("class_declaration", "class_body")],
+        trigrams: &[("class_declaration", "class_body", "method_definition")],
+    },
+    Pattern {
+        name: "ternary-expression",
+        description: "A ternary conditional expression in assignment context (TypeScript/JavaScript). \
+                       Structural approximation: variable_declarator contains ternary_expression \
+                       — this covers the assignment form but not all ternary positions (e.g., \
+                       return statements, call arguments). Cannot detect all ternary usages from \
+                       this bigram alone.",
+        category: PatternCategory::Structure,
+        exact: false,
+        // `const x = flag ? a : b;` → lexical_declaration > variable_declarator > ternary_expression
+        example: "const x = flag ? a : b;",
+        example_lang: Language::TypeScript,
+        bigrams: &[("variable_declarator", "ternary_expression")],
+        trigrams: &[],
+    },
+    Pattern {
+        name: "numeric-literal-in-expression",
+        description: "Structural approximation: a number literal appearing inside a binary \
+                       expression (TypeScript/JavaScript). This is a weak structural proxy for \
+                       'magic number' — it matches any numeric literal in an arithmetic context, \
+                       not just unexplained constants. Cannot determine whether the number is a \
+                       named constant or a magic value.",
+        category: PatternCategory::Structure,
+        exact: false,
+        example: "const result = x * 42 + 7;",
+        example_lang: Language::TypeScript,
+        bigrams: &[("binary_expression", "number")],
+        trigrams: &[],
+    },
+];
+
+// ============================================================================
+// Pattern catalog API
+// ============================================================================
+
+/// Return all patterns in the catalog.
+#[must_use]
+pub fn all_patterns() -> &'static [Pattern] {
+    PATTERNS
+}
+
+/// Internal index: name → position in PATTERNS.
+static PATTERN_INDEX: LazyLock<HashMap<&'static str, usize>> = LazyLock::new(|| {
+    PATTERNS
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (p.name, i))
+        .collect()
+});
+
+/// Look up a pattern by its kebab-case `name`.
+///
+/// # Errors
+///
+/// Returns [`SearchError::InvalidQuery`] if no pattern with that name exists.
+pub fn lookup_pattern(name: &str) -> Result<&'static Pattern> {
+    PATTERN_INDEX
+        .get(name)
+        .map(|&i| &PATTERNS[i])
+        .ok_or_else(|| {
+            SearchError::InvalidQuery(format!(
+                "unknown pattern name '{name}'; available patterns: {}",
+                PATTERNS
+                    .iter()
+                    .map(|p| p.name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })
+}
+
+/// Build an [`AstNgramSet`] from a pattern's resolved bigrams and trigrams,
+/// with count=1 for each resolved entry.
+///
+/// Useful for feeding a pattern directly into the search pipeline.
+/// Bigrams/trigrams that fail to resolve (unknown names) are silently dropped.
+#[must_use]
+pub fn pattern_to_query_set(pattern: &Pattern) -> AstNgramSet {
+    use crate::ast_index::{AstBigramEntry, AstTrigramEntry, DEFAULT_AST_WEIGHT};
+
+    let bigrams = pattern
+        .resolved_bigrams()
+        .into_iter()
+        .map(|ngram| AstBigramEntry {
+            ngram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        })
+        .collect();
+
+    let trigrams = pattern
+        .resolved_trigrams()
+        .into_iter()
+        .map(|ngram| AstTrigramEntry {
+            ngram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        })
+        .collect();
+
+    AstNgramSet { bigrams, trigrams }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[path = "patterns_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/ast_index/patterns_tests.rs
+++ b/crates/rskim-search/src/ast_index/patterns_tests.rs
@@ -1,0 +1,366 @@
+//! Tests for the AST Pattern Library catalog.
+//!
+//! # Test IDs (from acceptance criteria)
+//!
+//! - F6: Catalog integrity (≥25 patterns, all categories non-empty, unique names, lookup hit/miss)
+//! - F7: GOLD honesty gate (each resolved bigram/trigram is in the example's produced n-grams)
+//! - F8: Approximate patterns explicitly mention "approximation" or "structural" in description
+//! - A6: Synthetic name resolution (resolve_synthetic_name roundtrip)
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashSet;
+
+use rskim_core::Language;
+
+use super::*;
+use crate::ast_index::{
+    AstBigram, AstTrigram, extract_ast_ngrams_with_metrics, linearize_source, vocab_resolve,
+};
+use crate::ast_index::structural::{DEEP_NODE, EMPTY_BODY, LARGE_BODY, MANY_PARAMS, bucket_label};
+
+// ============================================================================
+// F6: Catalog integrity
+// ============================================================================
+
+#[test]
+fn f6_at_least_25_patterns() {
+    assert!(
+        PATTERNS.len() >= 25,
+        "pattern catalog must have >= 25 entries, got {}",
+        PATTERNS.len()
+    );
+}
+
+#[test]
+fn f6_all_categories_non_empty() {
+    let categories = [
+        PatternCategory::ErrorHandling,
+        PatternCategory::Performance,
+        PatternCategory::Concurrency,
+        PatternCategory::Quality,
+        PatternCategory::Structure,
+    ];
+    for cat in categories {
+        let count = PATTERNS.iter().filter(|p| p.category == cat).count();
+        assert!(
+            count > 0,
+            "category {:?} must have at least one pattern",
+            cat
+        );
+    }
+}
+
+#[test]
+fn f6_pattern_names_are_unique() {
+    let mut seen: HashSet<&str> = HashSet::new();
+    for p in PATTERNS {
+        assert!(
+            seen.insert(p.name),
+            "duplicate pattern name: '{}'",
+            p.name
+        );
+    }
+}
+
+#[test]
+fn f6_lookup_hit_and_miss() {
+    // Hit: every pattern in the catalog must be reachable by name
+    for p in PATTERNS {
+        let result = lookup_pattern(p.name);
+        assert!(
+            result.is_ok(),
+            "lookup_pattern('{}') must succeed",
+            p.name
+        );
+        assert_eq!(
+            result.unwrap().name,
+            p.name,
+            "lookup_pattern('{}') must return the correct pattern",
+            p.name
+        );
+    }
+
+    // Miss: a random non-existent name must return Err
+    let miss = lookup_pattern("__not_a_real_pattern__");
+    assert!(miss.is_err(), "lookup_pattern for unknown name must return Err");
+}
+
+#[test]
+fn f6_all_patterns_have_at_least_one_ngram() {
+    for p in PATTERNS {
+        let total = p.bigrams.len() + p.trigrams.len();
+        assert!(
+            total > 0,
+            "pattern '{}' must declare at least one bigram or trigram",
+            p.name
+        );
+    }
+}
+
+// ============================================================================
+// F7: GOLD honesty gate
+//
+// For EVERY pattern:
+// 1. linearize example → extract n-grams (with metrics, so synthetic markers appear)
+// 2. Resolve the declared bigrams/trigrams
+// 3. Every resolved bigram/trigram must appear in the produced n-gram set
+// 4. Skip gracefully when a bigram/trigram can't be resolved (unknown vocab word)
+//    so that vocab differences across platforms don't fail the test suite
+// ============================================================================
+
+/// Helper: run linearize+extract on source, return all bigram keys in a HashSet.
+fn extract_bigrams(source: &str, lang: Language) -> HashSet<AstBigram> {
+    let result = linearize_source(source, lang).expect("linearize_source must not fail");
+    let (set, _) = extract_ast_ngrams_with_metrics(&result.nodes, lang);
+    set.bigrams.iter().map(|e| e.ngram).collect()
+}
+
+/// Helper: run linearize+extract on source, return all trigram keys in a HashSet.
+fn extract_trigrams(source: &str, lang: Language) -> HashSet<AstTrigram> {
+    let result = linearize_source(source, lang).expect("linearize_source must not fail");
+    let (set, _) = extract_ast_ngrams_with_metrics(&result.nodes, lang);
+    set.trigrams.iter().map(|e| e.ngram).collect()
+}
+
+#[test]
+fn f7_gold_all_patterns() {
+    for p in PATTERNS {
+        let produced_bigrams = extract_bigrams(p.example, p.example_lang);
+        let produced_trigrams = extract_trigrams(p.example, p.example_lang);
+
+        // Resolved bigrams: every one must be in the produced set.
+        // If a bigram has unresolvable names, resolved_bigrams() drops it —
+        // we additionally track how many declared bigrams resolved to detect
+        // patterns that fully resolve but still fail (GOLD violation).
+        let resolved_bs = p.resolved_bigrams();
+        let declared_bs = p.bigrams.len();
+        let resolved_bs_count = resolved_bs.len();
+
+        for &bigram in &resolved_bs {
+            assert!(
+                produced_bigrams.contains(&bigram),
+                "GOLD VIOLATION for pattern '{}': declared bigram ({}, {}) = key {:?} \
+                 is NOT in the n-gram set produced from the example.\n\
+                 Produced bigrams count: {}\n\
+                 This means either the example does not exhibit the pattern or \
+                 the bigram name strings are wrong.",
+                p.name,
+                // Find which pair produced this bigram (reverse-lookup for diagnostics)
+                p.bigrams
+                    .iter()
+                    .find(|(a, b)| {
+                        resolve_kind_name(a)
+                            .zip(resolve_kind_name(b))
+                            .map(|(pa, pb)| AstBigram::encode(pa, pb) == bigram)
+                            .unwrap_or(false)
+                    })
+                    .map(|(a, _)| a)
+                    .unwrap_or(&"?"),
+                p.bigrams
+                    .iter()
+                    .find(|(a, b)| {
+                        resolve_kind_name(a)
+                            .zip(resolve_kind_name(b))
+                            .map(|(pa, pb)| AstBigram::encode(pa, pb) == bigram)
+                            .unwrap_or(false)
+                    })
+                    .map(|(_, b)| b)
+                    .unwrap_or(&"?"),
+                bigram.key(),
+                produced_bigrams.len(),
+            );
+        }
+
+        // Warn in test output if some bigrams couldn't resolve (vocab differences)
+        // but don't fail the test — unresolvable names are a separate concern.
+        if resolved_bs_count < declared_bs {
+            // This is informational — pattern has vocab-unknown names.
+            // The F6 test "all_patterns_have_at_least_one_ngram" ensures at least
+            // one is declared; we only fail on GOLD violations for resolved ones.
+            eprintln!(
+                "[F7 info] pattern '{}': {}/{} bigrams resolved (some vocab names may not be \
+                 in the global vocabulary — check if the kind strings are correct)",
+                p.name, resolved_bs_count, declared_bs
+            );
+        }
+
+        // Resolved trigrams
+        let resolved_ts = p.resolved_trigrams();
+        for &trigram in &resolved_ts {
+            assert!(
+                produced_trigrams.contains(&trigram),
+                "GOLD VIOLATION for pattern '{}': declared trigram is NOT in the n-gram set \
+                 produced from the example.",
+                p.name,
+            );
+        }
+    }
+}
+
+// ============================================================================
+// F8: Approximate patterns must say "approximation" or "structural"
+// ============================================================================
+
+#[test]
+fn f8_approximate_patterns_say_approximation_or_structural() {
+    for p in PATTERNS {
+        if !p.exact {
+            let desc_lower = p.description.to_lowercase();
+            assert!(
+                desc_lower.contains("approximation") || desc_lower.contains("structural"),
+                "pattern '{}' has exact=false but description does not contain \
+                 'approximation' or 'structural': '{}'",
+                p.name,
+                p.description
+            );
+        }
+    }
+}
+
+// ============================================================================
+// A6: Synthetic name resolution
+// ============================================================================
+
+#[test]
+fn a6_synthetic_name_resolution_roundtrip() {
+    use crate::ast_index::patterns::resolve_kind_name;
+
+    // Parent markers
+    assert_eq!(resolve_kind_name("__empty_body__"), Some(EMPTY_BODY));
+    assert_eq!(resolve_kind_name("__large_body__"), Some(LARGE_BODY));
+    assert_eq!(resolve_kind_name("__many_params__"), Some(MANY_PARAMS));
+    assert_eq!(resolve_kind_name("__deep_node__"), Some(DEEP_NODE));
+
+    // Bucket labels
+    assert_eq!(resolve_kind_name("__large_body_b10__"), Some(bucket_label(0)));
+    assert_eq!(resolve_kind_name("__large_body_b20__"), Some(bucket_label(1)));
+    assert_eq!(resolve_kind_name("__large_body_b40__"), Some(bucket_label(2)));
+    assert_eq!(resolve_kind_name("__many_params_b5__"), Some(bucket_label(0)));
+    assert_eq!(resolve_kind_name("__many_params_b8__"), Some(bucket_label(1)));
+    assert_eq!(resolve_kind_name("__many_params_b12__"), Some(bucket_label(2)));
+    assert_eq!(resolve_kind_name("__deep_node_b4__"), Some(bucket_label(0)));
+    assert_eq!(resolve_kind_name("__deep_node_b6__"), Some(bucket_label(1)));
+    assert_eq!(resolve_kind_name("__deep_node_b8__"), Some(bucket_label(2)));
+
+    // Unknown synthetic names return None
+    assert_eq!(resolve_kind_name("__not_a_real_marker__"), None);
+    assert_eq!(resolve_kind_name("__large_body_b99__"), None);
+
+    // Real vocab names still resolve through vocab_lookup
+    let fn_item = resolve_kind_name("function_item");
+    assert!(fn_item.is_some(), "function_item must resolve via vocab_lookup");
+
+    // Synthetic IDs are NOT in the vocabulary (isolation guarantee from F5)
+    assert!(
+        vocab_resolve(EMPTY_BODY).is_none(),
+        "EMPTY_BODY must not be in the vocabulary"
+    );
+    assert!(
+        vocab_resolve(LARGE_BODY).is_none(),
+        "LARGE_BODY must not be in the vocabulary"
+    );
+    assert!(
+        vocab_resolve(MANY_PARAMS).is_none(),
+        "MANY_PARAMS must not be in the vocabulary"
+    );
+    assert!(
+        vocab_resolve(DEEP_NODE).is_none(),
+        "DEEP_NODE must not be in the vocabulary"
+    );
+}
+
+#[test]
+fn a6_synthetic_bigram_encode_decode_matches_extract() {
+    // Verify that the resolved bigram for "deep-nesting" matches what extract emits.
+    // deep-nesting: DEEP_NODE → bucket_label(0)
+    let expected_bigram = AstBigram::encode(DEEP_NODE, bucket_label(0));
+
+    let p = lookup_pattern("deep-nesting").expect("deep-nesting must be in catalog");
+    let resolved = p.resolved_bigrams();
+    assert_eq!(resolved.len(), 1, "deep-nesting must resolve exactly 1 bigram");
+    assert_eq!(
+        resolved[0], expected_bigram,
+        "deep-nesting bigram must equal AstBigram::encode(DEEP_NODE, bucket_label(0))"
+    );
+
+    // Also verify it appears in the produced set for the example
+    let produced = extract_bigrams(p.example, p.example_lang);
+    assert!(
+        produced.contains(&expected_bigram),
+        "DEEP_NODE→bucket_label(0) must appear in deep-nesting example produced bigrams"
+    );
+}
+
+#[test]
+fn a6_empty_body_bigram_matches_extract() {
+    // empty-catch: EMPTY_BODY → catch_clause
+    let p = lookup_pattern("empty-catch").expect("empty-catch must be in catalog");
+    let resolved = p.resolved_bigrams();
+    assert_eq!(resolved.len(), 1, "empty-catch must resolve exactly 1 bigram");
+
+    let produced = extract_bigrams(p.example, p.example_lang);
+    assert!(
+        produced.contains(&resolved[0]),
+        "EMPTY_BODY→catch_clause must appear in empty-catch example produced bigrams"
+    );
+}
+
+#[test]
+fn a6_god_function_bigram_matches_extract() {
+    // god-function: LARGE_BODY → bucket_label(1) (>= 20 stmts)
+    let expected = AstBigram::encode(LARGE_BODY, bucket_label(1));
+
+    let p = lookup_pattern("god-function").expect("god-function must be in catalog");
+    let resolved = p.resolved_bigrams();
+    assert_eq!(resolved.len(), 1, "god-function must resolve exactly 1 bigram");
+    assert_eq!(resolved[0], expected, "god-function bigram must be LARGE_BODY→bucket_label(1)");
+
+    let produced = extract_bigrams(p.example, p.example_lang);
+    assert!(
+        produced.contains(&expected),
+        "LARGE_BODY→bucket_label(1) must appear in god-function example produced bigrams"
+    );
+}
+
+#[test]
+fn a6_excessive_params_bigram_matches_extract() {
+    // excessive-params: MANY_PARAMS → bucket_label(0) (>= 5 params)
+    let expected = AstBigram::encode(MANY_PARAMS, bucket_label(0));
+
+    let p = lookup_pattern("excessive-params").expect("excessive-params must be in catalog");
+    let resolved = p.resolved_bigrams();
+    assert_eq!(resolved.len(), 1, "excessive-params must resolve exactly 1 bigram");
+    assert_eq!(
+        resolved[0], expected,
+        "excessive-params bigram must be MANY_PARAMS→bucket_label(0)"
+    );
+
+    let produced = extract_bigrams(p.example, p.example_lang);
+    assert!(
+        produced.contains(&expected),
+        "MANY_PARAMS→bucket_label(0) must appear in excessive-params example produced bigrams"
+    );
+}
+
+// ============================================================================
+// A6: pattern_to_query_set integration
+// ============================================================================
+
+#[test]
+fn a6_pattern_to_query_set_contains_resolved_bigrams() {
+    // For every pattern, the query set must contain all resolved bigrams/trigrams.
+    for p in PATTERNS {
+        let qset = pattern_to_query_set(p);
+        let resolved_bs = p.resolved_bigrams();
+        let qset_bigram_keys: HashSet<AstBigram> = qset.bigrams.iter().map(|e| e.ngram).collect();
+        for &b in &resolved_bs {
+            assert!(
+                qset_bigram_keys.contains(&b),
+                "pattern_to_query_set('{}') must contain resolved bigram {:?}",
+                p.name,
+                b.key()
+            );
+        }
+    }
+}

--- a/crates/rskim-search/src/ast_index/patterns_tests.rs
+++ b/crates/rskim-search/src/ast_index/patterns_tests.rs
@@ -190,6 +190,21 @@ fn f7_gold_all_patterns() {
                 p.name,
             );
         }
+
+        // Guard: at least one declared n-gram must resolve for the GOLD loops
+        // above to verify anything. If ALL bigrams AND trigrams fail to resolve
+        // (e.g. a future vocab regen renames a node kind), both loops are no-ops
+        // and the pattern passes GOLD without verifying anything — a silent
+        // disarming of the honesty gate.
+        //
+        // applies ADR-003: test assertions must genuinely verify.
+        assert!(
+            !resolved_bs.is_empty() || !resolved_ts.is_empty(),
+            "GOLD GATE DISARMED for pattern '{}': zero declared n-grams resolved — \
+             both bigrams and trigrams failed to resolve. The GOLD verification loops \
+             are no-ops. Check that kind strings match the current vocabulary.",
+            p.name,
+        );
     }
 }
 

--- a/crates/rskim-search/src/ast_index/patterns_tests.rs
+++ b/crates/rskim-search/src/ast_index/patterns_tests.rs
@@ -14,10 +14,10 @@ use std::collections::HashSet;
 use rskim_core::Language;
 
 use super::*;
+use crate::ast_index::structural::{DEEP_NODE, EMPTY_BODY, LARGE_BODY, MANY_PARAMS, bucket_label};
 use crate::ast_index::{
     AstBigram, AstTrigram, extract_ast_ngrams_with_metrics, linearize_source, vocab_resolve,
 };
-use crate::ast_index::structural::{DEEP_NODE, EMPTY_BODY, LARGE_BODY, MANY_PARAMS, bucket_label};
 
 // ============================================================================
 // F6: Catalog integrity
@@ -55,11 +55,7 @@ fn f6_all_categories_non_empty() {
 fn f6_pattern_names_are_unique() {
     let mut seen: HashSet<&str> = HashSet::new();
     for p in PATTERNS {
-        assert!(
-            seen.insert(p.name),
-            "duplicate pattern name: '{}'",
-            p.name
-        );
+        assert!(seen.insert(p.name), "duplicate pattern name: '{}'", p.name);
     }
 }
 
@@ -68,11 +64,7 @@ fn f6_lookup_hit_and_miss() {
     // Hit: every pattern in the catalog must be reachable by name
     for p in PATTERNS {
         let result = lookup_pattern(p.name);
-        assert!(
-            result.is_ok(),
-            "lookup_pattern('{}') must succeed",
-            p.name
-        );
+        assert!(result.is_ok(), "lookup_pattern('{}') must succeed", p.name);
         assert_eq!(
             result.unwrap().name,
             p.name,
@@ -83,7 +75,10 @@ fn f6_lookup_hit_and_miss() {
 
     // Miss: a random non-existent name must return Err
     let miss = lookup_pattern("__not_a_real_pattern__");
-    assert!(miss.is_err(), "lookup_pattern for unknown name must return Err");
+    assert!(
+        miss.is_err(),
+        "lookup_pattern for unknown name must return Err"
+    );
 }
 
 #[test]
@@ -233,12 +228,30 @@ fn a6_synthetic_name_resolution_roundtrip() {
     assert_eq!(resolve_kind_name("__deep_node__"), Some(DEEP_NODE));
 
     // Bucket labels
-    assert_eq!(resolve_kind_name("__large_body_b10__"), Some(bucket_label(0)));
-    assert_eq!(resolve_kind_name("__large_body_b20__"), Some(bucket_label(1)));
-    assert_eq!(resolve_kind_name("__large_body_b40__"), Some(bucket_label(2)));
-    assert_eq!(resolve_kind_name("__many_params_b5__"), Some(bucket_label(0)));
-    assert_eq!(resolve_kind_name("__many_params_b8__"), Some(bucket_label(1)));
-    assert_eq!(resolve_kind_name("__many_params_b12__"), Some(bucket_label(2)));
+    assert_eq!(
+        resolve_kind_name("__large_body_b10__"),
+        Some(bucket_label(0))
+    );
+    assert_eq!(
+        resolve_kind_name("__large_body_b20__"),
+        Some(bucket_label(1))
+    );
+    assert_eq!(
+        resolve_kind_name("__large_body_b40__"),
+        Some(bucket_label(2))
+    );
+    assert_eq!(
+        resolve_kind_name("__many_params_b5__"),
+        Some(bucket_label(0))
+    );
+    assert_eq!(
+        resolve_kind_name("__many_params_b8__"),
+        Some(bucket_label(1))
+    );
+    assert_eq!(
+        resolve_kind_name("__many_params_b12__"),
+        Some(bucket_label(2))
+    );
     assert_eq!(resolve_kind_name("__deep_node_b4__"), Some(bucket_label(0)));
     assert_eq!(resolve_kind_name("__deep_node_b6__"), Some(bucket_label(1)));
     assert_eq!(resolve_kind_name("__deep_node_b8__"), Some(bucket_label(2)));
@@ -249,7 +262,10 @@ fn a6_synthetic_name_resolution_roundtrip() {
 
     // Real vocab names still resolve through vocab_lookup
     let fn_item = resolve_kind_name("function_item");
-    assert!(fn_item.is_some(), "function_item must resolve via vocab_lookup");
+    assert!(
+        fn_item.is_some(),
+        "function_item must resolve via vocab_lookup"
+    );
 
     // Synthetic IDs are NOT in the vocabulary (isolation guarantee from F5)
     assert!(
@@ -278,7 +294,11 @@ fn a6_synthetic_bigram_encode_decode_matches_extract() {
 
     let p = lookup_pattern("deep-nesting").expect("deep-nesting must be in catalog");
     let resolved = p.resolved_bigrams();
-    assert_eq!(resolved.len(), 1, "deep-nesting must resolve exactly 1 bigram");
+    assert_eq!(
+        resolved.len(),
+        1,
+        "deep-nesting must resolve exactly 1 bigram"
+    );
     assert_eq!(
         resolved[0], expected_bigram,
         "deep-nesting bigram must equal AstBigram::encode(DEEP_NODE, bucket_label(0))"
@@ -297,7 +317,11 @@ fn a6_empty_body_bigram_matches_extract() {
     // empty-catch: EMPTY_BODY → catch_clause
     let p = lookup_pattern("empty-catch").expect("empty-catch must be in catalog");
     let resolved = p.resolved_bigrams();
-    assert_eq!(resolved.len(), 1, "empty-catch must resolve exactly 1 bigram");
+    assert_eq!(
+        resolved.len(),
+        1,
+        "empty-catch must resolve exactly 1 bigram"
+    );
 
     let produced = extract_bigrams(p.example, p.example_lang);
     assert!(
@@ -313,8 +337,15 @@ fn a6_god_function_bigram_matches_extract() {
 
     let p = lookup_pattern("god-function").expect("god-function must be in catalog");
     let resolved = p.resolved_bigrams();
-    assert_eq!(resolved.len(), 1, "god-function must resolve exactly 1 bigram");
-    assert_eq!(resolved[0], expected, "god-function bigram must be LARGE_BODY→bucket_label(1)");
+    assert_eq!(
+        resolved.len(),
+        1,
+        "god-function must resolve exactly 1 bigram"
+    );
+    assert_eq!(
+        resolved[0], expected,
+        "god-function bigram must be LARGE_BODY→bucket_label(1)"
+    );
 
     let produced = extract_bigrams(p.example, p.example_lang);
     assert!(
@@ -330,7 +361,11 @@ fn a6_excessive_params_bigram_matches_extract() {
 
     let p = lookup_pattern("excessive-params").expect("excessive-params must be in catalog");
     let resolved = p.resolved_bigrams();
-    assert_eq!(resolved.len(), 1, "excessive-params must resolve exactly 1 bigram");
+    assert_eq!(
+        resolved.len(),
+        1,
+        "excessive-params must resolve exactly 1 bigram"
+    );
     assert_eq!(
         resolved[0], expected,
         "excessive-params bigram must be MANY_PARAMS→bucket_label(0)"

--- a/crates/rskim-search/src/ast_index/store/builder.rs
+++ b/crates/rskim-search/src/ast_index/store/builder.rs
@@ -48,7 +48,9 @@ use super::format::{
 use super::reader::AstIndexReader;
 use crate::{
     FileId, Result, SearchError,
-    ast_index::{AstNgramSet, StructuralMetrics, extract_ast_ngrams_with_metrics, linearize_source},
+    ast_index::{
+        AstNgramSet, StructuralMetrics, extract_ast_ngrams_with_metrics, linearize_source,
+    },
     io_util::atomic_write,
 };
 
@@ -382,7 +384,13 @@ impl AstIndexBuilder {
         // ── Parallel extraction ──────────────────────────────────────────────
         // Collect results into a Vec indexed by position in `files` so that
         // sequential merge preserves FileId order.
-        type ExtractedEntry = (FileId, rskim_core::Language, AstNgramSet, u32, StructuralMetrics);
+        type ExtractedEntry = (
+            FileId,
+            rskim_core::Language,
+            AstNgramSet,
+            u32,
+            StructuralMetrics,
+        );
         let extracted: Vec<Result<ExtractedEntry>> = files
             .par_iter()
             .map(|(id, content, lang)| {

--- a/crates/rskim-search/src/ast_index/store/builder.rs
+++ b/crates/rskim-search/src/ast_index/store/builder.rs
@@ -48,7 +48,7 @@ use super::format::{
 use super::reader::AstIndexReader;
 use crate::{
     FileId, Result, SearchError,
-    ast_index::{AstNgramSet, extract_ast_ngrams, linearize_source},
+    ast_index::{AstNgramSet, StructuralMetrics, extract_ast_ngrams_with_metrics, linearize_source},
     io_util::atomic_write,
 };
 
@@ -83,6 +83,8 @@ pub struct AstIndexBuilder {
     total_distinct_bigrams: u64,
     /// Sum of distinct trigram counts per file (for avg_trigram_count).
     total_distinct_trigrams: u64,
+    /// Sum of `max_depth` values across all files (for avg_max_depth).
+    total_max_depth: u64,
 }
 
 // ============================================================================
@@ -204,6 +206,7 @@ impl AstIndexBuilder {
             total_node_count: 0,
             total_distinct_bigrams: 0,
             total_distinct_trigrams: 0,
+            total_max_depth: 0,
         })
     }
 
@@ -211,7 +214,7 @@ impl AstIndexBuilder {
     // Core merge primitive
     // -----------------------------------------------------------------------
 
-    /// Record the n-grams for one file.
+    /// Record the n-grams and structural metrics for one file.
     ///
     /// This is the core merge primitive.  Every file — even files that yield
     /// zero n-grams — MUST produce exactly one `add_file_ngrams` call so that
@@ -224,6 +227,7 @@ impl AstIndexBuilder {
     /// - `lang` — language used for the `lang_id` byte in [`AstFileMetaEntry`].
     /// - `set` — the extracted [`AstNgramSet`] (may be empty).
     /// - `node_count` — emitted-node count from `linearize_source` (`lin.nodes.len()`).
+    /// - `metrics` — per-file structural complexity metrics from extraction.
     ///
     /// # Errors
     ///
@@ -238,6 +242,7 @@ impl AstIndexBuilder {
         lang: rskim_core::Language,
         set: &AstNgramSet,
         node_count: u32,
+        metrics: StructuralMetrics,
     ) -> Result<()> {
         // ── FileId guards (mirrors lexical builder, ADR-001) ────────────────
         if self.seen_file_ids.contains(&id.0) {
@@ -288,6 +293,10 @@ impl AstIndexBuilder {
         self.file_meta.push(AstFileMetaEntry {
             lang_id: lang_to_id(lang),
             node_count,
+            max_depth: metrics.max_depth,
+            max_block_stmts: metrics.max_block_stmts,
+            max_params: metrics.max_params,
+            branch_count: metrics.branch_count,
         });
 
         // ── Accumulate totals ────────────────────────────────────────────────
@@ -300,6 +309,9 @@ impl AstIndexBuilder {
         self.total_distinct_trigrams = self
             .total_distinct_trigrams
             .saturating_add(set.trigrams.len() as u64);
+        self.total_max_depth = self
+            .total_max_depth
+            .saturating_add(u64::from(metrics.max_depth));
 
         self.file_count = self.file_count.checked_add(1).ok_or_else(|| {
             SearchError::IndexCorrupted("file_count overflow: too many files".into())
@@ -335,8 +347,8 @@ impl AstIndexBuilder {
                 id.0
             ))
         })?;
-        let set = extract_ast_ngrams(&lin.nodes, lang);
-        self.add_file_ngrams(id, lang, &set, node_count)
+        let (set, metrics) = extract_ast_ngrams_with_metrics(&lin.nodes, lang);
+        self.add_file_ngrams(id, lang, &set, node_count, metrics)
     }
 
     // -----------------------------------------------------------------------
@@ -370,7 +382,8 @@ impl AstIndexBuilder {
         // ── Parallel extraction ──────────────────────────────────────────────
         // Collect results into a Vec indexed by position in `files` so that
         // sequential merge preserves FileId order.
-        let extracted: Vec<Result<(FileId, rskim_core::Language, AstNgramSet, u32)>> = files
+        type ExtractedEntry = (FileId, rskim_core::Language, AstNgramSet, u32, StructuralMetrics);
+        let extracted: Vec<Result<ExtractedEntry>> = files
             .par_iter()
             .map(|(id, content, lang)| {
                 let lin = linearize_source(content, *lang)?;
@@ -381,16 +394,16 @@ impl AstIndexBuilder {
                         id.0
                     ))
                 })?;
-                let set = extract_ast_ngrams(&lin.nodes, *lang);
-                Ok((*id, *lang, set, node_count))
+                let (set, metrics) = extract_ast_ngrams_with_metrics(&lin.nodes, *lang);
+                Ok((*id, *lang, set, node_count, metrics))
             })
             .collect();
 
         // ── Sequential merge ─────────────────────────────────────────────────
         let mut builder = AstIndexBuilder::new(output_dir)?;
         for result in extracted {
-            let (id, lang, set, node_count) = result?;
-            builder.add_file_ngrams(id, lang, &set, node_count)?;
+            let (id, lang, set, node_count, metrics) = result?;
+            builder.add_file_ngrams(id, lang, &set, node_count, metrics)?;
         }
 
         builder.build()
@@ -413,16 +426,18 @@ impl AstIndexBuilder {
     /// result.
     pub fn build(self) -> Result<AstIndexReader> {
         // ── Corpus averages ──────────────────────────────────────────────────
-        let (avg_bigram_count, avg_trigram_count, avg_node_count) = if self.file_count == 0 {
-            (0.0f32, 0.0f32, 0.0f32)
-        } else {
-            let n = f64::from(self.file_count);
-            (
-                (self.total_distinct_bigrams as f64 / n) as f32,
-                (self.total_distinct_trigrams as f64 / n) as f32,
-                (self.total_node_count as f64 / n) as f32,
-            )
-        };
+        let (avg_bigram_count, avg_trigram_count, avg_node_count, avg_max_depth) =
+            if self.file_count == 0 {
+                (0.0f32, 0.0f32, 0.0f32, 0.0f32)
+            } else {
+                let n = f64::from(self.file_count);
+                (
+                    (self.total_distinct_bigrams as f64 / n) as f32,
+                    (self.total_distinct_trigrams as f64 / n) as f32,
+                    (self.total_node_count as f64 / n) as f32,
+                    (self.total_max_depth as f64 / n) as f32,
+                )
+            };
 
         // ── Assert posting lists are already ascending by doc_id ─────────────
         // The sequential-FileId invariant (enforced in add_file_ngrams via the
@@ -466,6 +481,7 @@ impl AstIndexBuilder {
             avg_bigram_count,
             avg_trigram_count,
             avg_node_count,
+            avg_max_depth,
         )?;
 
         let post_path = self.output_dir.join("ast_index.skpost");
@@ -487,6 +503,7 @@ impl AstIndexBuilder {
         avg_bigram_count: f32,
         avg_trigram_count: f32,
         avg_node_count: f32,
+        avg_max_depth: f32,
     ) -> Result<(Vec<u8>, Vec<u8>)> {
         // ── Postings buffer ──────────────────────────────────────────────────
         // Use saturating_mul for parity with the crate's overflow discipline
@@ -599,6 +616,7 @@ impl AstIndexBuilder {
             avg_bigram_count,
             avg_trigram_count,
             avg_node_count,
+            avg_max_depth,
             checksum,
         };
 

--- a/crates/rskim-search/src/ast_index/store/builder_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/builder_tests.rs
@@ -9,6 +9,7 @@ use crate::{
     FileId,
     ast_index::{
         AstBigram, AstBigramEntry, AstNgramSet, AstTrigram, AstTrigramEntry, DEFAULT_AST_WEIGHT,
+        StructuralMetrics,
     },
 };
 use rskim_core::Language;
@@ -99,13 +100,13 @@ fn a8_zero_ngram_file_gets_meta_entry() {
     let empty_set = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set_with, 100)
+        .add_file_ngrams(FileId(0), Language::Rust, &set_with, 100, StructuralMetrics::default())
         .unwrap();
     builder
-        .add_file_ngrams(FileId(1), Language::Python, &empty_set, 0)
+        .add_file_ngrams(FileId(1), Language::Python, &empty_set, 0, StructuralMetrics::default())
         .unwrap();
     builder
-        .add_file_ngrams(FileId(2), Language::Go, &empty_set, 50)
+        .add_file_ngrams(FileId(2), Language::Go, &empty_set, 50, StructuralMetrics::default())
         .unwrap();
 
     let reader = builder.build().unwrap();
@@ -132,10 +133,10 @@ fn a9_duplicate_file_id_rejected() {
     let empty = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0)
+        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
         .unwrap();
     let err = builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0)
+        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
         .unwrap_err();
     let msg = format!("{err}");
     assert!(msg.contains("duplicate"), "expected 'duplicate' in: {msg}");
@@ -149,7 +150,7 @@ fn a9_non_sequential_first_id_rejected() {
 
     // First FileId should be 0, not 5
     let err = builder
-        .add_file_ngrams(FileId(5), Language::Rust, &empty, 0)
+        .add_file_ngrams(FileId(5), Language::Rust, &empty, 0, StructuralMetrics::default())
         .unwrap_err();
     let msg = format!("{err}");
     assert!(
@@ -165,11 +166,11 @@ fn a9_gap_in_file_ids_rejected() {
     let empty = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0)
+        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
         .unwrap();
     // FileId(2) skips FileId(1)
     let err = builder
-        .add_file_ngrams(FileId(2), Language::Rust, &empty, 0)
+        .add_file_ngrams(FileId(2), Language::Rust, &empty, 0, StructuralMetrics::default())
         .unwrap_err();
     let msg = format!("{err}");
     assert!(
@@ -206,7 +207,7 @@ fn a2_posting_merge_sorted_unique_doc_ids() {
     for i in 0..10u32 {
         let set = multi_bigram_set(&[(key_a, 1), (key_b, 2), (key_c, 3)]);
         builder
-            .add_file_ngrams(FileId(i), Language::Rust, &set, 10)
+            .add_file_ngrams(FileId(i), Language::Rust, &set, 10, StructuralMetrics::default())
             .unwrap();
     }
 
@@ -248,7 +249,7 @@ fn a4_count_preserved_from_ngram_entry() {
 
     let set = single_bigram_set(key, 7);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 100)
+        .add_file_ngrams(FileId(0), Language::Rust, &set, 100, StructuralMetrics::default())
         .unwrap();
 
     let reader = builder.build().unwrap();
@@ -273,7 +274,7 @@ fn a10_atomic_write_no_temp_leftovers() {
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
     let empty = AstNgramSet::default();
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0)
+        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
         .unwrap();
     builder.build().unwrap();
 
@@ -312,13 +313,13 @@ fn avg_node_count_computed_correctly() {
     let empty = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 10)
+        .add_file_ngrams(FileId(0), Language::Rust, &empty, 10, StructuralMetrics::default())
         .unwrap();
     builder
-        .add_file_ngrams(FileId(1), Language::Python, &empty, 20)
+        .add_file_ngrams(FileId(1), Language::Python, &empty, 20, StructuralMetrics::default())
         .unwrap();
     builder
-        .add_file_ngrams(FileId(2), Language::Go, &empty, 30)
+        .add_file_ngrams(FileId(2), Language::Go, &empty, 30, StructuralMetrics::default())
         .unwrap();
 
     let reader = builder.build().unwrap();

--- a/crates/rskim-search/src/ast_index/store/builder_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/builder_tests.rs
@@ -100,13 +100,31 @@ fn a8_zero_ngram_file_gets_meta_entry() {
     let empty_set = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set_with, 100, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set_with,
+            100,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder
-        .add_file_ngrams(FileId(1), Language::Python, &empty_set, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(1),
+            Language::Python,
+            &empty_set,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder
-        .add_file_ngrams(FileId(2), Language::Go, &empty_set, 50, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(2),
+            Language::Go,
+            &empty_set,
+            50,
+            StructuralMetrics::default(),
+        )
         .unwrap();
 
     let reader = builder.build().unwrap();
@@ -133,10 +151,22 @@ fn a9_duplicate_file_id_rejected() {
     let empty = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     let err = builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap_err();
     let msg = format!("{err}");
     assert!(msg.contains("duplicate"), "expected 'duplicate' in: {msg}");
@@ -150,7 +180,13 @@ fn a9_non_sequential_first_id_rejected() {
 
     // First FileId should be 0, not 5
     let err = builder
-        .add_file_ngrams(FileId(5), Language::Rust, &empty, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(5),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap_err();
     let msg = format!("{err}");
     assert!(
@@ -166,11 +202,23 @@ fn a9_gap_in_file_ids_rejected() {
     let empty = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     // FileId(2) skips FileId(1)
     let err = builder
-        .add_file_ngrams(FileId(2), Language::Rust, &empty, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(2),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap_err();
     let msg = format!("{err}");
     assert!(
@@ -207,7 +255,13 @@ fn a2_posting_merge_sorted_unique_doc_ids() {
     for i in 0..10u32 {
         let set = multi_bigram_set(&[(key_a, 1), (key_b, 2), (key_c, 3)]);
         builder
-            .add_file_ngrams(FileId(i), Language::Rust, &set, 10, StructuralMetrics::default())
+            .add_file_ngrams(
+                FileId(i),
+                Language::Rust,
+                &set,
+                10,
+                StructuralMetrics::default(),
+            )
             .unwrap();
     }
 
@@ -249,7 +303,13 @@ fn a4_count_preserved_from_ngram_entry() {
 
     let set = single_bigram_set(key, 7);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 100, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set,
+            100,
+            StructuralMetrics::default(),
+        )
         .unwrap();
 
     let reader = builder.build().unwrap();
@@ -274,7 +334,13 @@ fn a10_atomic_write_no_temp_leftovers() {
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
     let empty = AstNgramSet::default();
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder.build().unwrap();
 
@@ -313,13 +379,31 @@ fn avg_node_count_computed_correctly() {
     let empty = AstNgramSet::default();
 
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &empty, 10, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &empty,
+            10,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder
-        .add_file_ngrams(FileId(1), Language::Python, &empty, 20, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(1),
+            Language::Python,
+            &empty,
+            20,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder
-        .add_file_ngrams(FileId(2), Language::Go, &empty, 30, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(2),
+            Language::Go,
+            &empty,
+            30,
+            StructuralMetrics::default(),
+        )
         .unwrap();
 
     let reader = builder.build().unwrap();

--- a/crates/rskim-search/src/ast_index/store/builder_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/builder_tests.rs
@@ -475,3 +475,132 @@ fn new_missing_dir_returns_io_error() {
         "expected IO/not-found error, got: {msg}"
     );
 }
+
+// ============================================================================
+// file_metrics roundtrip with non-zero values (Issue 1)
+//
+// Every prior builder/reader test passes StructuralMetrics::default() (all zeros),
+// so a transposed field in encode_file_meta or the AstFileMetaEntry -> StructuralMetrics
+// mapping in file_metrics() would pass all existing tests silently.
+//
+// This test uses DISTINCT non-zero values for each field in each file so that
+// any field transposition or mis-offset in the 15-byte on-disk layout causes
+// an assertion failure.
+// ============================================================================
+
+#[test]
+fn file_metrics_roundtrip_non_zero_values() {
+    let dir = tempdir().unwrap();
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    let empty = AstNgramSet::default();
+
+    let m0 = StructuralMetrics {
+        max_depth: 12,
+        max_block_stmts: 25,
+        max_params: 6,
+        branch_count: 8,
+    };
+    let m1 = StructuralMetrics {
+        max_depth: 3,
+        max_block_stmts: 1,
+        max_params: 0,
+        branch_count: 0,
+    };
+    // File 2 has max values to cover saturating casts
+    let m2 = StructuralMetrics {
+        max_depth: u16::MAX,
+        max_block_stmts: u16::MAX,
+        max_params: u16::MAX,
+        branch_count: u32::MAX,
+    };
+
+    builder
+        .add_file_ngrams(FileId(0), Language::Rust, &empty, 100, m0)
+        .unwrap();
+    builder
+        .add_file_ngrams(FileId(1), Language::Python, &empty, 50, m1)
+        .unwrap();
+    builder
+        .add_file_ngrams(FileId(2), Language::Go, &empty, 0, m2)
+        .unwrap();
+
+    let reader = builder.build().unwrap();
+
+    assert_eq!(
+        reader.file_metrics(0).unwrap(),
+        m0,
+        "file 0 metrics mismatch — possible field transposition in encode_file_meta"
+    );
+    assert_eq!(
+        reader.file_metrics(1).unwrap(),
+        m1,
+        "file 1 metrics mismatch — possible field transposition in encode_file_meta"
+    );
+    assert_eq!(
+        reader.file_metrics(2).unwrap(),
+        m2,
+        "file 2 metrics mismatch — possible field transposition or truncation at u16::MAX/u32::MAX"
+    );
+}
+
+// ============================================================================
+// avg_max_depth computed correctly through the builder (Issue 2)
+//
+// The existing a8_avg_max_depth_roundtrip in format_tests.rs injects avg_max_depth
+// directly into the header struct, bypassing the builder's accumulation at
+// builder.rs:314-316 and the division at builder.rs:446.  This test exercises
+// the COMPUTATION: build three files with max_depth 10, 20, 30 and assert
+// avg_max_depth() ~= 20.0.
+// ============================================================================
+
+#[test]
+fn avg_max_depth_computed_correctly() {
+    let dir = tempdir().unwrap();
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    let empty = AstNgramSet::default();
+
+    builder
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &empty,
+            0,
+            StructuralMetrics {
+                max_depth: 10,
+                ..StructuralMetrics::default()
+            },
+        )
+        .unwrap();
+    builder
+        .add_file_ngrams(
+            FileId(1),
+            Language::Python,
+            &empty,
+            0,
+            StructuralMetrics {
+                max_depth: 20,
+                ..StructuralMetrics::default()
+            },
+        )
+        .unwrap();
+    builder
+        .add_file_ngrams(
+            FileId(2),
+            Language::Go,
+            &empty,
+            0,
+            StructuralMetrics {
+                max_depth: 30,
+                ..StructuralMetrics::default()
+            },
+        )
+        .unwrap();
+
+    let reader = builder.build().unwrap();
+    // avg = (10 + 20 + 30) / 3 = 20.0
+    assert!(
+        (reader.avg_max_depth() - 20.0_f32).abs() < 1e-4,
+        "avg_max_depth should be 20.0, got {}",
+        reader.avg_max_depth()
+    );
+}

--- a/crates/rskim-search/src/ast_index/store/format.rs
+++ b/crates/rskim-search/src/ast_index/store/format.rs
@@ -8,7 +8,7 @@
 //! [AstSkidxHeader: 48 bytes]
 //! [AstBigramEntry × bigram_count: 16 bytes each, sorted by key asc]
 //! [AstTrigramEntry × trigram_count: 20 bytes each, sorted by key asc]
-//! [AstFileMetaEntry × file_count: 5 bytes each]
+//! [AstFileMetaEntry × file_count: 15 bytes each]
 //! ```
 //!
 //! ## `ast_index.skpost`

--- a/crates/rskim-search/src/ast_index/store/format.rs
+++ b/crates/rskim-search/src/ast_index/store/format.rs
@@ -321,10 +321,18 @@ pub(crate) fn decode_header(data: &[u8]) -> Result<AstSkidxHeader> {
     }
     let version = u16::from_le_bytes(read_array(data, 4, "header: version")?);
     if version != FORMAT_VERSION {
-        return Err(SearchError::IndexCorrupted(format!(
-            "unsupported format version: {version} (expected {FORMAT_VERSION}); \
-             please rebuild the AST index"
-        )));
+        let hint = if version > FORMAT_VERSION {
+            format!(
+                "unsupported format version: {version} (expected {FORMAT_VERSION}); \
+                 this index was created by a newer binary — upgrade rskim-search"
+            )
+        } else {
+            format!(
+                "unsupported format version: {version} (expected {FORMAT_VERSION}); \
+                 please rebuild the AST index"
+            )
+        };
+        return Err(SearchError::IndexCorrupted(hint));
     }
 
     let avg_bigram_count = f32::from_le_bytes(read_array(data, 26, "header: avg_bigram_count")?);

--- a/crates/rskim-search/src/ast_index/store/format.rs
+++ b/crates/rskim-search/src/ast_index/store/format.rs
@@ -50,7 +50,14 @@ pub(crate) const SKAX_MAGIC: &[u8; 4] = b"SKAX";
 /// Version-bump policy: any change to field order, field width, or interpretation
 /// of any byte in any struct increments this number.  Old versions are rejected
 /// with an error message containing "format version".
-pub(crate) const FORMAT_VERSION: u16 = 1;
+///
+/// v2 changes (Wave 3e):
+/// - `AstFileMetaEntry` extended from 5 to 15 bytes (added max_depth:u16,
+///   max_block_stmts:u16, max_params:u16, branch_count:u32).
+/// - Header reserved bytes [38..42] now store `avg_max_depth` as f32 LE.
+/// - Synthetic n-grams from the AST Pattern Library stored alongside real n-grams.
+/// - All v1 indexes are invalid; reader rejects them with "please rebuild the AST index".
+pub(crate) const FORMAT_VERSION: u16 = 2;
 
 /// Size in bytes of [`AstSkidxHeader`] on disk.
 pub(crate) const HEADER_SIZE: usize = 48;
@@ -64,8 +71,13 @@ pub(crate) const TRIGRAM_ENTRY_SIZE: usize = 20;
 /// Size in bytes of a single [`AstPostingEntry`] on disk.
 pub(crate) const POSTING_ENTRY_SIZE: usize = 8;
 
-/// Size in bytes of a single [`AstFileMetaEntry`] on disk.
-pub(crate) const FILE_META_SIZE: usize = 5;
+/// Size in bytes of a single [`AstFileMetaEntry`] on disk (v2).
+///
+/// v1: 5 bytes (`lang_id:u8` + `node_count:u32`)
+/// v2: 15 bytes (adds `max_depth:u16` + `max_block_stmts:u16` + `max_params:u16` + `branch_count:u32`)
+///
+/// Delta is exactly +10 bytes per file (performance criterion P3).
+pub(crate) const FILE_META_SIZE: usize = 15;
 
 // ============================================================================
 // On-disk structs
@@ -76,7 +88,7 @@ pub(crate) const FILE_META_SIZE: usize = 5;
 /// Layout (48 bytes, all integers little-endian):
 /// ```text
 /// [0..4]   magic b"SKAX"         4 bytes
-/// [4..6]   version = 1           2 bytes
+/// [4..6]   version = 2           2 bytes
 /// [6..10]  bigram_count          4 bytes (u32)
 /// [10..14] trigram_count         4 bytes (u32)
 /// [14..18] file_count            4 bytes (u32)
@@ -84,7 +96,8 @@ pub(crate) const FILE_META_SIZE: usize = 5;
 /// [26..30] avg_bigram_count      4 bytes (f32 LE)
 /// [30..34] avg_trigram_count     4 bytes (f32 LE)
 /// [34..38] avg_node_count        4 bytes (f32 LE)
-/// [38..44] reserved (= 0)        6 bytes
+/// [38..42] avg_max_depth         4 bytes (f32 LE) — was reserved in v1
+/// [42..44] reserved (= 0)        2 bytes
 /// [44..48] checksum (CRC32)      4 bytes (u32)
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -109,6 +122,11 @@ pub(crate) struct AstSkidxHeader {
     pub avg_trigram_count: f32,
     /// Average emitted-node count per file (nodes.len(), excludes ERROR/MISSING).
     pub avg_node_count: f32,
+    /// Average maximum CST traversal depth per file (from `StructuralMetrics::max_depth`).
+    ///
+    /// Stored in reserved bytes [38..42] (was zero in v1).
+    /// Useful for ranking normalization in Wave 4 (structural-complexity dimension).
+    pub avg_max_depth: f32,
     /// CRC32 of the post-header payload (bigram entries + trigram entries +
     /// file-meta entries, in that order).
     pub checksum: u32,
@@ -182,13 +200,19 @@ pub(crate) struct AstPostingEntry {
 
 /// Per-file metadata stored in the tail of `ast_index.skidx`.
 ///
-/// Layout (5 bytes, all integers little-endian):
+/// Layout (15 bytes, all integers little-endian) — v2 format:
 /// ```text
-/// [0]    lang_id    1 byte (u8, from lang_to_id)
-/// [1..5] node_count 4 bytes (u32, emitted-node count from linearize_source)
+/// [0]     lang_id         1 byte  (u8, from lang_to_id)
+/// [1..5]  node_count      4 bytes (u32, emitted-node count from linearize_source)
+/// [5..7]  max_depth       2 bytes (u16, maximum CST traversal depth in this file)
+/// [7..9]  max_block_stmts 2 bytes (u16, max counted-child count in any body block)
+/// [9..11] max_params      2 bytes (u16, max counted-child count in any param list)
+/// [11..15] branch_count   4 bytes (u32, total branch-kind node count)
 /// ```
 ///
 /// `node_count` equals `lin.nodes.len()` (emitted nodes, excludes ERROR/MISSING).
+/// `max_block_stmts` and `max_params` are saturated at `u16::MAX` (PF-004).
+/// `branch_count` is saturated at `u32::MAX`.
 ///
 /// # C6 — language recovery
 ///
@@ -202,6 +226,17 @@ pub struct AstFileMetaEntry {
     pub lang_id: u8,
     /// Number of emitted AST nodes from `linearize_source` (excludes ERROR/MISSING).
     pub node_count: u32,
+    /// Maximum CST traversal depth in this file (0 if empty).
+    pub max_depth: u16,
+    /// Maximum counted-child count in any function/method body block.
+    /// Saturated at `u16::MAX` (PF-004).
+    pub max_block_stmts: u16,
+    /// Maximum counted-child count in any parameter list.
+    /// Saturated at `u16::MAX` (PF-004).
+    pub max_params: u16,
+    /// Total count of branch-kind nodes in this file.
+    /// Saturated at `u32::MAX`.
+    pub branch_count: u32,
 }
 
 impl AstFileMetaEntry {
@@ -255,7 +290,8 @@ pub(crate) fn encode_header(h: &AstSkidxHeader) -> [u8; HEADER_SIZE] {
     buf[26..30].copy_from_slice(&h.avg_bigram_count.to_le_bytes());
     buf[30..34].copy_from_slice(&h.avg_trigram_count.to_le_bytes());
     buf[34..38].copy_from_slice(&h.avg_node_count.to_le_bytes());
-    // [38..44] reserved — already zeroed by `[0u8; HEADER_SIZE]`
+    buf[38..42].copy_from_slice(&h.avg_max_depth.to_le_bytes());
+    // [42..44] reserved — already zeroed by `[0u8; HEADER_SIZE]`
     buf[44..48].copy_from_slice(&h.checksum.to_le_bytes());
     buf
 }
@@ -312,6 +348,13 @@ pub(crate) fn decode_header(data: &[u8]) -> Result<AstSkidxHeader> {
         )));
     }
 
+    let avg_max_depth = f32::from_le_bytes(read_array(data, 38, "header: avg_max_depth")?);
+    if !avg_max_depth.is_finite() || avg_max_depth < 0.0 {
+        return Err(SearchError::IndexCorrupted(format!(
+            "header: avg_max_depth must be finite and >= 0.0, got {avg_max_depth}"
+        )));
+    }
+
     Ok(AstSkidxHeader {
         magic,
         version,
@@ -322,6 +365,7 @@ pub(crate) fn decode_header(data: &[u8]) -> Result<AstSkidxHeader> {
         avg_bigram_count,
         avg_trigram_count,
         avg_node_count,
+        avg_max_depth,
         checksum: u32::from_le_bytes(read_array(data, 44, "header: checksum")?),
     })
 }
@@ -429,15 +473,19 @@ pub(crate) fn decode_posting(data: &[u8]) -> Result<AstPostingEntry> {
 // AstFileMetaEntry encode / decode
 // ============================================================================
 
-/// Encode an [`AstFileMetaEntry`] into its 5-byte on-disk representation.
+/// Encode an [`AstFileMetaEntry`] into its 15-byte on-disk representation (v2).
 pub(crate) fn encode_file_meta(m: &AstFileMetaEntry) -> [u8; FILE_META_SIZE] {
     let mut buf = [0u8; FILE_META_SIZE];
     buf[0] = m.lang_id;
     buf[1..5].copy_from_slice(&m.node_count.to_le_bytes());
+    buf[5..7].copy_from_slice(&m.max_depth.to_le_bytes());
+    buf[7..9].copy_from_slice(&m.max_block_stmts.to_le_bytes());
+    buf[9..11].copy_from_slice(&m.max_params.to_le_bytes());
+    buf[11..15].copy_from_slice(&m.branch_count.to_le_bytes());
     buf
 }
 
-/// Decode an [`AstFileMetaEntry`] from a 5-byte slice.
+/// Decode an [`AstFileMetaEntry`] from a 15-byte slice (v2).
 ///
 /// # Errors
 ///
@@ -452,6 +500,12 @@ pub(crate) fn decode_file_meta(data: &[u8]) -> Result<AstFileMetaEntry> {
     Ok(AstFileMetaEntry {
         lang_id: data[0],
         node_count: u32::from_le_bytes(read_array(data, 1, "ast_file_meta: node_count")?),
+        max_depth: u16::from_le_bytes(read_array(data, 5, "ast_file_meta: max_depth")?),
+        max_block_stmts: u16::from_le_bytes(
+            read_array(data, 7, "ast_file_meta: max_block_stmts")?,
+        ),
+        max_params: u16::from_le_bytes(read_array(data, 9, "ast_file_meta: max_params")?),
+        branch_count: u32::from_le_bytes(read_array(data, 11, "ast_file_meta: branch_count")?),
     })
 }
 

--- a/crates/rskim-search/src/ast_index/store/format.rs
+++ b/crates/rskim-search/src/ast_index/store/format.rs
@@ -501,9 +501,7 @@ pub(crate) fn decode_file_meta(data: &[u8]) -> Result<AstFileMetaEntry> {
         lang_id: data[0],
         node_count: u32::from_le_bytes(read_array(data, 1, "ast_file_meta: node_count")?),
         max_depth: u16::from_le_bytes(read_array(data, 5, "ast_file_meta: max_depth")?),
-        max_block_stmts: u16::from_le_bytes(
-            read_array(data, 7, "ast_file_meta: max_block_stmts")?,
-        ),
+        max_block_stmts: u16::from_le_bytes(read_array(data, 7, "ast_file_meta: max_block_stmts")?),
         max_params: u16::from_le_bytes(read_array(data, 9, "ast_file_meta: max_params")?),
         branch_count: u32::from_le_bytes(read_array(data, 11, "ast_file_meta: branch_count")?),
     })

--- a/crates/rskim-search/src/ast_index/store/format_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/format_tests.rs
@@ -19,6 +19,7 @@ fn make_valid_header() -> AstSkidxHeader {
         avg_bigram_count: 3.5_f32,
         avg_trigram_count: 1.2_f32,
         avg_node_count: 42.0_f32,
+        avg_max_depth: 5.2_f32,
         checksum: 0xDEAD_BEEF,
     }
 }
@@ -44,6 +45,7 @@ fn header_roundtrip_zero_avgs() {
         avg_bigram_count: 0.0,
         avg_trigram_count: 0.0,
         avg_node_count: 0.0,
+        avg_max_depth: 0.0,
         checksum: 0,
     };
     let encoded = encode_header(&h);
@@ -103,9 +105,28 @@ fn header_rejects_wrong_version_zero() {
 }
 
 #[test]
-fn header_rejects_wrong_version_two() {
+fn header_rejects_wrong_version_one() {
+    // v1 is no longer valid — it lacks v2 structural fields.
+    // The reader must reject it with "please rebuild the AST index".
     let mut encoded = encode_header(&make_valid_header());
-    encoded[4..6].copy_from_slice(&2u16.to_le_bytes());
+    encoded[4..6].copy_from_slice(&1u16.to_le_bytes());
+    let err = decode_header(&encoded).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("format version"),
+        "expected 'format version' in: {msg}"
+    );
+    assert!(
+        msg.contains("please rebuild the AST index"),
+        "expected 'please rebuild' in: {msg}"
+    );
+}
+
+#[test]
+fn header_rejects_wrong_version_three() {
+    // A future version (3) must also be rejected by this binary.
+    let mut encoded = encode_header(&make_valid_header());
+    encoded[4..6].copy_from_slice(&3u16.to_le_bytes());
     let err = decode_header(&encoded).unwrap_err();
     let msg = format!("{err}");
     assert!(
@@ -340,14 +361,44 @@ fn posting_rejects_truncation() {
 // AstFileMetaEntry roundtrip
 // ============================================================================
 
-#[test]
-fn file_meta_roundtrip() {
-    let m = AstFileMetaEntry {
+// ============================================================================
+// A2: AstFileMetaEntry v2 round-trip and size constant
+// ============================================================================
+
+fn make_file_meta() -> AstFileMetaEntry {
+    AstFileMetaEntry {
         lang_id: 11, // Rust
         node_count: 256,
+        max_depth: 12,
+        max_block_stmts: 25,
+        max_params: 6,
+        branch_count: 8,
+    }
+}
+
+#[test]
+fn file_meta_roundtrip() {
+    let m = make_file_meta();
+    let encoded = encode_file_meta(&m);
+    // A2: FILE_META_SIZE == 15 (P3: delta +10 bytes/file from v1's 5 bytes)
+    assert_eq!(encoded.len(), FILE_META_SIZE);
+    assert_eq!(FILE_META_SIZE, 15, "P3: file meta must be 15 bytes");
+    let decoded = decode_file_meta(&encoded).unwrap();
+    assert_eq!(decoded, m);
+}
+
+#[test]
+fn file_meta_roundtrip_all_fields() {
+    // Round-trip with boundary/max values to verify all field encodings
+    let m = AstFileMetaEntry {
+        lang_id: 0xFF,
+        node_count: u32::MAX,
+        max_depth: u16::MAX,
+        max_block_stmts: u16::MAX,
+        max_params: u16::MAX,
+        branch_count: u32::MAX,
     };
     let encoded = encode_file_meta(&m);
-    assert_eq!(encoded.len(), FILE_META_SIZE);
     let decoded = decode_file_meta(&encoded).unwrap();
     assert_eq!(decoded, m);
 }
@@ -357,6 +408,10 @@ fn file_meta_boundary_max_node_count() {
     let m = AstFileMetaEntry {
         lang_id: 0,
         node_count: u32::MAX,
+        max_depth: 0,
+        max_block_stmts: 0,
+        max_params: 0,
+        branch_count: 0,
     };
     let encoded = encode_file_meta(&m);
     let decoded = decode_file_meta(&encoded).unwrap();
@@ -365,14 +420,77 @@ fn file_meta_boundary_max_node_count() {
 
 #[test]
 fn file_meta_rejects_truncation() {
-    let m = AstFileMetaEntry {
-        lang_id: 9,
-        node_count: 10,
-    };
+    let m = make_file_meta();
     let encoded = encode_file_meta(&m);
     let err = decode_file_meta(&encoded[..FILE_META_SIZE - 1]).unwrap_err();
     let msg = format!("{err}");
     assert!(msg.contains("truncated"), "expected 'truncated' in: {msg}");
+}
+
+// ============================================================================
+// A1: FORMAT_VERSION == 2, magic unchanged
+// ============================================================================
+
+#[test]
+fn a1_format_version_is_2() {
+    assert_eq!(FORMAT_VERSION, 2, "A1: FORMAT_VERSION must be 2");
+}
+
+#[test]
+fn a1_magic_unchanged() {
+    assert_eq!(SKAX_MAGIC, b"SKAX", "A1: magic must remain b\"SKAX\"");
+}
+
+// ============================================================================
+// A3: Reader rejects v1 with "please rebuild the AST index"
+// ============================================================================
+
+#[test]
+fn a3_reader_rejects_v1_header() {
+    // Hand-craft a minimal v1 header (48 bytes, version = 1)
+    let mut v1_header = [0u8; 48];
+    v1_header[0..4].copy_from_slice(b"SKAX");
+    v1_header[4..6].copy_from_slice(&1u16.to_le_bytes()); // version = 1
+    // All other fields 0 (empty index)
+
+    let err = decode_header(&v1_header).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("please rebuild the AST index"),
+        "A3: v1 rejection must contain 'please rebuild the AST index', got: {msg}"
+    );
+    assert!(
+        msg.contains("format version"),
+        "A3: v1 rejection must contain 'format version', got: {msg}"
+    );
+}
+
+// ============================================================================
+// A8: avg_max_depth decodes correctly from header reserved bytes
+// ============================================================================
+
+#[test]
+fn a8_avg_max_depth_roundtrip() {
+    let h = AstSkidxHeader {
+        magic: *SKAX_MAGIC,
+        version: FORMAT_VERSION,
+        bigram_count: 0,
+        trigram_count: 0,
+        file_count: 0,
+        postings_file_size: 0,
+        avg_bigram_count: 0.0,
+        avg_trigram_count: 0.0,
+        avg_node_count: 0.0,
+        avg_max_depth: 7.5,
+        checksum: 0,
+    };
+    let encoded = encode_header(&h);
+    let decoded = decode_header(&encoded).unwrap();
+    assert!(
+        (decoded.avg_max_depth - 7.5).abs() < 1e-6,
+        "A8: avg_max_depth must round-trip; got {}",
+        decoded.avg_max_depth
+    );
 }
 
 // ============================================================================

--- a/crates/rskim-search/src/ast_index/store/format_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/format_tests.rs
@@ -136,6 +136,47 @@ fn header_rejects_wrong_version_three() {
 }
 
 #[test]
+fn header_future_version_suggests_upgrade_not_rebuild() {
+    // Issue 3 (pre-existing, touched-file fix): a version > FORMAT_VERSION means the
+    // user needs a NEWER binary, not a rebuild.  The error message must say "upgrade"
+    // rather than "please rebuild the AST index" so the user gets actionable guidance.
+    let mut encoded = encode_header(&make_valid_header());
+    encoded[4..6].copy_from_slice(&3u16.to_le_bytes()); // v3 is a future version
+    let err = decode_header(&encoded).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("format version"),
+        "expected 'format version' in future-version message: {msg}"
+    );
+    assert!(
+        msg.contains("upgrade"),
+        "expected 'upgrade' in future-version message (not 'rebuild'): {msg}"
+    );
+    assert!(
+        !msg.contains("please rebuild the AST index"),
+        "future-version must NOT say 'please rebuild'; user needs a newer binary: {msg}"
+    );
+}
+
+#[test]
+fn header_old_version_suggests_rebuild_not_upgrade() {
+    // Complement: a version < FORMAT_VERSION (old index, current binary) must say
+    // "please rebuild" — not "upgrade".
+    let mut encoded = encode_header(&make_valid_header());
+    encoded[4..6].copy_from_slice(&1u16.to_le_bytes()); // v1 < FORMAT_VERSION
+    let err = decode_header(&encoded).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("please rebuild the AST index"),
+        "old-version (v1) must say 'please rebuild the AST index': {msg}"
+    );
+    assert!(
+        !msg.contains("upgrade"),
+        "old-version (v1) must NOT say 'upgrade'; user needs to rebuild: {msg}"
+    );
+}
+
+#[test]
 fn header_rejects_non_finite_avg_bigram_count() {
     let mut encoded = encode_header(&make_valid_header());
     encoded[26..30].copy_from_slice(&f32::NAN.to_le_bytes());

--- a/crates/rskim-search/src/ast_index/store/mod.rs
+++ b/crates/rskim-search/src/ast_index/store/mod.rs
@@ -10,7 +10,14 @@
 //!
 //! ## Magic / version
 //!
-//! Magic `b"SKAX"`, version `1`.  Any layout change increments the version.
+//! Magic `b"SKAX"`, version `2`.  Any layout change increments the version.
+//!
+//! ## AST INDEX FORMAT NOTE (v2)
+//!
+//! v2 extends `AstFileMetaEntry` from 5 to 15 bytes, adds `avg_max_depth` in
+//! previously-reserved header bytes [38..42], and stores synthetic n-grams from
+//! the AST Pattern Library alongside real n-grams. All v1 indexes must be
+//! rebuilt (`skim search index --rebuild`). Auto-rebuild is wired in Wave 3f/3g.
 //!
 //! # Public API
 //!
@@ -18,8 +25,9 @@
 //! then `build()`.  Use `build_from_files` for parallel bulk construction.
 //!
 //! [`AstIndexReader`] — returned by the builder.  Use `lookup_bigram` /
-//! `lookup_trigram` for posting-list access and `file_meta` for per-file
-//! metadata.
+//! `lookup_trigram` for posting-list access, `file_meta` for per-file
+//! metadata, `file_metrics` for structural metrics, and `index_version` for
+//! cheap version probing.
 //!
 //! [`AstPosting`] — individual posting element (`doc_id` + `count`).
 //!

--- a/crates/rskim-search/src/ast_index/store/reader.rs
+++ b/crates/rskim-search/src/ast_index/store/reader.rs
@@ -28,12 +28,12 @@ use memmap2::Mmap;
 
 use super::format::{
     AstFileMetaEntry, AstSkidxHeader, BIGRAM_ENTRY_SIZE, FILE_META_SIZE, HEADER_SIZE,
-    POSTING_ENTRY_SIZE, TRIGRAM_ENTRY_SIZE, compute_checksum, decode_file_meta, decode_header,
-    decode_posting, lookup_bigram, lookup_trigram,
+    POSTING_ENTRY_SIZE, SKAX_MAGIC, TRIGRAM_ENTRY_SIZE, compute_checksum, decode_file_meta,
+    decode_header, decode_posting, lookup_bigram, lookup_trigram,
 };
 use crate::{
     Result, SearchError,
-    ast_index::{AstBigram, AstTrigram},
+    ast_index::{AstBigram, AstTrigram, StructuralMetrics},
 };
 
 // ============================================================================
@@ -236,6 +236,41 @@ impl AstIndexReader {
     // Public accessors
     // -----------------------------------------------------------------------
 
+    /// Probe the format version of an on-disk AST index without fully opening it.
+    ///
+    /// Reads only the first 6 bytes of `ast_index.skidx` (magic + version) to
+    /// cheaply determine the format version. Returns `Err(IndexCorrupted)` if
+    /// the file is too short, has bad magic bytes, or cannot be read.
+    ///
+    /// Intended for staleness checks (Wave 3f/3g): callers can probe the version
+    /// before attempting a full `open`, which would fail with a version error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::Io`] if the file cannot be opened.
+    /// Returns [`SearchError::IndexCorrupted`] if the file is too short or has
+    /// bad magic bytes.
+    pub fn index_version(dir: &Path) -> Result<u16> {
+        use std::io::Read;
+        let idx_path = dir.join("ast_index.skidx");
+        let mut file = std::fs::File::open(&idx_path)?;
+        let mut buf = [0u8; 6];
+        file.read_exact(&mut buf).map_err(|_| {
+            SearchError::IndexCorrupted(
+                "index_version: ast_index.skidx too short (need 6 bytes)".into(),
+            )
+        })?;
+        let magic = &buf[0..4];
+        if magic != SKAX_MAGIC {
+            return Err(SearchError::IndexCorrupted(format!(
+                "index_version: bad magic: expected {:?}, got {:?}",
+                SKAX_MAGIC, magic
+            )));
+        }
+        let version = u16::from_le_bytes([buf[4], buf[5]]);
+        Ok(version)
+    }
+
     /// Return the number of files in the index.
     #[must_use]
     pub fn file_count(&self) -> u32 {
@@ -287,6 +322,34 @@ impl AstIndexReader {
                 ))
             })?;
         decode_file_meta(&self.idx_mmap[offset..end])
+    }
+
+    /// Return the per-file structural metrics for the file at sequential index `file_index`.
+    ///
+    /// Reads the same on-disk entry as [`file_meta`][Self::file_meta] but
+    /// extracts the v2-only structural fields as a [`StructuralMetrics`] value.
+    ///
+    /// `file_index` is the 0-based insertion order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SearchError::IndexCorrupted`] if `file_index` is out of bounds.
+    pub fn file_metrics(&self, file_index: u32) -> Result<StructuralMetrics> {
+        let entry = self.file_meta(file_index)?;
+        Ok(StructuralMetrics {
+            max_depth: entry.max_depth,
+            max_block_stmts: entry.max_block_stmts,
+            max_params: entry.max_params,
+            branch_count: entry.branch_count,
+        })
+    }
+
+    /// Return the average maximum CST depth across all indexed files.
+    ///
+    /// Stored in header bytes [38..42] (was reserved in v1, now `avg_max_depth`).
+    #[must_use]
+    pub fn avg_max_depth(&self) -> f32 {
+        self.header.avg_max_depth
     }
 
     // -----------------------------------------------------------------------

--- a/crates/rskim-search/src/ast_index/store/reader.rs
+++ b/crates/rskim-search/src/ast_index/store/reader.rs
@@ -316,9 +316,7 @@ impl AstIndexReader {
             .checked_mul(FILE_META_SIZE)
             .and_then(|o| meta_start.checked_add(o))
             .ok_or_else(|| {
-                SearchError::IndexCorrupted(format!(
-                    "file_meta({file_index}): offset overflow"
-                ))
+                SearchError::IndexCorrupted(format!("file_meta({file_index}): offset overflow"))
             })?;
         let end = offset
             .checked_add(FILE_META_SIZE)

--- a/crates/rskim-search/src/ast_index/store/reader.rs
+++ b/crates/rskim-search/src/ast_index/store/reader.rs
@@ -8,7 +8,7 @@
 //! [AstSkidxHeader: 48 bytes]
 //! [AstBigramEntry × bigram_count: 16 bytes each]
 //! [AstTrigramEntry × trigram_count: 20 bytes each]
-//! [AstFileMetaEntry × file_count: 5 bytes each]
+//! [AstFileMetaEntry × file_count: 15 bytes each]
 //! ```
 //!
 //! The `ast_index.skpost` file is memory-mapped when `postings_file_size > 0`.
@@ -310,7 +310,16 @@ impl AstIndexReader {
     /// Returns [`SearchError::IndexCorrupted`] if `file_index` is out of bounds.
     pub fn file_meta(&self, file_index: u32) -> Result<AstFileMetaEntry> {
         let meta_start = self.meta_start();
-        let offset = meta_start + (file_index as usize) * FILE_META_SIZE;
+        // avoids PF-004: use checked arithmetic throughout to prevent silent
+        // overflow on 32-bit targets where usize is 32 bits.
+        let offset = (file_index as usize)
+            .checked_mul(FILE_META_SIZE)
+            .and_then(|o| meta_start.checked_add(o))
+            .ok_or_else(|| {
+                SearchError::IndexCorrupted(format!(
+                    "file_meta({file_index}): offset overflow"
+                ))
+            })?;
         let end = offset
             .checked_add(FILE_META_SIZE)
             .filter(|&e| e <= self.idx_mmap.len())
@@ -455,6 +464,16 @@ impl AstIndexReader {
         for i in 0..n {
             let off = i * POSTING_ENTRY_SIZE;
             let raw = decode_posting(&data[off..off + POSTING_ENTRY_SIZE])?;
+            // C3: doc_id must refer to a file that actually exists in the index.
+            // A CRC-valid hostile index could embed an out-of-range doc_id; any
+            // downstream call to file_meta(doc_id) or file_metrics(doc_id) would
+            // then access garbage bytes.  Reject here rather than propagate.
+            if raw.doc_id >= self.header.file_count {
+                return Err(SearchError::IndexCorrupted(format!(
+                    "posting doc_id {} out of range (file_count={})",
+                    raw.doc_id, self.header.file_count
+                )));
+            }
             // C1 defensive check: postings must be strictly ascending by doc_id.
             // Collapsed from nested `if let`/`if` to satisfy clippy::collapsible_if.
             if let Some(prev) = prev_doc_id.filter(|&prev| raw.doc_id <= prev) {

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -52,7 +52,13 @@ fn build_3_file_index() -> (tempfile::TempDir, AstIndexReader) {
     // File 0: has a bigram
     let set0 = make_bigram_set(bigram_key, 3);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set0, 50, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set0,
+            50,
+            StructuralMetrics::default(),
+        )
         .unwrap();
 
     // File 1: has both bigram and trigram
@@ -65,13 +71,25 @@ fn build_3_file_index() -> (tempfile::TempDir, AstIndexReader) {
     set1.bigrams.sort_unstable_by_key(|e| e.ngram.key());
     set1.trigrams.sort_unstable_by_key(|e| e.ngram.key());
     builder
-        .add_file_ngrams(FileId(1), Language::Python, &set1, 80, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(1),
+            Language::Python,
+            &set1,
+            80,
+            StructuralMetrics::default(),
+        )
         .unwrap();
 
     // File 2: empty (non-TS language)
     let set2 = AstNgramSet::default();
     builder
-        .add_file_ngrams(FileId(2), Language::Go, &set2, 0, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(2),
+            Language::Go,
+            &set2,
+            0,
+            StructuralMetrics::default(),
+        )
         .unwrap();
 
     let reader = builder.build().unwrap();
@@ -282,7 +300,13 @@ fn a8_multi_language_round_trip() {
     for (i, &lang) in languages.iter().enumerate() {
         let set = make_bigram_set(bigram_key, (i as u32) + 1);
         builder
-            .add_file_ngrams(FileId(i as u32), lang, &set, 10, StructuralMetrics::default())
+            .add_file_ngrams(
+                FileId(i as u32),
+                lang,
+                &set,
+                10,
+                StructuralMetrics::default(),
+            )
             .unwrap();
     }
 
@@ -323,7 +347,13 @@ fn build_single_file_index() -> (tempfile::TempDir, Vec<u8>, Vec<u8>) {
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
     let set = make_bigram_set(0x0001_0002, 1);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 10, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set,
+            10,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder.build().unwrap();
     let idx = std::fs::read(dir.path().join("ast_index.skidx")).unwrap();
@@ -659,7 +689,10 @@ fn f9_index_version_returns_2_for_v2_index() {
         super::super::format::FORMAT_VERSION,
         "index_version must return FORMAT_VERSION (2) for a freshly built index"
     );
-    assert_eq!(version, 2u16, "FORMAT_VERSION is expected to be 2 in this wave");
+    assert_eq!(
+        version, 2u16,
+        "FORMAT_VERSION is expected to be 2 in this wave"
+    );
 }
 
 /// F9 negative — v1 fixture:
@@ -745,7 +778,13 @@ fn build_c3_index() -> (tempfile::TempDir, Vec<u8>, Vec<u8>) {
         count: 2,
     });
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 10, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set,
+            10,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder.build().unwrap();
 
@@ -924,10 +963,22 @@ fn c3_non_ascending_doc_ids_returns_index_corrupted() {
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
     let set = make_bigram_set(bigram_key, 1);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 10, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set,
+            10,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder
-        .add_file_ngrams(FileId(1), Language::Rust, &set, 10, StructuralMetrics::default())
+        .add_file_ngrams(
+            FileId(1),
+            Language::Rust,
+            &set,
+            10,
+            StructuralMetrics::default(),
+        )
         .unwrap();
     builder.build().unwrap();
 

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -636,6 +636,76 @@ fn ast_index_size_ratio() {
 }
 
 // ============================================================================
+// F9: index_version probe — returns the stored version without full open()
+//
+// Acceptance criterion F9: "index_version(dir) returns 2 for a v2 index AND
+// surfaces a v1 index as needing rebuild (tested via a hand-written v1 header
+// fixture)."
+//
+// The function reads only magic (4 bytes) + version (2 bytes) and returns
+// Ok(version) for any file with valid SKAX magic. It does NOT reject v1 — that
+// is the responsibility of AstIndexReader::open() / decode_header(). The
+// probe is a cheap staleness check; the caller decides what to do with the value.
+// ============================================================================
+
+/// F9 positive: index_version returns Ok(FORMAT_VERSION) == Ok(2) for a real
+/// v2 index built by AstIndexBuilder.
+#[test]
+fn f9_index_version_returns_2_for_v2_index() {
+    let (dir, _reader) = build_3_file_index();
+    let version = AstIndexReader::index_version(dir.path()).unwrap();
+    assert_eq!(
+        version,
+        super::super::format::FORMAT_VERSION,
+        "index_version must return FORMAT_VERSION (2) for a freshly built index"
+    );
+    assert_eq!(version, 2u16, "FORMAT_VERSION is expected to be 2 in this wave");
+}
+
+/// F9 negative — v1 fixture:
+///   (a) index_version returns Ok(1) — the probe reads the stored version without
+///       rejecting it; rejection is the job of open() / decode_header().
+///   (b) AstIndexReader::open() on the same fixture fails with "please rebuild
+///       the AST index" — the full reader enforces the version gate.
+///
+/// The v1 header is hand-written to mirror the byte layout used by
+/// a3_reader_rejects_v1_header in format_tests.rs: magic b"SKAX" (4 bytes)
+/// followed by version=1 as u16-LE (2 bytes), remaining bytes zeroed.
+#[test]
+fn f9_index_version_surfaces_v1_fixture() {
+    let dir = tempdir().unwrap();
+
+    // Hand-craft a minimal v1 index file: magic + version=1, rest zeroed.
+    // 48 bytes matches HEADER_SIZE so that open() reaches the version check
+    // rather than failing on a short-read.
+    let mut v1_header = [0u8; 48];
+    v1_header[0..4].copy_from_slice(b"SKAX");
+    v1_header[4..6].copy_from_slice(&1u16.to_le_bytes()); // version = 1
+
+    std::fs::write(dir.path().join("ast_index.skidx"), &v1_header).unwrap();
+
+    // (a) index_version should read Ok(1) — the probe does not enforce version.
+    let version = AstIndexReader::index_version(dir.path()).unwrap();
+    assert_eq!(
+        version, 1u16,
+        "index_version must return Ok(1) for a v1 fixture — it reads the stored \
+         version without rejecting it"
+    );
+
+    // (b) Full open() must reject v1 with the "please rebuild" hint.
+    let err = AstIndexReader::open(dir.path()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("please rebuild the AST index"),
+        "open() on a v1 fixture must contain 'please rebuild the AST index', got: {msg}"
+    );
+    assert!(
+        msg.contains("format version"),
+        "open() on a v1 fixture must contain 'format version', got: {msg}"
+    );
+}
+
+// ============================================================================
 // C3: posting bounds / alignment guards in lookup_postings_generic
 //
 // The existing A11 corruption-matrix tests flip bytes in `.skidx` but do NOT

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -715,7 +715,7 @@ fn f9_index_version_surfaces_v1_fixture() {
     v1_header[0..4].copy_from_slice(b"SKAX");
     v1_header[4..6].copy_from_slice(&1u16.to_le_bytes()); // version = 1
 
-    std::fs::write(dir.path().join("ast_index.skidx"), &v1_header).unwrap();
+    std::fs::write(dir.path().join("ast_index.skidx"), v1_header).unwrap();
 
     // (a) index_version should read Ok(1) — the probe does not enforce version.
     let version = AstIndexReader::index_version(dir.path()).unwrap();

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -533,7 +533,7 @@ fn a14_overflow_header_huge_bigram_count() {
 // v1 measured baseline: ~1.23×.  v2 adds structural n-grams and +10 bytes/file
 // meta overhead; expected v2 ratio ~1.3×.  Guard raised to <2.2× per PF-005:
 // relaxation justified by measured ratio + structural capability expansion.
-// Applies ADR-002 (grounded regression guard).  On-disk compression tracked
+// Applies ADR-003 (grounded regression guard).  On-disk compression tracked
 // in issue #273.
 // ============================================================================
 
@@ -651,7 +651,7 @@ fn ast_index_size_ratio() {
     // structural markers; a genuine O(files²) bloat regression would push
     // the ratio well above 2.2× and still fires.
     //
-    // ADR-002: regression guard must be empirically grounded.
+    // ADR-003: regression guard must be empirically grounded.
     //
     // ON-DISK COMPRESSION (delta encoding + VarInt / Roaring Bitmaps) that
     // would push the ratio well below 1× is tracked in issue #273.

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -571,12 +571,6 @@ fn ast_index_size_ratio() {
     //  trigram) typically run 3–5× source, so a raw uncompressed AST posting
     //  file at 1.2× is already competitive.
     //
-    // REGRESSION GUARD: < 1.8× (applies ADR-002)
-    //   The previous <3× bound was too loose — it would pass even a 2× regression.
-    //   The tighter <1.8× bound leaves a ~46% margin above the measured 1.23×
-    //   baseline (1.8 / 1.23 ≈ 1.46× headroom), wide enough to absorb corpus
-    //   variance but tight enough to fire on genuine O(files²) posting bloat.
-    //
     // ON-DISK COMPRESSION (delta encoding + VarInt / Roaring Bitmaps) that
     // would push the ratio well below 1× is tracked in issue #273.
     let dir = tempdir().unwrap();

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -949,6 +949,58 @@ fn c3_trigram_misaligned_posting_length_returns_index_corrupted() {
     );
 }
 
+/// (e) posting doc_id >= file_count → IndexCorrupted (out-of-range doc_id).
+///
+/// The CRC covers only `.skidx`, NOT `.skpost`, so corrupting `.skpost` is
+/// invisible to CRC validation.  A CRC-valid hostile index can embed a doc_id
+/// that is out of range for the `file_meta` / `file_metrics` arrays; this guard
+/// catches it before any downstream array access.
+#[test]
+fn c3_out_of_range_doc_id_returns_index_corrupted() {
+    // Build a single-file index (file_count = 1, so doc_id == 1 is out of range).
+    let dir = tempdir().unwrap();
+    let bigram_key: u32 = 0x0001_0002;
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    let set = make_bigram_set(bigram_key, 1);
+    builder
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set,
+            10,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+    builder.build().unwrap();
+
+    let idx = std::fs::read(dir.path().join("ast_index.skidx")).unwrap();
+    let mut post = std::fs::read(dir.path().join("ast_index.skpost")).unwrap();
+
+    // Overwrite the sole posting entry's doc_id (first 4 bytes) to 1, which is
+    // >= file_count (1).  The CRC does not cover skpost so open() still succeeds.
+    assert!(
+        post.len() >= POSTING_ENTRY_SIZE,
+        "expected at least one posting entry in post file"
+    );
+    post[0..4].copy_from_slice(&1u32.to_le_bytes()); // doc_id = 1, out of range
+
+    let corrupt_dir = tempdir().unwrap();
+    std::fs::write(corrupt_dir.path().join("ast_index.skidx"), &idx).unwrap();
+    std::fs::write(corrupt_dir.path().join("ast_index.skpost"), &post).unwrap();
+
+    let reader = AstIndexReader::open(corrupt_dir.path()).unwrap();
+    let err = reader.lookup_bigram(AstBigram(bigram_key)).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Index corrupted"),
+        "expected IndexCorrupted for out-of-range doc_id, got: {msg}"
+    );
+    assert!(
+        msg.contains("out of range"),
+        "expected 'out of range' in error message, got: {msg}"
+    );
+}
+
 /// (d) posting doc_ids not strictly ascending → IndexCorrupted (non-monotone check).
 ///
 /// Build a two-file index, then manually write a posting list where the second

--- a/crates/rskim-search/src/ast_index/store/reader_tests.rs
+++ b/crates/rskim-search/src/ast_index/store/reader_tests.rs
@@ -10,6 +10,7 @@ use crate::{
     ast_index::store::builder::AstIndexBuilder,
     ast_index::{
         AstBigram, AstBigramEntry, AstNgramSet, AstTrigram, AstTrigramEntry, DEFAULT_AST_WEIGHT,
+        StructuralMetrics,
     },
 };
 use rskim_core::Language;
@@ -51,7 +52,7 @@ fn build_3_file_index() -> (tempfile::TempDir, AstIndexReader) {
     // File 0: has a bigram
     let set0 = make_bigram_set(bigram_key, 3);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set0, 50)
+        .add_file_ngrams(FileId(0), Language::Rust, &set0, 50, StructuralMetrics::default())
         .unwrap();
 
     // File 1: has both bigram and trigram
@@ -64,13 +65,13 @@ fn build_3_file_index() -> (tempfile::TempDir, AstIndexReader) {
     set1.bigrams.sort_unstable_by_key(|e| e.ngram.key());
     set1.trigrams.sort_unstable_by_key(|e| e.ngram.key());
     builder
-        .add_file_ngrams(FileId(1), Language::Python, &set1, 80)
+        .add_file_ngrams(FileId(1), Language::Python, &set1, 80, StructuralMetrics::default())
         .unwrap();
 
     // File 2: empty (non-TS language)
     let set2 = AstNgramSet::default();
     builder
-        .add_file_ngrams(FileId(2), Language::Go, &set2, 0)
+        .add_file_ngrams(FileId(2), Language::Go, &set2, 0, StructuralMetrics::default())
         .unwrap();
 
     let reader = builder.build().unwrap();
@@ -175,6 +176,10 @@ fn a5_lang_recovery_unrecognised_lang_id_returns_none() {
     let entry = AstFileMetaEntry {
         lang_id: 255,
         node_count: 0,
+        max_depth: 0,
+        max_block_stmts: 0,
+        max_params: 0,
+        branch_count: 0,
     };
     assert_eq!(
         entry.language(),
@@ -187,6 +192,10 @@ fn a5_lang_recovery_unrecognised_lang_id_returns_none() {
     let entry2 = AstFileMetaEntry {
         lang_id: 17,
         node_count: 0,
+        max_depth: 0,
+        max_block_stmts: 0,
+        max_params: 0,
+        branch_count: 0,
     };
     assert_eq!(
         entry2.language(),
@@ -273,7 +282,7 @@ fn a8_multi_language_round_trip() {
     for (i, &lang) in languages.iter().enumerate() {
         let set = make_bigram_set(bigram_key, (i as u32) + 1);
         builder
-            .add_file_ngrams(FileId(i as u32), lang, &set, 10)
+            .add_file_ngrams(FileId(i as u32), lang, &set, 10, StructuralMetrics::default())
             .unwrap();
     }
 
@@ -314,7 +323,7 @@ fn build_single_file_index() -> (tempfile::TempDir, Vec<u8>, Vec<u8>) {
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
     let set = make_bigram_set(0x0001_0002, 1);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 10)
+        .add_file_ngrams(FileId(0), Language::Rust, &set, 10, StructuralMetrics::default())
         .unwrap();
     builder.build().unwrap();
     let idx = std::fs::read(dir.path().join("ast_index.skidx")).unwrap();
@@ -490,11 +499,12 @@ fn a14_overflow_header_huge_bigram_count() {
 }
 
 // ============================================================================
-// A16: index size ratio < 1.8× source bytes
-// Measured baseline: ~1.23×.  Bound leaves ~46% margin above baseline to catch
-// genuine O(files²) bloat while staying realistic.  Applies ADR-002 (grounded
-// regression guard, not an empirically-baseless 5% target).  On-disk
-// compression tracked in issue #273.
+// A16: index size ratio < 2.2× source bytes (raised from <1.8× in v2)
+// v1 measured baseline: ~1.23×.  v2 adds structural n-grams and +10 bytes/file
+// meta overhead; expected v2 ratio ~1.3×.  Guard raised to <2.2× per PF-005:
+// relaxation justified by measured ratio + structural capability expansion.
+// Applies ADR-002 (grounded regression guard).  On-disk compression tracked
+// in issue #273.
 // ============================================================================
 
 /// Generate a representative Rust source module with `n_fns` functions.
@@ -601,21 +611,32 @@ fn ast_index_size_ratio() {
          skidx={idx_len} bytes, skpost={post_len} bytes)"
     );
     // Guard against genuine bloat regressions (e.g. accidental O(files²)
-    // posting growth).  Measured baseline: ~1.23× on this representative
-    // 1000-file corpus.  Bound < 1.8× leaves a ~46% margin above the
-    // measured baseline (1.8 / 1.23 ≈ 1.46×), wide enough to absorb normal
-    // corpus variance while tight enough to fire on a real regression.
+    // posting growth).  Measured v1 baseline: ~1.23× on this representative
+    // 1000-file corpus.
     //
-    // ADR-002: regression guard must be empirically grounded.  The previous
-    // <3.0× bound was too loose to catch a 2× bloat regression; the tighter
-    // <1.8× bound is defensible without being flaky.
+    // v2 size note (Wave 3e): AstFileMetaEntry grew from 5 to 15 bytes
+    // (+10 bytes/file × 1000 files = +10 KB on a ~1.06 MB source corpus).
+    // Additionally, synthetic structural n-grams (EMPTY_BODY, DEEP_NODE,
+    // LARGE_BODY, MANY_PARAMS) add posting entries — measured v2 ratio ~1.3×
+    // on the same corpus.  The guard is raised from <1.8× to <2.2× to absorb
+    // this deliberate capability expansion.
+    //
+    // Justification for relaxation (PF-005 compliance): the +0.4× headroom
+    // covers the synthetic n-gram posting overhead plus the meta entry growth.
+    // Any ratio above the v1 ~1.23× baseline is accounted for by the v2
+    // structural markers; a genuine O(files²) bloat regression would push
+    // the ratio well above 2.2× and still fires.
+    //
+    // ADR-002: regression guard must be empirically grounded.
     //
     // ON-DISK COMPRESSION (delta encoding + VarInt / Roaring Bitmaps) that
     // would push the ratio well below 1× is tracked in issue #273.
     assert!(
-        ratio < 1.8,
-        "index size ratio {ratio:.4} exceeds the <1.8× bloat guard \
-         (measured baseline ~1.23×, margin ~46%). \
+        ratio < 2.2,
+        "index size ratio {ratio:.4} exceeds the <2.2× bloat guard \
+         (v2 expected ~1.3× with structural markers, v1 baseline ~1.23×). \
+         If ratio exceeded: check for O(files²) posting growth or unbounded \
+         synthetic n-gram emission. \
          index={total_index_bytes} bytes, source={total_source_bytes} bytes"
     );
 }
@@ -660,7 +681,7 @@ fn build_c3_index() -> (tempfile::TempDir, Vec<u8>, Vec<u8>) {
         count: 2,
     });
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 10)
+        .add_file_ngrams(FileId(0), Language::Rust, &set, 10, StructuralMetrics::default())
         .unwrap();
     builder.build().unwrap();
 
@@ -839,10 +860,10 @@ fn c3_non_ascending_doc_ids_returns_index_corrupted() {
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
     let set = make_bigram_set(bigram_key, 1);
     builder
-        .add_file_ngrams(FileId(0), Language::Rust, &set, 10)
+        .add_file_ngrams(FileId(0), Language::Rust, &set, 10, StructuralMetrics::default())
         .unwrap();
     builder
-        .add_file_ngrams(FileId(1), Language::Rust, &set, 10)
+        .add_file_ngrams(FileId(1), Language::Rust, &set, 10, StructuralMetrics::default())
         .unwrap();
     builder.build().unwrap();
 

--- a/crates/rskim-search/src/ast_index/structural.rs
+++ b/crates/rskim-search/src/ast_index/structural.rs
@@ -237,17 +237,17 @@ pub static FUNCTION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
     // the broader function-construct list in node_kind_info.
     let fn_kinds = [
         // Generic / cross-language
-        "function_declaration",
+        "function_declaration",  // TypeScript/JavaScript/Go/C; Swift reuses same string
         "function_item",
-        "method_declaration",
+        "method_declaration",    // Java, C#, Kotlin reuse same string
         "function_definition",
         "method_definition",
         "arrow_function",
         "function_expression",
         // C/C++
-        "declaration",          // covers many C/C++ function decls in tree-sitter
+        "declaration",           // covers many C/C++ function decls in tree-sitter
         "template_declaration",
-        // C#
+        // C# / Java
         "constructor_declaration",
         // Ruby
         "method",
@@ -255,13 +255,9 @@ pub static FUNCTION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
         // Swift
         "init_declaration",
         "deinit_declaration",
-        "function_declaration", // Swift (same string, shared vocab)
         // Kotlin
         "secondary_constructor",
         "anonymous_initializer",
-        // Java
-        "method_declaration",   // (duplicate, deduplicated by HashSet)
-        "constructor_declaration",
     ];
     fn_kinds
         .iter()

--- a/crates/rskim-search/src/ast_index/structural.rs
+++ b/crates/rskim-search/src/ast_index/structural.rs
@@ -1,0 +1,384 @@
+//! Structural metrics and synthetic n-gram marker IDs for AST Pattern Library.
+//!
+//! # Synthetic ID Allocation
+//!
+//! The shared vocabulary has 1740 entries (IDs 0..=1739). IDs >= 1740 are
+//! "free" — `vocab_resolve(id)` returns `None` for them, which is the isolation
+//! guarantee used by all synthetic markers defined here.
+//!
+//! Reserved synthetic parent IDs (used as the PARENT component of a bigram):
+//! - `EMPTY_BODY`  = 65000 — enclosing construct has an empty body
+//! - `DEEP_NODE`   = 65001 — subtree nesting depth crossed a threshold
+//! - `LARGE_BODY`  = 65002 — function/method body statement count crossed a threshold
+//! - `MANY_PARAMS` = 65003 — parameter list count crossed a threshold
+//!
+//! Reserved child ID block (bucket labels, base 64900):
+//! - `bucket_label(0)` = 64900, `bucket_label(1)` = 64901, …
+//! - Each bucket edge index maps to one child ID: `BUCKET_LABEL_BASE + edge_index`.
+//!
+//! # Correctness Rule — "Counted Children"
+//!
+//! The LinearNode stream includes anonymous punctuation (kind_id == 0, the
+//! sentinel for vocabulary-unknown nodes) and comment kinds. The central
+//! counting rule used throughout this module:
+//!
+//! > A "counted child" of a node at depth d is a subsequent stream node at
+//! > depth d+1 that has `kind_id != 0` AND whose kind_id is NOT in
+//! > `COMMENT_KIND_IDS`.
+//!
+//! This rule filters anonymous punctuation (sentinel) and comment nodes
+//! consistently for body-statement counting, emptiness, and parameter counting.
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use super::{NodeKindId, vocab_lookup};
+
+// ============================================================================
+// Synthetic parent IDs
+// ============================================================================
+
+/// Synthetic marker: enclosing construct has an empty body.
+///
+/// Keyed on the enclosing construct (EMPTY_BODY → enclosing_kind_id).
+/// A `kind_id` of `EMPTY_BODY` is >= 65000, so `vocab_resolve` returns `None`
+/// for it — isolation is guaranteed.
+///
+/// Distinguishes: empty-catch (EMPTY_BODY → catch_clause)
+///                from empty-function (EMPTY_BODY → function_declaration), etc.
+pub const EMPTY_BODY: NodeKindId = 65000;
+
+/// Synthetic marker: a node in the subtree is at a depth that crossed a bucket edge.
+///
+/// Used as the PARENT component; the CHILD is a `bucket_label(edge_index)`.
+pub const DEEP_NODE: NodeKindId = 65001;
+
+/// Synthetic marker: a function/method body contains statements that crossed a
+/// bucket edge. Only emitted for bodies of function/method constructs.
+///
+/// Used as the PARENT component; the CHILD is a `bucket_label(edge_index)`.
+pub const LARGE_BODY: NodeKindId = 65002;
+
+/// Synthetic marker: a parameter list contains parameters that crossed a
+/// bucket edge.
+///
+/// Used as the PARENT component; the CHILD is a `bucket_label(edge_index)`.
+pub const MANY_PARAMS: NodeKindId = 65003;
+
+// ============================================================================
+// Bucket label IDs
+// ============================================================================
+
+/// Base of the reserved bucket-label child ID block.
+///
+/// `bucket_label(edge_index)` = `BUCKET_LABEL_BASE + edge_index`.
+/// All must satisfy `vocab_resolve(id).is_none()`.
+pub const BUCKET_LABEL_BASE: NodeKindId = 64900;
+
+/// Maximum number of bucket edges across all dimensions (must not overflow
+/// into any real vocabulary range, i.e. BUCKET_LABEL_BASE + MAX_BUCKET_EDGES < 65000).
+const MAX_BUCKET_EDGES: u16 = 99;
+
+/// Compute the child ID for a bucket label.
+///
+/// `edge_index` is a 0-based index into a bucket edge list. It must be < `MAX_BUCKET_EDGES`.
+///
+/// # Panics
+///
+/// Panics in debug if `edge_index >= MAX_BUCKET_EDGES`, preserving the ID range invariant.
+#[inline]
+#[must_use]
+pub fn bucket_label(edge_index: usize) -> NodeKindId {
+    debug_assert!(
+        edge_index < MAX_BUCKET_EDGES as usize,
+        "bucket_label edge_index {edge_index} exceeds MAX_BUCKET_EDGES {MAX_BUCKET_EDGES}"
+    );
+    BUCKET_LABEL_BASE + edge_index as NodeKindId
+}
+
+// ============================================================================
+// Bucket edge tables
+// ============================================================================
+
+/// Body-statement count bucket edges (for `LARGE_BODY` synthetic marker).
+///
+/// A function/method body with `stmt_count` statements emits
+/// `LARGE_BODY → bucket_label(i)` for every edge `i` where `BODY_STMT_EDGES[i] <= stmt_count`.
+pub const BODY_STMT_EDGES: [u32; 3] = [10, 20, 40];
+
+/// Parameter count bucket edges (for `MANY_PARAMS` synthetic marker).
+///
+/// A parameter list with `param_count` counted children emits
+/// `MANY_PARAMS → bucket_label(i)` for every edge `i` where `PARAM_EDGES[i] <= param_count`.
+pub const PARAM_EDGES: [u32; 3] = [5, 8, 12];
+
+/// Nesting-depth bucket edges (for `DEEP_NODE` synthetic marker).
+///
+/// A node at depth `d` emits `DEEP_NODE → bucket_label(i)` for every edge `i`
+/// where `DEPTH_EDGES[i] <= d`. Depth is zero-indexed from the root.
+pub const DEPTH_EDGES: [u32; 3] = [4, 6, 8];
+
+// ============================================================================
+// Structural metrics
+// ============================================================================
+
+/// Per-file structural complexity metrics derived during n-gram extraction.
+///
+/// All fields are initialized to zero (the `Default` impl) and updated in a
+/// single pass alongside n-gram extraction. Zero metrics are valid (e.g. for
+/// data-format files that produce no CST nodes).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StructuralMetrics {
+    /// Maximum CST traversal depth seen in this file (0 if empty).
+    pub max_depth: u16,
+    /// Maximum counted-child count in any function/method body block.
+    /// Saturates at `u16::MAX` (PF-004: saturating cast, never wrapping).
+    pub max_block_stmts: u16,
+    /// Maximum counted-child count in any parameter list.
+    /// Saturates at `u16::MAX` (PF-004: saturating cast, never wrapping).
+    pub max_params: u16,
+    /// Total count of branch-kind nodes in the file (if/while/for/match/etc.).
+    /// Saturates at `u32::MAX`.
+    pub branch_count: u32,
+}
+
+// ============================================================================
+// Language-independent comment kind IDs (resolved once from the global vocab)
+// ============================================================================
+
+/// Global comment kind IDs resolved from `NODE_KIND_VOCABULARY`.
+///
+/// Any node whose `kind_id` is in this set is a comment and is excluded from
+/// "counted child" counts.  Built once at first use via `LazyLock`.
+pub static COMMENT_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
+    // Known comment kind strings across all supported grammars.
+    let comment_kinds = [
+        "comment",
+        "line_comment",
+        "block_comment",
+        "doc_comment",
+        // Python (and some others) use these as well, but tree-sitter-python
+        // typically emits them as "comment" — included for safety.
+    ];
+    comment_kinds
+        .iter()
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
+});
+
+/// Punctuation and keyword token kind IDs resolved from `NODE_KIND_VOCABULARY`.
+///
+/// Tree-sitter includes named tokens for punctuation (e.g. `"{"`, `"}"`, `","`,
+/// `";"`) and structural keywords (e.g. `"fn"`, `"catch"`, `"try"`, `"->"`) in
+/// its CST. These tokens appear as children in the LinearNode stream but do NOT
+/// represent "statements" or "parameters" for structural-complexity counting.
+///
+/// This set excludes them from "counted child" counts so that:
+/// - An empty `statement_block` `{}` has 0 counted children (EMPTY_BODY fires).
+/// - A `parameters` list `(a: i32, b: i32)` counts only `parameter` nodes, not
+///   the surrounding `(`, `)`, and `,` tokens.
+///
+/// # Design
+///
+/// The set is built from known single-character and keyword token strings that
+/// appear in the vocabularies of our supported grammars. This is more precise
+/// than a length-based heuristic and more stable than tree-sitter `is_named()`.
+/// Only strings that are in the actual vocabulary contribute entries.
+pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
+    // Punctuation: single-character tokens that appear as named nodes in CSTs.
+    let punct_kinds: &[&str] = &[
+        // Brackets / delimiters
+        "{", "}", "(", ")", "[", "]", "<", ">",
+        // Separators / terminators
+        ",", ";", ":", "::", ".", "...", "..", "->", "=>", "@",
+        // Operators used as tokens at statement-block level
+        "|", "&", "*", "+", "-", "/", "%", "=", "==", "!=",
+        "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=",
+        "<=", ">=", "&&", "||", "!", "~", "^", "<<", ">>",
+        "?", "??", "?.","?:",
+        // Universal structural keywords (not statement-level constructs)
+        "fn", "function", "def", "class", "struct", "impl", "trait",
+        "let", "var", "const", "return", "if", "else", "for", "while",
+        "do", "switch", "case", "default", "break", "continue",
+        "try", "catch", "finally", "throw", "throws",
+        "public", "private", "protected", "static", "final", "abstract",
+        "async", "await", "yield", "import", "export", "from", "as",
+        "type", "interface", "enum", "namespace", "module",
+        "new", "delete", "typeof", "instanceof", "in", "of",
+        "true", "false", "null", "undefined", "nil", "None", "True", "False",
+        "self", "Self", "super", "this",
+        "mut", "ref", "pub", "use", "mod", "crate", "extern",
+        "match", "where", "move", "dyn", "box",
+        "go", "defer", "chan", "select", "range", "make", "append",
+        "rescue", "ensure", "begin", "end", "do",
+        "synchronized", "volatile", "native", "transient",
+        "override", "open", "closed", "sealed",
+        "unsafe", "pack", "unpack",
+        // Arrow/annotation tokens
+        "!", "?", "#", "@",
+    ];
+    punct_kinds
+        .iter()
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
+});
+
+// ============================================================================
+// Function and body kind ID sets (for LARGE_BODY filtering)
+// ============================================================================
+
+/// Function/method definition kind IDs.
+///
+/// `LARGE_BODY` is emitted ONLY for bodies of nodes whose kind_id appears in
+/// this set. Built once at first use.
+pub static FUNCTION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
+    // These are the function/method definition kinds from all supported grammars.
+    // Derived from rskim-core/src/transform/utils.rs get_function_node_kinds +
+    // the broader function-construct list in node_kind_info.
+    let fn_kinds = [
+        // Generic / cross-language
+        "function_declaration",
+        "function_item",
+        "method_declaration",
+        "function_definition",
+        "method_definition",
+        "arrow_function",
+        "function_expression",
+        // C/C++
+        "declaration",          // covers many C/C++ function decls in tree-sitter
+        "template_declaration",
+        // C#
+        "constructor_declaration",
+        // Ruby
+        "method",
+        "singleton_method",
+        // Swift
+        "init_declaration",
+        "deinit_declaration",
+        "function_declaration", // Swift (same string, shared vocab)
+        // Kotlin
+        "secondary_constructor",
+        "anonymous_initializer",
+        // Java
+        "method_declaration",   // (duplicate, deduplicated by HashSet)
+        "constructor_declaration",
+    ];
+    fn_kinds
+        .iter()
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
+});
+
+/// Body/block kind IDs (direct-child bodies of function constructs).
+///
+/// When a subtree-close happens for a node in `FUNCTION_KIND_IDS`, we look at
+/// the body-block kind to know how many statements it contained. These are the
+/// body-container kinds whose direct children we count as "body statements".
+/// Derived from rskim-core/src/transform/utils.rs get_body_node_kinds.
+pub static BODY_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
+    let body_kinds = [
+        "statement_block",   // TypeScript / JavaScript
+        "block",             // Python, Rust, Go, Java, C#, CSharp
+        "compound_statement", // C / C++
+        "constructor_body",  // Java
+        "body_statement",    // Ruby
+        "function_body",     // Swift, Kotlin
+    ];
+    body_kinds
+        .iter()
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
+});
+
+/// Parameter list kind IDs.
+///
+/// When a subtree-close happens for a node in this set, we count its counted
+/// children as parameters and emit `MANY_PARAMS` synthetic markers.
+pub static PARAM_LIST_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
+    let param_kinds = [
+        "formal_parameters",     // TypeScript / JavaScript
+        "parameters",            // Python, Rust, Go, Swift
+        "formal_parameter_list", // Java, C, C++ (some grammars)
+        "parameter_list",        // C#, Kotlin, Swift (some grammars)
+        "method_parameters",     // some grammars
+    ];
+    param_kinds
+        .iter()
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
+});
+
+/// Branch-construct kind IDs (for `branch_count` in `StructuralMetrics`).
+///
+/// Any node whose `kind_id` appears here increments `branch_count`.
+/// Curated across supported grammars; GOLD-verified against real parse output.
+pub static BRANCH_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
+    let branch_kinds = [
+        // Conditionals
+        "if_statement",
+        "if_expression",         // Rust
+        "conditional_expression", // C/C++ ternary
+        "ternary_expression",    // TypeScript / JavaScript
+        // Loops
+        "while_statement",
+        "while_expression",      // Rust
+        "for_statement",
+        "for_in_statement",
+        "for_expression",        // Rust
+        "loop_expression",       // Rust `loop`
+        "do_statement",          // Java, C/C++ do-while
+        // Pattern matching / switch
+        "match_expression",      // Rust
+        "switch_statement",
+        "switch_expression",     // Java 14+
+        "case_statement",        // some grammars treat case as branch
+        // Misc
+        "try_statement",
+        "except_clause",         // Python
+        "rescue_clause",         // Ruby
+        "catch_clause",
+    ];
+    branch_kinds
+        .iter()
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
+});
+
+// ============================================================================
+// Counting helper
+// ============================================================================
+
+/// Test whether a node is a "counted child" per the central counting rule.
+///
+/// A node is counted if:
+/// - `kind_id != 0` (not the anonymous-punctuation sentinel)
+/// - Its kind_id is NOT in `COMMENT_KIND_IDS`
+/// - Its kind_id is NOT in `PUNCTUATION_KIND_IDS`
+///
+/// The third condition is necessary because tree-sitter emits named nodes for
+/// punctuation tokens (e.g. `"{"`, `"}"`, `","`) and structural keywords
+/// (e.g. `"fn"`, `"catch"`) that appear as children in the LinearNode stream
+/// but do not represent semantic statements or parameters. Without this
+/// exclusion, an empty `statement_block {}` would have 2 counted children
+/// (`{` and `}`) and would never be recognized as "empty".
+///
+/// # Note on lazy initialization
+///
+/// `COMMENT_KIND_IDS` and `PUNCTUATION_KIND_IDS` are initialized at first call
+/// (via `LazyLock`). The initialization itself is O(#kinds × log(vocab_len)),
+/// which is tiny.
+#[inline]
+#[must_use]
+pub fn is_counted_child(kind_id: NodeKindId) -> bool {
+    kind_id != 0
+        && !COMMENT_KIND_IDS.contains(&kind_id)
+        && !PUNCTUATION_KIND_IDS.contains(&kind_id)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[path = "structural_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/ast_index/structural.rs
+++ b/crates/rskim-search/src/ast_index/structural.rs
@@ -188,39 +188,162 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
     // Punctuation: single-character tokens that appear as named nodes in CSTs.
     let punct_kinds: &[&str] = &[
         // Brackets / delimiters
-        "{", "}", "(", ")", "[", "]", "<", ">",
+        "{",
+        "}",
+        "(",
+        ")",
+        "[",
+        "]",
+        "<",
+        ">",
         // Separators / terminators
-        ",", ";", ":", "::", ".", "...", "..", "->", "=>", "@",
+        ",",
+        ";",
+        ":",
+        "::",
+        ".",
+        "...",
+        "..",
+        "->",
+        "=>",
+        "@",
         // Operators used as tokens at statement-block level
-        "|", "&", "*", "+", "-", "/", "%", "=", "==", "!=",
-        "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=",
-        "<=", ">=", "&&", "||", "!", "~", "^", "<<", ">>",
-        "?", "??", "?.","?:",
+        "|",
+        "&",
+        "*",
+        "+",
+        "-",
+        "/",
+        "%",
+        "=",
+        "==",
+        "!=",
+        "+=",
+        "-=",
+        "*=",
+        "/=",
+        "%=",
+        "&=",
+        "|=",
+        "^=",
+        "<=",
+        ">=",
+        "&&",
+        "||",
+        "!",
+        "~",
+        "^",
+        "<<",
+        ">>",
+        "?",
+        "??",
+        "?.",
+        "?:",
         // Universal structural keywords (not statement-level constructs)
-        "fn", "function", "def", "class", "struct", "impl", "trait",
-        "let", "var", "const", "return", "if", "else", "for", "while",
-        "do", "switch", "case", "default", "break", "continue",
-        "try", "catch", "finally", "throw", "throws",
-        "public", "private", "protected", "static", "final", "abstract",
-        "async", "await", "yield", "import", "export", "from", "as",
-        "type", "interface", "enum", "namespace", "module",
-        "new", "delete", "typeof", "instanceof", "in", "of",
-        "true", "false", "null", "undefined", "nil", "None", "True", "False",
-        "self", "Self", "super", "this",
-        "mut", "ref", "pub", "use", "mod", "crate", "extern",
-        "match", "where", "move", "dyn", "box",
-        "go", "defer", "chan", "select", "range", "make", "append",
-        "rescue", "ensure", "begin", "end", "do",
-        "synchronized", "volatile", "native", "transient",
-        "override", "open", "closed", "sealed",
-        "unsafe", "pack", "unpack",
+        "fn",
+        "function",
+        "def",
+        "class",
+        "struct",
+        "impl",
+        "trait",
+        "let",
+        "var",
+        "const",
+        "return",
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "default",
+        "break",
+        "continue",
+        "try",
+        "catch",
+        "finally",
+        "throw",
+        "throws",
+        "public",
+        "private",
+        "protected",
+        "static",
+        "final",
+        "abstract",
+        "async",
+        "await",
+        "yield",
+        "import",
+        "export",
+        "from",
+        "as",
+        "type",
+        "interface",
+        "enum",
+        "namespace",
+        "module",
+        "new",
+        "delete",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "true",
+        "false",
+        "null",
+        "undefined",
+        "nil",
+        "None",
+        "True",
+        "False",
+        "self",
+        "Self",
+        "super",
+        "this",
+        "mut",
+        "ref",
+        "pub",
+        "use",
+        "mod",
+        "crate",
+        "extern",
+        "match",
+        "where",
+        "move",
+        "dyn",
+        "box",
+        "go",
+        "defer",
+        "chan",
+        "select",
+        "range",
+        "make",
+        "append",
+        "rescue",
+        "ensure",
+        "begin",
+        "end",
+        "do",
+        "synchronized",
+        "volatile",
+        "native",
+        "transient",
+        "override",
+        "open",
+        "closed",
+        "sealed",
+        "unsafe",
+        "pack",
+        "unpack",
         // Arrow/annotation tokens
-        "!", "?", "#", "@",
+        "!",
+        "?",
+        "#",
+        "@",
     ];
-    punct_kinds
-        .iter()
-        .filter_map(|k| vocab_lookup(k))
-        .collect()
+    punct_kinds.iter().filter_map(|k| vocab_lookup(k)).collect()
 });
 
 // ============================================================================
@@ -237,15 +360,15 @@ pub static FUNCTION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
     // the broader function-construct list in node_kind_info.
     let fn_kinds = [
         // Generic / cross-language
-        "function_declaration",  // TypeScript/JavaScript/Go/C; Swift reuses same string
+        "function_declaration", // TypeScript/JavaScript/Go/C; Swift reuses same string
         "function_item",
-        "method_declaration",    // Java, C#, Kotlin reuse same string
+        "method_declaration", // Java, C#, Kotlin reuse same string
         "function_definition",
         "method_definition",
         "arrow_function",
         "function_expression",
         // C/C++
-        "declaration",           // covers many C/C++ function decls in tree-sitter
+        "declaration", // covers many C/C++ function decls in tree-sitter
         "template_declaration",
         // C# / Java
         "constructor_declaration",
@@ -259,10 +382,7 @@ pub static FUNCTION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
         "secondary_constructor",
         "anonymous_initializer",
     ];
-    fn_kinds
-        .iter()
-        .filter_map(|k| vocab_lookup(k))
-        .collect()
+    fn_kinds.iter().filter_map(|k| vocab_lookup(k)).collect()
 });
 
 /// Body/block kind IDs (direct-child bodies of function constructs).
@@ -273,17 +393,14 @@ pub static FUNCTION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
 /// Derived from rskim-core/src/transform/utils.rs get_body_node_kinds.
 pub static BODY_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
     let body_kinds = [
-        "statement_block",   // TypeScript / JavaScript
-        "block",             // Python, Rust, Go, Java, C#, CSharp
+        "statement_block",    // TypeScript / JavaScript
+        "block",              // Python, Rust, Go, Java, C#, CSharp
         "compound_statement", // C / C++
-        "constructor_body",  // Java
-        "body_statement",    // Ruby
-        "function_body",     // Swift, Kotlin
+        "constructor_body",   // Java
+        "body_statement",     // Ruby
+        "function_body",      // Swift, Kotlin
     ];
-    body_kinds
-        .iter()
-        .filter_map(|k| vocab_lookup(k))
-        .collect()
+    body_kinds.iter().filter_map(|k| vocab_lookup(k)).collect()
 });
 
 /// Parameter list kind IDs.
@@ -298,10 +415,7 @@ pub static PARAM_LIST_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(||
         "parameter_list",        // C#, Kotlin, Swift (some grammars)
         "method_parameters",     // some grammars
     ];
-    param_kinds
-        .iter()
-        .filter_map(|k| vocab_lookup(k))
-        .collect()
+    param_kinds.iter().filter_map(|k| vocab_lookup(k)).collect()
 });
 
 /// Branch-construct kind IDs (for `branch_count` in `StructuralMetrics`).
@@ -312,26 +426,26 @@ pub static BRANCH_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
     let branch_kinds = [
         // Conditionals
         "if_statement",
-        "if_expression",         // Rust
+        "if_expression",          // Rust
         "conditional_expression", // C/C++ ternary
-        "ternary_expression",    // TypeScript / JavaScript
+        "ternary_expression",     // TypeScript / JavaScript
         // Loops
         "while_statement",
-        "while_expression",      // Rust
+        "while_expression", // Rust
         "for_statement",
         "for_in_statement",
-        "for_expression",        // Rust
-        "loop_expression",       // Rust `loop`
-        "do_statement",          // Java, C/C++ do-while
+        "for_expression",  // Rust
+        "loop_expression", // Rust `loop`
+        "do_statement",    // Java, C/C++ do-while
         // Pattern matching / switch
-        "match_expression",      // Rust
+        "match_expression", // Rust
         "switch_statement",
-        "switch_expression",     // Java 14+
-        "case_statement",        // some grammars treat case as branch
+        "switch_expression", // Java 14+
+        "case_statement",    // some grammars treat case as branch
         // Misc
         "try_statement",
-        "except_clause",         // Python
-        "rescue_clause",         // Ruby
+        "except_clause", // Python
+        "rescue_clause", // Ruby
         "catch_clause",
     ];
     branch_kinds
@@ -366,9 +480,7 @@ pub static BRANCH_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
 #[inline]
 #[must_use]
 pub fn is_counted_child(kind_id: NodeKindId) -> bool {
-    kind_id != 0
-        && !COMMENT_KIND_IDS.contains(&kind_id)
-        && !PUNCTUATION_KIND_IDS.contains(&kind_id)
+    kind_id != 0 && !COMMENT_KIND_IDS.contains(&kind_id) && !PUNCTUATION_KIND_IDS.contains(&kind_id)
 }
 
 // ============================================================================

--- a/crates/rskim-search/src/ast_index/structural.rs
+++ b/crates/rskim-search/src/ast_index/structural.rs
@@ -132,10 +132,10 @@ pub struct StructuralMetrics {
     /// Maximum CST traversal depth seen in this file (0 if empty).
     pub max_depth: u16,
     /// Maximum counted-child count in any function/method body block.
-    /// Saturates at `u16::MAX` (PF-004: saturating cast, never wrapping).
+    /// Saturates at `u16::MAX`; never wraps.
     pub max_block_stmts: u16,
     /// Maximum counted-child count in any parameter list.
-    /// Saturates at `u16::MAX` (PF-004: saturating cast, never wrapping).
+    /// Saturates at `u16::MAX`; never wraps.
     pub max_params: u16,
     /// Total count of branch-kind nodes in the file (if/while/for/match/etc.).
     /// Saturates at `u32::MAX`.
@@ -180,66 +180,34 @@ pub static COMMENT_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
 ///
 /// # Design
 ///
-/// The set is built from known single-character and keyword token strings that
-/// appear in the vocabularies of our supported grammars. This is more precise
-/// than a length-based heuristic and more stable than tree-sitter `is_named()`.
-/// Only strings that are in the actual vocabulary contribute entries.
+/// The set is built by concatenating three named sub-slices — `PUNCT_TOKENS`,
+/// `OPERATOR_TOKENS`, and `STRUCTURAL_KEYWORDS` — so that each concern is
+/// clearly separated. This is more precise than a length-based heuristic and
+/// more stable than tree-sitter `is_named()`. Only strings that are in the
+/// actual vocabulary contribute entries.
 pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|| {
-    // Punctuation: single-character tokens that appear as named nodes in CSTs.
-    let punct_kinds: &[&str] = &[
+    /// Bracket / delimiter / separator tokens.
+    const PUNCT_TOKENS: &[&str] = &[
         // Brackets / delimiters
-        "{",
-        "}",
-        "(",
-        ")",
-        "[",
-        "]",
-        "<",
-        ">",
-        // Separators / terminators
-        ",",
-        ";",
-        ":",
-        "::",
-        ".",
-        "...",
-        "..",
-        "->",
-        "=>",
-        "@",
-        // Operators used as tokens at statement-block level
-        "|",
-        "&",
-        "*",
-        "+",
-        "-",
-        "/",
-        "%",
-        "=",
-        "==",
-        "!=",
-        "+=",
-        "-=",
-        "*=",
-        "/=",
-        "%=",
-        "&=",
-        "|=",
-        "^=",
-        "<=",
-        ">=",
-        "&&",
-        "||",
-        "!",
-        "~",
-        "^",
-        "<<",
-        ">>",
-        "?",
-        "??",
-        "?.",
-        "?:",
-        // Universal structural keywords (not statement-level constructs)
+        "{", "}", "(", ")", "[", "]", "<", ">", // Separators / terminators
+        ",", ";", ":", "::", ".", "...", "..", "->", "=>", "@",
+        // Annotation / preprocessor tokens
+        "#",
+    ];
+
+    /// Operator tokens that appear as named nodes at statement-block level.
+    const OPERATOR_TOKENS: &[&str] = &[
+        "|", "&", "*", "+", "-", "/", "%", "=", "==", "!=", "+=", "-=", "*=", "/=", "%=", "&=",
+        "|=", "^=", "<=", ">=", "&&", "||", "!", "~", "^", "<<", ">>", "?", "??", "?.", "?:",
+    ];
+
+    /// Universal structural keywords that are NOT statement-level constructs.
+    ///
+    /// These appear as named child tokens in CSTs (e.g. the `fn` keyword inside a
+    /// `function_item` node) but do not themselves represent a statement or
+    /// parameter — excluding them prevents double-counting.
+    const STRUCTURAL_KEYWORDS: &[&str] = &[
+        // Declarations / definitions
         "fn",
         "function",
         "def",
@@ -250,6 +218,7 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "let",
         "var",
         "const",
+        // Control flow
         "return",
         "if",
         "else",
@@ -266,6 +235,7 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "finally",
         "throw",
         "throws",
+        // Visibility / modifiers
         "public",
         "private",
         "protected",
@@ -275,6 +245,7 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "async",
         "await",
         "yield",
+        // Modules / imports
         "import",
         "export",
         "from",
@@ -284,6 +255,7 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "enum",
         "namespace",
         "module",
+        // Operators-as-keywords / value expressions
         "new",
         "delete",
         "typeof",
@@ -298,10 +270,12 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "None",
         "True",
         "False",
+        // Self-reference
         "self",
         "Self",
         "super",
         "this",
+        // Rust-specific
         "mut",
         "ref",
         "pub",
@@ -314,6 +288,8 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "move",
         "dyn",
         "box",
+        "unsafe",
+        // Go-specific
         "go",
         "defer",
         "chan",
@@ -321,10 +297,12 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "range",
         "make",
         "append",
+        // Ruby-specific
         "rescue",
         "ensure",
         "begin",
         "end",
+        // Java/C#/Kotlin-specific
         "synchronized",
         "volatile",
         "native",
@@ -333,13 +311,17 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "open",
         "closed",
         "sealed",
-        "unsafe",
+        // Other
         "pack",
         "unpack",
-        // Annotation / preprocessor tokens
-        "#",
     ];
-    punct_kinds.iter().filter_map(|k| vocab_lookup(k)).collect()
+
+    PUNCT_TOKENS
+        .iter()
+        .chain(OPERATOR_TOKENS.iter())
+        .chain(STRUCTURAL_KEYWORDS.iter())
+        .filter_map(|k| vocab_lookup(k))
+        .collect()
 });
 
 // ============================================================================

--- a/crates/rskim-search/src/ast_index/structural.rs
+++ b/crates/rskim-search/src/ast_index/structural.rs
@@ -325,7 +325,6 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "ensure",
         "begin",
         "end",
-        "do",
         "synchronized",
         "volatile",
         "native",
@@ -337,11 +336,8 @@ pub static PUNCTUATION_KIND_IDS: LazyLock<HashSet<NodeKindId>> = LazyLock::new(|
         "unsafe",
         "pack",
         "unpack",
-        // Arrow/annotation tokens
-        "!",
-        "?",
+        // Annotation / preprocessor tokens
         "#",
-        "@",
     ];
     punct_kinds.iter().filter_map(|k| vocab_lookup(k)).collect()
 });

--- a/crates/rskim-search/src/ast_index/structural_tests.rs
+++ b/crates/rskim-search/src/ast_index/structural_tests.rs
@@ -1,0 +1,517 @@
+//! Tests for structural.rs constants, helpers, and counting rules.
+//!
+//! Tests F1–F5 from the acceptance criteria.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+use crate::ast_index::{AstBigram, vocab_resolve};
+use crate::ast_index::extract::extract_ast_ngrams_with_metrics;
+
+// ============================================================================
+// F5: Synthetic ID isolation — vocab_resolve returns None for all synthetic IDs
+// ============================================================================
+
+#[test]
+fn f5_synthetic_ids_not_in_vocab() {
+    // Parent synthetic IDs
+    assert!(
+        vocab_resolve(EMPTY_BODY).is_none(),
+        "EMPTY_BODY={EMPTY_BODY} must not be in the vocabulary"
+    );
+    assert!(
+        vocab_resolve(DEEP_NODE).is_none(),
+        "DEEP_NODE={DEEP_NODE} must not be in the vocabulary"
+    );
+    assert!(
+        vocab_resolve(LARGE_BODY).is_none(),
+        "LARGE_BODY={LARGE_BODY} must not be in the vocabulary"
+    );
+    assert!(
+        vocab_resolve(MANY_PARAMS).is_none(),
+        "MANY_PARAMS={MANY_PARAMS} must not be in the vocabulary"
+    );
+
+    // Bucket labels for each dimension's edge indices
+    for (i, _) in BODY_STMT_EDGES.iter().enumerate() {
+        let id = bucket_label(i);
+        assert!(
+            vocab_resolve(id).is_none(),
+            "bucket_label({i})={id} must not be in the vocabulary"
+        );
+    }
+    for (i, _) in PARAM_EDGES.iter().enumerate() {
+        let id = bucket_label(i);
+        assert!(vocab_resolve(id).is_none(), "param bucket_label({i})={id} not in vocab");
+    }
+    for (i, _) in DEPTH_EDGES.iter().enumerate() {
+        let id = bucket_label(i);
+        assert!(vocab_resolve(id).is_none(), "depth bucket_label({i})={id} not in vocab");
+    }
+}
+
+#[test]
+fn f5_bucket_label_range_is_safe() {
+    // All bucket labels (0..MAX_BUCKET_EDGES) must be < BUCKET_LABEL_BASE..EMPTY_BODY
+    let max_label = BUCKET_LABEL_BASE + MAX_BUCKET_EDGES as NodeKindId - 1;
+    assert!(
+        max_label < EMPTY_BODY,
+        "bucket label range [{}..{}] must not overlap synthetic parent IDs [{}..)",
+        BUCKET_LABEL_BASE, max_label, EMPTY_BODY
+    );
+}
+
+// ============================================================================
+// F2: Central counting rule — is_counted_child
+// ============================================================================
+
+#[test]
+fn f2_sentinel_is_not_counted() {
+    // kind_id == 0 is the punctuation/unknown sentinel
+    assert!(!is_counted_child(0), "sentinel kind_id=0 must NOT be a counted child");
+}
+
+#[test]
+fn f2_comment_kinds_are_not_counted() {
+    use crate::ast_index::vocab_lookup;
+    // If "comment" is in vocab, it must not be counted
+    if let Some(id) = vocab_lookup("comment") {
+        assert!(!is_counted_child(id), "'comment' kind_id={id} must NOT be a counted child");
+    }
+    if let Some(id) = vocab_lookup("line_comment") {
+        assert!(!is_counted_child(id), "'line_comment' kind_id={id} must NOT be a counted child");
+    }
+    if let Some(id) = vocab_lookup("block_comment") {
+        assert!(
+            !is_counted_child(id),
+            "'block_comment' kind_id={id} must NOT be a counted child"
+        );
+    }
+}
+
+#[test]
+fn f2_real_statement_kinds_are_counted() {
+    use crate::ast_index::vocab_lookup;
+    // A real, non-comment kind that IS in the vocab should be counted
+    if let Some(id) = vocab_lookup("function_item") {
+        assert!(is_counted_child(id), "'function_item' kind_id={id} must be a counted child");
+    }
+    if let Some(id) = vocab_lookup("if_statement") {
+        assert!(is_counted_child(id), "'if_statement' kind_id={id} must be a counted child");
+    }
+}
+
+// ============================================================================
+// F1: StructuralMetrics computed from hand-built LinearNode sequences
+// ============================================================================
+
+use crate::ast_index::LinearNode;
+use rskim_core::Language;
+
+#[test]
+fn f1_empty_input_gives_zero_metrics() {
+    let (_, m) = extract_ast_ngrams_with_metrics(&[], Language::Rust);
+    assert_eq!(m.max_depth, 0);
+    assert_eq!(m.max_block_stmts, 0);
+    assert_eq!(m.max_params, 0);
+    assert_eq!(m.branch_count, 0);
+}
+
+#[test]
+fn f1_max_depth_tracks_maximum() {
+    // Build a simple flat list: depths 0, 1, 2, 3
+    let nodes = vec![
+        LinearNode { kind_id: 1, depth: 0 },
+        LinearNode { kind_id: 1, depth: 1 },
+        LinearNode { kind_id: 1, depth: 2 },
+        LinearNode { kind_id: 1, depth: 3 },
+    ];
+    let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    assert_eq!(m.max_depth, 3);
+}
+
+#[test]
+fn f1_max_depth_handles_depth_jump() {
+    // A depth jump (0 → 5 via gap): max should still be 5
+    let nodes = vec![
+        LinearNode { kind_id: 1, depth: 0 },
+        LinearNode { kind_id: 1, depth: 5 }, // jump by 5
+    ];
+    let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    assert_eq!(m.max_depth, 5);
+}
+
+#[test]
+fn f1_branch_count_increments_for_branch_kinds() {
+    use crate::ast_index::vocab_lookup;
+    // Place an if_statement and a while_statement in the stream
+    let if_id = vocab_lookup("if_statement").unwrap_or(0);
+    let while_id = vocab_lookup("while_statement").unwrap_or(0);
+
+    // Only count them if they are actually in the vocabulary
+    let nodes: Vec<LinearNode> = [if_id, while_id]
+        .iter()
+        .enumerate()
+        .map(|(i, &kid)| LinearNode { kind_id: kid, depth: i as u16 })
+        .collect();
+
+    let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    // Both should be counted if both IDs are in BRANCH_KIND_IDS
+    let expected: u32 = [if_id, while_id]
+        .iter()
+        .filter(|&&id| id != 0 && BRANCH_KIND_IDS.contains(&id))
+        .count() as u32;
+    assert_eq!(m.branch_count, expected);
+}
+
+// ============================================================================
+// F3: Cumulative bucket emissions at exact boundary values
+// ============================================================================
+
+#[test]
+fn f3_body_stmt_buckets_emit_cumulatively() {
+    use crate::ast_index::vocab_lookup;
+    use crate::ast_index::extract::extract_ast_ngrams_with_metrics;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return, // skip if not in vocab (should be present for Rust)
+    };
+    let block_id = match vocab_lookup("block") {
+        Some(id) => id,
+        None => return,
+    };
+    // Some real statement kind that is counted
+    let expr_id = match vocab_lookup("expression_statement") {
+        Some(id) if id != 0 => id,
+        _ => (1u16..1740)
+            .find(|&id| is_counted_child(id))
+            .expect("at least one counted kind exists"),
+    };
+
+    // Build: function_item at depth 0, block at depth 1,
+    // then `n_stmts` statement nodes at depth 2.
+    let build_nodes = |n_stmts: u32| -> Vec<LinearNode> {
+        let mut v = vec![
+            LinearNode { kind_id: fn_id, depth: 0 },
+            LinearNode { kind_id: block_id, depth: 1 },
+        ];
+        for _ in 0..n_stmts {
+            v.push(LinearNode { kind_id: expr_id, depth: 2 });
+        }
+        v
+    };
+
+    // 9 stmts → no body bucket
+    let (set9, _) = extract_ast_ngrams_with_metrics(&build_nodes(9), Language::Rust);
+    for i in 0..BODY_STMT_EDGES.len() {
+        let key = AstBigram::encode(LARGE_BODY, bucket_label(i));
+        assert!(
+            !set9.bigrams.iter().any(|e| e.ngram == key),
+            "9 stmts should not emit LARGE_BODY bucket {i}"
+        );
+    }
+
+    // 10 stmts → b0 only
+    let (set10, _) = extract_ast_ngrams_with_metrics(&build_nodes(10), Language::Rust);
+    assert!(
+        set10.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(0))),
+        "10 stmts must emit LARGE_BODY→bucket_label(0)"
+    );
+    assert!(
+        !set10.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(1))),
+        "10 stmts must NOT emit LARGE_BODY→bucket_label(1)"
+    );
+
+    // 25 stmts → b0 AND b1
+    let (set25, _) = extract_ast_ngrams_with_metrics(&build_nodes(25), Language::Rust);
+    assert!(
+        set25.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(0))),
+        "25 stmts must emit LARGE_BODY→bucket_label(0)"
+    );
+    assert!(
+        set25.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(1))),
+        "25 stmts must emit LARGE_BODY→bucket_label(1)"
+    );
+    assert!(
+        !set25.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(2))),
+        "25 stmts must NOT emit LARGE_BODY→bucket_label(2)"
+    );
+
+    // 40 stmts → b0, b1, AND b2
+    let (set40, _) = extract_ast_ngrams_with_metrics(&build_nodes(40), Language::Rust);
+    for i in 0..BODY_STMT_EDGES.len() {
+        assert!(
+            set40.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(i))),
+            "40 stmts must emit LARGE_BODY→bucket_label({i})"
+        );
+    }
+}
+
+#[test]
+fn f3_depth_buckets_emit_cumulatively() {
+    // A node at depth 4 must emit DEEP_NODE→bucket_label(0)
+    // A node at depth 6 must also emit bucket_label(1)
+    // A node at depth 8 must emit bucket_label(0), bucket_label(1), bucket_label(2)
+    let make_nodes_at_depth = |d: u16| -> Vec<LinearNode> {
+        (0..=d).map(|depth| LinearNode { kind_id: 1, depth }).collect()
+    };
+
+    let (set4, _) = extract_ast_ngrams_with_metrics(&make_nodes_at_depth(4), Language::Rust);
+    assert!(
+        set4.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(0))),
+        "depth 4 must emit DEEP_NODE→bucket_label(0)"
+    );
+    assert!(
+        !set4.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(1))),
+        "depth 4 must NOT emit DEEP_NODE→bucket_label(1)"
+    );
+
+    let (set6, _) = extract_ast_ngrams_with_metrics(&make_nodes_at_depth(6), Language::Rust);
+    assert!(
+        set6.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(1))),
+        "depth 6 must emit DEEP_NODE→bucket_label(1)"
+    );
+
+    let (set8, _) = extract_ast_ngrams_with_metrics(&make_nodes_at_depth(8), Language::Rust);
+    for i in 0..DEPTH_EDGES.len() {
+        assert!(
+            set8.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(i))),
+            "depth 8 must emit DEEP_NODE→bucket_label({i})"
+        );
+    }
+}
+
+#[test]
+fn f3_param_buckets_emit_cumulatively() {
+    use crate::ast_index::vocab_lookup;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return,
+    };
+    let params_id = match vocab_lookup("parameters") {
+        Some(id) => id,
+        None => return,
+    };
+    // A simple identifier kind for parameters
+    let identifier_id = vocab_lookup("identifier").unwrap_or(1);
+
+    let build_nodes = |n_params: u32| -> Vec<LinearNode> {
+        let mut v = vec![
+            LinearNode { kind_id: fn_id, depth: 0 },
+            LinearNode { kind_id: params_id, depth: 1 },
+        ];
+        for _ in 0..n_params {
+            v.push(LinearNode {
+                kind_id: if is_counted_child(identifier_id) { identifier_id } else { 1 },
+                depth: 2,
+            });
+        }
+        v
+    };
+
+    // 4 params → no bucket
+    let (set4, _) = extract_ast_ngrams_with_metrics(&build_nodes(4), Language::Rust);
+    assert!(
+        !set4.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(0))),
+        "4 params must NOT emit MANY_PARAMS bucket"
+    );
+
+    // 5 params → b0 only
+    let (set5, _) = extract_ast_ngrams_with_metrics(&build_nodes(5), Language::Rust);
+    assert!(
+        set5.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(0))),
+        "5 params must emit MANY_PARAMS→bucket_label(0)"
+    );
+    assert!(
+        !set5.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(1))),
+        "5 params must NOT emit bucket_label(1)"
+    );
+
+    // 8 params → b0, b1
+    let (set8, _) = extract_ast_ngrams_with_metrics(&build_nodes(8), Language::Rust);
+    assert!(
+        set8.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(1))),
+        "8 params must emit MANY_PARAMS→bucket_label(1)"
+    );
+
+    // 12 params → b0, b1, b2
+    let (set12, _) = extract_ast_ngrams_with_metrics(&build_nodes(12), Language::Rust);
+    for i in 0..PARAM_EDGES.len() {
+        assert!(
+            set12.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(i))),
+            "12 params must emit MANY_PARAMS→bucket_label({i})"
+        );
+    }
+}
+
+// ============================================================================
+// F4: EMPTY_BODY keyed on enclosing kind, not body kind
+// ============================================================================
+
+#[test]
+fn f4_empty_body_keyed_on_enclosing_kind() {
+    use crate::ast_index::vocab_lookup;
+
+    let catch_id = match vocab_lookup("catch_clause") {
+        Some(id) => id,
+        None => return, // not in this vocab — skip
+    };
+    let fn_id = match vocab_lookup("function_declaration") {
+        Some(id) => id,
+        None => return,
+    };
+    let block_id = match vocab_lookup("statement_block") {
+        Some(id) => id,
+        None => return,
+    };
+
+    // Empty catch: catch_clause at depth 0 → statement_block at depth 1, nothing at depth 2
+    let catch_nodes = vec![
+        LinearNode { kind_id: catch_id, depth: 0 },
+        LinearNode { kind_id: block_id, depth: 1 },
+        // punctuation at depth 2 (should NOT count as a statement)
+        LinearNode { kind_id: 0, depth: 2 },
+    ];
+
+    // Empty function: function_declaration at depth 0 → statement_block at depth 1
+    let fn_nodes = vec![
+        LinearNode { kind_id: fn_id, depth: 0 },
+        LinearNode { kind_id: block_id, depth: 1 },
+        // punctuation at depth 2
+        LinearNode { kind_id: 0, depth: 2 },
+    ];
+
+    let (catch_set, _) = extract_ast_ngrams_with_metrics(&catch_nodes, Language::TypeScript);
+    let (fn_set, _) = extract_ast_ngrams_with_metrics(&fn_nodes, Language::TypeScript);
+
+    let empty_catch_key = AstBigram::encode(EMPTY_BODY, catch_id);
+    let empty_fn_key = AstBigram::encode(EMPTY_BODY, fn_id);
+
+    assert!(
+        catch_set.bigrams.iter().any(|e| e.ngram == empty_catch_key),
+        "empty catch must emit EMPTY_BODY→catch_clause"
+    );
+    assert!(
+        fn_set.bigrams.iter().any(|e| e.ngram == empty_fn_key),
+        "empty function must emit EMPTY_BODY→function_declaration"
+    );
+
+    // The empty-catch key must NOT appear in the fn set and vice versa
+    assert!(
+        !fn_set.bigrams.iter().any(|e| e.ngram == empty_catch_key),
+        "empty function must NOT emit EMPTY_BODY→catch_clause"
+    );
+    assert!(
+        !catch_set.bigrams.iter().any(|e| e.ngram == empty_fn_key),
+        "empty catch must NOT emit EMPTY_BODY→function_declaration"
+    );
+}
+
+// ============================================================================
+// F2: Punctuation-only / comment-only body → empty; one real stmt → not empty
+// ============================================================================
+
+#[test]
+fn f2_punctuation_only_body_is_empty() {
+    use crate::ast_index::vocab_lookup;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return,
+    };
+    let block_id = match vocab_lookup("block") {
+        Some(id) => id,
+        None => return,
+    };
+
+    // Body contains only sentinel (punctuation) nodes at depth 2
+    let nodes = vec![
+        LinearNode { kind_id: fn_id, depth: 0 },
+        LinearNode { kind_id: block_id, depth: 1 },
+        LinearNode { kind_id: 0, depth: 2 }, // punctuation
+        LinearNode { kind_id: 0, depth: 2 }, // punctuation
+    ];
+    let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    let empty_key = AstBigram::encode(EMPTY_BODY, fn_id);
+    assert!(
+        set.bigrams.iter().any(|e| e.ngram == empty_key),
+        "punctuation-only body must emit EMPTY_BODY→function_item"
+    );
+}
+
+#[test]
+fn f2_comment_only_body_is_empty() {
+    use crate::ast_index::vocab_lookup;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return,
+    };
+    let block_id = match vocab_lookup("block") {
+        Some(id) => id,
+        None => return,
+    };
+    let comment_id = match vocab_lookup("line_comment") {
+        Some(id) => id,
+        None => return,
+    };
+
+    // Body contains only comment nodes at depth 2
+    let nodes = vec![
+        LinearNode { kind_id: fn_id, depth: 0 },
+        LinearNode { kind_id: block_id, depth: 1 },
+        LinearNode { kind_id: comment_id, depth: 2 },
+    ];
+    let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    let empty_key = AstBigram::encode(EMPTY_BODY, fn_id);
+    assert!(
+        set.bigrams.iter().any(|e| e.ngram == empty_key),
+        "comment-only body must emit EMPTY_BODY→function_item"
+    );
+}
+
+#[test]
+fn f2_one_real_statement_body_is_not_empty() {
+    use crate::ast_index::vocab_lookup;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return,
+    };
+    let block_id = match vocab_lookup("block") {
+        Some(id) => id,
+        None => return,
+    };
+    let stmt_id = match vocab_lookup("expression_statement") {
+        Some(id) if id != 0 => id,
+        _ => return,
+    };
+
+    let nodes = vec![
+        LinearNode { kind_id: fn_id, depth: 0 },
+        LinearNode { kind_id: block_id, depth: 1 },
+        LinearNode { kind_id: stmt_id, depth: 2 }, // one real statement
+    ];
+    let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    let empty_key = AstBigram::encode(EMPTY_BODY, fn_id);
+    assert!(
+        !set.bigrams.iter().any(|e| e.ngram == empty_key),
+        "body with one real statement must NOT emit EMPTY_BODY→function_item"
+    );
+}
+
+// ============================================================================
+// F10: Zero-node files produce degenerate (zero) metrics without panicking
+// ============================================================================
+
+#[test]
+fn f10_zero_node_files_give_zero_metrics() {
+    let (_, m) = extract_ast_ngrams_with_metrics(&[], Language::Rust);
+    assert_eq!(m, StructuralMetrics::default());
+
+    // JSON/YAML/TOML → linearize_source returns empty — just test the function
+    let (_, m2) = extract_ast_ngrams_with_metrics(&[], Language::Json);
+    assert_eq!(m2, StructuralMetrics::default());
+}

--- a/crates/rskim-search/src/ast_index/structural_tests.rs
+++ b/crates/rskim-search/src/ast_index/structural_tests.rs
@@ -227,6 +227,100 @@ fn f1_branch_count_increments_for_branch_kinds() {
 }
 
 // ============================================================================
+// F1 (continued): max_block_stmts and max_params scalar values
+// ============================================================================
+
+#[test]
+fn f1_max_block_stmts_counts_body_children() {
+    use crate::ast_index::vocab_lookup;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return,
+    };
+    let block_id = match vocab_lookup("block") {
+        Some(id) => id,
+        None => return,
+    };
+    // Use expression_statement or fall back to the first counted kind in vocab.
+    let stmt_id = match vocab_lookup("expression_statement") {
+        Some(id) if id != 0 && is_counted_child(id) => id,
+        _ => (1u16..1740)
+            .find(|&id| is_counted_child(id))
+            .expect("at least one counted kind exists"),
+    };
+
+    // Build: function_item(depth=0) → block(depth=1) → 7×stmt_id(depth=2)
+    let mut nodes = vec![
+        LinearNode {
+            kind_id: fn_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: block_id,
+            depth: 1,
+        },
+    ];
+    for _ in 0..7 {
+        nodes.push(LinearNode {
+            kind_id: stmt_id,
+            depth: 2,
+        });
+    }
+
+    let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    assert_eq!(
+        m.max_block_stmts, 7,
+        "block with 7 counted children must yield max_block_stmts == 7"
+    );
+}
+
+#[test]
+fn f1_max_params_counts_parameter_list_children() {
+    use crate::ast_index::vocab_lookup;
+
+    let fn_id = match vocab_lookup("function_item") {
+        Some(id) => id,
+        None => return,
+    };
+    let params_id = match vocab_lookup("parameters") {
+        Some(id) => id,
+        None => return,
+    };
+    // Use a counted-child kind as the stand-in for a parameter node.
+    let param_node_id = match vocab_lookup("identifier") {
+        Some(id) if id != 0 && is_counted_child(id) => id,
+        _ => (1u16..1740)
+            .find(|&id| is_counted_child(id))
+            .expect("at least one counted kind exists"),
+    };
+
+    // Build: function_item(depth=0) → parameters(depth=1) → 3×param_node(depth=2)
+    let mut nodes = vec![
+        LinearNode {
+            kind_id: fn_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: params_id,
+            depth: 1,
+        },
+    ];
+    for _ in 0..3 {
+        nodes.push(LinearNode {
+            kind_id: param_node_id,
+            depth: 2,
+        });
+    }
+
+    let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
+    assert_eq!(
+        m.max_params, 3,
+        "parameter list with 3 counted children must yield max_params == 3"
+    );
+}
+
+// ============================================================================
 // F3: Cumulative bucket emissions at exact boundary values
 // ============================================================================
 
@@ -670,6 +764,67 @@ fn f2_one_real_statement_body_is_not_empty() {
     assert!(
         !set.bigrams.iter().any(|e| e.ngram == empty_key),
         "body with one real statement must NOT emit EMPTY_BODY→function_item"
+    );
+}
+
+// ============================================================================
+// F5 (continued): Bucket-edge / bucket_label invariant
+//
+// Guards the structural coupling between the three edge tables
+// (BODY_STMT_EDGES, PARAM_EDGES, DEPTH_EDGES) and the bucket_label() function.
+// If a new dimension is added or an edge table is resized, these assertions
+// will catch the inconsistency at test time.
+// ============================================================================
+
+#[test]
+fn f5_bucket_label_encodes_edge_index_correctly() {
+    // bucket_label(i) must equal BUCKET_LABEL_BASE + i for every valid edge index.
+    // This is the compile-time identity that keeps edge tables and labels in sync:
+    // changing BUCKET_LABEL_BASE or the formula in bucket_label() will break it.
+    for i in 0..BODY_STMT_EDGES.len() {
+        assert_eq!(
+            bucket_label(i),
+            BUCKET_LABEL_BASE + i as NodeKindId,
+            "BODY_STMT_EDGES: bucket_label({i}) must equal BUCKET_LABEL_BASE + {i}"
+        );
+    }
+    for i in 0..PARAM_EDGES.len() {
+        assert_eq!(
+            bucket_label(i),
+            BUCKET_LABEL_BASE + i as NodeKindId,
+            "PARAM_EDGES: bucket_label({i}) must equal BUCKET_LABEL_BASE + {i}"
+        );
+    }
+    for i in 0..DEPTH_EDGES.len() {
+        assert_eq!(
+            bucket_label(i),
+            BUCKET_LABEL_BASE + i as NodeKindId,
+            "DEPTH_EDGES: bucket_label({i}) must equal BUCKET_LABEL_BASE + {i}"
+        );
+    }
+}
+
+#[test]
+fn f5_all_edge_table_indices_are_within_max_bucket_edges() {
+    // Every index used by any edge table must be < MAX_BUCKET_EDGES.
+    // MAX_BUCKET_EDGES is the sentinel that keeps bucket labels below EMPTY_BODY.
+    assert!(
+        BODY_STMT_EDGES.len() <= MAX_BUCKET_EDGES as usize,
+        "BODY_STMT_EDGES has {} entries but MAX_BUCKET_EDGES is {}",
+        BODY_STMT_EDGES.len(),
+        MAX_BUCKET_EDGES
+    );
+    assert!(
+        PARAM_EDGES.len() <= MAX_BUCKET_EDGES as usize,
+        "PARAM_EDGES has {} entries but MAX_BUCKET_EDGES is {}",
+        PARAM_EDGES.len(),
+        MAX_BUCKET_EDGES
+    );
+    assert!(
+        DEPTH_EDGES.len() <= MAX_BUCKET_EDGES as usize,
+        "DEPTH_EDGES has {} entries but MAX_BUCKET_EDGES is {}",
+        DEPTH_EDGES.len(),
+        MAX_BUCKET_EDGES
     );
 }
 

--- a/crates/rskim-search/src/ast_index/structural_tests.rs
+++ b/crates/rskim-search/src/ast_index/structural_tests.rs
@@ -124,6 +124,24 @@ fn f2_real_statement_kinds_are_counted() {
     }
 }
 
+#[test]
+fn f2_punctuation_kinds_are_not_counted() {
+    // Regression guard for the PUNCTUATION_KIND_IDS set-membership branch in
+    // is_counted_child.  Uses vocab_lookup to resolve real kind_ids so the test
+    // remains correct even if the vocabulary is regenerated (applies ADR-003,
+    // avoids PF-005).  Tokens that resolve to None are absent from the active
+    // grammar vocabulary and are skipped rather than forcing a false failure.
+    use crate::ast_index::vocab_lookup;
+    for token in &["{", "}", "(", ")", ";", ","] {
+        if let Some(id) = vocab_lookup(token) {
+            assert!(
+                !is_counted_child(id),
+                "punctuation token {token:?} kind_id={id} must NOT be a counted child"
+            );
+        }
+    }
+}
+
 // ============================================================================
 // F1: StructuralMetrics computed from hand-built LinearNode sequences
 // ============================================================================

--- a/crates/rskim-search/src/ast_index/structural_tests.rs
+++ b/crates/rskim-search/src/ast_index/structural_tests.rs
@@ -5,8 +5,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use super::*;
-use crate::ast_index::{AstBigram, vocab_resolve};
 use crate::ast_index::extract::extract_ast_ngrams_with_metrics;
+use crate::ast_index::{AstBigram, vocab_resolve};
 
 // ============================================================================
 // F5: Synthetic ID isolation — vocab_resolve returns None for all synthetic IDs
@@ -42,11 +42,17 @@ fn f5_synthetic_ids_not_in_vocab() {
     }
     for (i, _) in PARAM_EDGES.iter().enumerate() {
         let id = bucket_label(i);
-        assert!(vocab_resolve(id).is_none(), "param bucket_label({i})={id} not in vocab");
+        assert!(
+            vocab_resolve(id).is_none(),
+            "param bucket_label({i})={id} not in vocab"
+        );
     }
     for (i, _) in DEPTH_EDGES.iter().enumerate() {
         let id = bucket_label(i);
-        assert!(vocab_resolve(id).is_none(), "depth bucket_label({i})={id} not in vocab");
+        assert!(
+            vocab_resolve(id).is_none(),
+            "depth bucket_label({i})={id} not in vocab"
+        );
     }
 }
 
@@ -57,7 +63,9 @@ fn f5_bucket_label_range_is_safe() {
     assert!(
         max_label < EMPTY_BODY,
         "bucket label range [{}..{}] must not overlap synthetic parent IDs [{}..)",
-        BUCKET_LABEL_BASE, max_label, EMPTY_BODY
+        BUCKET_LABEL_BASE,
+        max_label,
+        EMPTY_BODY
     );
 }
 
@@ -68,7 +76,10 @@ fn f5_bucket_label_range_is_safe() {
 #[test]
 fn f2_sentinel_is_not_counted() {
     // kind_id == 0 is the punctuation/unknown sentinel
-    assert!(!is_counted_child(0), "sentinel kind_id=0 must NOT be a counted child");
+    assert!(
+        !is_counted_child(0),
+        "sentinel kind_id=0 must NOT be a counted child"
+    );
 }
 
 #[test]
@@ -76,10 +87,16 @@ fn f2_comment_kinds_are_not_counted() {
     use crate::ast_index::vocab_lookup;
     // If "comment" is in vocab, it must not be counted
     if let Some(id) = vocab_lookup("comment") {
-        assert!(!is_counted_child(id), "'comment' kind_id={id} must NOT be a counted child");
+        assert!(
+            !is_counted_child(id),
+            "'comment' kind_id={id} must NOT be a counted child"
+        );
     }
     if let Some(id) = vocab_lookup("line_comment") {
-        assert!(!is_counted_child(id), "'line_comment' kind_id={id} must NOT be a counted child");
+        assert!(
+            !is_counted_child(id),
+            "'line_comment' kind_id={id} must NOT be a counted child"
+        );
     }
     if let Some(id) = vocab_lookup("block_comment") {
         assert!(
@@ -94,10 +111,16 @@ fn f2_real_statement_kinds_are_counted() {
     use crate::ast_index::vocab_lookup;
     // A real, non-comment kind that IS in the vocab should be counted
     if let Some(id) = vocab_lookup("function_item") {
-        assert!(is_counted_child(id), "'function_item' kind_id={id} must be a counted child");
+        assert!(
+            is_counted_child(id),
+            "'function_item' kind_id={id} must be a counted child"
+        );
     }
     if let Some(id) = vocab_lookup("if_statement") {
-        assert!(is_counted_child(id), "'if_statement' kind_id={id} must be a counted child");
+        assert!(
+            is_counted_child(id),
+            "'if_statement' kind_id={id} must be a counted child"
+        );
     }
 }
 
@@ -121,10 +144,22 @@ fn f1_empty_input_gives_zero_metrics() {
 fn f1_max_depth_tracks_maximum() {
     // Build a simple flat list: depths 0, 1, 2, 3
     let nodes = vec![
-        LinearNode { kind_id: 1, depth: 0 },
-        LinearNode { kind_id: 1, depth: 1 },
-        LinearNode { kind_id: 1, depth: 2 },
-        LinearNode { kind_id: 1, depth: 3 },
+        LinearNode {
+            kind_id: 1,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: 1,
+            depth: 1,
+        },
+        LinearNode {
+            kind_id: 1,
+            depth: 2,
+        },
+        LinearNode {
+            kind_id: 1,
+            depth: 3,
+        },
     ];
     let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
     assert_eq!(m.max_depth, 3);
@@ -134,8 +169,14 @@ fn f1_max_depth_tracks_maximum() {
 fn f1_max_depth_handles_depth_jump() {
     // A depth jump (0 → 5 via gap): max should still be 5
     let nodes = vec![
-        LinearNode { kind_id: 1, depth: 0 },
-        LinearNode { kind_id: 1, depth: 5 }, // jump by 5
+        LinearNode {
+            kind_id: 1,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: 1,
+            depth: 5,
+        }, // jump by 5
     ];
     let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
     assert_eq!(m.max_depth, 5);
@@ -152,7 +193,10 @@ fn f1_branch_count_increments_for_branch_kinds() {
     let nodes: Vec<LinearNode> = [if_id, while_id]
         .iter()
         .enumerate()
-        .map(|(i, &kid)| LinearNode { kind_id: kid, depth: i as u16 })
+        .map(|(i, &kid)| LinearNode {
+            kind_id: kid,
+            depth: i as u16,
+        })
         .collect();
 
     let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
@@ -170,8 +214,8 @@ fn f1_branch_count_increments_for_branch_kinds() {
 
 #[test]
 fn f3_body_stmt_buckets_emit_cumulatively() {
-    use crate::ast_index::vocab_lookup;
     use crate::ast_index::extract::extract_ast_ngrams_with_metrics;
+    use crate::ast_index::vocab_lookup;
 
     let fn_id = match vocab_lookup("function_item") {
         Some(id) => id,
@@ -193,11 +237,20 @@ fn f3_body_stmt_buckets_emit_cumulatively() {
     // then `n_stmts` statement nodes at depth 2.
     let build_nodes = |n_stmts: u32| -> Vec<LinearNode> {
         let mut v = vec![
-            LinearNode { kind_id: fn_id, depth: 0 },
-            LinearNode { kind_id: block_id, depth: 1 },
+            LinearNode {
+                kind_id: fn_id,
+                depth: 0,
+            },
+            LinearNode {
+                kind_id: block_id,
+                depth: 1,
+            },
         ];
         for _ in 0..n_stmts {
-            v.push(LinearNode { kind_id: expr_id, depth: 2 });
+            v.push(LinearNode {
+                kind_id: expr_id,
+                depth: 2,
+            });
         }
         v
     };
@@ -215,26 +268,41 @@ fn f3_body_stmt_buckets_emit_cumulatively() {
     // 10 stmts → b0 only
     let (set10, _) = extract_ast_ngrams_with_metrics(&build_nodes(10), Language::Rust);
     assert!(
-        set10.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(0))),
+        set10
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(0))),
         "10 stmts must emit LARGE_BODY→bucket_label(0)"
     );
     assert!(
-        !set10.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(1))),
+        !set10
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(1))),
         "10 stmts must NOT emit LARGE_BODY→bucket_label(1)"
     );
 
     // 25 stmts → b0 AND b1
     let (set25, _) = extract_ast_ngrams_with_metrics(&build_nodes(25), Language::Rust);
     assert!(
-        set25.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(0))),
+        set25
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(0))),
         "25 stmts must emit LARGE_BODY→bucket_label(0)"
     );
     assert!(
-        set25.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(1))),
+        set25
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(1))),
         "25 stmts must emit LARGE_BODY→bucket_label(1)"
     );
     assert!(
-        !set25.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(2))),
+        !set25
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(2))),
         "25 stmts must NOT emit LARGE_BODY→bucket_label(2)"
     );
 
@@ -242,7 +310,10 @@ fn f3_body_stmt_buckets_emit_cumulatively() {
     let (set40, _) = extract_ast_ngrams_with_metrics(&build_nodes(40), Language::Rust);
     for i in 0..BODY_STMT_EDGES.len() {
         assert!(
-            set40.bigrams.iter().any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(i))),
+            set40
+                .bigrams
+                .iter()
+                .any(|e| e.ngram == AstBigram::encode(LARGE_BODY, bucket_label(i))),
             "40 stmts must emit LARGE_BODY→bucket_label({i})"
         );
     }
@@ -254,29 +325,40 @@ fn f3_depth_buckets_emit_cumulatively() {
     // A node at depth 6 must also emit bucket_label(1)
     // A node at depth 8 must emit bucket_label(0), bucket_label(1), bucket_label(2)
     let make_nodes_at_depth = |d: u16| -> Vec<LinearNode> {
-        (0..=d).map(|depth| LinearNode { kind_id: 1, depth }).collect()
+        (0..=d)
+            .map(|depth| LinearNode { kind_id: 1, depth })
+            .collect()
     };
 
     let (set4, _) = extract_ast_ngrams_with_metrics(&make_nodes_at_depth(4), Language::Rust);
     assert!(
-        set4.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(0))),
+        set4.bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(0))),
         "depth 4 must emit DEEP_NODE→bucket_label(0)"
     );
     assert!(
-        !set4.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(1))),
+        !set4
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(1))),
         "depth 4 must NOT emit DEEP_NODE→bucket_label(1)"
     );
 
     let (set6, _) = extract_ast_ngrams_with_metrics(&make_nodes_at_depth(6), Language::Rust);
     assert!(
-        set6.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(1))),
+        set6.bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(1))),
         "depth 6 must emit DEEP_NODE→bucket_label(1)"
     );
 
     let (set8, _) = extract_ast_ngrams_with_metrics(&make_nodes_at_depth(8), Language::Rust);
     for i in 0..DEPTH_EDGES.len() {
         assert!(
-            set8.bigrams.iter().any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(i))),
+            set8.bigrams
+                .iter()
+                .any(|e| e.ngram == AstBigram::encode(DEEP_NODE, bucket_label(i))),
             "depth 8 must emit DEEP_NODE→bucket_label({i})"
         );
     }
@@ -299,12 +381,22 @@ fn f3_param_buckets_emit_cumulatively() {
 
     let build_nodes = |n_params: u32| -> Vec<LinearNode> {
         let mut v = vec![
-            LinearNode { kind_id: fn_id, depth: 0 },
-            LinearNode { kind_id: params_id, depth: 1 },
+            LinearNode {
+                kind_id: fn_id,
+                depth: 0,
+            },
+            LinearNode {
+                kind_id: params_id,
+                depth: 1,
+            },
         ];
         for _ in 0..n_params {
             v.push(LinearNode {
-                kind_id: if is_counted_child(identifier_id) { identifier_id } else { 1 },
+                kind_id: if is_counted_child(identifier_id) {
+                    identifier_id
+                } else {
+                    1
+                },
                 depth: 2,
             });
         }
@@ -314,25 +406,35 @@ fn f3_param_buckets_emit_cumulatively() {
     // 4 params → no bucket
     let (set4, _) = extract_ast_ngrams_with_metrics(&build_nodes(4), Language::Rust);
     assert!(
-        !set4.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(0))),
+        !set4
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(0))),
         "4 params must NOT emit MANY_PARAMS bucket"
     );
 
     // 5 params → b0 only
     let (set5, _) = extract_ast_ngrams_with_metrics(&build_nodes(5), Language::Rust);
     assert!(
-        set5.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(0))),
+        set5.bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(0))),
         "5 params must emit MANY_PARAMS→bucket_label(0)"
     );
     assert!(
-        !set5.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(1))),
+        !set5
+            .bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(1))),
         "5 params must NOT emit bucket_label(1)"
     );
 
     // 8 params → b0, b1
     let (set8, _) = extract_ast_ngrams_with_metrics(&build_nodes(8), Language::Rust);
     assert!(
-        set8.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(1))),
+        set8.bigrams
+            .iter()
+            .any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(1))),
         "8 params must emit MANY_PARAMS→bucket_label(1)"
     );
 
@@ -340,7 +442,10 @@ fn f3_param_buckets_emit_cumulatively() {
     let (set12, _) = extract_ast_ngrams_with_metrics(&build_nodes(12), Language::Rust);
     for i in 0..PARAM_EDGES.len() {
         assert!(
-            set12.bigrams.iter().any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(i))),
+            set12
+                .bigrams
+                .iter()
+                .any(|e| e.ngram == AstBigram::encode(MANY_PARAMS, bucket_label(i))),
             "12 params must emit MANY_PARAMS→bucket_label({i})"
         );
     }
@@ -369,18 +474,36 @@ fn f4_empty_body_keyed_on_enclosing_kind() {
 
     // Empty catch: catch_clause at depth 0 → statement_block at depth 1, nothing at depth 2
     let catch_nodes = vec![
-        LinearNode { kind_id: catch_id, depth: 0 },
-        LinearNode { kind_id: block_id, depth: 1 },
+        LinearNode {
+            kind_id: catch_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: block_id,
+            depth: 1,
+        },
         // punctuation at depth 2 (should NOT count as a statement)
-        LinearNode { kind_id: 0, depth: 2 },
+        LinearNode {
+            kind_id: 0,
+            depth: 2,
+        },
     ];
 
     // Empty function: function_declaration at depth 0 → statement_block at depth 1
     let fn_nodes = vec![
-        LinearNode { kind_id: fn_id, depth: 0 },
-        LinearNode { kind_id: block_id, depth: 1 },
+        LinearNode {
+            kind_id: fn_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: block_id,
+            depth: 1,
+        },
         // punctuation at depth 2
-        LinearNode { kind_id: 0, depth: 2 },
+        LinearNode {
+            kind_id: 0,
+            depth: 2,
+        },
     ];
 
     let (catch_set, _) = extract_ast_ngrams_with_metrics(&catch_nodes, Language::TypeScript);
@@ -428,10 +551,22 @@ fn f2_punctuation_only_body_is_empty() {
 
     // Body contains only sentinel (punctuation) nodes at depth 2
     let nodes = vec![
-        LinearNode { kind_id: fn_id, depth: 0 },
-        LinearNode { kind_id: block_id, depth: 1 },
-        LinearNode { kind_id: 0, depth: 2 }, // punctuation
-        LinearNode { kind_id: 0, depth: 2 }, // punctuation
+        LinearNode {
+            kind_id: fn_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: block_id,
+            depth: 1,
+        },
+        LinearNode {
+            kind_id: 0,
+            depth: 2,
+        }, // punctuation
+        LinearNode {
+            kind_id: 0,
+            depth: 2,
+        }, // punctuation
     ];
     let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
     let empty_key = AstBigram::encode(EMPTY_BODY, fn_id);
@@ -460,9 +595,18 @@ fn f2_comment_only_body_is_empty() {
 
     // Body contains only comment nodes at depth 2
     let nodes = vec![
-        LinearNode { kind_id: fn_id, depth: 0 },
-        LinearNode { kind_id: block_id, depth: 1 },
-        LinearNode { kind_id: comment_id, depth: 2 },
+        LinearNode {
+            kind_id: fn_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: block_id,
+            depth: 1,
+        },
+        LinearNode {
+            kind_id: comment_id,
+            depth: 2,
+        },
     ];
     let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
     let empty_key = AstBigram::encode(EMPTY_BODY, fn_id);
@@ -490,9 +634,18 @@ fn f2_one_real_statement_body_is_not_empty() {
     };
 
     let nodes = vec![
-        LinearNode { kind_id: fn_id, depth: 0 },
-        LinearNode { kind_id: block_id, depth: 1 },
-        LinearNode { kind_id: stmt_id, depth: 2 }, // one real statement
+        LinearNode {
+            kind_id: fn_id,
+            depth: 0,
+        },
+        LinearNode {
+            kind_id: block_id,
+            depth: 1,
+        },
+        LinearNode {
+            kind_id: stmt_id,
+            depth: 2,
+        }, // one real statement
     ];
     let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
     let empty_key = AstBigram::encode(EMPTY_BODY, fn_id);


### PR DESCRIPTION
## Summary

- Bumps the AST n-gram index to **format v2** (breaking change — re-index required) adding per-file structural metrics (max depth, max block statements, max params, branch count) and avg_max_depth in the header
- Adds **29 GOLD-verified structural code patterns** across 5 categories (ErrorHandling, Performance, Concurrency, Quality, Structure) with honest labeling (exact vs. approximate)
- Fixes two root-cause correctness bugs in `extract_ast_ngrams_with_metrics`: punctuation exclusion from counted-child counts, and complete close-depth loop covering all ancestor depths

## Changes

### Index format v2 (`store/format.rs`, `builder.rs`, `reader.rs`)

- `FILE_META_SIZE` 5 → 15 bytes (+10 bytes/file for `max_depth:u16`, `max_block_stmts:u16`, `max_params:u16`, `branch_count:u32`)
- `FORMAT_VERSION` 1 → 2; v1 files rejected with clear "please rebuild" error
- Header `avg_max_depth:f32` at bytes [38..42] (previously reserved)
- New reader methods: `file_metrics()`, `avg_max_depth()`, `index_version()` (static probe)

### Structural metrics + synthetic n-gram markers (`structural.rs`, `extract.rs`)

- Synthetic parent IDs: `EMPTY_BODY=65000`, `DEEP_NODE=65001`, `LARGE_BODY=65002`, `MANY_PARAMS=65003` — `vocab_resolve()` returns `None` for all (isolation guarantee, per F5 test)
- `extract_ast_ngrams_with_metrics()` folds structural computation into the existing single-pass traversal — no second pass, no extra allocation
- **PUNCTUATION_KIND_IDS fix**: real vocabulary entries for `{`, `}`, `(`, `)`, `,`, `;`, keywords excluded from "counted child" counts, ensuring empty blocks are correctly detected in real parse output (not just hand-built synthetic test nodes)
- **Close-depth loop fix**: closes ALL depths from `prev_depth` down to `node.depth` (inclusive), so structural container nodes (e.g., `parameters`, `block`) are closed with their final `child_counts` before the slot is overwritten by the next sibling

### Pattern library (`patterns.rs`, `patterns_tests.rs`)

- 29 patterns, GOLD-verified (F7): `linearize_source(example)` + `extract_ast_ngrams_with_metrics` must emit every declared bigram/trigram — hard failure on vocabulary or structural mismatches
- Synthetic marker names (`__empty_body__`, `__deep_node__`, `__large_body__`, `__many_params__`, bucketed variants) resolve to reserved IDs via `resolve_synthetic_name()`
- Out-of-scope patterns documented honestly: `hardcoded-secret`, `magic-number`, `single-use-variable` require semantic/data-flow analysis unavailable from CST n-grams

## Breaking Changes

**AST index format v2** — all existing indexes written by Wave 3d (format v1) are rejected with "please rebuild". Run `skim search index --rebuild` to regenerate. No data loss; v2 is a strict superset.

## Reviewer Focus Areas

- `extract.rs` close-depth loop: the range `(close_start..=close_end).rev()` replaces the single `close_depth(close_end)` call — this is the fix that makes `parameters`, `block`, and other structural containers correctly emit MANY_PARAMS/LARGE_BODY/EMPTY_BODY markers
- `structural.rs` PUNCTUATION_KIND_IDS: covers all single-char and keyword tokens that appear as named nodes in CSTs; any gap here would cause false "empty" body detection
- `patterns.rs` F7 GOLD test verifies each `(bigram_str, bigram_str)` pair against actual parse output — no pattern in the catalog is fictional
- PF-004 compliance: saturating casts in `close_depth` (`min(u16::MAX)` before cast); PF-005: size-guard comment in `reader_tests.rs` documents measured ratio