### PR TITLE
feat(#197): Wave 3f — AST structural pattern query engine

### DIFF
--- a/.devflow/decisions/decisions.md
+++ b/.devflow/decisions/decisions.md
@@ -1,4 +1,4 @@
-<!-- TL;DR: 3 decisions. Key: ADR-001, ADR-002, ADR-003 -->
+<!-- TL;DR: 5 decisions. Key: ADR-001, ADR-002, ADR-003, ADR-004, ADR-005 -->
 # Architectural Decisions
 
 Append-only. Status changes allowed; deletions prohibited.
@@ -29,3 +29,21 @@ Append-only. Status changes allowed; deletions prohibited.
 - **Decision**: replace the 5% target with a defensible < 3x source-bytes regression guard (measured 1.23x) as a real non-ignored test, and file on-disk compression as a tracked follow-up (#273)
 - **Consequences**: a regression guard grounded in measurement and industry norms (uncompressed code-search trigram indexes run 3-5x) protects against real bloat, whereas an impossible target either blocks the PR or gets silently ignored
 - **Source**: self-learning:obs_a16x3g
+
+## ADR-004: File follow-up and integration tickets up front as Step 0 (before any code), never post-merge, and never leave #NEW placeholder numbers in source
+
+- **Date**: 2026-06-07
+- **Status**: Accepted
+- **Context**: implementation plans repeatedly deferred follow-up and integration ticket filing until after merge, and used #NEW placeholders in source for not-yet-filed issue numbers, creating a fix-it-later trap where the placeholder survives the PR and the real number is never wired in
+- **Decision**: front-load all ticketing as an explicit Step 0 that runs before any code is written — file the follow-up ticket first so its real issue number can be hardcoded directly into code (e.g. into an error string), and annotate consuming/integration issues up front with the contracts they depend on
+- **Consequences**: a placeholder in code is silent debt that is easily forgotten
+- **Source**: self-learning:obs_tk3f9w
+
+## ADR-005: Never auto-merge a green PR — hand off for the user to explicitly request the squash-merge once CI passes
+
+- **Date**: 2026-06-07
+- **Status**: Accepted
+- **Context**: a feature PR (#284) reached green CI through the full implement/validate/scrutinize/align/QA pipeline and the agent had the standing capability to merge it, yet the agent declined to merge automatically
+- **Decision**: the agent must not auto-merge even when CI is fully green — merge is a user-gated action
+- **Consequences**: the user keeps the merge decision as a deliberate human gate so the final integration step is never taken without explicit human intent, even when every automated check has passed. How to apply: after CI goes green, report the verdict and stop — do not run gh pr merge or any merge command until the user explicitly asks for the squash-merge.
+- **Source**: self-learning:obs_mrg7vk

--- a/.devflow/features/ast-index/KNOWLEDGE.md
+++ b/.devflow/features/ast-index/KNOWLEDGE.md
@@ -1,7 +1,7 @@
 ---
 feature: ast-index
 name: AST Index (CST Linearization + N-gram Encoding + On-Disk Store)
-description: "Use when implementing AST-based n-gram extraction, building or reading the on-disk structural index, adding a new language to the structural index, debugging depth or node-count truncation, extending the shared vocabulary, working with AstBigram/AstTrigram IDF weights, extracting structural n-grams or structural metrics from linearized nodes, using the Pattern Library (structural code patterns), or using the shared AstWalkIter traversal primitive. Keywords: linearize, CST, AST, n-gram, bigram, trigram, NodeKindId, AstBigram, AstTrigram, AstNgramSet, AstBigramEntry, AstTrigramEntry, NODE_KIND_VOCABULARY, LANG_MAPS, LinearNode, AstWalkIter, AstWalkConfig, tree-sitter, depth-encoded, pre-order, IDF, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights, StructuralMetrics, structural, Pattern, patterns, EMPTY_BODY, DEEP_NODE, LARGE_BODY, MANY_PARAMS, bucket_label, synthetic n-gram, store, AstIndexBuilder, AstIndexReader, AstPosting, AstFileMetaEntry, skidx, skpost, SKAX, FORMAT_VERSION, on-disk index, mmap, posting list, build_from_files, lookup_bigram, lookup_trigram, index_version."
+description: "Use when implementing AST-based n-gram extraction, building or reading the on-disk structural index, adding a new language to the structural index, debugging depth or node-count truncation, extending the shared vocabulary, working with AstBigram/AstTrigram IDF weights, extracting structural n-grams or structural metrics from linearized nodes, using the Pattern Library (structural code patterns), using the shared AstWalkIter traversal primitive, or working with the Wave 3f BM25-ranked AST structural query engine (AstQueryEngine, AstQuery, parse_ast_query, AstPostingSource). Keywords: linearize, CST, AST, n-gram, bigram, trigram, NodeKindId, AstBigram, AstTrigram, AstNgramSet, AstBigramEntry, AstTrigramEntry, NODE_KIND_VOCABULARY, LANG_MAPS, LinearNode, AstWalkIter, AstWalkConfig, tree-sitter, depth-encoded, pre-order, IDF, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights, StructuralMetrics, structural, Pattern, patterns, EMPTY_BODY, DEEP_NODE, LARGE_BODY, MANY_PARAMS, bucket_label, synthetic n-gram, store, AstIndexBuilder, AstIndexReader, AstPosting, AstFileMetaEntry, skidx, skpost, SKAX, FORMAT_VERSION, on-disk index, mmap, posting list, build_from_files, lookup_bigram, lookup_trigram, index_version, AstQuery, AstQueryEngine, AstPostingSource, parse_ast_query, search_ast, AST_BM25_K1, AST_BM25_B, query.rs, Wave 3f."
 category: architecture
 directories: [crates/rskim-search/src/ast_index/, crates/rskim-core/src/]
 referencedFiles:
@@ -12,6 +12,7 @@ referencedFiles:
   - crates/rskim-search/src/ast_index/extract.rs
   - crates/rskim-search/src/ast_index/structural.rs
   - crates/rskim-search/src/ast_index/patterns.rs
+  - crates/rskim-search/src/ast_index/query.rs
   - crates/rskim-search/src/ast_index/mod.rs
   - crates/rskim-search/src/ast_index/store/format.rs
   - crates/rskim-search/src/ast_index/store/builder.rs
@@ -19,8 +20,11 @@ referencedFiles:
   - crates/rskim-search/src/ast_index/store/mod.rs
   - crates/rskim-search/src/ast_weights.rs
   - crates/rskim-search/src/lib.rs
+  - crates/rskim-search/benches/ast_index_bench.rs
+  - crates/rskim-search/benches/ast_query.rs
 created: 2026-06-01
-updated: 2026-06-06
+updated: 2026-06-07
+version: 4
 ---
 
 # AST Index (CST Linearization + N-gram Encoding + On-Disk Store)
@@ -30,9 +34,9 @@ updated: 2026-06-06
 The `ast_index` module converts tree-sitter Concrete Syntax Trees (CSTs) into a
 compact, flat representation suitable for downstream n-gram extraction and IDF-weighted
 structural search. It is the AST layer of a 3-layer search system (Lexical, Temporal,
-AST n-gram) built across Waves 3a–3e.
+AST n-gram) built across Waves 3a–3f.
 
-Six sub-modules make up the full Wave 3e implementation:
+Seven sub-modules make up the full Wave 3f implementation:
 
 - **`linearize`** — converts source text into `Vec<LinearNode>` (pre-order depth-first
   sequence), each node carrying a shared vocabulary ID and traversal depth.
@@ -45,18 +49,53 @@ Six sub-modules make up the full Wave 3e implementation:
 - **`structural`** — (Wave 3e) defines reserved synthetic parent IDs
   (`EMPTY_BODY`, `DEEP_NODE`, `LARGE_BODY`, `MANY_PARAMS`), bucket-label child IDs
   (`BUCKET_LABEL_BASE`), cumulative bucket edge tables, `StructuralMetrics`, and
-  `is_counted_child` (the central counting rule).
+  `is_counted_child` (the central counting rule). Visibility: `pub(crate) mod structural`.
 - **`patterns`** — (Wave 3e) data-driven catalog of 29 named structural code patterns
   in 5 categories, GOLD-verified against real code examples.
 - **`store`** — (Wave 3d/3e) two-file mmap'd on-disk inverted index; format v2 adds
-  per-file structural metrics and `avg_max_depth`. Library-only; Wave 3f (#197) wires
-  the query engine, Wave 3g (#199) adds CLI.
+  per-file structural metrics and `avg_max_depth`.
+- **`query`** — (Wave 3f, #197) BM25-ranked structural pattern query engine. Exposes
+  `AstQueryEngine<R: AstPostingSource>`, `AstQuery` enum, and `parse_ast_query` parser.
+  Implements the `SearchLayer` adapter for Wave-3g CLI integration. `pub mod query` — the
+  only sub-module with public module visibility (others are `mod`-private, re-exported
+  via `mod.rs`).
 
 The design is intentionally minimal: `linearize_source` is the only stateful-setup
-entry point. All n-gram encoding, weight lookup, and extraction are pure.
+entry point. All n-gram encoding, weight lookup, extraction, and BM25 scoring are pure.
 
 The DFS traversal logic lives in `rskim-core::AstWalkIter` to be shared with
 `rskim-research` without duplicating cursor management or bounds guarding.
+
+## Public API Exports
+
+### From `rskim_search::ast_index::*`
+
+All items below are accessible via `rskim_search::ast_index::{name}`:
+
+- `extract_ast_ngrams`, `extract_ast_ngrams_with_metrics`, `extract_ast_ngrams_with_weights`
+- `AstBigramEntry`, `AstNgramSet`, `AstTrigramEntry`
+- `LinearNode`, `LinearizeResult`, `linearize_source`
+- `AstBigram`, `AstTrigram`, `DEFAULT_AST_WEIGHT`, `ast_bigram_idf`, `ast_trigram_idf`,
+  `vocab_len`, `vocab_lookup`, `vocab_resolve`
+- `Pattern`, `PatternCategory`, `all_patterns`, `lookup_pattern`, `pattern_to_query_set`
+- `AstFileMetaEntry`, `AstIndexBuilder`, `AstIndexReader`, `AstPosting`
+- `StructuralMetrics`
+- `NodeKindId` (type alias for `u16`)
+- **Wave 3f**: `AST_BM25_B`, `AST_BM25_K1`, `AstPostingSource`, `AstQuery`,
+  `AstQueryEngine`, `parse_ast_query`
+
+### From `rskim_search::*` (crate-root re-exports)
+
+Only a subset is re-exported at the crate root. Notably, `extract_ast_ngrams_with_metrics`,
+`Pattern`, `PatternCategory`, `all_patterns`, `lookup_pattern`, `pattern_to_query_set`, and
+`StructuralMetrics` are NOT yet at the crate root — access them via `rskim_search::ast_index::`.
+The crate root exports `AstBigram`, `AstBigramEntry`, `AstFileMetaEntry`, `AstIndexBuilder`,
+`AstIndexReader`, `AstNgramSet`, `AstPosting`, `AstTrigram`, `AstTrigramEntry`,
+`DEFAULT_AST_WEIGHT`, `LinearNode`, `LinearizeResult`, `NodeKindId`, `ast_bigram_idf`,
+`ast_trigram_idf`, `extract_ast_ngrams`, `extract_ast_ngrams_with_weights`, `linearize_source`,
+`vocab_len`, `vocab_lookup`, `vocab_resolve`.
+**Wave 3f additions at crate root**: `AST_BM25_B`, `AST_BM25_K1`, `AstPostingSource`,
+`AstQuery`, `AstQueryEngine`, `parse_ast_query`.
 
 ## System Context
 
@@ -68,8 +107,12 @@ The DFS traversal logic lives in `rskim-core::AstWalkIter` to be shared with
   **1740** node kind strings (IDs 0–1739); IDs ≥ 1740 are free for synthetic use
 - `crate::ast_weights::{ast_bigram_weight, ast_trigram_weight}` — per-language IDF tables
 - `crate::types::SearchError::Ast` for the one error path not silenced gracefully
+- `crate::types::{SearchLayer, SearchQuery, SearchResult, SearchField}` — implemented by
+  `AstQueryEngine<AstIndexReader>` in `query.rs` (Wave 3g adapter)
 - `crate::index::lang_map::{lang_to_id, lang_from_id}` — single source of truth for
   language ↔ u8 ID mapping (widened to `pub(crate)` in `index/mod.rs` so `store/` reuses it)
+- `crate::io_util::atomic_write` — shared atomic-write helper (NamedTempFile + sync_all +
+  persist); also used by `cochange::builder`
 
 Non-tree-sitter languages (JSON, YAML, TOML) have no entry in `LANG_MAPS`.
 `linearize_source` returns an empty default; `ast_bigram_idf` returns `DEFAULT_AST_WEIGHT`.
@@ -112,7 +155,7 @@ non-tree-sitter languages.
 
 ### extract.rs — N-gram Extraction and Structural Metrics
 
-The document-side extraction layer. Two main entry points:
+The document-side extraction layer. Three main entry points:
 
 ```rust
 // Dependency-injected core — testable with synthetic weights
@@ -168,38 +211,17 @@ at indices 0 and 1, emitting both `LARGE_BODY → 64900` and `LARGE_BODY → 649
 
 Depth bucket edges: `[4, 6, 8]`. Param bucket edges: `[5, 8, 12]`.
 
-**The central counting rule (`is_counted_child`):**
-
-The LinearNode stream includes anonymous punctuation (kind_id == 0) and comment nodes.
-A "counted child" satisfies: `kind_id != 0` AND not in `COMMENT_KIND_IDS` AND not in
-`PUNCTUATION_KIND_IDS`. This ensures empty blocks are correctly identified: a
-`statement_block {}` has 0 counted children so `EMPTY_BODY` fires.
-
-`COMMENT_KIND_IDS` and `PUNCTUATION_KIND_IDS` are `LazyLock<HashSet<NodeKindId>>`
-built once from `NODE_KIND_VOCABULARY`. The `PUNCTUATION_KIND_IDS` set includes
-bracket tokens (`{`, `}`, `(`, `)`, etc.) and structural keywords (`fn`, `if`, `let`,
-etc.) because tree-sitter emits these as named nodes that must not count as statements.
-
-**PF-004 compliance in structural accumulation:**
-
-- `max_block_stmts` and `max_params`: `count.min(u32::from(u16::MAX)) as u16` before
-  assignment (saturating cast, no silent truncation).
-- `branch_count`: `metrics.branch_count.saturating_add(1)` (saturates at u32::MAX).
-
-**Residual documented edge case:**
-
-A dropped ERROR node that had a same-depth preceding sibling leaves no depth gap, so
-the orphaned child binds to that sibling as its parent — a spurious edge. Confined to
-malformed code regions; characterized intentionally by test B2.
-
 ### structural.rs (Wave 3e)
 
-Defines all shared constants, sets, and helpers for structural n-gram emission:
+Defines all shared constants, sets, and helpers for structural n-gram emission.
+Visibility is `pub(crate) mod structural` — consumers outside `rskim-search` must go
+through `rskim_search::ast_index::StructuralMetrics` (re-exported from `mod.rs`).
 
 - Synthetic parent IDs: `EMPTY_BODY` (65000), `DEEP_NODE` (65001), `LARGE_BODY` (65002),
   `MANY_PARAMS` (65003)
 - Bucket constants: `BUCKET_LABEL_BASE` (64900), `MAX_BUCKET_EDGES` (99), `bucket_label(i)`
-- Bucket edge tables: `BODY_STMT_EDGES`, `PARAM_EDGES`, `DEPTH_EDGES`
+- Bucket edge tables: `BODY_STMT_EDGES = [10, 20, 40]`, `PARAM_EDGES = [5, 8, 12]`,
+  `DEPTH_EDGES = [4, 6, 8]`
 - `StructuralMetrics { max_depth: u16, max_block_stmts: u16, max_params: u16, branch_count: u32 }`
 - `COMMENT_KIND_IDS`, `PUNCTUATION_KIND_IDS`, `FUNCTION_KIND_IDS`, `BODY_KIND_IDS`,
   `PARAM_LIST_KIND_IDS`, `BRANCH_KIND_IDS` — all `LazyLock<HashSet<NodeKindId>>`
@@ -233,16 +255,6 @@ and extracted with `extract_ast_ngrams_with_metrics`.
 | Quality | 7 | god-function, excessive-params, empty-function, match-with-arms, unhandled-result |
 | Structure | 5 | impl-method, class-method, switch-with-cases, ternary-expression |
 
-**Honest omissions (deliberately excluded):**
-
-- `hardcoded-secret` — requires semantic analysis of literal content
-- `single-use-variable` — requires data-flow analysis
-- `magic-number` (named) — a weak proxy is available as `numeric-literal-in-expression`
-  but is NOT named "magic-number" to avoid overclaiming
-
-**Ranking status:** Patterns are queryable but do NOT affect ranking today. Ranking
-integration of structural-complexity scoring is deferred to Wave 4 (#198/#200).
-
 Pattern API:
 
 ```rust
@@ -252,6 +264,100 @@ pattern_to_query_set(pattern: &Pattern) -> AstNgramSet   // count=1 per resolved
 pattern.resolved_bigrams() -> Vec<AstBigram>             // silently drops unresolved
 pattern.resolved_trigrams() -> Vec<AstTrigram>
 ```
+
+### query.rs — AST Structural Query Engine (Wave 3f, #197)
+
+The query-side of the AST index. Implements BM25-ranked structural pattern search over
+the on-disk index. Three key types:
+
+**`AstQuery` enum** — the only `String → AstQuery` boundary is `parse_ast_query`:
+
+| Variant | Created by | Meaning |
+|---|---|---|
+| `Pattern(&'static Pattern)` | hyphenated input e.g. `"try-catch"` | Named catalog pattern |
+| `Containment(AstNgramSet)` | `A > B` or `A > B > C` | Direct containment bigram/trigram |
+| `SingleNode(NodeKindId)` | underscore-separated vocab name | Deferred to #283 (unigram index) |
+
+`AstQuery` implements `PartialEq` using pointer equality for `Pattern` variants.
+
+**`AstPostingSource` trait** — DI seam between the query engine and its index:
+
+```rust
+pub trait AstPostingSource: Send + Sync {
+    fn lookup_bigram(&self, b: AstBigram) -> Result<Vec<AstPosting>>;
+    fn lookup_trigram(&self, t: AstTrigram) -> Result<Vec<AstPosting>>;
+    fn file_meta(&self, doc_id: u32) -> Result<AstFileMetaEntry>;
+    fn avg_node_count(&self) -> f32;
+    fn file_count(&self) -> u32;
+}
+```
+
+`AstIndexReader` implements this trait. Tests use `FakePostingSource` (in `query_tests.rs`).
+
+**`AstQueryEngine<R: AstPostingSource>`** — immutable, `&self`-only, `Send + Sync`:
+
+```rust
+impl<R: AstPostingSource> AstQueryEngine<R> {
+    pub fn new(reader: R) -> Self                          // DI constructor (tests/Wave 4)
+    pub fn search_ast(&self, q: &AstQuery) -> Result<Vec<(FileId, f64)>>  // Wave-4 hook
+}
+impl AstQueryEngine<AstIndexReader> {
+    pub fn open(dir: &Path) -> Result<Self>                // CLI convenience constructor
+}
+```
+
+`search_ast` returns results sorted **FileId-ASC** (Wave-4 merge-join contract).
+`SingleNode` variant returns `SearchError::InvalidQuery` referencing #283.
+
+**OR-union BM25 scoring:**
+
+```
+score(file) = Σ idf(lang, ngram) · (tf_norm / (tf_norm + k1))
+  where tf_norm = tf / length_norm
+        length_norm = 1 - b + b · (node_count / avg_node_count)
+        k1 = 1.2, b = 0.75
+```
+
+Length normalization uses `node_count` (from `AstFileMetaEntry`) not byte count. IDF is
+per-language (from `ast_bigram_idf`/`ast_trigram_idf`); falls back to `1.0` for unknown
+language. When `avg_node_count == 0`, `length_norm = 1.0`.
+
+**Gap-fix #6**: query n-gram keys are deduped before lookup (`dedup_by_key` on sorted
+bigrams and trigrams). Without this, a pattern with duplicate n-gram entries would
+double-score files. `debug_assert!` verifies post-dedup uniqueness.
+
+**C4 guarantee**: `AstPosting.count >= 1` is validated by `decode_posting` in the reader;
+the `bm25` helper relies on this — no separate guard for `tf > 0`.
+
+**`SearchLayer` adapter (Wave 3g)**:
+
+`AstQueryEngine<AstIndexReader>` implements `SearchLayer` via a concrete `impl` block
+(not a blanket). The `search` method:
+
+1. Returns `Ok(vec![])` if `query.ast_pattern == None` (Wave-4 no-op)
+2. Returns `Err(InvalidQuery("empty AST query"))` if pattern is `Some("")`
+3. Otherwise: `parse_ast_query` → `search_ast` → apply `file_filter` → apply `lang` filter
+   → sort score-DESC/FileId-ASC tie-break → apply `offset`/`limit` → return `Vec<SearchResult>`
+
+`line_range: 0..0` and `match_positions: vec![]` are stub values — full match attribution
+is deferred to Wave 4.
+
+**`parse_ast_query`** — total function, never panics:
+
+| Input form | Dispatch rule |
+|---|---|
+| Contains `-` and one segment | `lookup_pattern` → `AstQuery::Pattern` |
+| `A > B` (2 segments) | `parse_bigram_q` → `AstQuery::Containment` |
+| `A > B > C` (3 segments) | `parse_trigram_q` → `AstQuery::Containment` |
+| One segment, no `-` | `vocab_lookup` → `AstQuery::SingleNode` |
+| `>>` (transitive ancestor) | `Err(InvalidQuery)` |
+| Empty segment or > 3 segments | `Err(InvalidQuery)` |
+| > 4096 bytes | `Err(InvalidQuery)` |
+
+**Test coverage**: 42 unit tests in `query_tests.rs` using `FakePostingSource` harness.
+Groups: A1–A6 (engine correctness), B2–B6 (scoring, dedup, sort), parse error tests.
+Criterion bench in `benches/ast_query.rs`: 3 scenarios × 10k synthetic files
+(`bench_hot_bigram`, `bench_rare_trigram`, `bench_multi_ngram_pattern`).
 
 ### store sub-module — On-Disk Format v2
 
@@ -288,7 +394,7 @@ and recomputed at query time via `ast_bigram_idf`/`ast_trigram_idf`.
 
 **Atomic write:** `ast_index.skpost` first, then `ast_index.skidx` (commit point).
 A reader finding `.skidx` can assume `.skpost` is coherent. Uses `atomic_write` from
-`crate::io_util`.
+`crate::io_util` (the same shared helper now used by `cochange::builder`).
 
 **FileId invariant (PRECONDITION):** FileIds must be dense, sequential, starting from
 zero. Every file — including those yielding zero n-grams — must receive exactly one
@@ -354,23 +460,17 @@ extract_ast_ngrams_with_metrics(&[LinearNode], Language)
     ├── Close remaining open depths (end-of-stream)
     └── Collect → sort → (AstNgramSet, StructuralMetrics)
 
-AstIndexBuilder::build_from_files(output_dir, files)
+AstQueryEngine::search_ast(q: &AstQuery)
     │
-    ├── rayon par_iter → linearize_source + extract_ast_ngrams_with_metrics (parallel)
-    ├── Sequential merge: add_file_ngrams(id, lang, set, node_count, metrics)
-    └── build()
-            ├── Compute corpus averages (avg_bigram_count, avg_node_count, avg_max_depth, …)
-            ├── Sort keys ascending; serialize postings + entries + file_meta
-            ├── CRC32 over post-header payload
-            ├── Atomic write: skpost first, then skidx (commit point)
-            └── AstIndexReader::open(output_dir)
+    ├── SingleNode     → Err(InvalidQuery) [deferred to #283]
+    ├── Pattern(p)     → pattern_to_query_set(p) → run_ngram_set
+    └── Containment(s) → run_ngram_set(s)
 
-AstIndexReader::lookup_bigram(AstBigram)
-    │
-    ├── Binary search bigram entries in idx_mmap[48..bigram_end]
-    ├── Found → fetch offset/length into post_mmap
-    ├── Validate bounds + alignment (len % 8 == 0)
-    └── Decode AstPostingEntry × n → Vec<AstPosting> (C1 sort enforced defensively)
+    run_ngram_set(set: &AstNgramSet)
+        ├── dedup_by_key bigrams and trigrams (gap-fix #6)
+        ├── For each bigram: lookup_bigram → bm25 → scores[doc_id] += score
+        ├── For each trigram: lookup_trigram → bm25 → scores[doc_id] += score
+        └── filter (score > 0) → sort FileId-ASC → Vec<(FileId, f64)>
 ```
 
 ## Constraints and Bounds
@@ -381,11 +481,14 @@ AstIndexReader::lookup_bigram(AstBigram)
 | `MAX_FILE_SIZE_LARGE` (SQL) | 1 MiB | `linearize.rs` |
 | `DEFAULT_MAX_DEPTH` | 500 | `AstWalkConfig` |
 | `DEFAULT_MAX_NODES` | 100,000 | `AstWalkConfig` |
+| `MAX_AST_QUERY_BYTES` | 4096 | `query.rs` |
 | `HEADER_SIZE` | 48 B | `store/format.rs` |
 | `BIGRAM_ENTRY_SIZE` | 16 B | `store/format.rs` |
 | `TRIGRAM_ENTRY_SIZE` | 20 B | `store/format.rs` |
 | `POSTING_ENTRY_SIZE` | 8 B | `store/format.rs` |
 | `FILE_META_SIZE` (v2) | **15 B** | `store/format.rs` |
+| `AST_BM25_K1` | 1.2 | `query.rs` |
+| `AST_BM25_B` | 0.75 | `query.rs` |
 | Vocabulary size | 1740 | `ast_weights.rs` |
 | Free synthetic ID start | 1740 | `structural.rs` comment |
 | `EMPTY_BODY` | 65000 | `structural.rs` |
@@ -421,6 +524,17 @@ AstIndexReader::lookup_bigram(AstBigram)
   `SearchError::InvalidQuery` for unknown names. All 29 pattern names are kebab-case;
   the error message lists all valid names.
 
+- **Passing the `AstQuery::SingleNode` variant to `search_ast`**: always returns
+  `SearchError::InvalidQuery` until #283 lands. Parse the query and check the variant
+  before calling `search_ast` if `SingleNode` is a case you need to handle.
+
+- **Skipping the gap-fix #6 dedup when building a custom `AstNgramSet` for queries**:
+  duplicate keys in the query set cause double-scoring. Use `dedup_by_key` on sorted
+  entries, or prefer `parse_ast_query` / `pattern_to_query_set` which produce unique sets.
+
+- **Constructing `AstQueryEngine` with `open` in tests**: tests should use `new(FakePostingSource)`
+  to avoid touching disk and to control corpus statistics.
+
 - **Adding non-tree-sitter languages to the `LANG_MAPS` init list**: JSON, YAML, TOML
   have no tree-sitter grammar. They return empty results from `linearize_source` and
   `DEFAULT_AST_WEIGHT` from IDF lookups. This is correct behavior.
@@ -436,9 +550,8 @@ AstIndexReader::lookup_bigram(AstBigram)
   `count` is term frequency (occurrences in one file), not the number of documents
   containing the n-gram.
 
-- **Using `as u16` for `max_block_stmts` / `max_params` in structural code**: always
-  `count.min(u32::from(u16::MAX)) as u16` (saturating cast — applies PF-004). Similarly,
-  `branch_count` uses `saturating_add`.
+- **Accessing `structural` internals directly from outside `rskim-search`**: the module is
+  `pub(crate)`. External callers use only `StructuralMetrics` re-exported from `ast_index`.
 
 ## Gotchas
 
@@ -466,8 +579,8 @@ AstIndexReader::lookup_bigram(AstBigram)
 
 - **v1 indexes are hard-rejected**: `decode_header` returns "unsupported format version: 1
   (expected 2); please rebuild the AST index". The `index_version` probe lets callers detect
-  this before a full `open` call fails. Auto-rebuild wiring arrives in Wave 3f/3g, mirroring
-  `cmd/search/staleness.rs::auto_refresh_if_stale`.
+  this before a full `open` call fails. Auto-rebuild wiring arrives in Wave 3g (#199),
+  mirroring `cmd/search/staleness.rs::auto_refresh_if_stale`.
 
 - **`COMMENT_KIND_IDS` and `PUNCTUATION_KIND_IDS` lazy init at first `is_counted_child` call**:
   the initialization is O(#kinds × log(vocab_len)), tiny but not zero. Benchmarks should
@@ -489,19 +602,29 @@ AstIndexReader::lookup_bigram(AstBigram)
   and exposed via `AstIndexReader::file_metrics`, but ranking integration is deferred
   to Wave 4 (#198/#200). Do not factor them into scoring before the integration is wired.
 
+- **`query.rs` is `pub mod`, not `mod`**: it is the only `ast_index` sub-module with
+  public module visibility. This is intentional to expose the `AstPostingSource` trait
+  for external implementors (Wave 4 integrators, test fakes).
+
+- **BM25 uses node_count for length normalization, not byte count**: this means two files
+  with the same byte size but different language grammars will have different `length_norm`
+  values if their node densities differ.
+
 ## Key Files
 
 - `crates/rskim-core/src/ast_walk.rs` — `AstWalkIter`, `AstWalkConfig` (canonical limit source), `AstWalkNode`
 - `crates/rskim-search/src/ast_index/linearize.rs` — `LANG_MAPS`, `linearize_source`, `linearize_tree`; SQL size override; delegates DFS to `AstWalkIter`
 - `crates/rskim-search/src/ast_index/ngram.rs` — `AstBigram`, `AstTrigram`, vocabulary helpers, IDF weight lookups
 - `crates/rskim-search/src/ast_index/extract.rs` — `extract_ast_ngrams_with_metrics` (single-pass, Wave 3e), `extract_ast_ngrams_with_weights` (DI core), `AstNgramSet`, `AstBigramEntry`, `AstTrigramEntry`
-- `crates/rskim-search/src/ast_index/structural.rs` — synthetic IDs, bucket edge tables, `StructuralMetrics`, `is_counted_child`, `COMMENT_KIND_IDS`, `PUNCTUATION_KIND_IDS` (Wave 3e)
+- `crates/rskim-search/src/ast_index/structural.rs` — synthetic IDs, bucket edge tables, `StructuralMetrics`, `is_counted_child`, `COMMENT_KIND_IDS`, `PUNCTUATION_KIND_IDS` (Wave 3e); `pub(crate)` visibility
 - `crates/rskim-search/src/ast_index/patterns.rs` — 29-pattern GOLD-verified catalog, `Pattern`, `PatternCategory`, `lookup_pattern`, `pattern_to_query_set` (Wave 3e)
+- **`crates/rskim-search/src/ast_index/query.rs`** — `AstQuery`, `AstQueryEngine`, `AstPostingSource`, `parse_ast_query`, BM25 scoring (Wave 3f, #197); `pub mod`
 - `crates/rskim-search/src/ast_index/store/format.rs` — pure binary codec: all on-disk struct definitions (v2), encode/decode, binary search helpers, CRC32; no I/O
-- `crates/rskim-search/src/ast_index/store/builder.rs` — `AstIndexBuilder`: merge primitive, parallel `build_from_files`, atomic write, FileId enforcement
+- `crates/rskim-search/src/ast_index/store/builder.rs` — `AstIndexBuilder`: merge primitive, parallel `build_from_files`, atomic write via `crate::io_util::atomic_write`, FileId enforcement
 - `crates/rskim-search/src/ast_index/store/reader.rs` — `AstIndexReader`, `AstPosting`: mmap open/validate, `lookup_bigram`, `lookup_trigram`, `file_meta`, `file_metrics`, `index_version`, `avg_max_depth`
-- `crates/rskim-search/src/ast_index/mod.rs` — public re-exports for all six sub-modules
+- `crates/rskim-search/src/ast_index/mod.rs` — public re-exports for all seven sub-modules
 - `crates/rskim-search/src/ast_weights.rs` — auto-generated `NODE_KIND_VOCABULARY` (1740 entries, sorted) and per-language IDF tables; do not edit manually
+- `crates/rskim-search/benches/ast_query.rs` — Criterion benchmark: 3 scenarios × 10k synthetic files
 
 ## Related
 
@@ -514,13 +637,15 @@ AstIndexReader::lookup_bigram(AstBigram)
   the index size guard is a measured `< 2.2×` regression guard (measured ~1.23×), not a
   phantom number. Background: `< 5%` is structurally unachievable for structural AST n-grams.
 - Feature: `cochange` — consumes `FileId`-keyed data built from git history; the store
-  builder's atomic-write pattern matches the cochange sibling.
+  builder's atomic-write pattern mirrors this module (both now use `crate::io_util::atomic_write`).
 - Feature: `temporal-scoring` — parallel sibling in `rskim-search`; same `SearchError` type
   and `Result<T>` alias pattern.
 - Feature: `research-ast` — `rskim-research` crate that produces `ast_weights.rs` via
   `ast-codegen`; also uses `AstWalkIter` from `rskim-core`.
 - `crates/rskim-search/src/index/mod.rs` — lexical sibling; `lang_map` widened to `pub(crate)` here.
-- Issue #197 (deferred, Wave 3f): query-side covering-set from `AstNgramSet`, query engine.
+- `crates/rskim-search/src/io_util.rs` — `atomic_write` shared helper (NamedTempFile + sync_all + persist).
+- Issue #197 (complete, Wave 3f): `AstQueryEngine`, `AstQuery`, `parse_ast_query`, BM25 scoring, `SearchLayer` adapter.
 - Issue #199 (deferred, Wave 3g): CLI `--ast` flag and auto-rebuild-on-version-mismatch.
 - Issue #198 / #200 (deferred, Wave 4): ranking integration of structural-complexity scoring.
 - Issue #273 (follow-up): on-disk compression (delta + VarInt / Roaring Bitmaps).
+- Issue #283 (deferred): unigram index for `AstQuery::SingleNode` execution.

--- a/.devflow/features/ast-index/KNOWLEDGE.md
+++ b/.devflow/features/ast-index/KNOWLEDGE.md
@@ -327,7 +327,7 @@ bigrams and trigrams). Without this, a pattern with duplicate n-gram entries wou
 double-score files. `debug_assert!` verifies post-dedup uniqueness.
 
 **C4 guarantee**: `AstPosting.count >= 1` is validated by `decode_posting` in the reader;
-the `bm25` helper relies on this — no separate guard for `tf > 0`.
+the `bm25_with_idf` helper relies on this — no separate guard for `tf > 0`.
 
 **`SearchLayer` adapter (Wave 3g)**:
 
@@ -347,15 +347,15 @@ is deferred to Wave 4.
 | Input form | Dispatch rule |
 |---|---|
 | Contains `-` and one segment | `lookup_pattern` → `AstQuery::Pattern` |
-| `A > B` (2 segments) | `parse_bigram_q` → `AstQuery::Containment` |
-| `A > B > C` (3 segments) | `parse_trigram_q` → `AstQuery::Containment` |
+| `A > B` (2 segments) | `parse_bigram` → `AstQuery::Containment` |
+| `A > B > C` (3 segments) | `parse_trigram` → `AstQuery::Containment` |
 | One segment, no `-` | `vocab_lookup` → `AstQuery::SingleNode` |
 | `>>` (transitive ancestor) | `Err(InvalidQuery)` |
 | Empty segment or > 3 segments | `Err(InvalidQuery)` |
 | > 4096 bytes | `Err(InvalidQuery)` |
 
-**Test coverage**: 42 unit tests in `query_tests.rs` using `FakePostingSource` harness.
-Groups: A1–A6 (engine correctness), B2–B6 (scoring, dedup, sort), parse error tests.
+**Test coverage**: comprehensive unit suite (groups A1–A6 engine correctness, B2–B6
+scoring/dedup/sort, plus parse-error tests) in `query_tests.rs` using `FakePostingSource` harness.
 Criterion bench in `benches/ast_query.rs`: 3 scenarios × 10k synthetic files
 (`bench_hot_bigram`, `bench_rare_trigram`, `bench_multi_ngram_pattern`).
 

--- a/.devflow/features/build-parsers/KNOWLEDGE.md
+++ b/.devflow/features/build-parsers/KNOWLEDGE.md
@@ -15,8 +15,8 @@ referencedFiles:
   - crates/rskim/src/output/canonical.rs
   - crates/rskim/src/cmd/mod.rs
 created: 2026-05-14
-updated: 2026-05-26
-version: 9
+updated: 2026-06-07
+version: 10
 ---
 
 # Build Tool Output Parsers
@@ -25,7 +25,9 @@ version: 9
 
 The build parsers module (`crates/rskim/src/cmd/build/`) compresses output from build tools (cargo, clippy, tsc, make, gradle, maven) into compact summaries for AI context windows. Each tool has a dedicated file (`cargo.rs`, `tsc.rs`, `make.rs`, `gradle.rs`, `maven.rs`) plus a shared `mod.rs` that provides the dispatcher and the `run_parsed_command` infrastructure function used by all five.
 
-The module is invoked via flat dispatch (`skim tsc`) or multi-category dispatch (`skim cargo build`, `skim cargo clippy`). All parsers share the same three-tier degradation model: Full (clean structured parse) → Degraded (partial parse with warning markers) → Passthrough (raw output returned unchanged).
+The module is invoked via flat dispatch (`skim tsc`) or multi-category dispatch (`skim cargo build`, `skim cargo check`, `skim cargo fmt`, `skim cargo clippy`). All parsers share the same three-tier degradation model: Full (clean structured parse) → Degraded (partial parse with warning markers) → Passthrough (raw output returned unchanged).
+
+The `cargo.rs` module gained two additional handlers in PR #264: `run_check()` (reuses existing JSON parser by injecting `--message-format=json`) and `run_fmt()` (thin success/passthrough splitter — empty output on success, passthrough diff on failure). These share the same `run_parsed_command` path as `run()` and `run_clippy()`. The internal `run_with_json_format(subcmd, ...)` helper deduplicates the JSON-injection pattern across `build`, `check`, and `clippy`.
 
 ## Core Responsibilities
 
@@ -191,11 +193,12 @@ Use `.expect("valid regex")` not `.unwrap()` — the expect message documents in
 
 ## Shared Test Helpers
 
-All build parser tests (and tests across the `cmd` subtree) use the shared helpers from `crate::cmd::test_support`, defined under `#[cfg(test)]` in `cmd/mod.rs`. As of #214, the ~34 local `make_output` definitions and ~41 local `load_fixture` definitions that existed across `cmd` subtree modules were replaced by this single canonical source.
+All build parser tests (and tests across the `cmd` subtree) use the shared helpers from `crate::cmd::test_support`. As of PR #267 (cmd/mod.rs complexity reduction), `test_support` is a dedicated file at `crates/rskim/src/cmd/test_support.rs` — no longer embedded as an inline `#[cfg(test)]` module inside `mod.rs`.
 
-The three helpers are:
+Four helpers are now available:
 - `make_output(stdout: &str) -> CommandOutput` — success case: stderr empty, exit_code Some(0), duration ZERO
 - `make_output_full(stdout, stderr, exit_code: Option<i32>) -> CommandOutput` — full control for non-zero exits, stderr content, signal-kill (None exit code)
+- `make_output_stderr(stderr: &str) -> CommandOutput` — stderr-only success case (stdout empty, exit_code Some(0)); for tools that write to stderr by default (e.g. wget, curl)
 - `load_fixture(subdir: &str, name: &str) -> String` — loads from `tests/fixtures/cmd/{subdir}/{name}`; panics with clear message on missing file
 
 Build parser tests import these as `use super::super::test_support::{make_output, make_output_full, load_fixture}`. Do not redeclare local versions — use the canonical source to prevent drift.
@@ -216,7 +219,7 @@ Build parser tests import these as `use super::super::test_support::{make_output
 
 - **Adding a build tool as a passthrough dispatcher**: build tools should use the strict dispatcher model (error on unknown subcommand), not the passthrough model used by `swift`/`dotnet`. Build commands have a finite, well-defined subcommand set; passthrough is reserved for tools with wide lifecycle subcommand surfaces that agents invoke routinely.
 
-- **Declaring local `make_output` or `load_fixture` in build test modules**: use `super::super::test_support` instead. Local redeclarations drift from the canonical definition (e.g., duration field set to arbitrary millisecond values instead of `Duration::ZERO`).
+- **Declaring local `make_output` or `load_fixture` in build test modules**: use `super::super::test_support` instead. Local redeclarations drift from the canonical definition (e.g., duration field set to arbitrary millisecond values instead of `Duration::ZERO`). Since PR #267, `test_support` is a dedicated file at `crates/rskim/src/cmd/test_support.rs`, not an inline `#[cfg(test)]` module.
 
 ## Gotchas
 
@@ -256,7 +259,12 @@ Build parser tests import these as `use super::super::test_support::{make_output
 - `crates/rskim/src/cmd/build/maven.rs` — Maven/Mvnw: `[ERROR]`/`[WARNING]` + build summary Tier 1 (with duration), noise-strip Tier 2 (two `LazyLock<Regex>` patterns, two duration formats)
 - `crates/rskim/src/output/mod.rs` — `ParseResult<T>` enum definition and helpers (`is_full`, `is_degraded`, `tier_name`, `content`, `into_content`, `emit_markers`); `strip_ansi` and `strip_ansi_cow` (zero-copy fast path: borrows when no ESC byte present); `to_json_envelope` (not used by build family — build has no `--json` mode); `OutputMode`, `clean`, `PassthroughTruncator`, `FilterTransparencyHeader` (used by other families); sub-modules `guardrail` and `tee` (not used by build parsers — used by other consumers of the output infrastructure)
 - `crates/rskim/src/output/canonical.rs` — `BuildResult` struct with pre-rendered output; also owns `TestResult`, `GitResult`, `LintResult`, `DbResult`, `PkgResult` — the `DbResult::render` was decomposed into 5 private helpers in #214 as a model for growing render logic
-- `crates/rskim/src/cmd/mod.rs` — `user_has_flag`, `inject_flag_before_separator`, `extract_show_stats`, `extract_json_flag`, `extract_output_format`, `combine_output`, `sanitize_for_display`, `format_analytics_label`, `scrub_db_args`; structs `RunContext`, `ParsedCommandConfig<'_>`, `ToolRunConfig<'_>`, `OutputFormat`; generic runner `run_tool<T>` (used by lint, db, infra, file families — NOT by build); stdin infrastructure: `should_read_stdin`, `read_bounded`, `read_stdin_bounded`, `MAX_STDIN_BYTES`; passthrough infrastructure: `is_passthrough_mode`, `check_passthrough_str`, `check_passthrough_value`; resolver: `resolve_cache_dir`; `is_known_subcommand` (linear scan of `KNOWN_SUBCOMMANDS`); shared test helpers: `test_support` module (under `#[cfg(test)]`) with `make_output`, `make_output_full`, `load_fixture`; private `obtain_output` (soft spawn-failure path for non-build families); private `render_output<T>`; `run_parsed_command_with_mode` (used by non-build families); dispatcher helpers `dispatch()`, `dispatch_cargo()`, `dispatch_go()`, `dispatch_swift()`, `dispatch_dotnet()`, `run_raw_passthrough()`, `passthrough_subcmd()`; `extract_subcmd`, `prepend_without`; `KNOWN_SUBCOMMANDS`
+- `crates/rskim/src/cmd/mod.rs` — (PR #267: reduced from 2,070 to ~420 lines) module declarations + re-exports of all `pub(crate)` items from sub-modules; retains shared utilities: `user_has_flag`, `inject_flag_before_separator`, `extract_show_stats`, `extract_json_flag`, `extract_output_format`, `combine_output`, `format_analytics_label`; stdin infrastructure: `should_read_stdin`, `read_bounded`, `read_stdin_bounded`, `MAX_STDIN_BYTES`; passthrough infrastructure: `is_passthrough_mode`, `check_passthrough_str`, `check_passthrough_value`; resolver: `resolve_cache_dir`; `prepend_without`, `extract_subcmd`
+- `crates/rskim/src/cmd/security.rs` — credential scrubbing: `scrub_db_args`, `sanitize_for_display`, `TokenAction` enum + `classify_token` helper (eliminated 4-level nesting)
+- `crates/rskim/src/cmd/registry.rs` — subcommand registry: `KNOWN_SUBCOMMANDS`, `META_SUBCOMMANDS`, `wrapper_targets`, `is_known_subcommand`
+- `crates/rskim/src/cmd/execution.rs` — execution pipeline: `RunContext`, `ParsedCommandConfig<'_>`, `ToolRunConfig<'_>`, `OutputFormat`, `run_tool<T>` (used by lint, db, infra, file families — NOT by build), `run_parsed_command_with_mode` (used by non-build families), `obtain_output`, `render_output<T>`, `passthrough_raw`, `record_and_report`
+- `crates/rskim/src/cmd/dispatch.rs` — top-level routing: `dispatch()`, `dispatch_cargo()`, `dispatch_go()`, `dispatch_swift()`, `dispatch_dotnet()`, `run_raw_passthrough()`, `passthrough_subcmd()`
+- `crates/rskim/src/cmd/test_support.rs` — test helpers (moved from inline `#[cfg(test)]` module): `make_output`, `make_output_full`, `make_output_stderr`, `load_fixture`; all items `pub(crate)`
 
 ## Related
 

--- a/.devflow/features/cochange/KNOWLEDGE.md
+++ b/.devflow/features/cochange/KNOWLEDGE.md
@@ -19,7 +19,7 @@ referencedFiles:
   - crates/rskim-search/src/temporal/storage_types.rs
   - crates/rskim-search/src/temporal/storage_ops.rs
 created: 2026-05-24
-updated: 2026-06-05
+updated: 2026-06-07
 ---
 
 # Co-Change Matrix
@@ -172,9 +172,11 @@ concatenated with the `PairEntry` array bytes. When a format-breaking change is 
 
 ### Atomic write contract
 
-`builder.rs` uses `tempfile::NamedTempFile::new_in(dir)`, writes all bytes, calls `sync_all()` to
-flush to storage (crash safety), and then calls `.persist(path)` (a rename) so readers never
-observe a partially written file.
+`builder.rs` delegates atomic writes to `crate::io_util::atomic_write` (PR #272 extracted the
+previously inline function into a shared helper). The helper uses `tempfile::NamedTempFile::new_in(dir)`,
+writes all bytes, calls `sync_all()` to flush to storage (crash safety), sets `0o644` permissions
+on Unix, and then calls `.persist(path)` (a rename) so readers never observe a partially written file.
+The `ast_index` store builder uses the same `atomic_write` helper.
 
 ### SQLite co-change table schema
 
@@ -250,9 +252,11 @@ DELETE + batch INSERT in a single transaction.
 - `crates/rskim-search/src/types.rs` — `FileId`, `CochangeStats`, `HistoryResult`, `SearchError`
 - `crates/rskim-search/src/index/` — sibling persistence layer using the same atomic-write and
   mmap-read patterns; useful cross-reference for format evolution precedent
-- `crates/rskim-search/src/ast_index/store/` (Wave 3d, #194) — the closest format sibling: a
-  two-file mmap'd on-disk index (magic `b"SKAX"`, v1) for AST structural n-grams, built with the
+- `crates/rskim-search/src/ast_index/store/` (Wave 3d–3f) — the closest format sibling: a
+  two-file mmap'd on-disk index (magic `b"SKAX"`, v2) for AST structural n-grams, built with the
   identical `NamedTempFile` + `sync_all` + `persist` atomic-write contract and CRC32-validated
   binary-search reader. Mirror its `format.rs`/`builder.rs`/`reader.rs` split when evolving `.skcc`.
-  Note `lib.rs` now also re-exports `AstIndexBuilder`/`AstIndexReader`/`AstPosting`/`AstFileMetaEntry`
-  alongside the cochange re-exports — no change to the cochange API surface itself.
+  As of Wave 3f (#197), `ast_index` additionally exports `AstQuery`, `AstQueryEngine`,
+  `AstPostingSource`, `parse_ast_query`, `AST_BM25_K1`, `AST_BM25_B` at both the `ast_index` and
+  crate-root levels. `Pattern`, `PatternCategory`, `StructuralMetrics`, and
+  `extract_ast_ngrams_with_metrics` remain accessible only via `rskim_search::ast_index::`.

--- a/.devflow/features/index.json
+++ b/.devflow/features/index.json
@@ -3,7 +3,7 @@
   "features": {
     "build-parsers": {
       "name": "Build Tool Output Parsers",
-      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection. NOTE: cmd/mod.rs was refactored in PR #267 — scrubbing logic is in security.rs, command execution in execution.rs, dispatch in dispatch.rs.",
+      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, check, fmt, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, run_clippy, security.rs, registry.rs, execution.rs, dispatch.rs, test_support.rs, make_output_stderr, TokenAction.",
       "directories": [
         "crates/rskim/src/cmd/build/",
         "crates/rskim/src/cmd/"
@@ -21,14 +21,16 @@
         "crates/rskim/src/cmd/execution.rs",
         "crates/rskim/src/cmd/dispatch.rs",
         "crates/rskim/src/cmd/security.rs",
+        "crates/rskim/src/cmd/registry.rs",
+        "crates/rskim/src/cmd/test_support.rs",
         "crates/rskim/src/runner.rs"
       ],
-      "lastUpdated": "2026-06-03T00:00:00.000Z",
+      "lastUpdated": "2026-06-07T10:05:21.359Z",
       "createdBy": "devflow-knowledge"
     },
     "cochange": {
       "name": "Co-Change Matrix",
-      "description": "Use when implementing co-change coupling queries, modifying the .skcc binary format, adding new query methods to CochangeMatrixReader, debugging Jaccard similarity calculations, or working with the SQLite temporal persistence layer for co-change pairs. Keywords: cochange, co-change, coupling, jaccard, skcc, binary format, cochange.skcc, CochangeMatrixBuilder, CochangeMatrixReader, CochangeRow, TemporalDb, HistoryResult, COUPLING_MAX_FILES, builder_tests, format_tests, reader_tests, test_helpers.",
+      "description": "Use when implementing co-change coupling queries, modifying the .skcc binary format, adding new query methods to CochangeMatrixReader, debugging Jaccard similarity calculations, or working with the SQLite temporal persistence layer for co-change pairs. Keywords: cochange, co-change, coupling, jaccard, skcc, binary format, cochange.skcc, CochangeMatrixBuilder, CochangeMatrixReader, CochangeRow, TemporalDb, HistoryResult, COUPLING_MAX_FILES, builder_tests, format_tests, reader_tests, test_helpers, atomic_write, io_util.",
       "directories": [
         "crates/rskim-search/src/cochange/"
       ],
@@ -47,12 +49,12 @@
         "crates/rskim-search/src/temporal/storage_types.rs",
         "crates/rskim-search/src/temporal/storage_ops.rs"
       ],
-      "lastUpdated": "2026-06-04T21:27:24.860Z",
+      "lastUpdated": "2026-06-07T16:20:48.693Z",
       "createdBy": "implement"
     },
     "temporal-scoring": {
       "name": "Temporal Risk Scoring",
-      "description": "Use when adding per-file risk metrics from git history, tuning decay parameters, integrating hotspot scores into search ranking, extending the temporal module with new scoring signals, or working with the SQLite temporal persistence layer. Keywords: temporal, hotspot, fix density, exponential decay, git history, risk scores, half-life, FileRiskScores, FileTemporalStats, compute_file_risk_scores, compute_file_temporal_stats, decay_weight, TemporalDb, storage, HotspotRow, RiskRow, CochangeRow, file_filter, SearchQuery, per-file lookup, top-N, hotspot_for_file, risk_for_file, cochanges_for_file, top_hotspots, top_risks, top_coldspots, blast-radius, storage_tests, storage_perf_tests, git_parser_tests.",
+      "description": "Use when adding per-file risk metrics from git history, tuning decay parameters, integrating hotspot scores into search ranking, extending the temporal module with new scoring signals, or working with the SQLite temporal persistence layer. Keywords: temporal, hotspot, fix density, exponential decay, git history, risk scores, half-life, FileRiskScores, FileTemporalStats, compute_file_risk_scores, compute_file_temporal_stats, decay_weight, TemporalDb, storage, HotspotRow, RiskRow, CochangeRow, file_filter, SearchQuery, per-file lookup, top-N, hotspot_for_file, risk_for_file, cochanges_for_file, top_hotspots, top_risks, top_coldspots, blast-radius, storage_tests, storage_perf_tests, git_parser_tests, META_GIT_HEAD, META_LAST_UPDATED.",
       "directories": [
         "crates/rskim-search/src/temporal/"
       ],
@@ -70,12 +72,12 @@
         "crates/rskim-search/src/types.rs",
         "crates/rskim-search/src/lib.rs"
       ],
-      "lastUpdated": "2026-06-04T21:27:34.451Z",
+      "lastUpdated": "2026-06-07T16:20:40.949Z",
       "createdBy": "implement"
     },
     "ast-index": {
       "name": "AST Index (CST Linearization + N-gram Encoding + On-Disk Store)",
-      "description": "Use when implementing AST-based n-gram extraction, building or reading the on-disk structural index, adding a new language to the structural index, debugging depth or node-count truncation, extending the shared vocabulary, working with AstBigram/AstTrigram IDF weights, extracting structural n-grams from linearized nodes, or using the shared AstWalkIter traversal primitive. Keywords: linearize, CST, AST, n-gram, bigram, trigram, NodeKindId, AstBigram, AstTrigram, AstNgramSet, AstBigramEntry, AstTrigramEntry, NODE_KIND_VOCABULARY, LANG_MAPS, LinearNode, AstWalkIter, AstWalkConfig, tree-sitter, depth-encoded, pre-order, IDF, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_weights, store, AstIndexBuilder, AstIndexReader, AstPosting, AstFileMetaEntry, skidx, skpost, SKAX, on-disk index, mmap, posting list, build_from_files, lookup_bigram, lookup_trigram.",
+      "description": "Use when implementing AST-based n-gram extraction, building or reading the on-disk structural index, adding a new language to the structural index, debugging depth or node-count truncation, extending the shared vocabulary, working with AstBigram/AstTrigram IDF weights, extracting structural n-grams or structural metrics from linearized nodes, using the Pattern Library (structural code patterns), using the shared AstWalkIter traversal primitive, or working with the Wave 3f BM25-ranked AST structural query engine (AstQueryEngine, AstQuery, parse_ast_query, AstPostingSource). Keywords: linearize, CST, AST, n-gram, bigram, trigram, NodeKindId, AstBigram, AstTrigram, AstNgramSet, AstBigramEntry, AstTrigramEntry, NODE_KIND_VOCABULARY, LANG_MAPS, LinearNode, AstWalkIter, AstWalkConfig, tree-sitter, depth-encoded, pre-order, IDF, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights, StructuralMetrics, structural, Pattern, patterns, EMPTY_BODY, DEEP_NODE, LARGE_BODY, MANY_PARAMS, bucket_label, synthetic n-gram, store, AstIndexBuilder, AstIndexReader, AstPosting, AstFileMetaEntry, skidx, skpost, SKAX, FORMAT_VERSION, on-disk index, mmap, posting list, build_from_files, lookup_bigram, lookup_trigram, index_version, AstQuery, AstQueryEngine, AstPostingSource, parse_ast_query, search_ast, AST_BM25_K1, AST_BM25_B, query.rs, Wave 3f.",
       "directories": [
         "crates/rskim-search/src/ast_index/",
         "crates/rskim-core/src/"
@@ -86,6 +88,9 @@
         "crates/rskim-search/src/ast_index/linearize.rs",
         "crates/rskim-search/src/ast_index/ngram.rs",
         "crates/rskim-search/src/ast_index/extract.rs",
+        "crates/rskim-search/src/ast_index/structural.rs",
+        "crates/rskim-search/src/ast_index/patterns.rs",
+        "crates/rskim-search/src/ast_index/query.rs",
         "crates/rskim-search/src/ast_index/mod.rs",
         "crates/rskim-search/src/ast_index/store/format.rs",
         "crates/rskim-search/src/ast_index/store/builder.rs",
@@ -93,9 +98,10 @@
         "crates/rskim-search/src/ast_index/store/mod.rs",
         "crates/rskim-search/src/ast_weights.rs",
         "crates/rskim-search/src/lib.rs",
-        "crates/rskim-search/benches/ast_index_bench.rs"
+        "crates/rskim-search/benches/ast_index_bench.rs",
+        "crates/rskim-search/benches/ast_query.rs"
       ],
-      "lastUpdated": "2026-06-05T10:05:57.000Z",
+      "lastUpdated": "2026-06-07T16:20:31.320Z",
       "createdBy": "implement"
     }
   }

--- a/.devflow/features/temporal-scoring/KNOWLEDGE.md
+++ b/.devflow/features/temporal-scoring/KNOWLEDGE.md
@@ -17,8 +17,8 @@ referencedFiles:
   - crates/rskim-search/src/types.rs
   - crates/rskim-search/src/lib.rs
 created: 2026-06-01
-updated: 2026-06-01
-version: 1
+updated: 2026-06-07
+version: 3
 ---
 
 # Temporal Risk Scoring
@@ -178,6 +178,19 @@ Migrations are forward-only, driven by `PRAGMA user_version`:
 
 Current version is **v2** (v1: tables, v2: performance indexes).
 
+### Meta Table Constants
+
+Two public string constants are defined in `storage.rs` and re-exported at the crate root:
+
+```rust
+pub const META_LAST_UPDATED: &str = "last_updated";  // Unix timestamp written by sync
+pub const META_GIT_HEAD: &str = "git_head";           // Commit SHA written by sync
+```
+
+These are the only keys written by `TemporalDb::sync`. External callers reading the `meta`
+table should use these constants rather than inline strings. Both are exported via
+`rskim_search::temporal::storage::{META_GIT_HEAD, META_LAST_UPDATED}` and at the crate root.
+
 ### `TemporalDb::sync`
 
 ```rust
@@ -190,7 +203,7 @@ pub fn sync(
 ) -> Result<()>
 ```
 
-Atomically replaces all three tables in a single transaction: DELETE + batch INSERT for hotspot, risk, and cochange. Also writes `git_head` to the `meta` table. This is the preferred way to update all signals together — it ensures no partial state is visible.
+Atomically replaces all three tables in a single transaction: DELETE + batch INSERT for hotspot, risk, and cochange. Also writes `git_head` to `META_GIT_HEAD` and a Unix timestamp to `META_LAST_UPDATED` in the `meta` table. This is the preferred way to update all signals together — it ensures no partial state is visible.
 
 ### Point Queries
 
@@ -224,7 +237,7 @@ Atomically replaces all three tables in a single transaction: DELETE + batch INS
 - `crates/rskim-search/src/temporal/scoring_tests.rs` — unit tests for decay formula and file score aggregation
 - `crates/rskim-search/src/temporal/mod.rs` — public re-exports; `is_fix_commit` keyword classifier
 - `crates/rskim-search/src/temporal/git_parser.rs` — `GixSource` (gix-based git history reader producing `HistoryResult`)
-- `crates/rskim-search/src/temporal/storage.rs` — `TemporalDb` struct, `open`, `schema_version`, migration runner
+- `crates/rskim-search/src/temporal/storage.rs` — `TemporalDb` struct, `open`, `schema_version`, migration runner; `META_GIT_HEAD` and `META_LAST_UPDATED` public constants
 - `crates/rskim-search/src/temporal/storage_ops.rs` — all query and mutation methods for `TemporalDb` (impl block continues from storage.rs)
 - `crates/rskim-search/src/temporal/storage_types.rs` — `HotspotRow`, `RiskRow`, `CochangeRow` row structs
 - `crates/rskim-search/src/temporal/storage_tests.rs` — integration tests against in-memory SQLite
@@ -244,11 +257,12 @@ Atomically replaces all three tables in a single transaction: DELETE + batch INS
 - `compute_file_risk_scores` per-deduplicates changed files within each commit via `dedup_changed_files` (private helper). Without this, a commit with renames would count the same file twice.
 - Schema version mismatch returns `SearchError::Database(...)`, not `IndexCorrupted`. Rebuild by deleting `temporal.db`.
 - `top_coldspots` returns rows sorted by `score ASC` — not the inverse of `top_hotspots` sort, but an explicit ascending sort. Files with score 0.0 come first.
-- The `meta` table stores arbitrary key-value strings; `git_head` is the only key written by `TemporalDb::sync`. Future callers may add their own keys without schema migration.
+- The `meta` table stores arbitrary key-value strings. `TemporalDb::sync` writes two keys: `META_GIT_HEAD` (commit SHA) and `META_LAST_UPDATED` (Unix timestamp as a string). Future callers may add their own keys without schema migration, but should avoid these reserved key names.
 - `changes_30d` and `changes_90d` are raw counts — they are NOT decay-weighted and do NOT correlate with `score`. A file may have `score = 0.9` but `changes_30d = 0` if all its commits were just outside the 30-day window.
 
 ## Related
 
 - `crates/rskim-search/src/cochange/` — sibling module; both consume `HistoryResult`; co-change data shares the same `temporal.db` file via the `cochange` table
 - `crates/rskim-search/src/types.rs` — `HistoryResult`, `CommitInfo`, `FileId`, `SearchError`
+- `crates/rskim-search/src/io_util.rs` — `atomic_write` shared helper; used by the cochange builder and the AST index store builder (not by `TemporalDb` which uses rusqlite transactions instead)
 - Temporal CLI flags: `skim search --hot`, `--cold`, `--risky`, `--blast-radius FILE` — all backed by `TemporalDb` queries at search time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,7 @@ dependencies = [
  "regex",
  "rskim-core",
  "rusqlite",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ memmap2 = "0.9"
 crc32fast = "1.4"
 insta = "1.39"
 criterion = "0.5"
+# Pinned to 1.x (not 2.x) to unify with tiktoken-rs's transitive rustc-hash ^1.1.0
+# requirement — bumping to 2.x would force two major versions into the binary for
+# a zero-functional-gain hasher swap.  Review when tiktoken-rs drops the 1.x pin.
+rustc-hash = "1"
 serial_test = "3.0"
 libc = "0.2"
 filetime = "0.2"

--- a/crates/rskim-search/Cargo.toml
+++ b/crates/rskim-search/Cargo.toml
@@ -39,6 +39,10 @@ harness = false
 name = "ast_index_bench"
 harness = false
 
+[[bench]]
+name = "ast_query"
+harness = false
+
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"

--- a/crates/rskim-search/Cargo.toml
+++ b/crates/rskim-search/Cargo.toml
@@ -26,6 +26,7 @@ gix = { workspace = true }
 regex = { workspace = true }
 rusqlite = { workspace = true }
 rayon = { workspace = true }
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/rskim-search/Cargo.toml
+++ b/crates/rskim-search/Cargo.toml
@@ -26,7 +26,7 @@ gix = { workspace = true }
 regex = { workspace = true }
 rusqlite = { workspace = true }
 rayon = { workspace = true }
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -41,7 +41,7 @@ name = "ast_index_bench"
 harness = false
 
 [[bench]]
-name = "ast_query"
+name = "ast_query_bench"
 harness = false
 
 [lints.clippy]

--- a/crates/rskim-search/benches/ast_query.rs
+++ b/crates/rskim-search/benches/ast_query.rs
@@ -5,9 +5,11 @@
 //! Goal: `search_ast` over a 10k-file synthetic index < 100ms (C1).
 //!
 //! Benchmark groups:
-//!   1. hot_bigram        — query a bigram present in every file
-//!   2. rare_trigram      — query a trigram in few files
-//!   3. multi_ngram       — query a multi-n-gram pattern (try-catch)
+//!   1. hot_bigram             — query a bigram present in every file (single lang)
+//!   2. hot_bigram_mixed_lang  — same bigram over a mixed-language corpus (exercises IDF cache)
+//!   3. rare_trigram           — query a trigram in few files
+//!   4. multi_ngram            — query a multi-n-gram pattern (try-catch)
+//!   5. multi_ngram_overlap    — multi-n-gram with bigram+trigram overlap (exercises meta_cache)
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -16,14 +18,14 @@ use rskim_core::Language;
 use rskim_search::{
     AstIndexBuilder, FileId,
     ast_index::{
-        AstBigram, AstBigramEntry, AstNgramSet, AstQueryEngine, AstTrigram, AstTrigramEntry,
-        DEFAULT_AST_WEIGHT, StructuralMetrics, parse_ast_query, vocab_lookup,
+        AstBigram, AstBigramEntry, AstNgramSet, AstQuery, AstQueryEngine, AstTrigram,
+        AstTrigramEntry, DEFAULT_AST_WEIGHT, StructuralMetrics, parse_ast_query, vocab_lookup,
     },
 };
 use tempfile::TempDir;
 
 // ============================================================================
-// Synthetic index builder
+// Synthetic index builder helpers
 // ============================================================================
 
 /// Build a synthetic index with `n` Rust files, each containing the given
@@ -50,6 +52,47 @@ fn build_index_with_bigram(
             .add_file_ngrams(
                 FileId(i as u32),
                 Language::Rust,
+                &set,
+                100,
+                StructuralMetrics::default(),
+            )
+            .unwrap();
+    }
+
+    let reader = builder.build().unwrap();
+    (dir, reader)
+}
+
+/// Build a synthetic index with `n` files, cycling through Rust/Python/Go/Java
+/// languages. Each file contains the given bigram (count=1). This exercises the
+/// per-n-gram IDF last-value cache over multiple distinct languages.
+fn build_index_mixed_language(
+    n: usize,
+    bigram: AstBigram,
+) -> (TempDir, rskim_search::ast_index::AstIndexReader) {
+    let langs = [
+        Language::Rust,
+        Language::Python,
+        Language::Go,
+        Language::Java,
+    ];
+    let dir = TempDir::new().unwrap();
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+
+    for i in 0..n {
+        let lang = langs[i % langs.len()];
+        let set = AstNgramSet {
+            bigrams: vec![AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1 + (i as u32 % 5),
+            }],
+            trigrams: vec![],
+        };
+        builder
+            .add_file_ngrams(
+                FileId(i as u32),
+                lang,
                 &set,
                 100,
                 StructuralMetrics::default(),
@@ -102,8 +145,47 @@ fn build_index_with_rare_trigram(
     (dir, reader)
 }
 
+/// Build a synthetic index with `n` Rust files, each containing BOTH
+/// the given bigram and trigram. This exercises the meta_cache cross-n-gram
+/// hit path: scoring two n-grams means the same file_meta is requested twice.
+fn build_index_with_bigram_and_trigram(
+    n: usize,
+    bigram: AstBigram,
+    trigram: AstTrigram,
+) -> (TempDir, rskim_search::ast_index::AstIndexReader) {
+    let dir = TempDir::new().unwrap();
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+
+    for i in 0..n {
+        let set = AstNgramSet {
+            bigrams: vec![AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 2 + (i as u32 % 3),
+            }],
+            trigrams: vec![AstTrigramEntry {
+                ngram: trigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1 + (i as u32 % 2),
+            }],
+        };
+        builder
+            .add_file_ngrams(
+                FileId(i as u32),
+                Language::Rust,
+                &set,
+                100,
+                StructuralMetrics::default(),
+            )
+            .unwrap();
+    }
+
+    let reader = builder.build().unwrap();
+    (dir, reader)
+}
+
 // ============================================================================
-// Bench: hot bigram (all 10k files match)
+// Bench: hot bigram (all 10k files match, single language)
 // ============================================================================
 
 fn bench_hot_bigram(c: &mut Criterion) {
@@ -118,6 +200,32 @@ fn bench_hot_bigram(c: &mut Criterion) {
     let mut group = c.benchmark_group("ast_query");
     group.sample_size(10);
     group.bench_function("hot_bigram_10k_files", |b| {
+        b.iter(|| engine.search_ast(black_box(&q)).unwrap())
+    });
+    group.finish();
+}
+
+// ============================================================================
+// Bench: hot bigram (all 10k files match, mixed languages)
+//
+// Exercises the per-n-gram IDF last-value cache: with 4 cycling languages,
+// the cache must update on each language transition rather than hitting on
+// every posting. This reveals the actual IDF cache cost masked by single-lang
+// benchmarks.
+// ============================================================================
+
+fn bench_hot_bigram_mixed_lang(c: &mut Criterion) {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let (_dir, reader) = build_index_mixed_language(10_000, bigram);
+    let engine = AstQueryEngine::new(reader);
+    let q = parse_ast_query("function_item > block").unwrap();
+
+    let mut group = c.benchmark_group("ast_query");
+    group.sample_size(10);
+    group.bench_function("hot_bigram_mixed_lang_10k_files", |b| {
         b.iter(|| engine.search_ast(black_box(&q)).unwrap())
     });
     group.finish();
@@ -169,13 +277,56 @@ fn bench_multi_ngram_pattern(c: &mut Criterion) {
 }
 
 // ============================================================================
+// Bench: multi-n-gram with bigram+trigram overlap (exercises meta_cache)
+//
+// Every file has both the bigram and trigram, so scoring them both exercises
+// the cross-n-gram meta_cache hit path. This scenario was absent from the
+// original bench, masking the meta_cache cost.
+// ============================================================================
+
+fn bench_multi_ngram_overlap(c: &mut Criterion) {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let expr_id = vocab_lookup("expression_statement").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+    let trigram = AstTrigram::encode(fn_id, block_id, expr_id);
+
+    let (_dir, reader) = build_index_with_bigram_and_trigram(10_000, bigram, trigram);
+    let engine = AstQueryEngine::new(reader);
+
+    // Build a query set with both the bigram and trigram.
+    let set = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![AstTrigramEntry {
+            ngram: trigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+    };
+    let q = AstQuery::Containment(set);
+
+    let mut group = c.benchmark_group("ast_query");
+    group.sample_size(10);
+    group.bench_function("multi_ngram_overlap_10k_files", |b| {
+        b.iter(|| engine.search_ast(black_box(&q)).unwrap())
+    });
+    group.finish();
+}
+
+// ============================================================================
 // Criterion main
 // ============================================================================
 
 criterion_group!(
     benches,
     bench_hot_bigram,
+    bench_hot_bigram_mixed_lang,
     bench_rare_trigram,
-    bench_multi_ngram_pattern
+    bench_multi_ngram_pattern,
+    bench_multi_ngram_overlap,
 );
 criterion_main!(benches);

--- a/crates/rskim-search/benches/ast_query.rs
+++ b/crates/rskim-search/benches/ast_query.rs
@@ -1,0 +1,181 @@
+//! Criterion benchmarks for Wave 3f: AST Structural Pattern Query Engine.
+//!
+//! Run with: cargo bench -p rskim-search --bench ast_query
+//!
+//! Goal: `search_ast` over a 10k-file synthetic index < 100ms (C1).
+//!
+//! Benchmark groups:
+//!   1. hot_bigram        — query a bigram present in every file
+//!   2. rare_trigram      — query a trigram in few files
+//!   3. multi_ngram       — query a multi-n-gram pattern (try-catch)
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rskim_core::Language;
+use rskim_search::{
+    AstIndexBuilder, FileId,
+    ast_index::{
+        AstBigram, AstBigramEntry, AstNgramSet, AstQueryEngine, AstTrigram, AstTrigramEntry,
+        DEFAULT_AST_WEIGHT, StructuralMetrics, parse_ast_query, vocab_lookup,
+    },
+};
+use tempfile::TempDir;
+
+// ============================================================================
+// Synthetic index builder
+// ============================================================================
+
+/// Build a synthetic index with `n` Rust files, each containing the given
+/// bigram (count=1) and node_count=100.
+///
+/// Returns the TempDir (keep alive) and the opened reader.
+fn build_index_with_bigram(
+    n: usize,
+    bigram: AstBigram,
+) -> (TempDir, rskim_search::ast_index::AstIndexReader) {
+    let dir = TempDir::new().unwrap();
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+
+    for i in 0..n {
+        let set = AstNgramSet {
+            bigrams: vec![AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1 + (i as u32 % 5),
+            }],
+            trigrams: vec![],
+        };
+        builder
+            .add_file_ngrams(
+                FileId(i as u32),
+                Language::Rust,
+                &set,
+                100,
+                StructuralMetrics::default(),
+            )
+            .unwrap();
+    }
+
+    let reader = builder.build().unwrap();
+    (dir, reader)
+}
+
+/// Build a synthetic index with `n` Rust files.
+/// Every 10th file contains the given trigram in addition to the bigram.
+fn build_index_with_rare_trigram(
+    n: usize,
+    bigram: AstBigram,
+    trigram: AstTrigram,
+) -> (TempDir, rskim_search::ast_index::AstIndexReader) {
+    let dir = TempDir::new().unwrap();
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+
+    for i in 0..n {
+        let mut set = AstNgramSet {
+            bigrams: vec![AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1,
+            }],
+            trigrams: vec![],
+        };
+        if i % 10 == 0 {
+            set.trigrams.push(AstTrigramEntry {
+                ngram: trigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1,
+            });
+        }
+        builder
+            .add_file_ngrams(
+                FileId(i as u32),
+                Language::Rust,
+                &set,
+                100,
+                StructuralMetrics::default(),
+            )
+            .unwrap();
+    }
+
+    let reader = builder.build().unwrap();
+    (dir, reader)
+}
+
+// ============================================================================
+// Bench: hot bigram (all 10k files match)
+// ============================================================================
+
+fn bench_hot_bigram(c: &mut Criterion) {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let (_dir, reader) = build_index_with_bigram(10_000, bigram);
+    let engine = AstQueryEngine::new(reader);
+    let q = parse_ast_query("function_item > block").unwrap();
+
+    let mut group = c.benchmark_group("ast_query");
+    group.sample_size(10);
+    group.bench_function("hot_bigram_10k_files", |b| {
+        b.iter(|| engine.search_ast(black_box(&q)).unwrap())
+    });
+    group.finish();
+}
+
+// ============================================================================
+// Bench: rare trigram (~1k/10k files match)
+// ============================================================================
+
+fn bench_rare_trigram(c: &mut Criterion) {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let expr_id = vocab_lookup("expression_statement").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+    let trigram = AstTrigram::encode(fn_id, block_id, expr_id);
+
+    let (_dir, reader) = build_index_with_rare_trigram(10_000, bigram, trigram);
+    let engine = AstQueryEngine::new(reader);
+    let q = parse_ast_query("function_item > block > expression_statement").unwrap();
+
+    let mut group = c.benchmark_group("ast_query");
+    group.sample_size(10);
+    group.bench_function("rare_trigram_10k_files", |b| {
+        b.iter(|| engine.search_ast(black_box(&q)).unwrap())
+    });
+    group.finish();
+}
+
+// ============================================================================
+// Bench: multi-n-gram named pattern (try-catch)
+// ============================================================================
+
+fn bench_multi_ngram_pattern(c: &mut Criterion) {
+    // Build index with the try-catch bigram: try_statement → catch_clause.
+    let try_id = vocab_lookup("try_statement").unwrap();
+    let catch_id = vocab_lookup("catch_clause").unwrap();
+    let bigram = AstBigram::encode(try_id, catch_id);
+
+    let (_dir, reader) = build_index_with_bigram(10_000, bigram);
+    let engine = AstQueryEngine::new(reader);
+    let q = parse_ast_query("try-catch").unwrap();
+
+    let mut group = c.benchmark_group("ast_query");
+    group.sample_size(10);
+    group.bench_function("multi_ngram_pattern_10k_files", |b| {
+        b.iter(|| engine.search_ast(black_box(&q)).unwrap())
+    });
+    group.finish();
+}
+
+// ============================================================================
+// Criterion main
+// ============================================================================
+
+criterion_group!(
+    benches,
+    bench_hot_bigram,
+    bench_rare_trigram,
+    bench_multi_ngram_pattern
+);
+criterion_main!(benches);

--- a/crates/rskim-search/benches/ast_query_bench.rs
+++ b/crates/rskim-search/benches/ast_query_bench.rs
@@ -1,6 +1,6 @@
 //! Criterion benchmarks for Wave 3f: AST Structural Pattern Query Engine.
 //!
-//! Run with: cargo bench -p rskim-search --bench ast_query
+//! Run with: cargo bench -p rskim-search --bench ast_query_bench
 //!
 //! Goal: `search_ast` over a 10k-file synthetic index < 100ms (C1).
 //!

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -33,6 +33,7 @@ mod extract;
 mod linearize;
 mod ngram;
 mod patterns;
+pub mod query;
 mod store;
 pub(crate) mod structural;
 
@@ -60,5 +61,8 @@ pub use ngram::{
     vocab_lookup, vocab_resolve,
 };
 pub use patterns::{Pattern, PatternCategory, all_patterns, lookup_pattern, pattern_to_query_set};
+pub use query::{
+    AST_BM25_B, AST_BM25_K1, AstPostingSource, AstQuery, AstQueryEngine, parse_ast_query,
+};
 pub use store::{AstFileMetaEntry, AstIndexBuilder, AstIndexReader, AstPosting};
 pub use structural::StructuralMetrics;

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -28,7 +28,8 @@ pub const AST_BM25_K1: f64 = 1.2;
 /// BM25 length-normalisation parameter b for AST structural scoring.
 pub const AST_BM25_B: f64 = 0.75;
 /// Maximum allowed byte length for a raw query string (reliability bound).
-const MAX_AST_QUERY_BYTES: usize = 4096;
+/// Aliased from [`crate::lexical::MAX_QUERY_BYTES`] so both layers share one source of truth.
+const MAX_AST_QUERY_BYTES: usize = crate::lexical::MAX_QUERY_BYTES;
 
 /// Shared error message for empty query strings — used in both `SearchLayer::search`
 /// and `parse_ast_query` so the two sites cannot silently drift.
@@ -73,6 +74,11 @@ impl PartialEq for AstQuery {
 /// value. `node_count` values in `AstFileMetaEntry` MUST be non-negative.
 /// The production reader validates these at header/entry decode time; custom
 /// implementations must uphold the same contract.
+///
+/// **Count contract (C4).** `count` in every returned [`AstPosting`] MUST be
+/// `>= 1`. Sources returning `count == 0` break the all-scores-positive
+/// invariant (`count >= 1 → tf > 0 → score > 0`) relied on by BM25 and the
+/// `debug_assert!` in [`AstQueryEngine::run_ngram_set`].
 pub trait AstPostingSource: Send + Sync {
     /// Look up postings for an [`AstBigram`]; `Ok(vec![])` when absent (C2).
     fn lookup_bigram(&self, b: AstBigram) -> Result<Vec<AstPosting>>;
@@ -233,7 +239,23 @@ impl SearchLayer for AstQueryEngine<AstIndexReader> {
     /// `ast_pattern = Some(s)` → parse + execute; apply filters; return score-DESC results.
     /// Filters (in order): `file_filter` allowlist, `lang`, `offset`/`limit`.
     /// Defaults: `offset` → 0, `limit` → 20 (results truncated when unset).
+    ///
+    /// `bm25f_config` is intentionally ignored: the AST layer uses its own BM25
+    /// parameterisation ([`AST_BM25_K1`] / [`AST_BM25_B`]) and the lexical BM25F
+    /// config has no meaning here.
+    ///
+    /// # Errors
+    /// Returns [`SearchError::InvalidQuery`] when `temporal_flags` is set —
+    /// temporal sorting is not yet supported on the AST layer (deferred to Wave 4).
     fn search(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
+        if query.temporal_flags.is_some() {
+            return Err(SearchError::InvalidQuery(
+                "temporal sorting (--hot / --cold / --risky) is not yet supported on the AST \
+                 layer; omit temporal flags or use the lexical search layer"
+                    .into(),
+            ));
+        }
+
         let raw = match &query.ast_pattern {
             None => return Ok(vec![]),
             Some(s) => s,
@@ -362,6 +384,7 @@ fn parse_bigram(a: &str, b: &str) -> Result<AstQuery> {
     Ok(AstQuery::Containment(AstNgramSet {
         bigrams: vec![AstBigramEntry {
             ngram: bigram,
+            // weight/count unused on query path; meaningful only at index build.
             weight: DEFAULT_AST_WEIGHT,
             count: 1,
         }],
@@ -375,6 +398,7 @@ fn parse_trigram(a: &str, b: &str, c: &str) -> Result<AstQuery> {
         bigrams: vec![],
         trigrams: vec![AstTrigramEntry {
             ngram: trigram,
+            // weight/count unused on query path; meaningful only at index build.
             weight: DEFAULT_AST_WEIGHT,
             count: 1,
         }],
@@ -390,6 +414,10 @@ fn kind(seg: &str) -> Result<NodeKindId> {
         ))
     })
 }
+
+/// IDF fallback for files whose language byte is unrecognised (neutral weight —
+/// does not amplify or suppress the BM25 term-frequency contribution).
+const UNKNOWN_LANG_IDF: f64 = 1.0;
 
 // Scoring helpers
 
@@ -412,7 +440,7 @@ fn score_postings<R: AstPostingSource>(
     // Per-n-gram IDF memoization: at most one distinct value per language.
     // Avoid HashMap overhead — track only the last seen (lang, idf) pair.
     let mut last_lang: Option<Language> = None;
-    let mut last_idf: f64 = 1.0;
+    let mut last_idf: f64 = UNKNOWN_LANG_IDF;
 
     for posting in postings {
         let meta = match meta_cache {
@@ -430,7 +458,7 @@ fn score_postings<R: AstPostingSource>(
                     v
                 }
             }
-            None => 1.0,
+            None => UNKNOWN_LANG_IDF,
         };
         *scores.entry(posting.doc_id).or_insert(0.0) += bm25_with_idf(posting, &meta, avg, idf);
     }
@@ -446,6 +474,10 @@ fn bm25_with_idf(posting: &AstPosting, meta: &AstFileMetaEntry, avg: f64, idf: f
     debug_assert!(
         avg.is_finite(),
         "avg_node_count must be finite (AstPostingSource contract)"
+    );
+    debug_assert!(
+        idf.is_finite() && idf > 0.0,
+        "idf must be finite and positive (language IDF contract)"
     );
     // Release-safe fallback: treat non-finite avg as 0 → length_norm=1.0.
     let avg = if avg.is_finite() { avg } else { 0.0 };

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 
 // BM25 constants
-
 /// BM25 saturation parameter k1 for AST structural scoring.
 pub const AST_BM25_K1: f64 = 1.2;
 /// BM25 length-normalisation parameter b for AST structural scoring.
@@ -31,7 +30,6 @@ pub const AST_BM25_B: f64 = 0.75;
 const MAX_AST_QUERY_BYTES: usize = 4096;
 
 // Query enum
-
 /// A parsed, validated AST structural query.
 ///
 /// Created exclusively via [`parse_ast_query`] — the only `String → AstQuery`
@@ -58,7 +56,6 @@ impl PartialEq for AstQuery {
 }
 
 // DI seam
-
 /// Dependency-injection seam: implemented by [`AstIndexReader`] and test fakes.
 pub trait AstPostingSource: Send + Sync {
     /// Look up postings for an [`AstBigram`]; `Ok(vec![])` when absent (C2).
@@ -92,7 +89,6 @@ impl AstPostingSource for AstIndexReader {
 }
 
 // Query engine
-
 /// AST structural pattern query engine. Immutable; `&self`-only; `Send + Sync`.
 ///
 /// Use [`AstQueryEngine::new`] for DI (tests, Wave 4) or
@@ -136,10 +132,23 @@ impl<R: AstPostingSource> AstQueryEngine<R> {
         // Per-call meta cache: manual check-then-insert (or_insert_with can't propagate Result).
         let mut meta_cache: HashMap<u32, AstFileMetaEntry> = HashMap::new();
 
-        // AstNgramSet invariant: bigrams/trigrams are sorted-unique by key.
-        // debug_assert omitted here; enforced by the set construction site.
+        // Gap-fix #6: dedup by key (entries are sorted; O(n); prevents double-scoring dups).
+        let mut bigrams: Vec<&AstBigramEntry> = set.bigrams.iter().collect();
+        bigrams.dedup_by_key(|e| e.ngram.key());
+        debug_assert!({
+            bigrams
+                .windows(2)
+                .all(|w| w[0].ngram.key() != w[1].ngram.key())
+        });
+        let mut trigrams: Vec<&AstTrigramEntry> = set.trigrams.iter().collect();
+        trigrams.dedup_by_key(|e| e.ngram.key());
+        debug_assert!({
+            trigrams
+                .windows(2)
+                .all(|w| w[0].ngram.key() != w[1].ngram.key())
+        });
 
-        for entry in &set.bigrams {
+        for entry in bigrams {
             for posting in self.reader.lookup_bigram(entry.ngram)? {
                 let meta = cached_meta(&self.reader, &mut meta_cache, posting.doc_id)?;
                 // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
@@ -149,7 +158,7 @@ impl<R: AstPostingSource> AstQueryEngine<R> {
                 });
             }
         }
-        for entry in &set.trigrams {
+        for entry in trigrams {
             for posting in self.reader.lookup_trigram(entry.ngram)? {
                 let meta = cached_meta(&self.reader, &mut meta_cache, posting.doc_id)?;
                 // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
@@ -183,7 +192,6 @@ impl AstQueryEngine<AstIndexReader> {
 }
 
 // SearchLayer adapter (Wave 3g)
-
 impl SearchLayer for AstQueryEngine<AstIndexReader> {
     /// `ast_pattern = None` → `Ok(vec![])` (Wave-4 no-op).
     /// `ast_pattern = Some("")` → `Err(InvalidQuery("empty AST query"))`.
@@ -220,7 +228,7 @@ impl SearchLayer for AstQueryEngine<AstIndexReader> {
             hits
         };
 
-        // Sort score-DESC, FileId-ASC tie-break (NaN-safe; mirrors lexical reader.rs ~406).
+        // Sort score-DESC, FileId-ASC tie-break (NaN-safe; mirrors index/reader.rs ~406).
         filtered.sort_unstable_by(|a, b| {
             b.1.partial_cmp(&a.1)
                 .unwrap_or(Ordering::Equal)
@@ -248,7 +256,6 @@ impl SearchLayer for AstQueryEngine<AstIndexReader> {
 }
 
 // Parser
-
 /// Parse a raw string into an [`AstQuery`].
 ///
 /// **Only** `String → AstQuery` boundary; total (never panics). Rejects
@@ -349,7 +356,6 @@ fn kind(seg: &str) -> Result<NodeKindId> {
 }
 
 // Scoring helpers
-
 /// BM25 score contribution for one n-gram posting.
 ///
 /// IDF = 1.0 when `meta.language()` is `None` (unknown lang fallback).

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -5,10 +5,9 @@
 //! Wave-3g [`SearchLayer`] adapter.
 
 use std::cmp::Ordering;
-use std::hash::BuildHasherDefault;
 use std::path::Path;
 
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::FxHashMap;
 
 use rskim_core::Language;
 
@@ -149,10 +148,8 @@ impl<R: AstPostingSource> AstQueryEngine<R> {
 
         // Use FxHashMap (integer keys, trusted in-range doc_ids) with a capacity
         // hint to avoid rehashing on the hot insert path.
-        let mut scores: FxHashMap<u32, f64> = FxHashMap::with_capacity_and_hasher(
-            capacity,
-            BuildHasherDefault::<FxHasher>::default(),
-        );
+        let mut scores: FxHashMap<u32, f64> =
+            FxHashMap::with_capacity_and_hasher(capacity, Default::default());
 
         // Gap-fix #6: dedup by key (entries are sorted; O(n); prevents double-scoring dups).
         let mut bigrams: Vec<&AstBigramEntry> = set.bigrams.iter().collect();
@@ -178,7 +175,7 @@ impl<R: AstPostingSource> AstQueryEngine<R> {
         let mut meta_cache: Option<FxHashMap<u32, AstFileMetaEntry>> = if total_ngrams > 1 {
             Some(FxHashMap::with_capacity_and_hasher(
                 capacity,
-                BuildHasherDefault::<FxHasher>::default(),
+                Default::default(),
             ))
         } else {
             None

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -370,9 +370,6 @@ fn bm25(
         if n <= 0.0 { 1.0 } else { n }
     };
     let tf_norm = tf / ln;
-    if tf_norm == 0.0 {
-        return 0.0;
-    }
     idf * (tf_norm / (tf_norm + AST_BM25_K1))
 }
 

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -5,8 +5,10 @@
 //! Wave-3g [`SearchLayer`] adapter.
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
 use std::path::Path;
+
+use rustc_hash::{FxHashMap, FxHasher};
 
 use rskim_core::Language;
 
@@ -28,6 +30,10 @@ pub const AST_BM25_K1: f64 = 1.2;
 pub const AST_BM25_B: f64 = 0.75;
 /// Maximum allowed byte length for a raw query string (reliability bound).
 const MAX_AST_QUERY_BYTES: usize = 4096;
+
+/// Shared error message for empty query strings — used in both `SearchLayer::search`
+/// and `parse_ast_query` so the two sites cannot silently drift.
+const EMPTY_QUERY_MSG: &str = "empty AST query";
 
 // Query enum
 /// A parsed, validated AST structural query.
@@ -57,6 +63,17 @@ impl PartialEq for AstQuery {
 
 // DI seam
 /// Dependency-injection seam: implemented by [`AstIndexReader`] and test fakes.
+///
+/// **Value-type coupling is intentional and bounded.** `AstPosting` and
+/// `AstFileMetaEntry` are deliberately treated as the stable query-layer value
+/// contract — they are `Copy`, gix-free, and mmap-free — so coupling to them
+/// is bounded and intentional, mirroring the "free of gix types" note on
+/// `CommitInfo` in `types.rs`.
+///
+/// **Finiteness contract.** `avg_node_count()` MUST return a finite, non-NaN
+/// value. `node_count` values in `AstFileMetaEntry` MUST be non-negative.
+/// The production reader validates these at header/entry decode time; custom
+/// implementations must uphold the same contract.
 pub trait AstPostingSource: Send + Sync {
     /// Look up postings for an [`AstBigram`]; `Ok(vec![])` when absent (C2).
     fn lookup_bigram(&self, b: AstBigram) -> Result<Vec<AstPosting>>;
@@ -64,7 +81,7 @@ pub trait AstPostingSource: Send + Sync {
     fn lookup_trigram(&self, t: AstTrigram) -> Result<Vec<AstPosting>>;
     /// Per-file metadata for `doc_id`; `Err(IndexCorrupted)` when out of range.
     fn file_meta(&self, doc_id: u32) -> Result<AstFileMetaEntry>;
-    /// Average per-file node count across the corpus.
+    /// Average per-file node count across the corpus. MUST be finite and non-NaN.
     fn avg_node_count(&self) -> f32;
     /// Total number of files in the index.
     fn file_count(&self) -> u32;
@@ -72,19 +89,19 @@ pub trait AstPostingSource: Send + Sync {
 
 impl AstPostingSource for AstIndexReader {
     fn lookup_bigram(&self, b: AstBigram) -> Result<Vec<AstPosting>> {
-        self.lookup_bigram(b)
+        AstIndexReader::lookup_bigram(self, b)
     }
     fn lookup_trigram(&self, t: AstTrigram) -> Result<Vec<AstPosting>> {
-        self.lookup_trigram(t)
+        AstIndexReader::lookup_trigram(self, t)
     }
     fn file_meta(&self, doc_id: u32) -> Result<AstFileMetaEntry> {
-        self.file_meta(doc_id)
+        AstIndexReader::file_meta(self, doc_id)
     }
     fn avg_node_count(&self) -> f32 {
-        self.avg_node_count()
+        AstIndexReader::avg_node_count(self)
     }
     fn file_count(&self) -> u32 {
-        self.file_count()
+        AstIndexReader::file_count(self)
     }
 }
 
@@ -128,9 +145,14 @@ impl<R: AstPostingSource> AstQueryEngine<R> {
 
     fn run_ngram_set(&self, set: &AstNgramSet) -> Result<Vec<(FileId, f64)>> {
         let avg = f64::from(self.reader.avg_node_count());
-        let mut scores: HashMap<u32, f64> = HashMap::new();
-        // Per-call meta cache: manual check-then-insert (or_insert_with can't propagate Result).
-        let mut meta_cache: HashMap<u32, AstFileMetaEntry> = HashMap::new();
+        let capacity = self.reader.file_count() as usize;
+
+        // Use FxHashMap (integer keys, trusted in-range doc_ids) with a capacity
+        // hint to avoid rehashing on the hot insert path.
+        let mut scores: FxHashMap<u32, f64> = FxHashMap::with_capacity_and_hasher(
+            capacity,
+            BuildHasherDefault::<FxHasher>::default(),
+        );
 
         // Gap-fix #6: dedup by key (entries are sorted; O(n); prevents double-scoring dups).
         let mut bigrams: Vec<&AstBigramEntry> = set.bigrams.iter().collect();
@@ -148,34 +170,50 @@ impl<R: AstPostingSource> AstQueryEngine<R> {
                 .all(|w| w[0].ngram.key() != w[1].ngram.key())
         });
 
-        for entry in bigrams {
-            for posting in self.reader.lookup_bigram(entry.ngram)? {
-                let meta = cached_meta(&self.reader, &mut meta_cache, posting.doc_id)?;
-                // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
-                // double-counting (#198). For now, contributions are additive.
-                *scores.entry(posting.doc_id).or_insert(0.0) += bm25(posting, &meta, avg, |lang| {
-                    f64::from(ast_bigram_idf(lang, entry.ngram))
-                });
-            }
+        let total_ngrams = bigrams.len() + trigrams.len();
+
+        // Per-call meta cache: skip for single-n-gram queries — by contract C1,
+        // each posting list has at most one posting per doc_id, so cross-n-gram
+        // cache hits only occur when total_ngrams > 1.
+        let mut meta_cache: Option<FxHashMap<u32, AstFileMetaEntry>> = if total_ngrams > 1 {
+            Some(FxHashMap::with_capacity_and_hasher(
+                capacity,
+                BuildHasherDefault::<FxHasher>::default(),
+            ))
+        } else {
+            None
+        };
+
+        for entry in &bigrams {
+            let postings = self.reader.lookup_bigram(entry.ngram)?;
+            score_postings(
+                &postings,
+                &mut scores,
+                &mut meta_cache,
+                &self.reader,
+                avg,
+                |lang| f64::from(ast_bigram_idf(lang, entry.ngram)),
+            )?;
         }
-        for entry in trigrams {
-            for posting in self.reader.lookup_trigram(entry.ngram)? {
-                let meta = cached_meta(&self.reader, &mut meta_cache, posting.doc_id)?;
-                // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
-                // double-counting (#198).
-                *scores.entry(posting.doc_id).or_insert(0.0) += bm25(posting, &meta, avg, |lang| {
-                    f64::from(ast_trigram_idf(lang, entry.ngram))
-                });
-            }
+        for entry in &trigrams {
+            let postings = self.reader.lookup_trigram(entry.ngram)?;
+            // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
+            // double-counting (#198). For now, contributions are additive.
+            score_postings(
+                &postings,
+                &mut scores,
+                &mut meta_cache,
+                &self.reader,
+                avg,
+                |lang| f64::from(ast_trigram_idf(lang, entry.ngram)),
+            )?;
         }
 
-        let mut out: Vec<(FileId, f64)> = scores
-            .into_iter()
-            .filter(|(_, s)| *s > 0.0)
-            .map(|(id, s)| (FileId(id), s))
-            .collect();
+        let mut out: Vec<(FileId, f64)> =
+            scores.into_iter().map(|(id, s)| (FileId(id), s)).collect();
 
-        // B2: unique (HashMap), all > 0 (filtered), sorted FileId-ASC (Wave-4 contract).
+        // B2: unique (FxHashMap), all > 0 (BM25 with C4: count>=1 → tf>0 → score>0),
+        // sorted FileId-ASC (Wave-4 contract).
         debug_assert!(out.iter().all(|(_, s)| *s > 0.0), "all scores must be > 0");
         out.sort_unstable_by_key(|(fid, _)| *fid);
         Ok(out)
@@ -197,6 +235,7 @@ impl SearchLayer for AstQueryEngine<AstIndexReader> {
     /// `ast_pattern = Some("")` → `Err(InvalidQuery("empty AST query"))`.
     /// `ast_pattern = Some(s)` → parse + execute; apply filters; return score-DESC results.
     /// Filters (in order): `file_filter` allowlist, `lang`, `offset`/`limit`.
+    /// Defaults: `offset` → 0, `limit` → 20 (results truncated when unset).
     fn search(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
         let raw = match &query.ast_pattern {
             None => return Ok(vec![]),
@@ -204,7 +243,7 @@ impl SearchLayer for AstQueryEngine<AstIndexReader> {
         };
         let trimmed = raw.trim();
         if trimmed.is_empty() {
-            return Err(SearchError::InvalidQuery("empty AST query".into()));
+            return Err(SearchError::InvalidQuery(EMPTY_QUERY_MSG.into()));
         }
 
         let mut hits = self.search_ast(&parse_ast_query(trimmed)?)?;
@@ -228,7 +267,7 @@ impl SearchLayer for AstQueryEngine<AstIndexReader> {
             hits
         };
 
-        // Sort score-DESC, FileId-ASC tie-break (NaN-safe; mirrors index/reader.rs ~406).
+        // Sort score-DESC, FileId-ASC tie-break (NaN-safe; mirrors index/reader.rs sort).
         filtered.sort_unstable_by(|a, b| {
             b.1.partial_cmp(&a.1)
                 .unwrap_or(Ordering::Equal)
@@ -279,7 +318,7 @@ pub fn parse_ast_query(s: &str) -> Result<AstQuery> {
     }
     let trimmed = s.trim();
     if trimmed.is_empty() {
-        return Err(SearchError::InvalidQuery("empty AST query".into()));
+        return Err(SearchError::InvalidQuery(EMPTY_QUERY_MSG.into()));
     }
     if trimmed.contains(">>") {
         return Err(SearchError::InvalidQuery(
@@ -299,8 +338,8 @@ pub fn parse_ast_query(s: &str) -> Result<AstQuery> {
 
     match segments.len() {
         1 => parse_single(segments[0]),
-        2 => parse_bigram_q(segments[0], segments[1]),
-        3 => parse_trigram_q(segments[0], segments[1], segments[2]),
+        2 => parse_bigram(segments[0], segments[1]),
+        3 => parse_trigram(segments[0], segments[1], segments[2]),
         n => Err(SearchError::InvalidQuery(format!(
             "containment depth > 2 is not supported ({n} segments); maximum is `A > B > C`"
         ))),
@@ -321,7 +360,7 @@ fn parse_single(token: &str) -> Result<AstQuery> {
         })
 }
 
-fn parse_bigram_q(a: &str, b: &str) -> Result<AstQuery> {
+fn parse_bigram(a: &str, b: &str) -> Result<AstQuery> {
     let bigram = AstBigram::encode(kind(a)?, kind(b)?);
     Ok(AstQuery::Containment(AstNgramSet {
         bigrams: vec![AstBigramEntry {
@@ -333,7 +372,7 @@ fn parse_bigram_q(a: &str, b: &str) -> Result<AstQuery> {
     }))
 }
 
-fn parse_trigram_q(a: &str, b: &str, c: &str) -> Result<AstQuery> {
+fn parse_trigram(a: &str, b: &str, c: &str) -> Result<AstQuery> {
     let trigram = AstTrigram::encode(kind(a)?, kind(b)?, kind(c)?);
     Ok(AstQuery::Containment(AstNgramSet {
         bigrams: vec![],
@@ -356,17 +395,63 @@ fn kind(seg: &str) -> Result<NodeKindId> {
 }
 
 // Scoring helpers
-/// BM25 score contribution for one n-gram posting.
+
+/// Accumulate BM25 scores for one set of postings into `scores`.
 ///
-/// IDF = 1.0 when `meta.language()` is `None` (unknown lang fallback).
-/// `tf_norm = tf / length_norm`; avdl==0 → length_norm=1.0; norm<=0 → 1.0.
-fn bm25(
-    posting: AstPosting,
-    meta: &AstFileMetaEntry,
+/// IDF is computed once per distinct language via a tiny last-value cache,
+/// reducing O(postings) binary-search calls to O(distinct_languages).
+///
+/// When `meta_cache` is `None` (single-n-gram query), `file_meta` is called
+/// directly without caching — by contract C1 each posting list has at most one
+/// posting per doc_id, so cross-list cache hits never occur for a single n-gram.
+fn score_postings<R: AstPostingSource>(
+    postings: &[AstPosting],
+    scores: &mut FxHashMap<u32, f64>,
+    meta_cache: &mut Option<FxHashMap<u32, AstFileMetaEntry>>,
+    reader: &R,
     avg: f64,
     idf_fn: impl Fn(Language) -> f64,
-) -> f64 {
-    let idf = meta.language().map_or(1.0, idf_fn);
+) -> Result<()> {
+    // Per-n-gram IDF memoization: at most one distinct value per language.
+    // Avoid HashMap overhead — track only the last seen (lang, idf) pair.
+    let mut last_lang: Option<Language> = None;
+    let mut last_idf: f64 = 1.0;
+
+    for posting in postings {
+        let meta = match meta_cache {
+            Some(cache) => cached_meta_fx(reader, cache, posting.doc_id)?,
+            None => reader.file_meta(posting.doc_id)?,
+        };
+        let idf = match meta.language() {
+            Some(lang) => {
+                if last_lang == Some(lang) {
+                    last_idf
+                } else {
+                    let v = idf_fn(lang);
+                    last_lang = Some(lang);
+                    last_idf = v;
+                    v
+                }
+            }
+            None => 1.0,
+        };
+        *scores.entry(posting.doc_id).or_insert(0.0) += bm25_with_idf(posting, &meta, avg, idf);
+    }
+    Ok(())
+}
+
+/// BM25 score contribution for one n-gram posting, given a pre-computed IDF.
+///
+/// `tf_norm = tf / length_norm`; avdl==0 → length_norm=1.0; norm<=0 → 1.0
+/// (defensive-only: with b=0.75 and nc>=0, n is always >= 0.25, so n<=0.0 is
+/// unreachable in practice).
+fn bm25_with_idf(posting: &AstPosting, meta: &AstFileMetaEntry, avg: f64, idf: f64) -> f64 {
+    debug_assert!(
+        avg.is_finite(),
+        "avg_node_count must be finite (AstPostingSource contract)"
+    );
+    // Release-safe fallback: treat non-finite avg as 0 → length_norm=1.0.
+    let avg = if avg.is_finite() { avg } else { 0.0 };
     let tf = f64::from(posting.count);
     let nc = f64::from(meta.node_count);
     let ln = if avg <= 0.0 {
@@ -379,12 +464,12 @@ fn bm25(
     idf * (tf_norm / (tf_norm + AST_BM25_K1))
 }
 
-/// Fetch meta from cache; insert on miss.
+/// Fetch meta from FxHashMap cache; insert on miss.
 ///
 /// Manual check-then-insert because `or_insert_with` cannot propagate `Result`.
-fn cached_meta<R: AstPostingSource>(
+fn cached_meta_fx<R: AstPostingSource>(
     reader: &R,
-    cache: &mut HashMap<u32, AstFileMetaEntry>,
+    cache: &mut FxHashMap<u32, AstFileMetaEntry>,
     doc_id: u32,
 ) -> Result<AstFileMetaEntry> {
     if let Some(e) = cache.get(&doc_id) {

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -66,9 +66,8 @@ impl PartialEq for AstQuery {
 ///
 /// **Value-type coupling is intentional and bounded.** `AstPosting` and
 /// `AstFileMetaEntry` are deliberately treated as the stable query-layer value
-/// contract — they are `Copy`, gix-free, and mmap-free — so coupling to them
-/// is bounded and intentional, mirroring the "free of gix types" note on
-/// `CommitInfo` in `types.rs`.
+/// contract — they are `Copy`, gix-free, and mmap-free — mirroring the
+/// "free of gix types" note on `CommitInfo` in `types.rs`.
 ///
 /// **Finiteness contract.** `avg_node_count()` MUST return a finite, non-NaN
 /// value. `node_count` values in `AstFileMetaEntry` MUST be non-negative.

--- a/crates/rskim-search/src/ast_index/query.rs
+++ b/crates/rskim-search/src/ast_index/query.rs
@@ -1,0 +1,397 @@
+//! AST Structural Pattern Query Engine — Wave 3f (#197).
+//!
+//! Answers named-pattern and containment queries with OR-union additive BM25
+//! ranking. Exposes a Wave-4 intersection hook (`search_ast`) and a
+//! Wave-3g [`SearchLayer`] adapter.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::path::Path;
+
+use rskim_core::Language;
+
+use super::patterns::Pattern;
+use super::{
+    AstBigram, AstBigramEntry, AstFileMetaEntry, AstIndexReader, AstNgramSet, AstPosting,
+    AstTrigram, AstTrigramEntry, DEFAULT_AST_WEIGHT, NodeKindId, ast_bigram_idf, ast_trigram_idf,
+    lookup_pattern, vocab_lookup,
+};
+use crate::{
+    FileId, Result, SearchError,
+    types::{SearchField, SearchLayer, SearchQuery, SearchResult},
+};
+
+// BM25 constants
+
+/// BM25 saturation parameter k1 for AST structural scoring.
+pub const AST_BM25_K1: f64 = 1.2;
+/// BM25 length-normalisation parameter b for AST structural scoring.
+pub const AST_BM25_B: f64 = 0.75;
+/// Maximum allowed byte length for a raw query string (reliability bound).
+const MAX_AST_QUERY_BYTES: usize = 4096;
+
+// Query enum
+
+/// A parsed, validated AST structural query.
+///
+/// Created exclusively via [`parse_ast_query`] — the only `String → AstQuery`
+/// boundary.
+#[derive(Debug, Clone)]
+pub enum AstQuery {
+    /// Named catalog pattern (e.g. `"try-catch"`). Resolved at execution time.
+    Pattern(&'static Pattern),
+    /// Depth-1 bigram (`A > B`) or depth-2 trigram (`A > B > C`); deduped.
+    Containment(AstNgramSet),
+    /// Validated single node kind. Execution deferred to #283 (unigram index).
+    SingleNode(NodeKindId),
+}
+
+impl PartialEq for AstQuery {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Pattern(a), Self::Pattern(b)) => std::ptr::eq(*a, *b),
+            (Self::Containment(a), Self::Containment(b)) => a == b,
+            (Self::SingleNode(a), Self::SingleNode(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+// DI seam
+
+/// Dependency-injection seam: implemented by [`AstIndexReader`] and test fakes.
+pub trait AstPostingSource: Send + Sync {
+    /// Look up postings for an [`AstBigram`]; `Ok(vec![])` when absent (C2).
+    fn lookup_bigram(&self, b: AstBigram) -> Result<Vec<AstPosting>>;
+    /// Look up postings for an [`AstTrigram`]; `Ok(vec![])` when absent (C2).
+    fn lookup_trigram(&self, t: AstTrigram) -> Result<Vec<AstPosting>>;
+    /// Per-file metadata for `doc_id`; `Err(IndexCorrupted)` when out of range.
+    fn file_meta(&self, doc_id: u32) -> Result<AstFileMetaEntry>;
+    /// Average per-file node count across the corpus.
+    fn avg_node_count(&self) -> f32;
+    /// Total number of files in the index.
+    fn file_count(&self) -> u32;
+}
+
+impl AstPostingSource for AstIndexReader {
+    fn lookup_bigram(&self, b: AstBigram) -> Result<Vec<AstPosting>> {
+        self.lookup_bigram(b)
+    }
+    fn lookup_trigram(&self, t: AstTrigram) -> Result<Vec<AstPosting>> {
+        self.lookup_trigram(t)
+    }
+    fn file_meta(&self, doc_id: u32) -> Result<AstFileMetaEntry> {
+        self.file_meta(doc_id)
+    }
+    fn avg_node_count(&self) -> f32 {
+        self.avg_node_count()
+    }
+    fn file_count(&self) -> u32 {
+        self.file_count()
+    }
+}
+
+// Query engine
+
+/// AST structural pattern query engine. Immutable; `&self`-only; `Send + Sync`.
+///
+/// Use [`AstQueryEngine::new`] for DI (tests, Wave 4) or
+/// [`AstQueryEngine::open`] for CLI convenience.
+pub struct AstQueryEngine<R: AstPostingSource = AstIndexReader> {
+    reader: R,
+}
+
+impl<R: AstPostingSource> AstQueryEngine<R> {
+    /// Wrap any [`AstPostingSource`].
+    #[must_use]
+    pub fn new(reader: R) -> Self {
+        Self { reader }
+    }
+
+    /// Execute a structural query; returns `(FileId, score)` sorted **ascending
+    /// by FileId**, unique, all scores > 0. Wave-4 merge-join contract.
+    ///
+    /// OR-union BM25: every file with ≥1 matching n-gram is a candidate.
+    /// `score = Σ idf · (tf_norm / (tf_norm + k1))`.
+    ///
+    /// # Errors
+    /// - [`SearchError::InvalidQuery`] for [`AstQuery::SingleNode`] (→ #283).
+    /// - [`SearchError::IndexCorrupted`] on corrupt backing index.
+    pub fn search_ast(&self, q: &AstQuery) -> Result<Vec<(FileId, f64)>> {
+        match q {
+            AstQuery::SingleNode(_) => Err(SearchError::InvalidQuery(
+                "single-node structural search requires the unigram index — tracked in #283".into(),
+            )),
+            AstQuery::Pattern(pattern) => {
+                let set = crate::ast_index::pattern_to_query_set(pattern);
+                self.run_ngram_set(&set)
+            }
+            AstQuery::Containment(set) => self.run_ngram_set(set),
+        }
+    }
+
+    fn run_ngram_set(&self, set: &AstNgramSet) -> Result<Vec<(FileId, f64)>> {
+        let avg = f64::from(self.reader.avg_node_count());
+        let mut scores: HashMap<u32, f64> = HashMap::new();
+        // Per-call meta cache: manual check-then-insert (or_insert_with can't propagate Result).
+        let mut meta_cache: HashMap<u32, AstFileMetaEntry> = HashMap::new();
+
+        // AstNgramSet invariant: bigrams/trigrams are sorted-unique by key.
+        // debug_assert omitted here; enforced by the set construction site.
+
+        for entry in &set.bigrams {
+            for posting in self.reader.lookup_bigram(entry.ngram)? {
+                let meta = cached_meta(&self.reader, &mut meta_cache, posting.doc_id)?;
+                // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
+                // double-counting (#198). For now, contributions are additive.
+                *scores.entry(posting.doc_id).or_insert(0.0) += bm25(posting, &meta, avg, |lang| {
+                    f64::from(ast_bigram_idf(lang, entry.ngram))
+                });
+            }
+        }
+        for entry in &set.trigrams {
+            for posting in self.reader.lookup_trigram(entry.ngram)? {
+                let meta = cached_meta(&self.reader, &mut meta_cache, posting.doc_id)?;
+                // DEFERRED (Wave 4): minimal-covering-set to remove trigram/sub-bigram
+                // double-counting (#198).
+                *scores.entry(posting.doc_id).or_insert(0.0) += bm25(posting, &meta, avg, |lang| {
+                    f64::from(ast_trigram_idf(lang, entry.ngram))
+                });
+            }
+        }
+
+        let mut out: Vec<(FileId, f64)> = scores
+            .into_iter()
+            .filter(|(_, s)| *s > 0.0)
+            .map(|(id, s)| (FileId(id), s))
+            .collect();
+
+        // B2: unique (HashMap), all > 0 (filtered), sorted FileId-ASC (Wave-4 contract).
+        debug_assert!(out.iter().all(|(_, s)| *s > 0.0), "all scores must be > 0");
+        out.sort_unstable_by_key(|(fid, _)| *fid);
+        Ok(out)
+    }
+}
+
+impl AstQueryEngine<AstIndexReader> {
+    /// Open the index at `dir`. Surfaces all [`AstIndexReader::open`] errors.
+    pub fn open(dir: &Path) -> Result<Self> {
+        Ok(Self {
+            reader: AstIndexReader::open(dir)?,
+        })
+    }
+}
+
+// SearchLayer adapter (Wave 3g)
+
+impl SearchLayer for AstQueryEngine<AstIndexReader> {
+    /// `ast_pattern = None` → `Ok(vec![])` (Wave-4 no-op).
+    /// `ast_pattern = Some("")` → `Err(InvalidQuery("empty AST query"))`.
+    /// `ast_pattern = Some(s)` → parse + execute; apply filters; return score-DESC results.
+    /// Filters (in order): `file_filter` allowlist, `lang`, `offset`/`limit`.
+    fn search(&self, query: &SearchQuery) -> Result<Vec<SearchResult>> {
+        let raw = match &query.ast_pattern {
+            None => return Ok(vec![]),
+            Some(s) => s,
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(SearchError::InvalidQuery("empty AST query".into()));
+        }
+
+        let mut hits = self.search_ast(&parse_ast_query(trimmed)?)?;
+        // hits is FileId-ASC from search_ast.
+
+        // Apply file_filter allowlist (no I/O).
+        if let Some(ref filter) = query.file_filter {
+            hits.retain(|(fid, _)| filter.contains(fid));
+        }
+
+        // Apply lang filter (one file_meta per surviving candidate).
+        let mut filtered: Vec<(FileId, f64)> = if let Some(lang) = query.lang {
+            let mut out = Vec::with_capacity(hits.len());
+            for (fid, score) in hits {
+                if self.reader.file_meta(fid.0)?.language() == Some(lang) {
+                    out.push((fid, score));
+                }
+            }
+            out
+        } else {
+            hits
+        };
+
+        // Sort score-DESC, FileId-ASC tie-break (NaN-safe; mirrors lexical reader.rs ~406).
+        filtered.sort_unstable_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+
+        Ok(filtered
+            .into_iter()
+            .skip(query.offset.unwrap_or(0))
+            .take(query.limit.unwrap_or(20))
+            .map(|(fid, score)| SearchResult {
+                file_id: fid,
+                score,
+                line_range: 0..0,
+                match_positions: vec![],
+                field: SearchField::Other,
+                snippet: None,
+            })
+            .collect())
+    }
+
+    fn name(&self) -> &str {
+        "ast"
+    }
+}
+
+// Parser
+
+/// Parse a raw string into an [`AstQuery`].
+///
+/// **Only** `String → AstQuery` boundary; total (never panics). Rejects
+/// strings longer than `MAX_AST_QUERY_BYTES` (4096 bytes).
+///
+/// | Input form | Result |
+/// |---|---|
+/// | `"try-catch"` | [`AstQuery::Pattern`] (hyphen → catalog lookup) |
+/// | `"A > B"` | [`AstQuery::Containment`] bigram |
+/// | `"A > B > C"` | [`AstQuery::Containment`] trigram |
+/// | `"try_statement"` | [`AstQuery::SingleNode`] (vocab-validated) |
+///
+/// Returns [`SearchError::InvalidQuery`] for unknown kinds/patterns, empty
+/// segments, `>>`, depth > 2, or inputs > 4096 bytes.
+pub fn parse_ast_query(s: &str) -> Result<AstQuery> {
+    if s.len() > MAX_AST_QUERY_BYTES {
+        return Err(SearchError::InvalidQuery(format!(
+            "AST query too long: {} bytes (max {MAX_AST_QUERY_BYTES})",
+            s.len()
+        )));
+    }
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err(SearchError::InvalidQuery("empty AST query".into()));
+    }
+    if trimmed.contains(">>") {
+        return Err(SearchError::InvalidQuery(
+            "transitive ancestor operator `>>` is not supported; use `>` for direct containment"
+                .into(),
+        ));
+    }
+
+    let segments: Vec<&str> = trimmed.split('>').map(str::trim).collect();
+    for seg in &segments {
+        if seg.is_empty() {
+            return Err(SearchError::InvalidQuery(
+                "empty segment in query: check for trailing or doubled `>` operators".into(),
+            ));
+        }
+    }
+
+    match segments.len() {
+        1 => parse_single(segments[0]),
+        2 => parse_bigram_q(segments[0], segments[1]),
+        3 => parse_trigram_q(segments[0], segments[1], segments[2]),
+        n => Err(SearchError::InvalidQuery(format!(
+            "containment depth > 2 is not supported ({n} segments); maximum is `A > B > C`"
+        ))),
+    }
+}
+
+fn parse_single(token: &str) -> Result<AstQuery> {
+    if token.contains('-') {
+        return Ok(AstQuery::Pattern(lookup_pattern(token)?));
+    }
+    vocab_lookup(token)
+        .map(AstQuery::SingleNode)
+        .ok_or_else(|| {
+            SearchError::InvalidQuery(format!(
+                "unknown node kind '{token}'; \
+             use a valid tree-sitter node kind or a hyphenated pattern name"
+            ))
+        })
+}
+
+fn parse_bigram_q(a: &str, b: &str) -> Result<AstQuery> {
+    let bigram = AstBigram::encode(kind(a)?, kind(b)?);
+    Ok(AstQuery::Containment(AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![],
+    }))
+}
+
+fn parse_trigram_q(a: &str, b: &str, c: &str) -> Result<AstQuery> {
+    let trigram = AstTrigram::encode(kind(a)?, kind(b)?, kind(c)?);
+    Ok(AstQuery::Containment(AstNgramSet {
+        bigrams: vec![],
+        trigrams: vec![AstTrigramEntry {
+            ngram: trigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+    }))
+}
+
+/// Resolve a containment segment to a [`NodeKindId`] or return `InvalidQuery`.
+fn kind(seg: &str) -> Result<NodeKindId> {
+    vocab_lookup(seg).ok_or_else(|| {
+        SearchError::InvalidQuery(format!(
+            "unknown node kind '{seg}' in containment query; \
+             use a valid tree-sitter node kind (e.g. `function_item`, `block`)"
+        ))
+    })
+}
+
+// Scoring helpers
+
+/// BM25 score contribution for one n-gram posting.
+///
+/// IDF = 1.0 when `meta.language()` is `None` (unknown lang fallback).
+/// `tf_norm = tf / length_norm`; avdl==0 → length_norm=1.0; norm<=0 → 1.0.
+fn bm25(
+    posting: AstPosting,
+    meta: &AstFileMetaEntry,
+    avg: f64,
+    idf_fn: impl Fn(Language) -> f64,
+) -> f64 {
+    let idf = meta.language().map_or(1.0, idf_fn);
+    let tf = f64::from(posting.count);
+    let nc = f64::from(meta.node_count);
+    let ln = if avg <= 0.0 {
+        1.0
+    } else {
+        let n = 1.0 - AST_BM25_B + AST_BM25_B * (nc / avg);
+        if n <= 0.0 { 1.0 } else { n }
+    };
+    let tf_norm = tf / ln;
+    if tf_norm == 0.0 {
+        return 0.0;
+    }
+    idf * (tf_norm / (tf_norm + AST_BM25_K1))
+}
+
+/// Fetch meta from cache; insert on miss.
+///
+/// Manual check-then-insert because `or_insert_with` cannot propagate `Result`.
+fn cached_meta<R: AstPostingSource>(
+    reader: &R,
+    cache: &mut HashMap<u32, AstFileMetaEntry>,
+    doc_id: u32,
+) -> Result<AstFileMetaEntry> {
+    if let Some(e) = cache.get(&doc_id) {
+        return Ok(*e);
+    }
+    let e = reader.file_meta(doc_id)?;
+    cache.insert(doc_id, e);
+    Ok(e)
+}
+
+#[cfg(test)]
+#[path = "query_tests.rs"]
+mod tests;

--- a/crates/rskim-search/src/ast_index/query_tests.rs
+++ b/crates/rskim-search/src/ast_index/query_tests.rs
@@ -820,6 +820,62 @@ fn perf_tripwire_10k_postings_under_1s() {
     );
 }
 
+// --- Gap-fix #6: duplicate query n-gram key must score exactly once ---
+
+#[test]
+fn gap6_duplicate_query_ngram_key_scores_once() {
+    // Construct an AstNgramSet with two AstBigramEntry items sharing the same key.
+    // run_ngram_set must dedup before lookup so the key is looked up once, not twice.
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    // Build a source that returns a known posting for the bigram key.
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 100)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 2,
+            }],
+        )
+        .with_avg_node_count(100.0);
+
+    let engine = AstQueryEngine::new(source);
+
+    // Single-entry set → baseline score.
+    let single = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let single_results = engine.search_ast(&single).unwrap();
+    assert_eq!(single_results.len(), 1);
+    let baseline_score = single_results[0].1;
+
+    // Duplicate-entry set (same key, same ngram, sorted): should produce same score.
+    let dup_set = AstNgramSet {
+        bigrams: vec![
+            AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1,
+            },
+            AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1,
+            },
+        ],
+        trigrams: vec![],
+    };
+    let dup_results = engine.search_ast(&AstQuery::Containment(dup_set)).unwrap();
+    assert_eq!(dup_results.len(), 1);
+    let dup_score = dup_results[0].1;
+
+    assert!(
+        (dup_score - baseline_score).abs() < 1e-12,
+        "duplicate key must score once: baseline={baseline_score}, dup={dup_score}"
+    );
+}
+
 // ============================================================================
 // GROUP 3: SearchLayer adapter — real AstIndexBuilder/AstIndexReader
 // ============================================================================

--- a/crates/rskim-search/src/ast_index/query_tests.rs
+++ b/crates/rskim-search/src/ast_index/query_tests.rs
@@ -303,15 +303,23 @@ fn parse_query_too_long_invalid() {
 
 #[test]
 fn parse_exactly_4096_bytes_ok() {
-    // A 4096-byte string of spaces trims to empty → "empty" error, not length error.
-    // Use a valid name repeated/padded to be exactly 4096 bytes containing '>'.
-    // Simplest: just check boundary at 4096 with an actual query that is valid length.
-    let s = "a".repeat(4096);
-    // This is at the limit — could be InvalidQuery for unknown kind, but NOT for length.
-    let err = parse_ast_query(&s).unwrap_err();
+    // Build a valid containment query (bigram "function_item > block") padded to
+    // exactly 4096 bytes with leading spaces — trimming removes them, so the
+    // length guard passes and the query is valid.
+    let base = "function_item > block";
+    let padding = " ".repeat(4096 - base.len());
+    let s = format!("{padding}{base}");
+    assert_eq!(s.len(), 4096, "precondition: string is exactly 4096 bytes");
+    // Should succeed (valid query within length limit).
+    let result = parse_ast_query(&s);
     assert!(
-        !err.to_string().contains("too long"),
-        "should not be length error: {err}"
+        result.is_ok(),
+        "4096-byte valid query should be accepted: {result:?}"
+    );
+    // Result should be a Containment bigram.
+    assert!(
+        matches!(result.unwrap(), AstQuery::Containment(_)),
+        "expected Containment bigram"
     );
 }
 
@@ -579,6 +587,88 @@ fn a5_synthetic_marker_pattern_matches() {
     );
 }
 
+// --- Golden BM25 with non-trivial length_norm (nc != avg) ---
+
+#[test]
+fn bm25_golden_value_non_trivial_length_norm() {
+    // Verifies the full BM25 formula with nc != avg so length_norm != 1.0.
+    //
+    // Setup: node_count=200, avg=100, count=1, Language::Rust.
+    //   length_norm = 1 - 0.75 + 0.75 * (200/100) = 0.25 + 1.5 = 1.75
+    //   tf_norm = 1.0 / 1.75
+    //   idf = ast_bigram_idf(Rust, bigram)
+    //   expected = idf * (tf_norm / (tf_norm + 1.2))
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 200)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 1,
+            }],
+        )
+        .with_avg_node_count(100.0);
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 1);
+
+    use crate::ast_index::ast_bigram_idf;
+    let idf = f64::from(ast_bigram_idf(Language::Rust, bigram));
+    let avg = 100.0_f64;
+    let nc = 200.0_f64;
+    let k1 = AST_BM25_K1;
+    let b = AST_BM25_B;
+    let length_norm = 1.0 - b + b * (nc / avg); // = 1.75
+    let tf_norm = 1.0_f64 / length_norm;
+    let expected = idf * (tf_norm / (tf_norm + k1));
+
+    let got = results[0].1;
+    assert!(
+        (got - expected).abs() < 1e-9,
+        "golden BM25 mismatch: got {got}, expected {expected} (length_norm={length_norm})"
+    );
+}
+
+// --- avg_node_count == 0.0 path: length_norm → 1.0 ---
+
+#[test]
+fn bm25_avg_zero_length_norm_fallback_positive_score() {
+    // When avg_node_count == 0.0, the bm25 function takes the length_norm=1.0
+    // branch. The result must still be a positive score.
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    // avg = 0.0 triggers the defensive branch.
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 100)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 1,
+            }],
+        )
+        .with_avg_node_count(0.0);
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 1, "should return the file even with avg=0");
+    assert!(
+        results[0].1 > 0.0,
+        "score must be positive with avg=0 (length_norm=1.0 fallback)"
+    );
+}
+
 // --- Double-counting PINNED test ---
 
 #[test]
@@ -782,9 +872,10 @@ fn b3_corrupt_doc_id_propagated() {
     );
 }
 
-// --- Performance unit tripwire (CI-safe) ---
+// --- Performance unit tripwire (CI-safe, gated behind --ignored for flake safety) ---
 
 #[test]
+#[ignore = "wall-clock assertion: run explicitly or rely on Criterion bench (ast_query.rs) for the real perf signal"]
 fn perf_tripwire_10k_postings_under_1s() {
     use std::time::Instant;
 
@@ -999,7 +1090,7 @@ fn b4_named_pattern_search_returns_results() {
     drop(dir);
 }
 
-// B4: limit / offset honored
+// B4: limit / offset honored — assert exact FileId identities in score-DESC order
 
 #[test]
 fn b4_limit_and_offset_honored() {
@@ -1009,6 +1100,8 @@ fn b4_limit_and_offset_honored() {
     let bigram = AstBigram::encode(fn_id, block_id);
 
     let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    // Files 0–4 with counts 5,4,3,2,1 → scores strictly decreasing by FileId.
+    // score-DESC order is FileId(0), FileId(1), FileId(2), FileId(3), FileId(4).
     for i in 0..5u32 {
         let set = AstNgramSet {
             bigrams: vec![AstBigramEntry {
@@ -1037,7 +1130,26 @@ fn b4_limit_and_offset_honored() {
     query.offset = Some(1);
     let results = engine.search(&query).unwrap();
 
+    // offset=1, limit=2 → skip the top-scored file (FileId(0)), take FileId(1) and FileId(2).
     assert_eq!(results.len(), 2, "limit=2 should yield 2 results");
+    let ids: Vec<FileId> = results.iter().map(|r| r.file_id).collect();
+    assert_eq!(
+        ids,
+        vec![FileId(1), FileId(2)],
+        "offset=1,limit=2 should yield [FileId(1), FileId(2)] in score-DESC order: got {ids:?}"
+    );
+
+    // Sibling: offset past the end → empty result.
+    let mut query_past = SearchQuery::new("q");
+    query_past.ast_pattern = Some("function_item > block".into());
+    query_past.limit = Some(2);
+    query_past.offset = Some(10);
+    let past_results = engine.search(&query_past).unwrap();
+    assert!(
+        past_results.is_empty(),
+        "offset=10 past end should return empty"
+    );
+
     drop(dir);
 }
 

--- a/crates/rskim-search/src/ast_index/query_tests.rs
+++ b/crates/rskim-search/src/ast_index/query_tests.rs
@@ -1368,8 +1368,16 @@ fn b4_equal_scores_tie_break_file_id_asc() {
     assert_eq!(results.len(), 2, "both files should match");
 
     // Scores must be bitwise-equal (same inputs, deterministic formula).
-    let score0 = results.iter().find(|r| r.file_id == FileId(0)).unwrap().score;
-    let score1 = results.iter().find(|r| r.file_id == FileId(1)).unwrap().score;
+    let score0 = results
+        .iter()
+        .find(|r| r.file_id == FileId(0))
+        .unwrap()
+        .score;
+    let score1 = results
+        .iter()
+        .find(|r| r.file_id == FileId(1))
+        .unwrap()
+        .score;
     assert_eq!(
         score0, score1,
         "precondition: both files must have equal scores (score0={score0}, score1={score1})"

--- a/crates/rskim-search/src/ast_index/query_tests.rs
+++ b/crates/rskim-search/src/ast_index/query_tests.rs
@@ -1,0 +1,1146 @@
+//! Tests for [`crate::ast_index::query`] — Wave 3f (#197).
+//!
+//! Organized into three test groups:
+//! 1. **Parser** — pure `parse_ast_query` tests (no I/O).
+//! 2. **Execution/scoring** — via `FakePostingSource` (no I/O, deterministic).
+//! 3. **SearchLayer adapter** — via real `AstIndexBuilder`/`AstIndexReader`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{HashMap, HashSet};
+
+use rskim_core::Language;
+use tempfile::tempdir;
+
+use super::*;
+use crate::{
+    FileId,
+    ast_index::{
+        AstBigram, AstBigramEntry, AstFileMetaEntry, AstIndexBuilder, AstNgramSet, AstPosting,
+        AstTrigram, AstTrigramEntry, DEFAULT_AST_WEIGHT, StructuralMetrics, lookup_pattern,
+        parse_ast_query, vocab_lookup,
+    },
+    types::SearchQuery,
+};
+
+// ============================================================================
+// Compile-time Send + Sync assertion (B5)
+// ============================================================================
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn b5_query_engine_is_send_sync() {
+    assert_send_sync::<AstQueryEngine<AstIndexReader>>();
+}
+
+// ============================================================================
+// FakePostingSource — in-memory test double
+// ============================================================================
+
+#[derive(Default)]
+struct FakePostingSource {
+    bigrams: HashMap<u32, Vec<AstPosting>>,
+    trigrams: HashMap<u64, Vec<AstPosting>>,
+    file_metas: HashMap<u32, AstFileMetaEntry>,
+    avg_node_count: f32,
+    file_count: u32,
+}
+
+impl FakePostingSource {
+    fn with_file(mut self, doc_id: u32, lang: Language, node_count: u32) -> Self {
+        use crate::index::lang_map::lang_to_id;
+        self.file_metas.insert(
+            doc_id,
+            AstFileMetaEntry {
+                lang_id: lang_to_id(lang),
+                node_count,
+                max_depth: 3,
+                max_block_stmts: 5,
+                max_params: 2,
+                branch_count: 1,
+            },
+        );
+        self.file_count = self.file_count.max(doc_id + 1);
+        self
+    }
+
+    fn with_bigram(mut self, key: u32, postings: Vec<AstPosting>) -> Self {
+        self.bigrams.insert(key, postings);
+        self
+    }
+
+    fn with_trigram(mut self, key: u64, postings: Vec<AstPosting>) -> Self {
+        self.trigrams.insert(key, postings);
+        self
+    }
+
+    fn with_avg_node_count(mut self, avg: f32) -> Self {
+        self.avg_node_count = avg;
+        self
+    }
+}
+
+impl AstPostingSource for FakePostingSource {
+    fn lookup_bigram(&self, b: AstBigram) -> crate::Result<Vec<AstPosting>> {
+        Ok(self.bigrams.get(&b.key()).cloned().unwrap_or_default())
+    }
+
+    fn lookup_trigram(&self, t: AstTrigram) -> crate::Result<Vec<AstPosting>> {
+        Ok(self.trigrams.get(&t.key()).cloned().unwrap_or_default())
+    }
+
+    fn file_meta(&self, doc_id: u32) -> crate::Result<AstFileMetaEntry> {
+        self.file_metas.get(&doc_id).copied().ok_or_else(|| {
+            crate::SearchError::IndexCorrupted(format!("FakePostingSource: no meta for {doc_id}"))
+        })
+    }
+
+    fn avg_node_count(&self) -> f32 {
+        self.avg_node_count
+    }
+
+    fn file_count(&self) -> u32 {
+        self.file_count
+    }
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+fn make_bigram_set(ngram: AstBigram, count: u32) -> AstNgramSet {
+    AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram,
+            weight: DEFAULT_AST_WEIGHT,
+            count,
+        }],
+        trigrams: vec![],
+    }
+}
+
+fn make_trigram_set(ngram: AstTrigram, count: u32) -> AstNgramSet {
+    AstNgramSet {
+        bigrams: vec![],
+        trigrams: vec![AstTrigramEntry {
+            ngram,
+            weight: DEFAULT_AST_WEIGHT,
+            count,
+        }],
+    }
+}
+
+// ============================================================================
+// GROUP 1: Parser tests (no I/O)
+// ============================================================================
+
+// --- Named pattern ---
+
+#[test]
+fn parse_named_pattern_returns_pattern_variant() {
+    let q = parse_ast_query("try-catch").unwrap();
+    let expected_pattern = lookup_pattern("try-catch").unwrap();
+    assert!(matches!(q, AstQuery::Pattern(p) if std::ptr::eq(p, expected_pattern)));
+}
+
+#[test]
+fn parse_named_pattern_trimmed() {
+    let q = parse_ast_query("  try-catch  ").unwrap();
+    assert!(matches!(q, AstQuery::Pattern(_)));
+}
+
+#[test]
+fn parse_unknown_pattern_returns_error_with_list() {
+    let err = parse_ast_query("no-such-pattern").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("no-such-pattern"), "msg: {msg}");
+    // lookup_pattern lists all patterns in its error
+    assert!(
+        msg.contains("try-catch"),
+        "should list valid patterns: {msg}"
+    );
+}
+
+// --- Containment bigram ---
+
+#[test]
+fn parse_bigram_containment() {
+    let for_id = vocab_lookup("for_statement").unwrap();
+    let await_id = vocab_lookup("await_expression").unwrap();
+    let expected_bigram = AstBigram::encode(for_id, await_id);
+
+    let q = parse_ast_query("for_statement > await_expression").unwrap();
+    match q {
+        AstQuery::Containment(set) => {
+            assert_eq!(set.bigrams.len(), 1);
+            assert_eq!(set.trigrams.len(), 0);
+            assert_eq!(set.bigrams[0].ngram, expected_bigram);
+        }
+        _ => unreachable!("expected Containment bigram"),
+    }
+}
+
+#[test]
+fn parse_bigram_whitespace_normalized() {
+    let q1 = parse_ast_query("for_statement > await_expression").unwrap();
+    let q2 = parse_ast_query("  for_statement  >  await_expression  ").unwrap();
+    assert_eq!(q1, q2);
+}
+
+// --- Containment trigram ---
+
+#[test]
+fn parse_trigram_containment() {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let expr_id = vocab_lookup("expression_statement").unwrap();
+    let expected_trigram = AstTrigram::encode(fn_id, block_id, expr_id);
+
+    let q = parse_ast_query("function_item > block > expression_statement").unwrap();
+    match q {
+        AstQuery::Containment(set) => {
+            assert_eq!(set.bigrams.len(), 0);
+            assert_eq!(set.trigrams.len(), 1);
+            assert_eq!(set.trigrams[0].ngram, expected_trigram);
+        }
+        _ => unreachable!("expected Containment trigram"),
+    }
+}
+
+// --- Single node ---
+
+#[test]
+fn parse_single_node_valid_kind() {
+    let try_id = vocab_lookup("try_statement").unwrap();
+    let q = parse_ast_query("try_statement").unwrap();
+    assert_eq!(q, AstQuery::SingleNode(try_id));
+}
+
+// --- Error cases ---
+
+#[test]
+fn parse_empty_string_invalid() {
+    let err = parse_ast_query("").unwrap_err();
+    assert!(err.to_string().contains("empty"), "err: {err}");
+}
+
+#[test]
+fn parse_whitespace_only_invalid() {
+    let err = parse_ast_query("   ").unwrap_err();
+    assert!(err.to_string().contains("empty"), "err: {err}");
+}
+
+#[test]
+fn parse_transitive_operator_invalid() {
+    let err = parse_ast_query("a >> b").unwrap_err();
+    assert!(err.to_string().contains(">>"), "err: {err}");
+}
+
+#[test]
+fn parse_depth_gt2_invalid() {
+    // A > B > C > D — 4 segments
+    let err =
+        parse_ast_query("function_item > block > expression_statement > identifier").unwrap_err();
+    assert!(
+        err.to_string().contains("depth") || err.to_string().contains("segment"),
+        "err: {err}"
+    );
+}
+
+#[test]
+fn parse_trailing_gt_invalid() {
+    let err = parse_ast_query("function_item >").unwrap_err();
+    assert!(
+        err.to_string().contains("empty segment") || err.to_string().contains("empty"),
+        "err: {err}"
+    );
+}
+
+#[test]
+fn parse_leading_gt_invalid() {
+    let err = parse_ast_query("> function_item").unwrap_err();
+    assert!(
+        err.to_string().contains("empty segment") || err.to_string().contains("empty"),
+        "err: {err}"
+    );
+}
+
+#[test]
+fn parse_double_gt_invalid() {
+    // a > > b (not >> but two separate >, with empty middle segment)
+    let err = parse_ast_query("function_item > > block").unwrap_err();
+    assert!(err.to_string().contains("empty"), "err: {err}");
+}
+
+#[test]
+fn parse_unknown_kind_in_containment_invalid() {
+    let err = parse_ast_query("not_a_kind > block").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("not_a_kind"), "err: {msg}");
+}
+
+#[test]
+fn parse_unknown_single_kind_invalid() {
+    // Non-hyphenated unknown name → InvalidQuery
+    let err = parse_ast_query("totally_unknown_node_xyz").unwrap_err();
+    assert!(
+        err.to_string().contains("totally_unknown_node_xyz"),
+        "err: {err}"
+    );
+}
+
+#[test]
+fn parse_query_too_long_invalid() {
+    let long = "a".repeat(4097);
+    let err = parse_ast_query(&long).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("4097") || msg.contains("too long"),
+        "err: {msg}"
+    );
+}
+
+#[test]
+fn parse_exactly_4096_bytes_ok() {
+    // A 4096-byte string of spaces trims to empty → "empty" error, not length error.
+    // Use a valid name repeated/padded to be exactly 4096 bytes containing '>'.
+    // Simplest: just check boundary at 4096 with an actual query that is valid length.
+    let s = "a".repeat(4096);
+    // This is at the limit — could be InvalidQuery for unknown kind, but NOT for length.
+    let err = parse_ast_query(&s).unwrap_err();
+    assert!(
+        !err.to_string().contains("too long"),
+        "should not be length error: {err}"
+    );
+}
+
+// ============================================================================
+// GROUP 2: Execution/scoring — FakePostingSource
+// ============================================================================
+
+// --- A1: named hit score > 0 ---
+
+#[test]
+fn a1_named_pattern_returns_positive_score() {
+    // try-catch has bigram: try_statement → catch_clause
+    let try_id = vocab_lookup("try_statement").unwrap();
+    let catch_id = vocab_lookup("catch_clause").unwrap();
+    let bigram = AstBigram::encode(try_id, catch_id);
+
+    let source = FakePostingSource::default()
+        .with_file(0, Language::TypeScript, 100)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 2,
+            }],
+        )
+        .with_avg_node_count(100.0);
+
+    let engine = AstQueryEngine::new(source);
+    let q = parse_ast_query("try-catch").unwrap();
+    let results = engine.search_ast(&q).unwrap();
+
+    assert!(!results.is_empty(), "expected at least one result");
+    assert!(results[0].1 > 0.0, "score must be positive");
+}
+
+// --- A2: depth filter — bigram matches, trigram is empty for adjacency-only ---
+
+#[test]
+fn a2_bigram_matches_adjacency_only_file() {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let expr_id = vocab_lookup("expression_statement").unwrap();
+
+    let bigram = AstBigram::encode(fn_id, block_id);
+    let trigram = AstTrigram::encode(fn_id, block_id, expr_id);
+
+    // File 0: has the bigram but NOT the trigram.
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 50)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 1,
+            }],
+        )
+        // trigram posting list is empty (absent key)
+        .with_avg_node_count(50.0);
+
+    let engine = AstQueryEngine::new(source);
+
+    // Bigram query: should return file 0.
+    let bigram_q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let bigram_results = engine.search_ast(&bigram_q).unwrap();
+    assert_eq!(bigram_results.len(), 1);
+    assert_eq!(bigram_results[0].0, FileId(0));
+
+    // Trigram query: should return empty (depth filter).
+    let trigram_q = AstQuery::Containment(make_trigram_set(trigram, 1));
+    let trigram_results = engine.search_ast(&trigram_q).unwrap();
+    assert!(
+        trigram_results.is_empty(),
+        "trigram should be absent for adjacency-only file"
+    );
+}
+
+// --- A3: OR-union ranking — both-clause file outscores one-clause ---
+
+#[test]
+fn a3_union_ranking_both_clauses_scores_higher() {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let expr_id = vocab_lookup("expression_statement").unwrap();
+
+    let bigram1 = AstBigram::encode(fn_id, block_id);
+    let bigram2 = AstBigram::encode(block_id, expr_id);
+
+    // File 0 has both bigrams; file 1 has only bigram1.
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 50)
+        .with_file(1, Language::Rust, 50)
+        .with_bigram(
+            bigram1.key(),
+            vec![
+                AstPosting {
+                    doc_id: 0,
+                    count: 2,
+                },
+                AstPosting {
+                    doc_id: 1,
+                    count: 2,
+                },
+            ],
+        )
+        .with_bigram(
+            bigram2.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 1,
+            }],
+        )
+        .with_avg_node_count(50.0);
+
+    let engine = AstQueryEngine::new(source);
+
+    // Query: both bigrams (multi-n-gram set)
+    let set = AstNgramSet {
+        bigrams: {
+            let mut v = vec![
+                AstBigramEntry {
+                    ngram: bigram1,
+                    weight: DEFAULT_AST_WEIGHT,
+                    count: 1,
+                },
+                AstBigramEntry {
+                    ngram: bigram2,
+                    weight: DEFAULT_AST_WEIGHT,
+                    count: 1,
+                },
+            ];
+            v.sort_unstable_by_key(|e| e.ngram.key());
+            v
+        },
+        trigrams: vec![],
+    };
+    let q = AstQuery::Containment(set);
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 2);
+    // Find scores by FileId (results are FileId-asc)
+    let score0 = results.iter().find(|(f, _)| *f == FileId(0)).unwrap().1;
+    let score1 = results.iter().find(|(f, _)| *f == FileId(1)).unwrap().1;
+    assert!(
+        score0 > score1,
+        "file with both n-grams should score higher: {score0} vs {score1}"
+    );
+}
+
+// --- A4: per-lang IDF + length-norm ---
+
+#[test]
+fn a4_larger_node_count_lower_score() {
+    // Same bigram, same TF, different node_count → larger file gets lower score.
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 50) // small file
+        .with_file(1, Language::Rust, 200) // large file
+        .with_bigram(
+            bigram.key(),
+            vec![
+                AstPosting {
+                    doc_id: 0,
+                    count: 1,
+                },
+                AstPosting {
+                    doc_id: 1,
+                    count: 1,
+                },
+            ],
+        )
+        .with_avg_node_count(100.0); // avg is between small and large
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 2);
+    let score0 = results.iter().find(|(f, _)| *f == FileId(0)).unwrap().1;
+    let score1 = results.iter().find(|(f, _)| *f == FileId(1)).unwrap().1;
+    assert!(
+        score0 > score1,
+        "smaller file should score higher: {score0} vs {score1}"
+    );
+}
+
+#[test]
+fn a4_unknown_lang_uses_1_0_idf_fallback() {
+    // A file with an unrecognized lang_id (255) should still be scored with IDF=1.0.
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    // Use an unrecognized lang_id for file 0.
+    let mut source = FakePostingSource::default().with_avg_node_count(100.0);
+    source.file_metas.insert(
+        0,
+        AstFileMetaEntry {
+            lang_id: 255, // unrecognized
+            node_count: 100,
+            max_depth: 3,
+            max_block_stmts: 5,
+            max_params: 2,
+            branch_count: 1,
+        },
+    );
+    source.file_count = 1;
+    source.bigrams.insert(
+        bigram.key(),
+        vec![AstPosting {
+            doc_id: 0,
+            count: 1,
+        }],
+    );
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+
+    // File should still appear with a positive score (IDF=1.0 fallback).
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].1 > 0.0,
+        "unknown-lang file should have positive score"
+    );
+}
+
+// --- A5: synthetic-marker patterns match with IDF 1.0 ---
+
+#[test]
+fn a5_synthetic_marker_pattern_matches() {
+    use crate::ast_index::structural::{DEEP_NODE, bucket_label};
+
+    let bigram = AstBigram::encode(DEEP_NODE, bucket_label(0));
+
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 80)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 3,
+            }],
+        )
+        .with_avg_node_count(80.0);
+
+    let engine = AstQueryEngine::new(source);
+    let set = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![],
+    };
+    let q = AstQuery::Containment(set);
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 1, "synthetic marker file should match");
+    assert!(
+        results[0].1 > 0.0,
+        "score must be positive (IDF=1.0 fallback for synthetic)"
+    );
+}
+
+// --- Double-counting PINNED test ---
+
+#[test]
+fn double_counting_pinned_bigram_plus_trigram() {
+    // A file matching both a bigram and its containing trigram gets
+    // contributions from BOTH (double-counting tolerated in Wave 3f).
+    // This test pins the current additive behavior.
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let expr_id = vocab_lookup("expression_statement").unwrap();
+
+    let bigram = AstBigram::encode(fn_id, block_id);
+    let trigram = AstTrigram::encode(fn_id, block_id, expr_id);
+
+    let node_count: u32 = 100;
+    let avg: f32 = 100.0;
+
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, node_count)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 2,
+            }],
+        )
+        .with_trigram(
+            trigram.key(),
+            vec![AstPosting {
+                doc_id: 0,
+                count: 1,
+            }],
+        )
+        .with_avg_node_count(avg);
+
+    let engine = AstQueryEngine::new(source);
+
+    // Build a set with both bigram + trigram.
+    let set = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![AstTrigramEntry {
+            ngram: trigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+    };
+    let q = AstQuery::Containment(set);
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 1);
+
+    // Manually compute expected score for pinning.
+    // length_norm = 1 - 0.75 + 0.75 * (100/100) = 1.0
+    // IDF for bigram in Rust: ast_bigram_idf(Rust, bigram) as f64
+    // IDF for trigram in Rust: ast_trigram_idf(Rust, trigram) as f64
+    use crate::ast_index::{ast_bigram_idf, ast_trigram_idf};
+    let idf_b = f64::from(ast_bigram_idf(Language::Rust, bigram));
+    let idf_t = f64::from(ast_trigram_idf(Language::Rust, trigram));
+    let k1 = AST_BM25_K1;
+    // tf_norm for bigram (count=2, length_norm=1.0): 2.0 / 1.0 = 2.0
+    let tf_norm_b = 2.0_f64 / 1.0;
+    let contrib_b = idf_b * (tf_norm_b / (tf_norm_b + k1));
+    // tf_norm for trigram (count=1, length_norm=1.0): 1.0
+    let tf_norm_t = 1.0_f64;
+    let contrib_t = idf_t * (tf_norm_t / (tf_norm_t + k1));
+    let expected = contrib_b + contrib_t;
+
+    let got = results[0].1;
+    assert!(
+        (got - expected).abs() < 1e-9,
+        "double-count golden score mismatch: got {got}, expected {expected}"
+    );
+}
+
+// --- A6: SingleNode execute → InvalidQuery with "unigram" and "#283" ---
+
+#[test]
+fn a6_single_node_execution_defers_to_283() {
+    let try_id = vocab_lookup("try_statement").unwrap();
+    let source = FakePostingSource::default().with_avg_node_count(0.0);
+    let engine = AstQueryEngine::new(source);
+
+    let q = AstQuery::SingleNode(try_id);
+    let err = engine.search_ast(&q).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unigram"),
+        "error must mention 'unigram': {msg}"
+    );
+    assert!(msg.contains("#283"), "error must reference '#283': {msg}");
+}
+
+// --- B2: postcondition — FileId-asc, unique, all scores > 0 ---
+
+#[test]
+fn b2_results_sorted_file_id_asc_unique() {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    // 5 files, all matching the bigram.
+    let postings: Vec<AstPosting> = (0..5u32)
+        .map(|i| AstPosting {
+            doc_id: i,
+            count: 1,
+        })
+        .collect();
+
+    let mut source = FakePostingSource::default().with_avg_node_count(100.0);
+    for i in 0..5u32 {
+        source = source.with_file(i, Language::Rust, 100);
+    }
+    source.bigrams.insert(bigram.key(), postings);
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+
+    assert_eq!(results.len(), 5);
+
+    // Sorted ascending by FileId.
+    for i in 1..results.len() {
+        assert!(
+            results[i - 1].0 < results[i].0,
+            "results not sorted: {:?} before {:?}",
+            results[i - 1].0,
+            results[i].0
+        );
+    }
+
+    // All scores > 0.
+    for (fid, score) in &results {
+        assert!(*score > 0.0, "score for {fid} must be positive: {score}");
+    }
+
+    // Unique FileIds (no duplicates).
+    let ids: HashSet<FileId> = results.iter().map(|(f, _)| *f).collect();
+    assert_eq!(ids.len(), 5, "duplicate FileIds in result");
+}
+
+// --- B3: absent key → Ok(vec![]), empty index → Ok(vec[]) ---
+
+#[test]
+fn b3_absent_key_returns_empty() {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let source = FakePostingSource::default()
+        .with_file(0, Language::Rust, 100)
+        .with_avg_node_count(100.0);
+    // No bigram posting inserted → absent key.
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+    assert!(results.is_empty(), "absent key should return empty results");
+}
+
+#[test]
+fn b3_empty_index_returns_empty() {
+    let source = FakePostingSource::default(); // no files, no postings
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let results = engine.search_ast(&q).unwrap();
+    assert!(results.is_empty());
+}
+
+#[test]
+fn b3_corrupt_doc_id_propagated() {
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    // Posting references doc_id=99 but no meta for it.
+    let source = FakePostingSource::default()
+        .with_avg_node_count(100.0)
+        .with_bigram(
+            bigram.key(),
+            vec![AstPosting {
+                doc_id: 99,
+                count: 1,
+            }],
+        );
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+    let err = engine.search_ast(&q).unwrap_err();
+    // Should propagate as IndexCorrupted (from FakePostingSource.file_meta)
+    assert!(
+        matches!(err, crate::SearchError::IndexCorrupted(_)),
+        "expected IndexCorrupted, got: {err:?}"
+    );
+}
+
+// --- Performance unit tripwire (CI-safe) ---
+
+#[test]
+fn perf_tripwire_10k_postings_under_1s() {
+    use std::time::Instant;
+
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    // 10k postings (one per file).
+    let postings: Vec<AstPosting> = (0..10_000u32)
+        .map(|i| AstPosting {
+            doc_id: i,
+            count: 1 + (i % 5),
+        })
+        .collect();
+
+    let mut source = FakePostingSource::default().with_avg_node_count(100.0);
+    for i in 0..10_000u32 {
+        source = source.with_file(i, Language::Rust, 100);
+    }
+    source.bigrams.insert(bigram.key(), postings);
+
+    let engine = AstQueryEngine::new(source);
+    let q = AstQuery::Containment(make_bigram_set(bigram, 1));
+
+    let start = Instant::now();
+    let results = engine.search_ast(&q).unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(results.len(), 10_000);
+    assert!(
+        elapsed.as_secs() < 1,
+        "10k posting query took too long: {elapsed:?}"
+    );
+}
+
+// ============================================================================
+// GROUP 3: SearchLayer adapter — real AstIndexBuilder/AstIndexReader
+// ============================================================================
+
+fn build_small_index() -> (tempfile::TempDir, AstIndexReader) {
+    let dir = tempdir().unwrap();
+
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+
+    // File 0: Rust, has bigram, count=3
+    let set0 = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 3,
+        }],
+        trigrams: vec![],
+    };
+    builder
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set0,
+            100,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+
+    // File 1: Python, has bigram, count=1
+    let set1 = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![],
+    };
+    builder
+        .add_file_ngrams(
+            FileId(1),
+            Language::Python,
+            &set1,
+            80,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+
+    let reader = builder.build().unwrap();
+    (dir, reader)
+}
+
+// B4: ast_pattern = None → Ok(vec![])
+
+#[test]
+fn b4_none_ast_pattern_returns_empty() {
+    let (dir, reader) = build_small_index();
+    let engine = AstQueryEngine::new(reader);
+
+    let query = SearchQuery::new("some text"); // ast_pattern = None
+    let results = engine.search(&query).unwrap();
+    assert!(results.is_empty(), "None ast_pattern should return empty");
+    drop(dir);
+}
+
+// B4: Some("") → InvalidQuery
+
+#[test]
+fn b4_empty_string_ast_pattern_invalid() {
+    let (dir, reader) = build_small_index();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("text");
+    query.ast_pattern = Some("".into());
+    let err = engine.search(&query).unwrap_err();
+    assert!(err.to_string().contains("empty"), "err: {err}");
+    drop(dir);
+}
+
+// B4: Some("try-catch") → results, score-desc
+
+#[test]
+fn b4_named_pattern_search_returns_results() {
+    // Build an index with the try-catch bigram.
+    let dir = tempdir().unwrap();
+    let try_id = vocab_lookup("try_statement").unwrap();
+    let catch_id = vocab_lookup("catch_clause").unwrap();
+    let bigram = AstBigram::encode(try_id, catch_id);
+
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    let set = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 2,
+        }],
+        trigrams: vec![],
+    };
+    builder
+        .add_file_ngrams(
+            FileId(0),
+            Language::TypeScript,
+            &set,
+            100,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+
+    let reader = builder.build().unwrap();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("query text");
+    query.ast_pattern = Some("try-catch".into());
+    let results = engine.search(&query).unwrap();
+
+    assert!(!results.is_empty(), "should return results for try-catch");
+    assert_eq!(results[0].file_id, FileId(0));
+    drop(dir);
+}
+
+// B4: limit / offset honored
+
+#[test]
+fn b4_limit_and_offset_honored() {
+    let dir = tempdir().unwrap();
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    for i in 0..5u32 {
+        let set = AstNgramSet {
+            bigrams: vec![AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 5 - i, // different counts → different scores
+            }],
+            trigrams: vec![],
+        };
+        builder
+            .add_file_ngrams(
+                FileId(i),
+                Language::Rust,
+                &set,
+                100,
+                StructuralMetrics::default(),
+            )
+            .unwrap();
+    }
+    let reader = builder.build().unwrap();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("q");
+    query.ast_pattern = Some("function_item > block".into());
+    query.limit = Some(2);
+    query.offset = Some(1);
+    let results = engine.search(&query).unwrap();
+
+    assert_eq!(results.len(), 2, "limit=2 should yield 2 results");
+    drop(dir);
+}
+
+// B4: lang filter restricts to one language
+
+#[test]
+fn b4_lang_filter_restricts_results() {
+    let (dir, reader) = build_small_index();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("q");
+    query.ast_pattern = Some("function_item > block".into());
+    query.lang = Some(Language::Python);
+    let results = engine.search(&query).unwrap();
+
+    // Only file 1 is Python.
+    assert!(
+        results.iter().all(|r| r.file_id == FileId(1)),
+        "lang filter should restrict to Python file (FileId 1): {results:?}"
+    );
+    drop(dir);
+}
+
+// B4: file_filter allowlist restricts FileIds
+
+#[test]
+fn b4_file_filter_restricts_file_ids() {
+    let (dir, reader) = build_small_index();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("q");
+    query.ast_pattern = Some("function_item > block".into());
+    query.file_filter = Some(HashSet::from([FileId(0)]));
+    let results = engine.search(&query).unwrap();
+
+    assert!(
+        results.iter().all(|r| r.file_id == FileId(0)),
+        "file_filter should restrict to FileId(0): {results:?}"
+    );
+    drop(dir);
+}
+
+// B4: results sorted score-DESC, FileId-ASC tie-break; name()=="ast"
+
+#[test]
+fn b4_results_sorted_score_desc() {
+    let dir = tempdir().unwrap();
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    // File 0: low count, high node_count → lower score
+    let set0 = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![],
+    };
+    builder
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set0,
+            500,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+    // File 1: higher count, low node_count → higher score
+    let set1 = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 5,
+        }],
+        trigrams: vec![],
+    };
+    builder
+        .add_file_ngrams(
+            FileId(1),
+            Language::Rust,
+            &set1,
+            50,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+    let reader = builder.build().unwrap();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("q");
+    query.ast_pattern = Some("function_item > block".into());
+    let results = engine.search(&query).unwrap();
+
+    assert_eq!(results.len(), 2);
+    // First result should be FileId(1) (higher score).
+    assert_eq!(
+        results[0].file_id,
+        FileId(1),
+        "higher-score file should be first"
+    );
+    drop(dir);
+}
+
+#[test]
+fn b4_name_is_ast() {
+    let (dir, reader) = build_small_index();
+    let engine = AstQueryEngine::new(reader);
+    assert_eq!(engine.name(), "ast");
+    drop(dir);
+}
+
+// B6: result fields — line_range==0..0, match_positions==[], field==Other, snippet==None
+
+#[test]
+fn b6_result_fields_are_honest_defaults() {
+    let dir = tempdir().unwrap();
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    let set = AstNgramSet {
+        bigrams: vec![AstBigramEntry {
+            ngram: bigram,
+            weight: DEFAULT_AST_WEIGHT,
+            count: 1,
+        }],
+        trigrams: vec![],
+    };
+    builder
+        .add_file_ngrams(
+            FileId(0),
+            Language::Rust,
+            &set,
+            100,
+            StructuralMetrics::default(),
+        )
+        .unwrap();
+    let reader = builder.build().unwrap();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("q");
+    query.ast_pattern = Some("function_item > block".into());
+    let results = engine.search(&query).unwrap();
+
+    assert!(!results.is_empty());
+    let r = &results[0];
+    assert_eq!(r.line_range, 0..0, "line_range should be 0..0");
+    assert!(
+        r.match_positions.is_empty(),
+        "match_positions should be empty"
+    );
+    assert_eq!(
+        r.field,
+        crate::types::SearchField::Other,
+        "field should be Other"
+    );
+    assert!(r.snippet.is_none(), "snippet should be None");
+    drop(dir);
+}

--- a/crates/rskim-search/src/ast_index/query_tests.rs
+++ b/crates/rskim-search/src/ast_index/query_tests.rs
@@ -581,9 +581,19 @@ fn a5_synthetic_marker_pattern_matches() {
     let results = engine.search_ast(&q).unwrap();
 
     assert_eq!(results.len(), 1, "synthetic marker file should match");
+
+    // A5 exact score: synthetic keys are absent from the weight table, so
+    // ast_bigram_idf falls back to DEFAULT_AST_WEIGHT = 1.0.
+    // Setup: node_count=80, avg=80.0 → nc == avg → length_norm = 1.0
+    //   tf_norm = count / length_norm = 3.0 / 1.0 = 3.0
+    //   score = idf * (tf_norm / (tf_norm + k1)) = 1.0 * (3.0 / (3.0 + 1.2))
+    let k1 = AST_BM25_K1;
+    let tf_norm = 3.0_f64; // count=3, length_norm=1.0
+    let expected = tf_norm / (tf_norm + k1); // idf=1.0
+    let got = results[0].1;
     assert!(
-        results[0].1 > 0.0,
-        "score must be positive (IDF=1.0 fallback for synthetic)"
+        (got - expected).abs() < 1e-9,
+        "A5 synthetic score mismatch: got {got}, expected {expected} (idf=1.0, tf_norm={tf_norm})"
     );
 }
 
@@ -1310,5 +1320,68 @@ fn b6_result_fields_are_honest_defaults() {
         "field should be Other"
     );
     assert!(r.snippet.is_none(), "snippet should be None");
+    drop(dir);
+}
+
+// B4: equal scores exercise the FileId-ASC tie-break
+//
+// Two files built from identical inputs (same language, same node_count, same
+// bigram count) produce bitwise-equal BM25 scores. The SearchLayer sort is
+// score-DESC with FileId-ASC as a tie-break. This test confirms the tie-break
+// branch is live: a refactor inverting the order would fail here.
+#[test]
+fn b4_equal_scores_tie_break_file_id_asc() {
+    let dir = tempdir().unwrap();
+    let fn_id = vocab_lookup("function_item").unwrap();
+    let block_id = vocab_lookup("block").unwrap();
+    let bigram = AstBigram::encode(fn_id, block_id);
+
+    let mut builder = AstIndexBuilder::new(dir.path().to_path_buf()).unwrap();
+    // Two files with identical inputs → identical BM25 scores.
+    // Same language, node_count, posting count → same length_norm, tf_norm, idf.
+    for i in 0..2u32 {
+        let set = AstNgramSet {
+            bigrams: vec![AstBigramEntry {
+                ngram: bigram,
+                weight: DEFAULT_AST_WEIGHT,
+                count: 1,
+            }],
+            trigrams: vec![],
+        };
+        builder
+            .add_file_ngrams(
+                FileId(i),
+                Language::Rust,
+                &set,
+                100,
+                StructuralMetrics::default(),
+            )
+            .unwrap();
+    }
+    let reader = builder.build().unwrap();
+    let engine = AstQueryEngine::new(reader);
+
+    let mut query = SearchQuery::new("q");
+    query.ast_pattern = Some("function_item > block".into());
+    let results = engine.search(&query).unwrap();
+
+    assert_eq!(results.len(), 2, "both files should match");
+
+    // Scores must be bitwise-equal (same inputs, deterministic formula).
+    let score0 = results.iter().find(|r| r.file_id == FileId(0)).unwrap().score;
+    let score1 = results.iter().find(|r| r.file_id == FileId(1)).unwrap().score;
+    assert_eq!(
+        score0, score1,
+        "precondition: both files must have equal scores (score0={score0}, score1={score1})"
+    );
+
+    // When scores tie, FileId-ASC tie-break must apply: FileId(0) before FileId(1).
+    let ids: Vec<FileId> = results.iter().map(|r| r.file_id).collect();
+    assert_eq!(
+        ids,
+        vec![FileId(0), FileId(1)],
+        "tied scores must be broken FileId-ASC: got {ids:?}"
+    );
+
     drop(dir);
 }

--- a/crates/rskim-search/src/ast_index/query_tests.rs
+++ b/crates/rskim-search/src/ast_index/query_tests.rs
@@ -1323,12 +1323,8 @@ fn b6_result_fields_are_honest_defaults() {
     drop(dir);
 }
 
-// B4: equal scores exercise the FileId-ASC tie-break
-//
-// Two files built from identical inputs (same language, same node_count, same
-// bigram count) produce bitwise-equal BM25 scores. The SearchLayer sort is
-// score-DESC with FileId-ASC as a tie-break. This test confirms the tie-break
-// branch is live: a refactor inverting the order would fail here.
+// B4: equal-score tie-break — identical inputs produce bitwise-equal scores, FileId-ASC wins
+
 #[test]
 fn b4_equal_scores_tie_break_file_id_asc() {
     let dir = tempdir().unwrap();

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -34,10 +34,11 @@ mod types;
 pub mod weights;
 
 pub use ast_index::{
-    AstBigram, AstBigramEntry, AstFileMetaEntry, AstIndexBuilder, AstIndexReader, AstNgramSet,
-    AstPosting, AstTrigram, AstTrigramEntry, DEFAULT_AST_WEIGHT, LinearNode, LinearizeResult,
-    NodeKindId, ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams,
-    extract_ast_ngrams_with_weights, linearize_source, vocab_len, vocab_lookup, vocab_resolve,
+    AST_BM25_B, AST_BM25_K1, AstBigram, AstBigramEntry, AstFileMetaEntry, AstIndexBuilder,
+    AstIndexReader, AstNgramSet, AstPosting, AstPostingSource, AstQuery, AstQueryEngine,
+    AstTrigram, AstTrigramEntry, DEFAULT_AST_WEIGHT, LinearNode, LinearizeResult, NodeKindId,
+    ast_bigram_idf, ast_trigram_idf, extract_ast_ngrams, extract_ast_ngrams_with_weights,
+    linearize_source, parse_ast_query, vocab_len, vocab_lookup, vocab_resolve,
 };
 pub use cochange::{CochangeMatrixBuilder, CochangeMatrixReader};
 pub use index::{NgramIndexBuilder, NgramIndexReader};


### PR DESCRIPTION
## Summary

Closes #197. Implements the BM25-ranked AST structural pattern query engine over the on-disk n-gram index built in Waves 3d/3e.

- **`parse_ast_query`** — total string→`AstQuery` boundary (never panics, rejects `>>` transitive, depth>2, >4 096 bytes, unknown kinds/patterns)
- **`AstQueryEngine`** with three query forms: named pattern (`empty-catch`, `empty-function`, `deep-nesting`, `god-function`), containment bigram/trigram (`A > B`, `A > B > C`), single-node (`function_declaration` — returns `InvalidQuery` pointing at #283 unigram-index work)
- **BM25 OR-union scoring**: `score = Σ idf · tf_norm / (tf_norm + k1)`, k1=1.2, b=0.75; IDF=1.0 fallback for synthetic n-gram markers and unknown language
- **`AstPostingSource` trait** — DI seam so tests run entirely in-memory (no disk I/O)
- **`search_ast()`** returns `Vec<(FileId, f64)>` sorted FileId-ASC — Wave-4 merge-join contract preserved
- **`SearchLayer::search`** adapter: filter chain (file_filter → lang → offset/limit), score-DESC sort, `None` query → empty, `Some("")` → `InvalidQuery`
- Double-counting from bigram+trigram overlap tolerated; deferred to #198

## Changes

| File | Change |
|---|---|
| `crates/rskim-search/src/ast_index/query.rs` | NEW — engine, 397 lines (≤400 cap) |
| `crates/rskim-search/src/ast_index/query_tests.rs` | NEW — 41 tests, FakePostingSource harness |
| `crates/rskim-search/benches/ast_query.rs` | NEW — 3 Criterion scenarios × 10k synthetic files |
| `crates/rskim-search/src/ast_index/mod.rs` | re-export new `query` module |
| `crates/rskim-search/src/lib.rs` | re-export new public types |
| `crates/rskim-search/Cargo.toml` | register `ast_query` bench |

## Breaking Changes

None. All additions are additive exports in `rskim-search`; no existing public APIs changed.

## Reviewer Focus Areas

- **BM25 scoring in `run_ngram_set`** (query.rs ~L120–180): verify length-norm formula, IDF-1.0 fallback for synthetic IDs, and the `cached_meta` check-then-insert pattern (can't use `or_insert_with` because `Result` propagation is needed)
- **SingleNode arm** (query.rs `search_ast`): must return `Err(SearchError::InvalidQuery(...))` with both "unigram" and "#283" in the message
- **`parse_ast_query` rejection paths** (query.rs ~L280–360): `>>` transitive syntax, depth>2, empty segments, 4 096-byte cap
- **Wave-4 contract**: `search_ast` returns FileId-ASC; `SearchLayer::search` applies score-DESC on top — confirm sort directions are not swapped
- **Test A5 (double-counting pinned)** in query_tests.rs: deliberately pinned to document the overlap, not to assert it's wrong; deferred to #198

## Downstream

- #283 — unigram index (enables `SingleNode` query form)
- #198 — deduplicate bigram+trigram overlap in OR-union scoring
- #199 — Wave 3g: `--ast` CLI flag wiring (`SearchLayer` is ready)