### PR TITLE
docs: build/test resource-limit policy (cargo caps + sccache + nextest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ cargo run --bin skim -- file.ts --mode=signatures   # run locally
 
 `rskim` is bin-only (the `skim` binary; no `src/lib.rs`) — scope its tests with `cargo test -p rskim --bins` (or `--all-targets`). `cargo test -p rskim --lib` errors with "no library targets found" (a cargo target-selection behavior, not a skim bug). `rskim-core`/`rskim-search` are libraries and accept `--lib`.
 
+### Build/test resource limits
+
+A machine-global `~/.cargo/config.toml` caps every cargo invocation at `jobs = 4` and `RUST_TEST_THREADS = 4`, and routes compilation through `sccache` (a compile cache shared across parallel clones). **That config file is the enforcement layer — it protects every branch and clone regardless of this doc; the guidance below exists because the cap alone can still be multiplied by parallelism.** Running unbounded parallel builds across two clones once exhausted 64 GB RAM (heavy tree-sitter/SQLite/rustls deps + release LTO/`codegen-units=1`) and hard-restarted the machine. The root multiplier was **two clones with separate `target/` dirs compiling identical heavy deps at once**. Rules for agents and workflows:
+
+- **Scope cargo per-crate** (`-p <crate>`). Never `--workspace` or `--all-features` *inside an agent* — those fan out across all 5 crates and their heavy deps simultaneously.
+- **Never `cargo test -p rskim` in an agent**: it spawns a *nested* cargo (daemon meta-tests) on top of subprocess-spawning E2E tests. Use `cargo test -p rskim --bins` / `--all-targets` (see the scoping note above).
+- **Prefer `cargo nextest run -p <crate> -j 4`** for unit/integration tests, **plus `cargo test -p <crate> --doc`** for doctests (nextest cannot run doctests).
+- **Never run two release/LTO builds concurrently**, and never kick off a heavy build in both clones at the same time.
+- **Defer the full `--all-features` regression** to the main loop or a human, run when the machine is otherwise idle.
+
 Modes are set via `--mode` only (no config file): `structure` (default), `signatures`, `types`, `minimal`, `pseudo`, `full`.
 
 ### Subcommands


### PR DESCRIPTION
## What

Adds a **Build/test resource limits** subsection to `CLAUDE.md` (under Commands, next to the existing cargo test-scoping note).

## Why

Running `/devflow:dynamic-*` workflows in parallel across two clones (`~/Sandbox/skim` and `~/Sandbox/skim-search`) repeatedly choked the machine to a force-restart. Root cause: nothing in the toolchain capped parallelism — agents × 2 clones (separate `target/`, no shared cache) × all 10 cores × 10 test-threads × subprocess-spawning tests, on top of heavy tree-sitter/SQLite/rustls + release LTO deps → 64 GB exhausted → swap thrash → hard restart.

The durable fix is **outside the repo**: a machine-global `~/.cargo/config.toml` capping `jobs = 4` + `RUST_TEST_THREADS = 4` and routing compilation through `sccache` (shared cross-clone cache). That config is the enforcement layer and already active on this machine. This PR documents the policy so agents and workflows follow it consistently:

- Scope cargo per-crate (`-p <crate>`); never `--workspace`/`--all-features` inside an agent.
- Never `cargo test -p rskim` in an agent (nested cargo + subprocess E2E); use `--bins`/`--all-targets`.
- Prefer `cargo nextest run -p <crate> -j 4` + `cargo test -p <crate> --doc` for doctests.
- Never run two release/LTO builds — or heavy builds in both clones — concurrently.
- Defer the full `--all-features` regression to the idle main loop/human.

## Scope

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)