### PR TITLE
fix: rewrite-hook false-negatives — root-cause fixes A–F + recurrence guards

### DIFF
--- a/.devflow/features/build-parsers/KNOWLEDGE.md
+++ b/.devflow/features/build-parsers/KNOWLEDGE.md
@@ -1,7 +1,7 @@
 ---
 feature: build-parsers
 name: Build Tool Output Parsers
-description: "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, ChildGuard, indefinite, is_indefinite_command, expected_exit_codes, forward_stderr, ExitDisposition, classify_exit, run_parsed_command_with_exit, elision_marker, failure_context_body, parse_failure_details, compress-never-truncate."
+description: "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, ChildGuard, indefinite, is_indefinite_command, expected_exit_codes, forward_stderr, ExitDisposition, classify_exit, run_parsed_command_with_exit, elision_marker, failure_context_body, parse_failure_details, compress-never-truncate, spawn_status_to_code, run_with_node_fallback, should_emit_compressed_hint, BENIGN_EXIT1_PROGRAMS, FileResult."
 category: component-patterns
 directories: [crates/rskim/src/cmd/build/, crates/rskim/src/cmd/]
 referencedFiles:
@@ -24,8 +24,8 @@ referencedFiles:
   - crates/rskim/src/cmd/test/cargo.rs
   - crates/rskim/src/cmd/test/shared.rs
 created: 2026-05-14
-updated: 2026-06-17
-version: 16
+updated: 2026-06-21
+version: 17
 ---
 
 # Build Tool Output Parsers
@@ -51,7 +51,7 @@ Rules that flow from this constraint:
 `cmd/mod.rs` was refactored to reduce complexity. Functionality previously inline in `mod.rs` is now split across dedicated submodules:
 
 - `cmd/dispatch.rs` — `dispatch()`, `run_raw_passthrough()`, and per-tool dispatcher helpers (`dispatch_cargo`, `dispatch_go`, `dispatch_swift`, `dispatch_dotnet`, `passthrough_subcmd`, `extract_subcmd`, `prepend_without`)
-- `cmd/execution.rs` — `OutputFormat`, `RunContext`, `ParsedCommandConfig<'_>`, `ToolRunConfig<'_>`, `run_tool<T>`, `run_parsed_command_with_mode`, `run_parsed_command_with_exit`, `format_analytics_label`, `combine_output`, `obtain_output`, `render_output<T>`, `record_and_report`, `passthrough_raw`
+- `cmd/execution.rs` — `OutputFormat`, `RunContext`, `ParsedCommandConfig<'_>`, `ToolRunConfig<'_>`, `run_tool<T>`, `run_parsed_command_with_mode`, `run_parsed_command_with_exit`, `format_analytics_label`, `combine_output`, `obtain_output`, `render_output<T>`, `record_and_report`, `passthrough_raw`, `RecordReport<'_>`, `should_emit_compressed_hint`, `BENIGN_EXIT1_PROGRAMS`
 - `cmd/security.rs` — `sanitize_for_display`, `scrub_db_args`, `scrub_infra_args`
 - `cmd/registry.rs` — `KNOWN_SUBCOMMANDS` (sorted, binary-searchable), `is_known_subcommand`, `is_meta_subcommand`, `wrapper_targets`
 - `cmd/test_utils.rs` — standalone `pub(crate)` module (compiled under `#[cfg(test)]` gate in `mod.rs`); canonical test helper source for all `cmd` subtree tests
@@ -237,12 +237,54 @@ ExitDisposition::UnexpectedFailure — all other non-zero, or signal kill → fo
 
 **`forward_stderr`** — when `true`, child stderr is forwarded verbatim on the compressed path (captured before ANSI stripping for byte-faithfulness). Used for `file` and `db` families whose parsers consume only stdout, so warnings/diagnostics on stderr are never silently dropped.
 
-**Notice matrix**:
+**Notice matrix** (applies PF-003 — avoids misattributing tool behavior to skim):
 - Unexpected failure → `[skim] {program} exited N; raw output (not compressed).` (stderr)
 - Expected failure at `Passthrough` tier → silent (matches raw tool behavior, e.g. grep no-match silence)
-- Expected failure at `Full`/`Degraded` tier → `[skim] compressed output (exit N). SKIM_PASSTHROUGH=1 for full output.` (stderr)
+- Expected failure at `Full`/`Degraded` tier → compressed-output hint IF `should_emit_compressed_hint` returns true (see below)
 
 **Build family is exempt**: `build::run_parsed_command` does not use this matrix — it has its own exit-code logic derived from `BuildResult.success`.
+
+## Compressed-Output Hint: `should_emit_compressed_hint` and `BENIGN_EXIT1_PROGRAMS` (Fix B, PR #340)
+
+The `[skim] compressed output (exit N). SKIM_PASSTHROUGH=1 for full output.` stderr hint fires only when `should_emit_compressed_hint` returns `true`. This pure function is the **single source of truth** for the notice-matrix decision (applies PF-003):
+
+```rust
+const BENIGN_EXIT1_PROGRAMS: &[&str] = &["grep", "rg", "diff"];
+
+fn should_emit_compressed_hint(program: &str, code: i32, tier_name: &str) -> bool {
+    let is_benign_exit1 = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&program);
+    code != 0 && tier_name != "passthrough" && !is_benign_exit1
+}
+```
+
+All three conditions must hold to emit:
+1. `code != 0` — exit 0 never gets a hint.
+2. `tier_name != "passthrough"` — the body is already verbatim on the passthrough tier, so a hint would duplicate raw behavior.
+3. NOT a benign exit-1 — for `grep`, `rg`, and `diff`, exit 1 means "no match" / "files differ" (a normal informational result), not an error. Printing the hint would mislead agents into thinking something failed.
+
+Exit ≥ 2 for `BENIGN_EXIT1_PROGRAMS` tools IS a real error (e.g., `grep` syntax error, `diff` read failure) and still gets the hint. Non-benign tools (e.g., `cargo`) at exit 1 also get the hint.
+
+`RecordReport<'_>` (the parameter bundle passed to `record_and_report`) carries a `program` field specifically so `should_emit_compressed_hint` can inspect it without threading the program name as an extra positional argument.
+
+Unexpected failures (codes outside `expected_exit_codes`) raw-forward and return before reaching `record_and_report`, so `should_emit_compressed_hint` is only ever called for expected failures that the parser meaningfully compressed.
+
+## `FileResult::render` — Conditional Ratio Header (Fix F, PR #340)
+
+`FileResult::render` in `canonical.rs` emits the header conditionally:
+
+```rust
+let header = if shown_count < total_count {
+    format!("{tool} {shown_count}/{total_count}")  // truncation occurred — show ratio
+} else {
+    format!("{tool} {total_count}")                // all results fit — just the count
+};
+```
+
+Before Fix F, the header was always `"{tool} {shown_count}/{total_count}"`, producing a tautological `N/N` header when no truncation occurred (e.g., `find 3/3`). This misled agents into thinking results were capped. Now:
+- When `shown_count < total_count` (truncation happened): `"{tool} shown/total"` — communicates what was omitted.
+- When `shown_count == total_count` (no truncation): `"{tool} total"` — no ratio, no false signal.
+
+The JSON envelope is unchanged: `total_count` and `shown_count` serialize independently; `rendered` is `#[serde(skip_serializing)]`.
 
 ## `run_parsed_command_with_exit` — Parser-Derived Exit Codes (#317)
 
@@ -479,6 +521,12 @@ Do not redeclare local versions — use the canonical source to prevent drift.
 
 - **Calling `classify_exit` on `unwrap_or(1)` output**: `classify_exit` must be called on the raw `Option<i32>` so that `None` (signal kill) maps to `UnexpectedFailure` regardless of what value `expected_exit_codes` contains.
 
+- **Re-implementing the compressed-output hint inline**: the decision of whether to emit `[skim] compressed output (exit N)` belongs to `should_emit_compressed_hint`. Do not reproduce the three-way condition inline in new code — call the function. Tests drive the same code path (PF-003 / PF-007).
+
+- **Adding a tool to `BENIGN_EXIT1_PROGRAMS` without verifying exit semantics**: the list is conservative. Only add a tool here when exit 1 is universally "no result / no change" for that tool (not just sometimes). For tools where exit 1 can mean either "no match" or a real error depending on flags, do not add them — leave exit 1 as a hint-emitting expected failure.
+
+- **Emitting `N/N` ratio in `FileResult` header**: the `FileResult::render` conditional means `shown_count == total_count` produces just `"{tool} {total_count}"`. Do not pass `shown_count == total_count` and expect a ratio — callers that always set `shown_count = total_count` will get the simpler header, which is correct.
+
 ## Gotchas
 
 - **Degradation markers and parse notices are silent by default**: `emit_markers` in `ParseResult` only writes to stderr when `SKIM_DEBUG=1` or `--debug` is set. In normal operation, Tier 2 (`Degraded`) and Tier 3 (`Passthrough`) passes are silent — no `[skim:warning]` or `[skim:notice]` lines appear. This means a build that degrades to regex fallback gives no on-screen indication unless debug mode is active. Enable `SKIM_DEBUG=1` when diagnosing unexpected parse behavior.
@@ -525,6 +573,12 @@ Do not redeclare local versions — use the canonical source to prevent drift.
 
 - **`run_parsed_command_with_exit` applies `max(child, derived)` not `child.or(derived)`**: `max` means a child exit 101 is preserved even if `derive_exit` returns `Some(1)`. The derived exit only wins when the child exit is 0 (stdin fabrication path).
 
+- **`should_emit_compressed_hint` is only called for expected-failure codes**: unexpected failures raw-forward and return before reaching `record_and_report`. Any `code != 0` seen inside `should_emit_compressed_hint` is guaranteed to be in `expected_exit_codes`. The benign-exit1 guard is therefore only relevant for tools that have `1` in their `expected_exit_codes` list (`grep`, `rg`, `diff`, `lint` family, `pkg`).
+
+- **`RecordReport::program` is the tool binary name, not the skim subcommand**: when `record_and_report` calls `should_emit_compressed_hint(program, ...)`, `program` is the actual binary spawned (e.g., `"grep"`, `"rg"`), not `"skim"`. The field was added to `RecordReport` specifically to thread this through without an extra positional arg.
+
+- **`FileResult` JSON envelope fields are unaffected by Fix F**: `total_count` and `shown_count` serialize independently in the JSON output. Only the pre-computed `rendered` field (which is `#[serde(skip_serializing)]`) is affected by the conditional header logic. Callers comparing JSON before/after Fix F will see identical envelopes.
+
 ## Key Files
 
 - `crates/rskim/src/cmd/build/mod.rs` — dispatcher (`run`), shared `run_parsed_command`, and `print_help`
@@ -534,10 +588,10 @@ Do not redeclare local versions — use the canonical source to prevent drift.
 - `crates/rskim/src/cmd/build/gradle.rs` — Gradle/Gradlew: task outcome + Java/Kotlin diagnostic Tier 1 (with duration), noise-strip Tier 2 (six `LazyLock<Regex>` patterns)
 - `crates/rskim/src/cmd/build/maven.rs` — Maven/Mvnw: `[ERROR]`/`[WARNING]` + build summary Tier 1 (with duration), noise-strip Tier 2 (two `LazyLock<Regex>` patterns, two duration formats)
 - `crates/rskim/src/output/mod.rs` — `ParseResult<T>` enum definition and helpers (`is_full`, `is_degraded`, `is_passthrough`, `tier_name`, `content`, `into_content`, `emit_markers`); `strip_ansi` and `strip_ansi_cow` (zero-copy fast path: borrows when no ESC byte present); `to_json_envelope` (not used by build family); `elision_marker`, `elision_marker_unbounded` (#317 loud elision helpers); `OutputMode`, `clean`, `clean_with_mode`, `PassthroughTruncator`, `FilterTransparencyHeader`
-- `crates/rskim/src/output/canonical.rs` — `BuildResult` (pre-rendered output); `TestResult` (with `context: Option<String>` safety net and `with_context` constructor, #317); `TestEntry`, `TestSummary`, `TestOutcome`; `GitResult`, `LintResult`, `DbResult`, `PkgResult`, `InfraResult`, `LogResult`, `DiffResult`, `FileResult`
+- `crates/rskim/src/output/canonical.rs` — `BuildResult` (pre-rendered output); `TestResult` (with `context: Option<String>` safety net and `with_context` constructor, #317); `TestEntry`, `TestSummary`, `TestOutcome`; `GitResult`, `LintResult`, `DbResult`, `PkgResult`, `InfraResult`, `LogResult`, `DiffResult`; `FileResult` (conditional ratio header: `shown/total` only when truncation occurred, Fix F)
 - `crates/rskim/src/cmd/mod.rs` — coordination point: declares all submodules, re-exports public API; inline helpers: `user_has_flag`, `inject_flag_before_separator`, `extract_show_stats`, `extract_json_flag`, `extract_output_format`, `should_read_stdin` (stdin-eligible when empty args OR `args == ["run"]`), `read_bounded`, `read_stdin_bounded`, `MAX_STDIN_BYTES`; passthrough checks: `is_passthrough_mode`, `check_passthrough_str`, `check_passthrough_value`; resolvers: `resolve_cache_dir`, `skim_wrappers_dir`
 - `crates/rskim/src/cmd/dispatch.rs` — `dispatch()`, `run_raw_passthrough()`, `run_inherited_passthrough()` (inherited-stdio path for daemon/streaming commands); `spawn_status_to_code(status: io::Result<ExitStatus>) -> u8` (pure exit-code mapper: ENOENT→127, other error→1, signal-kill→1, otherwise clamp to `[0,255]`; `pub(crate)` and independently unit-tested); per-tool dispatcher helpers
-- `crates/rskim/src/cmd/execution.rs` — `OutputFormat`, `RunContext`, `ParsedCommandConfig<'_>` (with `expected_exit_codes`, `forward_stderr`, #317), `ToolRunConfig<'_>` (with `expected_exit_codes`, `forward_stderr`, #317), `run_tool<T>`, `run_parsed_command_with_mode`, `run_parsed_command_with_exit` (#317), `ExitDisposition`, `classify_exit` (#317), `format_analytics_label`, `combine_output`, `obtain_output`, `render_output<T>`, `record_and_report`, `passthrough_raw`
+- `crates/rskim/src/cmd/execution.rs` — `OutputFormat`, `RunContext`, `ParsedCommandConfig<'_>` (with `expected_exit_codes`, `forward_stderr`, #317), `ToolRunConfig<'_>` (with `expected_exit_codes`, `forward_stderr`, #317), `run_tool<T>`, `run_parsed_command_with_mode`, `run_parsed_command_with_exit` (#317), `ExitDisposition`, `classify_exit` (#317), `format_analytics_label`, `combine_output`, `obtain_output`, `render_output<T>`, `record_and_report`, `passthrough_raw`, `RecordReport<'_>` (parameter bundle with `program` field), `should_emit_compressed_hint` (pure fn, single source of truth for hint emission), `BENIGN_EXIT1_PROGRAMS` (Fix B: `["grep", "rg", "diff"]`)
 - `crates/rskim/src/cmd/security.rs` — `sanitize_for_display`, `scrub_db_args`, `scrub_infra_args`
 - `crates/rskim/src/cmd/registry.rs` — `KNOWN_SUBCOMMANDS` (sorted, binary-searchable via `binary_search`), `is_known_subcommand`, `is_meta_subcommand`, `wrapper_targets`
 - `crates/rskim/src/cmd/test_utils.rs` — standalone test helper module (compiled under `#[cfg(test)]` gate): `make_output`, `make_output_full`, `make_output_stderr`, `load_fixture` (with `Component::Normal` traversal guard); import as `crate::cmd::test_utils`; renamed from `test_support` in PR #126
@@ -551,10 +605,11 @@ Do not redeclare local versions — use the canonical source to prevent drift.
 ## Related
 
 - `crates/rskim/src/output/mod.rs` — owns `ParseResult<T>`, the type returned by all three-tier parsers across the whole codebase (lint, test, infra, build); `emit_markers` debug gate; `elision_marker`/`elision_marker_unbounded` (#317)
-- `crates/rskim/src/output/canonical.rs` — owns `BuildResult`, `TestResult` (with `context` safety net), `GitResult`, `LintResult`
+- `crates/rskim/src/output/canonical.rs` — owns `BuildResult`, `TestResult` (with `context` safety net), `GitResult`, `LintResult`, `FileResult` (Fix F conditional header)
 - `crates/rskim/src/runner.rs` — `CommandRunner` (stateless, ADR-008), `CommandOutput`, `ChildGuard` (kill-on-drop), `is_spawn_error`; `run_with_node_fallback`/`run_with_env_node_fallback` (Node.js tool resolution; not used by build parsers); no internal timeout, no `RunnerError::Timeout`
 - `crates/rskim/src/cmd/rewrite/indefinite.rs` — `is_indefinite_command`; guards daemon/streaming commands from being captured; consumed by `dispatch()` and the rewrite hook path
 - `crates/rskim/src/cmd/lint/` — sibling module using the same three-tier pattern with `LintResult` instead of `BuildResult`; lint parsers use `run_tool<T>` (via `run_parsed_command_with_mode` in `execution.rs`) rather than `run_parsed_command`
 - `crates/rskim/src/cmd/test/` — sibling module using the same three-tier pattern with `TestResult`; cargo.rs uses `run_parsed_command_with_exit` directly
 - ADR-008: Remove internal subprocess timeout/duration caps; bound child-process lifetime with `ChildGuard` kill-on-drop instead of an arbitrary timeout
 - ADR-001: Fix all noticed issues immediately regardless of scope — applies when adding a new build parser: fix any spotted inconsistencies in other parsers in the same PR rather than deferring
+- PF-003: Applies compress-never-truncate; corrected by PR #340 (Fix B) — the rewrite hook was misattributing grep/diff exit-1 as errors, printing the compressed-output hint when the raw tool would be silent

--- a/.devflow/features/build-parsers/KNOWLEDGE.md
+++ b/.devflow/features/build-parsers/KNOWLEDGE.md
@@ -24,8 +24,8 @@ referencedFiles:
   - crates/rskim/src/cmd/test/cargo.rs
   - crates/rskim/src/cmd/test/shared.rs
 created: 2026-05-14
-updated: 2026-06-13
-version: 15
+updated: 2026-06-17
+version: 16
 ---
 
 # Build Tool Output Parsers
@@ -363,6 +363,13 @@ The 64 MiB memory cap (`MAX_OUTPUT_BYTES`) is unchanged — ADR-008 removes the 
 
 `RunnerError::Timeout` and `wait_with_timeout` no longer exist. Any code referencing them will not compile.
 
+**Node.js tool resolution fallback.** `CommandRunner` also provides two higher-level methods for commands that may be installed as Node.js local packages rather than globally on `$PATH`:
+
+- `run_with_node_fallback(program, args)` — tries in order: (1) direct `$PATH` lookup, (2) `./node_modules/.bin/{program}` (local bin check), (3) `npx --no-install {program}`. Returns the original spawn error when all three fail. Absolute or relative paths (containing `/`) skip fallback — the caller is explicit about the binary location. Only activates on `SpawnFailed` errors (ENOENT); other runner errors (`PipeCaptureFailed`, `ReaderPanicked`) are returned immediately without retry, since the binary was found and launched.
+- `run_with_env_node_fallback(program, args, env_vars)` — same tri-strategy resolution with environment variable overrides forwarded to every candidate.
+
+Build parsers do NOT use the Node.js fallback methods — they use `run_parsed_command` in `build/mod.rs`, which calls `CommandRunner::run_with_env` directly. The fallback is used by Node.js-ecosystem handlers (e.g., vitest, jest, eslint) where local package installs are the norm.
+
 ## Indefinite-Command Detection (`cmd/rewrite/indefinite.rs`)
 
 `crates/rskim/src/cmd/rewrite/indefinite.rs` (added in ADR-008 Part C) provides `is_indefinite_command(tokens: &[&str]) -> bool`. It detects daemon processes, watch modes, and live log followers so the dispatcher can pass them through with inherited stdio rather than capturing and compressing their output.
@@ -529,12 +536,12 @@ Do not redeclare local versions — use the canonical source to prevent drift.
 - `crates/rskim/src/output/mod.rs` — `ParseResult<T>` enum definition and helpers (`is_full`, `is_degraded`, `is_passthrough`, `tier_name`, `content`, `into_content`, `emit_markers`); `strip_ansi` and `strip_ansi_cow` (zero-copy fast path: borrows when no ESC byte present); `to_json_envelope` (not used by build family); `elision_marker`, `elision_marker_unbounded` (#317 loud elision helpers); `OutputMode`, `clean`, `clean_with_mode`, `PassthroughTruncator`, `FilterTransparencyHeader`
 - `crates/rskim/src/output/canonical.rs` — `BuildResult` (pre-rendered output); `TestResult` (with `context: Option<String>` safety net and `with_context` constructor, #317); `TestEntry`, `TestSummary`, `TestOutcome`; `GitResult`, `LintResult`, `DbResult`, `PkgResult`, `InfraResult`, `LogResult`, `DiffResult`, `FileResult`
 - `crates/rskim/src/cmd/mod.rs` — coordination point: declares all submodules, re-exports public API; inline helpers: `user_has_flag`, `inject_flag_before_separator`, `extract_show_stats`, `extract_json_flag`, `extract_output_format`, `should_read_stdin` (stdin-eligible when empty args OR `args == ["run"]`), `read_bounded`, `read_stdin_bounded`, `MAX_STDIN_BYTES`; passthrough checks: `is_passthrough_mode`, `check_passthrough_str`, `check_passthrough_value`; resolvers: `resolve_cache_dir`, `skim_wrappers_dir`
-- `crates/rskim/src/cmd/dispatch.rs` — `dispatch()`, `run_raw_passthrough()`, `run_inherited_passthrough()` (inherited-stdio path for daemon/streaming commands); per-tool dispatcher helpers
+- `crates/rskim/src/cmd/dispatch.rs` — `dispatch()`, `run_raw_passthrough()`, `run_inherited_passthrough()` (inherited-stdio path for daemon/streaming commands); `spawn_status_to_code(status: io::Result<ExitStatus>) -> u8` (pure exit-code mapper: ENOENT→127, other error→1, signal-kill→1, otherwise clamp to `[0,255]`; `pub(crate)` and independently unit-tested); per-tool dispatcher helpers
 - `crates/rskim/src/cmd/execution.rs` — `OutputFormat`, `RunContext`, `ParsedCommandConfig<'_>` (with `expected_exit_codes`, `forward_stderr`, #317), `ToolRunConfig<'_>` (with `expected_exit_codes`, `forward_stderr`, #317), `run_tool<T>`, `run_parsed_command_with_mode`, `run_parsed_command_with_exit` (#317), `ExitDisposition`, `classify_exit` (#317), `format_analytics_label`, `combine_output`, `obtain_output`, `render_output<T>`, `record_and_report`, `passthrough_raw`
 - `crates/rskim/src/cmd/security.rs` — `sanitize_for_display`, `scrub_db_args`, `scrub_infra_args`
 - `crates/rskim/src/cmd/registry.rs` — `KNOWN_SUBCOMMANDS` (sorted, binary-searchable via `binary_search`), `is_known_subcommand`, `is_meta_subcommand`, `wrapper_targets`
 - `crates/rskim/src/cmd/test_utils.rs` — standalone test helper module (compiled under `#[cfg(test)]` gate): `make_output`, `make_output_full`, `make_output_stderr`, `load_fixture` (with `Component::Normal` traversal guard); import as `crate::cmd::test_utils`; renamed from `test_support` in PR #126
-- `crates/rskim/src/runner.rs` — `CommandRunner` (stateless unit struct, `#[derive(Default)]`), `CommandOutput`, `ChildGuard` (kill-on-drop RAII), `is_spawn_error`, `MAX_OUTPUT_BYTES` (64 MiB); no timeout, no `RunnerError::Timeout`
+- `crates/rskim/src/runner.rs` — `CommandRunner` (stateless unit struct, `#[derive(Default)]`), `CommandOutput`, `ChildGuard` (kill-on-drop RAII), `is_spawn_error`, `MAX_OUTPUT_BYTES` (64 MiB); no timeout, no `RunnerError::Timeout`; `run_with_node_fallback` / `run_with_env_node_fallback` for three-strategy Node.js tool resolution (PATH → `./node_modules/.bin/` → `npx --no-install`; not used by build parsers)
 - `crates/rskim/src/cmd/rewrite/indefinite.rs` — `is_indefinite_command(tokens: &[&str]) -> bool`; program-aware daemon/streaming detection with env-var prefix stripping; consumed by the rewrite hook path and by `dispatch()`'s `run_inherited_passthrough` gate
 - `crates/rskim/src/cmd/test/cargo.rs` — `run()` for `skim cargo test`; uses `run_parsed_command_with_exit` with `expected_exit_codes: &[101]`; `parse_failure_details` state machine for stable-toolchain `---- name stdout ----` blocks (#317)
 - `crates/rskim/src/cmd/test/shared.rs` — `run_test_runner`, `scrape_failures`, `failure_context_body`, `emit_failure_context` (#317), `try_read_stdin`, `TestKind`, `ExitSource`, `ArgPreparation`, `TestRunnerConfig`
@@ -545,7 +552,7 @@ Do not redeclare local versions — use the canonical source to prevent drift.
 
 - `crates/rskim/src/output/mod.rs` — owns `ParseResult<T>`, the type returned by all three-tier parsers across the whole codebase (lint, test, infra, build); `emit_markers` debug gate; `elision_marker`/`elision_marker_unbounded` (#317)
 - `crates/rskim/src/output/canonical.rs` — owns `BuildResult`, `TestResult` (with `context` safety net), `GitResult`, `LintResult`
-- `crates/rskim/src/runner.rs` — `CommandRunner` (stateless, ADR-008), `CommandOutput`, `ChildGuard` (kill-on-drop), `is_spawn_error`; no internal timeout, no `RunnerError::Timeout`
+- `crates/rskim/src/runner.rs` — `CommandRunner` (stateless, ADR-008), `CommandOutput`, `ChildGuard` (kill-on-drop), `is_spawn_error`; `run_with_node_fallback`/`run_with_env_node_fallback` (Node.js tool resolution; not used by build parsers); no internal timeout, no `RunnerError::Timeout`
 - `crates/rskim/src/cmd/rewrite/indefinite.rs` — `is_indefinite_command`; guards daemon/streaming commands from being captured; consumed by `dispatch()` and the rewrite hook path
 - `crates/rskim/src/cmd/lint/` — sibling module using the same three-tier pattern with `LintResult` instead of `BuildResult`; lint parsers use `run_tool<T>` (via `run_parsed_command_with_mode` in `execution.rs`) rather than `run_parsed_command`
 - `crates/rskim/src/cmd/test/` — sibling module using the same three-tier pattern with `TestResult`; cargo.rs uses `run_parsed_command_with_exit` directly

--- a/.devflow/features/index.json
+++ b/.devflow/features/index.json
@@ -3,7 +3,7 @@
   "features": {
     "build-parsers": {
       "name": "Build Tool Output Parsers",
-      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, ChildGuard, indefinite, is_indefinite_command, expected_exit_codes, forward_stderr, ExitDisposition, classify_exit, run_parsed_command_with_exit, elision_marker, failure_context_body, parse_failure_details, compress-never-truncate.",
+      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, ChildGuard, indefinite, is_indefinite_command, expected_exit_codes, forward_stderr, ExitDisposition, classify_exit, run_parsed_command_with_exit, elision_marker, failure_context_body, parse_failure_details, compress-never-truncate, spawn_status_to_code, run_with_node_fallback.",
       "directories": [
         "crates/rskim/src/cmd/build/",
         "crates/rskim/src/cmd/"
@@ -28,7 +28,7 @@
         "crates/rskim/src/cmd/test/cargo.rs",
         "crates/rskim/src/cmd/test/shared.rs"
       ],
-      "lastUpdated": "2026-06-13T08:30:34.026Z",
+      "lastUpdated": "2026-06-17T11:53:10.154Z",
       "createdBy": "devflow-knowledge"
     },
     "cochange": {

--- a/.devflow/features/index.json
+++ b/.devflow/features/index.json
@@ -3,7 +3,7 @@
   "features": {
     "build-parsers": {
       "name": "Build Tool Output Parsers",
-      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, ChildGuard, indefinite, is_indefinite_command, expected_exit_codes, forward_stderr, ExitDisposition, classify_exit, run_parsed_command_with_exit, elision_marker, failure_context_body, parse_failure_details, compress-never-truncate, spawn_status_to_code, run_with_node_fallback.",
+      "description": "Use when adding a new build tool parser, modifying cargo/tsc/make/gradle/maven compression, or debugging three-tier parse degradation for build commands. Keywords: build, cargo, tsc, make, gradle, maven, clippy, ParseResult, BuildResult, three-tier, NDJSON, flag injection, run_check, run_fmt, ChildGuard, indefinite, is_indefinite_command, expected_exit_codes, forward_stderr, ExitDisposition, classify_exit, run_parsed_command_with_exit, elision_marker, failure_context_body, parse_failure_details, compress-never-truncate, spawn_status_to_code, run_with_node_fallback, should_emit_compressed_hint, BENIGN_EXIT1_PROGRAMS, FileResult.",
       "directories": [
         "crates/rskim/src/cmd/build/",
         "crates/rskim/src/cmd/"
@@ -28,8 +28,8 @@
         "crates/rskim/src/cmd/test/cargo.rs",
         "crates/rskim/src/cmd/test/shared.rs"
       ],
-      "lastUpdated": "2026-06-17T11:53:10.154Z",
-      "createdBy": "devflow-knowledge"
+      "lastUpdated": "2026-06-21T09:14:02.872Z",
+      "createdBy": "implement"
     },
     "cochange": {
       "name": "Co-Change Matrix",

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ crates/rskim-search/data/
 # Stale build artifacts
 librust_out.rlib
 package-lock.json
+
+# Devflow runtime data (local by default; remove to share via git)
+.devflow/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,15 @@ Most subcommands wrap a dev tool (cargo, git, npm, pytest, eslint, docker, psql,
 - `stats` — token analytics dashboard (`--since`, `--format json`, `--verbose`, `--clear`).
 - `discover` / `learn` / `rewrite` — scan agent sessions for missed optimizations, learn error-retry correction rules, and rewrite commands into skim equivalents.
 
-### Shell interception (PATH wrappers)
+### Two interception surfaces (they work differently — don't conflate them)
 
-`skim init --wrappers` symlinks `~/.skim/bin/<tool>` → the skim binary so sub-agent shells route through skim even when they bypass PreToolUse hooks. The binary calls `strip_skim_wrappers_from_path()` as the very first statement in `main()` (before any thread spawns), so wrapped commands resolve to the real tool — this is what prevents infinite recursion. `SKIM_PASSTHROUGH=1` is the escape hatch. Wrapper install/uninstall only ever touches symlinks whose target stem is `skim`/`rskim` — never regular files.
+skim intercepts a sub-agent's shell command through **two independent mechanisms**, and only one of them rewrites anything. Confusing them produces false coverage claims (e.g. "flag preservation verified on both surfaces" — it can't be; see below).
+
+1. **Rewrite engine** — the PreToolUse hook and the `skim rewrite` CLI. Operates on the command *as text, before it runs*: `cmd/rewrite/` `try_rewrite()` transforms the string `grep -rn x` → `skim grep -rn x`. This is the **only** surface where flag preservation (Fix A — don't drop `-rn` during the rewrite), corruption-bail (Fix C), and pipe-source passthrough (Fix E) exist — they are properties of the *text transformation*.
+
+2. **PATH wrappers** — `skim init --wrappers` symlinks `~/.skim/bin/<tool>` → the skim binary (with `~/.skim/bin` first on `PATH`) so sub-agent shells route through skim even when they bypass PreToolUse hooks. Here skim *is* the tool: the OS runs the binary with `argv[0]=<tool>`, `main()` calls `strip_skim_wrappers_from_path()` as its very first statement (before any thread spawns, so the real tool is found and recursion is impossible), then `detect_argv0_dispatch()` routes straight to `cmd::dispatch(tool, args)` — **`try_rewrite` is never called**. Flags arrive as ordinary argv and pass to the handler unchanged; there is no rewrite step to "preserve" them through. `SKIM_PASSTHROUGH=1` is the escape hatch. Wrapper install/uninstall only ever touches symlinks whose target stem is `skim`/`rskim` — never regular files.
+
+**Testing / verification implication:** the two surfaces share the per-tool *handlers* (output compression) but NOT the dispatch front-end. A test that drives the `--hook`/`rewrite` path does **not** exercise the wrapper path, and vice-versa. When verifying behavior — and when confirming Snyk/CI actually cover a change — identify *which* surface a test hits and cover both where the behavior could diverge. Rewrite-engine guarantees (flag preservation, corruption-bail, pipe passthrough) simply do not apply to the wrapper surface.
 
 ## Environment Variables
 

--- a/crates/rskim/src/cmd/execution.rs
+++ b/crates/rskim/src/cmd/execution.rs
@@ -240,6 +240,30 @@ fn passthrough_raw(output: &CommandOutput) -> anyhow::Result<ExitCode> {
 /// Fix B (fix/rewrite-hook-falseneg).
 const BENIGN_EXIT1_PROGRAMS: &[&str] = &["grep", "rg", "diff"];
 
+/// Decide whether [`record_and_report`] should emit the compressed-output hint.
+///
+/// This is the single source of truth for the notice-matrix decision (#317),
+/// extracted as a pure function so it is unit-testable without spawning a
+/// process — the test and the production path call the *same* code, so a
+/// regression in any of the three conditions is caught (PF-007: a test that
+/// re-derives the expression inline asserts nothing).
+///
+/// Emit the hint when ALL hold:
+/// - `code != 0` — exit 0 never gets a hint.
+/// - `tier_name != "passthrough"` — a verbatim body needs no escape-hatch
+///   notice (it already matches the raw tool, e.g. grep's no-match silence).
+/// - NOT a benign exit-1 (Fix B): `code == 1` for a [`BENIGN_EXIT1_PROGRAMS`]
+///   tool is "no match"/"differs", a normal informational result. Exit ≥ 2 for
+///   those tools is a real error and still gets the hint.
+///
+/// Unexpected failures (codes outside `expected_exit_codes`) raw-forward and
+/// return BEFORE reaching `record_and_report`, so a non-zero `code` seen here
+/// is always an EXPECTED failure the parser meaningfully compresses.
+fn should_emit_compressed_hint(program: &str, code: i32, tier_name: &str) -> bool {
+    let is_benign_exit1 = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&program);
+    code != 0 && tier_name != "passthrough" && !is_benign_exit1
+}
+
 /// Parameters for recording token savings and emitting the analytics event.
 ///
 /// Bundles the fields that [`record_and_report`] needs, replacing the
@@ -285,8 +309,9 @@ fn record_and_report(report: RecordReport<'_>) {
     // Fix B (fix/rewrite-hook-falseneg): suppress hint for BENIGN_EXIT1_PROGRAMS
     // at exit 1.  For these tools, exit 1 is "no match"/"differs" — a normal
     // informational result.  Exit ≥ 2 is a real error and still shows the hint.
-    let is_benign_exit1 = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&program);
-    if code != 0 && tier_name != "passthrough" && !is_benign_exit1 {
+    // The decision lives in `should_emit_compressed_hint` so it is unit-tested
+    // against the same code path (PF-007).
+    if should_emit_compressed_hint(program, code, tier_name) {
         eprintln!("{}", crate::output::compressed_output_hint(code));
     }
 
@@ -715,53 +740,97 @@ mod tests {
     // BENIGN_EXIT1_PROGRAMS guard (Fix B, fix/rewrite-hook-falseneg)
     // ========================================================================
 
-    /// grep exit 1 = "no match" — classified as benign; hint must be suppressed.
+    // These tests drive the real `should_emit_compressed_hint` decision used by
+    // `record_and_report` (PF-007): each one would FAIL if the production guard
+    // regressed (e.g. dropping `program` from the check, flipping `code == 1`,
+    // or removing the `!is_benign_exit1` term). The Full and Degraded tier names
+    // exercise the non-passthrough branch where the hint is live.
+
+    /// grep exit 1 = "no match" — benign; the compressed-output hint is suppressed.
     #[test]
     fn test_benign_exit1_grep() {
         assert!(
             BENIGN_EXIT1_PROGRAMS.contains(&"grep"),
             "grep must be in BENIGN_EXIT1_PROGRAMS"
         );
-        let is_benign = 1 == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"grep");
-        assert!(is_benign, "grep exit 1 must be benign (no hint)");
+        assert!(
+            !should_emit_compressed_hint("grep", 1, "full"),
+            "grep exit 1 is benign — hint must be suppressed"
+        );
+        assert!(
+            !should_emit_compressed_hint("grep", 1, "degraded"),
+            "grep exit 1 is benign at the degraded tier too"
+        );
     }
 
-    /// rg exit 1 = "no match" — classified as benign.
+    /// rg exit 1 = "no match" — benign; hint suppressed.
     #[test]
     fn test_benign_exit1_rg() {
         assert!(
             BENIGN_EXIT1_PROGRAMS.contains(&"rg"),
             "rg must be in BENIGN_EXIT1_PROGRAMS"
         );
+        assert!(
+            !should_emit_compressed_hint("rg", 1, "full"),
+            "rg exit 1 is benign — hint must be suppressed"
+        );
     }
 
-    /// diff exit 1 = "files differ" — classified as benign.
+    /// diff exit 1 = "files differ" — benign; hint suppressed.
     #[test]
     fn test_benign_exit1_diff() {
         assert!(
             BENIGN_EXIT1_PROGRAMS.contains(&"diff"),
             "diff must be in BENIGN_EXIT1_PROGRAMS"
         );
+        assert!(
+            !should_emit_compressed_hint("diff", 1, "full"),
+            "diff exit 1 is benign — hint must be suppressed"
+        );
     }
 
     /// grep exit 2 = real error (e.g., syntax error) — NOT benign; hint fires.
     #[test]
     fn test_grep_exit2_is_not_benign() {
-        let code = 2;
-        let is_benign = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"grep");
         assert!(
-            !is_benign,
-            "grep exit 2 must NOT be benign — hint should fire"
+            should_emit_compressed_hint("grep", 2, "full"),
+            "grep exit 2 is a real error — hint must fire"
         );
     }
 
-    /// A non-benign tool (e.g., cargo) at exit 1 is NOT suppressed.
+    /// A non-benign tool (e.g., cargo) at exit 1 still gets the hint.
     #[test]
     fn test_non_benign_tool_exit1_is_not_suppressed() {
-        let is_benign = 1 == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"cargo");
         assert!(
-            !is_benign,
-            "cargo exit 1 must NOT be benign — hint should still fire"
+            should_emit_compressed_hint("cargo", 1, "full"),
+            "cargo exit 1 is not benign — hint must still fire"
+        );
+    }
+
+    /// Passthrough tier is always silent: the body is already verbatim, so even
+    /// a non-benign non-zero exit emits no hint (would duplicate raw behavior).
+    #[test]
+    fn test_passthrough_tier_never_hints() {
+        assert!(
+            !should_emit_compressed_hint("cargo", 1, "passthrough"),
+            "passthrough tier must never emit the compressed-output hint"
+        );
+        assert!(
+            !should_emit_compressed_hint("grep", 2, "passthrough"),
+            "passthrough tier is silent even for a real grep error"
+        );
+    }
+
+    /// Exit 0 never emits the hint, regardless of tier.
+    #[test]
+    fn test_exit0_never_hints() {
+        assert!(
+            !should_emit_compressed_hint("cargo", 0, "full"),
+            "exit 0 must never emit the compressed-output hint"
+        );
+        assert!(
+            !should_emit_compressed_hint("grep", 0, "degraded"),
+            "exit 0 is success — no hint"
         );
     }
 }

--- a/crates/rskim/src/cmd/execution.rs
+++ b/crates/rskim/src/cmd/execution.rs
@@ -749,7 +749,10 @@ mod tests {
     fn test_grep_exit2_is_not_benign() {
         let code = 2;
         let is_benign = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"grep");
-        assert!(!is_benign, "grep exit 2 must NOT be benign — hint should fire");
+        assert!(
+            !is_benign,
+            "grep exit 2 must NOT be benign — hint should fire"
+        );
     }
 
     /// A non-benign tool (e.g., cargo) at exit 1 is NOT suppressed.

--- a/crates/rskim/src/cmd/execution.rs
+++ b/crates/rskim/src/cmd/execution.rs
@@ -229,6 +229,17 @@ fn passthrough_raw(output: &CommandOutput) -> anyhow::Result<ExitCode> {
     Ok(ExitCode::from(code.clamp(0, 255) as u8))
 }
 
+/// Tools for which exit code 1 means "no match" / "differs" — a benign
+/// informational result that must not trigger the compressed-output hint.
+///
+/// These tools emit exit 1 when they find no matches or detect a difference,
+/// which is not an error: the silence (or diff) IS the output.  Printing
+/// "[skim] compressed output (exit 1)" is misleading — it implies something
+/// went wrong when it did not.  Exit ≥ 2 for these tools IS a real error
+/// (e.g., grep syntax error, diff read failure) and DOES get the hint.
+/// Fix B (fix/rewrite-hook-falseneg).
+const BENIGN_EXIT1_PROGRAMS: &[&str] = &["grep", "rg", "diff"];
+
 /// Parameters for recording token savings and emitting the analytics event.
 ///
 /// Bundles the fields that [`record_and_report`] needs, replacing the
@@ -238,6 +249,7 @@ fn passthrough_raw(output: &CommandOutput) -> anyhow::Result<ExitCode> {
 struct RecordReport<'a> {
     show_stats: bool,
     code: i32,
+    program: &'a str,
     original_stdout: String,
     compressed: String,
     rec: crate::analytics::RecordingContext<'a>,
@@ -254,6 +266,7 @@ fn record_and_report(report: RecordReport<'_>) {
     let RecordReport {
         show_stats,
         code,
+        program,
         original_stdout,
         compressed,
         rec,
@@ -268,7 +281,12 @@ fn record_and_report(report: RecordReport<'_>) {
     // - tier Full/Degraded → surface the escape hatch: the body was re-encoded.
     // - tier Passthrough → silent: the body is already verbatim, so any notice
     //   would be noise the raw tool does not emit (grep's no-match silence).
-    if code != 0 && tier_name != "passthrough" {
+    //
+    // Fix B (fix/rewrite-hook-falseneg): suppress hint for BENIGN_EXIT1_PROGRAMS
+    // at exit 1.  For these tools, exit 1 is "no match"/"differs" — a normal
+    // informational result.  Exit ≥ 2 is a real error and still shows the hint.
+    let is_benign_exit1 = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&program);
+    if code != 0 && tier_name != "passthrough" && !is_benign_exit1 {
         eprintln!("{}", crate::output::compressed_output_hint(code));
     }
 
@@ -413,6 +431,7 @@ where
     record_and_report(RecordReport {
         show_stats,
         code,
+        program,
         original_stdout: output.stdout,
         compressed,
         rec,
@@ -690,5 +709,56 @@ mod tests {
             "both empty must produce Cow::Borrowed: {combined:?}"
         );
         assert_eq!(combined.as_ref(), "");
+    }
+
+    // ========================================================================
+    // BENIGN_EXIT1_PROGRAMS guard (Fix B, fix/rewrite-hook-falseneg)
+    // ========================================================================
+
+    /// grep exit 1 = "no match" — classified as benign; hint must be suppressed.
+    #[test]
+    fn test_benign_exit1_grep() {
+        assert!(
+            BENIGN_EXIT1_PROGRAMS.contains(&"grep"),
+            "grep must be in BENIGN_EXIT1_PROGRAMS"
+        );
+        let is_benign = 1 == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"grep");
+        assert!(is_benign, "grep exit 1 must be benign (no hint)");
+    }
+
+    /// rg exit 1 = "no match" — classified as benign.
+    #[test]
+    fn test_benign_exit1_rg() {
+        assert!(
+            BENIGN_EXIT1_PROGRAMS.contains(&"rg"),
+            "rg must be in BENIGN_EXIT1_PROGRAMS"
+        );
+    }
+
+    /// diff exit 1 = "files differ" — classified as benign.
+    #[test]
+    fn test_benign_exit1_diff() {
+        assert!(
+            BENIGN_EXIT1_PROGRAMS.contains(&"diff"),
+            "diff must be in BENIGN_EXIT1_PROGRAMS"
+        );
+    }
+
+    /// grep exit 2 = real error (e.g., syntax error) — NOT benign; hint fires.
+    #[test]
+    fn test_grep_exit2_is_not_benign() {
+        let code = 2;
+        let is_benign = code == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"grep");
+        assert!(!is_benign, "grep exit 2 must NOT be benign — hint should fire");
+    }
+
+    /// A non-benign tool (e.g., cargo) at exit 1 is NOT suppressed.
+    #[test]
+    fn test_non_benign_tool_exit1_is_not_suppressed() {
+        let is_benign = 1 == 1 && BENIGN_EXIT1_PROGRAMS.contains(&"cargo");
+        assert!(
+            !is_benign,
+            "cargo exit 1 must NOT be benign — hint should still fire"
+        );
     }
 }

--- a/crates/rskim/src/cmd/execution.rs
+++ b/crates/rskim/src/cmd/execution.rs
@@ -833,4 +833,45 @@ mod tests {
             "exit 0 is success — no hint"
         );
     }
+
+    /// Lint and pkg tools at exit 1 are NOT in BENIGN_EXIT1_PROGRAMS, so the
+    /// hint MUST fire when they produce a compressed (Full/Degraded) body.
+    ///
+    /// This complements the grep/rg/diff benign-suppression tests: those assert
+    /// the hint is suppressed; these assert it is NOT suppressed for families
+    /// where exit 1 means "lint violations found" or "package op failed" — a
+    /// real problem, not a normal informational result.
+    ///
+    /// Discriminates against a future regression that blanket-suppresses exit-1
+    /// for ALL programs regardless of BENIGN_EXIT1_PROGRAMS membership.
+    #[test]
+    fn test_lint_exit1_is_not_suppressed() {
+        // eslint exit 1 = lint violations found — not benign; hint must fire.
+        assert!(
+            !BENIGN_EXIT1_PROGRAMS.contains(&"eslint"),
+            "eslint must NOT be in BENIGN_EXIT1_PROGRAMS"
+        );
+        assert!(
+            should_emit_compressed_hint("eslint", 1, "full"),
+            "eslint exit 1 is lint violations — hint must fire (not suppressed)"
+        );
+        assert!(
+            should_emit_compressed_hint("eslint", 1, "degraded"),
+            "eslint exit 1 hint must fire at the degraded tier too"
+        );
+    }
+
+    /// pkg tool (cargo subcommand) at exit 1 — hint fires.
+    #[test]
+    fn test_pkg_exit1_is_not_suppressed() {
+        // npm exit 1 = package operation error — not a benign "no result".
+        assert!(
+            !BENIGN_EXIT1_PROGRAMS.contains(&"npm"),
+            "npm must NOT be in BENIGN_EXIT1_PROGRAMS"
+        );
+        assert!(
+            should_emit_compressed_hint("npm", 1, "full"),
+            "npm exit 1 is a real error — hint must fire"
+        );
+    }
 }

--- a/crates/rskim/src/cmd/file/mod.rs
+++ b/crates/rskim/src/cmd/file/mod.rs
@@ -190,8 +190,8 @@ pub(super) fn try_parse_file_line_content(
 /// Build a [`FileResult`] from grouped file matches.
 ///
 /// Emits every match in every file — no per-file or file-count caps, no
-/// `(showing K)` footer. `shown_count == total_count` so the canonical
-/// `tool N/N` header reads truthfully. (#317)
+/// elision footer. `shown_count == total_count` so the canonical header
+/// renders as `tool N` (no truncation ratio; Fix F). (#317)
 ///
 /// `tool` — binary name (e.g. `"grep"`, `"rg"`).
 /// `total_matches` — total match count across all files.

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -1509,7 +1509,10 @@ mod tests {
 }
 "#;
         let result = rskim_core::transform(rust_src, Language::Rust, Mode::Pseudo);
-        assert!(result.is_ok(), "Pseudo transform of Rust source must succeed");
+        assert!(
+            result.is_ok(),
+            "Pseudo transform of Rust source must succeed"
+        );
         let output = result.unwrap();
         // In Pseudo mode the body should be visible (unlike Structure which strips it).
         assert!(

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -791,10 +791,7 @@ fn run_show_file_content(
     // signatures.  Pseudo preserves logic flow while stripping syntactic noise
     // (type annotations, visibility modifiers, etc.), giving ~30-50% reduction
     // without hiding implementation detail the agent is trying to read.
-    let config = TransformConfig {
-        mode: Mode::Pseudo,
-        ..TransformConfig::default()
-    };
+    let config = TransformConfig::with_mode(Mode::Pseudo);
     let transformed = match rskim_core::transform(&raw, lang, config.mode) {
         Ok(t) => t,
         Err(e) => {
@@ -1479,11 +1476,8 @@ mod tests {
     /// which is wrong when the agent is reading a specific file at a ref.
     /// Pseudo preserves logic flow while reducing token count.
     #[test]
-    fn fix_d_file_content_transform_uses_pseudo_mode() {
-        let config = TransformConfig {
-            mode: Mode::Pseudo,
-            ..TransformConfig::default()
-        };
+    fn test_fix_d_file_content_transform_uses_pseudo_mode() {
+        let config = TransformConfig::with_mode(Mode::Pseudo);
         assert_eq!(
             config.mode,
             Mode::Pseudo,
@@ -1502,7 +1496,7 @@ mod tests {
     /// Guards that Pseudo mode does not silently strip function bodies when
     /// given Rust source — agents reading file content must see the logic.
     #[test]
-    fn fix_d_pseudo_mode_preserves_function_body() {
+    fn test_fix_d_pseudo_mode_preserves_function_body() {
         use rskim_core::Language;
         let rust_src = r#"fn greet(name: &str) -> String {
     format!("Hello, {}!", name)
@@ -1519,5 +1513,55 @@ mod tests {
             output.contains("Hello") || output.contains("format") || output.contains("greet"),
             "Pseudo output must contain function body content, got: {output:?}"
         );
+    }
+
+    /// Pseudo mode retains body logic that Structure mode strips.
+    ///
+    /// Transform-level companion to the production-path E2E
+    /// `test_skim_git_show_file_content_pseudo_preserves_bodies` (tests/cli_git.rs).
+    /// This asserts WHY Fix D's mode choice matters: at the `rskim_core::transform`
+    /// layer that `run_show_file_content` drives, Pseudo surfaces function-body
+    /// tokens while Structure collapses bodies to `{...}` and drops them.  It does
+    /// NOT, on its own, guard the production mode constant — it calls `transform`
+    /// with explicit modes, so it would pass even if show.rs reverted to Structure.
+    /// That production guard is the cli_git.rs E2E, which drives the real
+    /// `git show <ref>:<file>` path end-to-end.
+    ///
+    /// The tokens below live ONLY inside function bodies in the fixture (not in
+    /// any signature, doc comment, `use`, or struct field), so Structure — which
+    /// keeps signatures/imports — must drop every one of them.
+    #[test]
+    fn test_fix_d_pseudo_vs_structure_discriminates_body_tokens() {
+        use rskim_core::Language;
+        let source = include_str!("../../../tests/fixtures/cmd/git/show_file.rs");
+        let lang = Language::from_path(std::path::Path::new("show_file.rs"))
+            .expect("show_file.rs must be detected as Rust");
+
+        // Structure mode — what Fix D replaces — collapses function bodies.
+        let structure_out = rskim_core::transform(source, lang, Mode::Structure)
+            .expect("Structure transform must succeed");
+
+        // Pseudo mode — what Fix D uses — preserves logic flow inside bodies.
+        let pseudo_out = rskim_core::transform(source, lang, Mode::Pseudo)
+            .expect("Pseudo transform must succeed");
+
+        // Body-only tokens: a method call, an error string, and a stdlib call
+        // that each appear solely inside a collapsed function body.
+        let body_tokens = [
+            "find_user_by_username",
+            "Invalid credentials",
+            "duration_since",
+        ];
+        for t in body_tokens {
+            assert!(
+                pseudo_out.contains(t),
+                "Pseudo mode must retain body token {t:?} so agents can read logic; got: {pseudo_out:?}"
+            );
+            assert!(
+                !structure_out.contains(t),
+                "Structure mode must strip body token {t:?} — confirms the modes \
+                 differ, validating that Fix D's Pseudo choice matters; got: {structure_out:?}"
+            );
+        }
     }
 }

--- a/crates/rskim/src/cmd/git/show.rs
+++ b/crates/rskim/src/cmd/git/show.rs
@@ -46,7 +46,7 @@
 use std::path::Path;
 use std::process::ExitCode;
 
-use rskim_core::{Language, TransformConfig};
+use rskim_core::{Language, Mode, TransformConfig};
 
 use crate::cmd::{OutputFormat, extract_output_format, user_has_flag};
 use crate::output::canonical::{DiffFileEntry, ShowCommitResult};
@@ -783,7 +783,18 @@ fn run_show_file_content(
     };
 
     // Tier 1: transform in memory.
-    let config = TransformConfig::default();
+    //
+    // Fix D (fix/rewrite-hook-falseneg, AD-GIT-SHOW-PSEUDO): use Pseudo mode
+    // instead of Structure mode for file-content paths.  Structure strips
+    // function bodies, which is unhelpful when the agent asked to read a
+    // specific file at a specific ref — it needs to see the logic, not just
+    // signatures.  Pseudo preserves logic flow while stripping syntactic noise
+    // (type annotations, visibility modifiers, etc.), giving ~30-50% reduction
+    // without hiding implementation detail the agent is trying to read.
+    let config = TransformConfig {
+        mode: Mode::Pseudo,
+        ..TransformConfig::default()
+    };
     let transformed = match rskim_core::transform(&raw, lang, config.mode) {
         Ok(t) => t,
         Err(e) => {
@@ -1455,6 +1466,55 @@ mod tests {
             header.parents.is_none(),
             "non-merge commit must have no parents: {:?}",
             header.parents
+        );
+    }
+
+    // ========================================================================
+    // Fix D: file-content mode uses Pseudo, not Structure
+    // ========================================================================
+
+    /// The file-content transform config must use Pseudo mode, not Structure.
+    ///
+    /// Fix D (fix/rewrite-hook-falseneg): Structure strips function bodies,
+    /// which is wrong when the agent is reading a specific file at a ref.
+    /// Pseudo preserves logic flow while reducing token count.
+    #[test]
+    fn fix_d_file_content_transform_uses_pseudo_mode() {
+        let config = TransformConfig {
+            mode: Mode::Pseudo,
+            ..TransformConfig::default()
+        };
+        assert_eq!(
+            config.mode,
+            Mode::Pseudo,
+            "file-content transform must use Pseudo mode, not Structure (Fix D)"
+        );
+        // Confirm default is NOT Pseudo (so the Fix D change is meaningful).
+        assert_ne!(
+            TransformConfig::default().mode,
+            Mode::Pseudo,
+            "TransformConfig::default() must not be Pseudo — Fix D must actively set it"
+        );
+    }
+
+    /// Pseudo mode produces non-empty output for a simple Rust function.
+    ///
+    /// Guards that Pseudo mode does not silently strip function bodies when
+    /// given Rust source — agents reading file content must see the logic.
+    #[test]
+    fn fix_d_pseudo_mode_preserves_function_body() {
+        use rskim_core::Language;
+        let rust_src = r#"fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+"#;
+        let result = rskim_core::transform(rust_src, Language::Rust, Mode::Pseudo);
+        assert!(result.is_ok(), "Pseudo transform of Rust source must succeed");
+        let output = result.unwrap();
+        // In Pseudo mode the body should be visible (unlike Structure which strips it).
+        assert!(
+            output.contains("Hello") || output.contains("format") || output.contains("greet"),
+            "Pseudo output must contain function body content, got: {output:?}"
         );
     }
 }

--- a/crates/rskim/src/cmd/lint/gofmt.rs
+++ b/crates/rskim/src/cmd/lint/gofmt.rs
@@ -50,10 +50,18 @@ pub(crate) fn run(
     run_tool(CONFIG, args, ctx, prepare_args, parse_impl)
 }
 
-/// Inject `-l` if no mode flag is present.
+/// Flags this handler injects when absent from user args.
+///
+/// Consumed by the `WRAPPER_REINJECTS` coupling test in
+/// `crates/rskim/src/cmd/rewrite/rules.rs` to assert that every allowlist
+/// entry's exempted flag is actually re-injected here.
+pub(crate) const INJECTS: &[&str] = &["-l"];
+
+/// Inject `-l` if no mode flag is present. Injects `INJECTS` so the
+/// re-injection set stays the single source of truth for the coupling test.
 fn prepare_args(cmd_args: &mut Vec<String>) {
     if !user_has_flag(cmd_args, &["-l", "-d", "-w", "-e"]) {
-        cmd_args.insert(0, "-l".to_string());
+        cmd_args.insert(0, INJECTS[0].to_string());
     }
 }
 

--- a/crates/rskim/src/cmd/lint/gofmt.rs
+++ b/crates/rskim/src/cmd/lint/gofmt.rs
@@ -57,8 +57,8 @@ pub(crate) fn run(
 /// entry's exempted flag is actually re-injected here.
 pub(crate) const INJECTS: &[&str] = &["-l"];
 
-/// Inject `-l` if no mode flag is present. Injects `INJECTS` so the
-/// re-injection set stays the single source of truth for the coupling test.
+/// Inject `-l` if no mode flag is present; uses `INJECTS[0]` so the flag
+/// literal is not duplicated across the const and the injection site.
 fn prepare_args(cmd_args: &mut Vec<String>) {
     if !user_has_flag(cmd_args, &["-l", "-d", "-w", "-e"]) {
         cmd_args.insert(0, INJECTS[0].to_string());

--- a/crates/rskim/src/cmd/lint/prettier.rs
+++ b/crates/rskim/src/cmd/lint/prettier.rs
@@ -88,10 +88,18 @@ fn run_check(
     run_tool(CONFIG, args, ctx, prepare_check_args, parse_check_impl)
 }
 
-/// Inject `--check` if not already present.
+/// Flags this handler injects in check mode when absent from user args.
+///
+/// Consumed by the `WRAPPER_REINJECTS` coupling test in
+/// `crates/rskim/src/cmd/rewrite/rules.rs` to assert that every allowlist
+/// entry's exempted flag is actually re-injected here.
+pub(crate) const INJECTS: &[&str] = &["--check"];
+
+/// Inject `--check` if not already present. Injects `INJECTS` so the
+/// re-injection set stays the single source of truth for the coupling test.
 fn prepare_check_args(cmd_args: &mut Vec<String>) {
     if !user_has_flag(cmd_args, &["--check", "-c", "--list-different", "-l"]) {
-        cmd_args.insert(0, "--check".to_string());
+        cmd_args.insert(0, INJECTS[0].to_string());
     }
 }
 

--- a/crates/rskim/src/cmd/lint/prettier.rs
+++ b/crates/rskim/src/cmd/lint/prettier.rs
@@ -95,8 +95,8 @@ fn run_check(
 /// entry's exempted flag is actually re-injected here.
 pub(crate) const INJECTS: &[&str] = &["--check"];
 
-/// Inject `--check` if not already present. Injects `INJECTS` so the
-/// re-injection set stays the single source of truth for the coupling test.
+/// Inject `--check` if not already present; uses `INJECTS[0]` so the flag
+/// literal is not duplicated across the const and the injection site.
 fn prepare_check_args(cmd_args: &mut Vec<String>) {
     if !user_has_flag(cmd_args, &["--check", "-c", "--list-different", "-l"]) {
         cmd_args.insert(0, INJECTS[0].to_string());

--- a/crates/rskim/src/cmd/lint/rustfmt.rs
+++ b/crates/rskim/src/cmd/lint/rustfmt.rs
@@ -90,10 +90,18 @@ fn run_check(
     run_tool(CONFIG, args, ctx, prepare_check_args, parse_check_impl)
 }
 
-/// Inject `--check` if not already present.
+/// Flags this handler injects in check mode when absent from user args.
+///
+/// Consumed by the `WRAPPER_REINJECTS` coupling test in
+/// `crates/rskim/src/cmd/rewrite/rules.rs` to assert that every allowlist
+/// entry's exempted flag is actually re-injected here.
+pub(crate) const INJECTS: &[&str] = &["--check"];
+
+/// Inject `--check` if not already present. Injects `INJECTS` so the
+/// re-injection set stays the single source of truth for the coupling test.
 fn prepare_check_args(cmd_args: &mut Vec<String>) {
     if !user_has_flag(cmd_args, &["--check", "-c"]) {
-        cmd_args.insert(0, "--check".to_string());
+        cmd_args.insert(0, INJECTS[0].to_string());
     }
 }
 

--- a/crates/rskim/src/cmd/lint/rustfmt.rs
+++ b/crates/rskim/src/cmd/lint/rustfmt.rs
@@ -97,8 +97,8 @@ fn run_check(
 /// entry's exempted flag is actually re-injected here.
 pub(crate) const INJECTS: &[&str] = &["--check"];
 
-/// Inject `--check` if not already present. Injects `INJECTS` so the
-/// re-injection set stays the single source of truth for the coupling test.
+/// Inject `--check` if not already present; uses `INJECTS[0]` so the flag
+/// literal is not duplicated across the const and the injection site.
 fn prepare_check_args(cmd_args: &mut Vec<String>) {
     if !user_has_flag(cmd_args, &["--check", "-c"]) {
         cmd_args.insert(0, INJECTS[0].to_string());

--- a/crates/rskim/src/cmd/rewrite/compound.rs
+++ b/crates/rskim/src/cmd/rewrite/compound.rs
@@ -20,6 +20,26 @@ use super::types::{
 
 // ---- Round-trip safety (#317) ----
 
+/// Return `true` when `cmd` (after stripping trailing whitespace) contains an
+/// **interior** newline that would make the command unsafe to rewrite.
+///
+/// Trailing newlines are benign — agent PreToolUse hooks often add a trailing
+/// `\n` to the command string, which does not affect tokenization.  Interior
+/// newlines (e.g., a multi-line commit message) indicate multi-line commands
+/// that `split_whitespace` would flatten, corrupting the byte sequence.
+///
+/// Fix C (fix/rewrite-hook-falseneg): the hook layer previously called
+/// `rewrite_would_corrupt` which checks `cmd.contains('\n')`, bailing even on
+/// commands with only a trailing newline — commands from agent hooks that were
+/// otherwise safely rewritable.  This function is the hook-layer guard: it
+/// trims trailing whitespace first so trailing newlines pass through, then
+/// delegates the full corruption check to [`rewrite_would_corrupt`].
+///
+/// Must be called with the raw hook-input command string.
+pub(super) fn command_needs_passthrough(cmd: &str) -> bool {
+    rewrite_would_corrupt(cmd.trim_end())
+}
+
 /// Return `true` when `cmd` contains shell syntax that the rewrite pipeline
 /// cannot reconstruct byte-faithfully — every rewrite path MUST bail.
 ///
@@ -1227,5 +1247,62 @@ mod tests {
                 panic!("foo >&1&& bar should split on && but got Bail")
             }
         }
+    }
+
+    // ========================================================================
+    // command_needs_passthrough — Fix C (fix/rewrite-hook-falseneg)
+    // ========================================================================
+
+    /// A trailing newline only (agent hooks add one) must NOT trigger passthrough.
+    ///
+    /// Fix C regression guard: `rewrite_would_corrupt` bails on ALL `\n`,
+    /// including trailing ones added by agent hook infrastructure.  A command
+    /// like `"cargo test\n"` is safe to rewrite after trimming.
+    #[test]
+    fn fix_c_trailing_newline_passes() {
+        assert!(
+            !command_needs_passthrough("cargo test\n"),
+            "trailing newline must not force passthrough"
+        );
+        assert!(
+            !command_needs_passthrough("grep -rn pattern src/\n"),
+            "grep -rn with trailing newline must not force passthrough"
+        );
+        assert!(
+            !command_needs_passthrough("cargo test\r\n"),
+            "Windows-style trailing CRLF must not force passthrough"
+        );
+    }
+
+    /// An interior newline (multi-line command body) MUST still trigger passthrough.
+    ///
+    /// This is the corruption case: `split_whitespace` flattens `\n` into a
+    /// space, destroying the original byte sequence.
+    #[test]
+    fn fix_c_interior_newline_bails() {
+        assert!(
+            command_needs_passthrough(
+                "git commit -m \"feat: subject\n\nBody paragraph.\""
+            ),
+            "interior newline must force passthrough"
+        );
+        assert!(
+            command_needs_passthrough("echo first\necho second"),
+            "two commands joined by interior newline must force passthrough"
+        );
+    }
+
+    /// A clean command with no newline must pass through `command_needs_passthrough`
+    /// unaffected — the wrapper must not introduce false positives.
+    #[test]
+    fn fix_c_clean_command_passes() {
+        assert!(
+            !command_needs_passthrough("cargo test"),
+            "clean command must not need passthrough"
+        );
+        assert!(
+            !command_needs_passthrough("cargo test && cargo build"),
+            "compound clean command must not need passthrough"
+        );
     }
 }

--- a/crates/rskim/src/cmd/rewrite/compound.rs
+++ b/crates/rskim/src/cmd/rewrite/compound.rs
@@ -1281,9 +1281,7 @@ mod tests {
     #[test]
     fn fix_c_interior_newline_bails() {
         assert!(
-            command_needs_passthrough(
-                "git commit -m \"feat: subject\n\nBody paragraph.\""
-            ),
+            command_needs_passthrough("git commit -m \"feat: subject\n\nBody paragraph.\""),
             "interior newline must force passthrough"
         );
         assert!(

--- a/crates/rskim/src/cmd/rewrite/compound.rs
+++ b/crates/rskim/src/cmd/rewrite/compound.rs
@@ -1259,7 +1259,7 @@ mod tests {
     /// including trailing ones added by agent hook infrastructure.  A command
     /// like `"cargo test\n"` is safe to rewrite after trimming.
     #[test]
-    fn fix_c_trailing_newline_passes() {
+    fn test_fix_c_trailing_newline_passes() {
         assert!(
             !command_needs_passthrough("cargo test\n"),
             "trailing newline must not force passthrough"
@@ -1279,7 +1279,7 @@ mod tests {
     /// This is the corruption case: `split_whitespace` flattens `\n` into a
     /// space, destroying the original byte sequence.
     #[test]
-    fn fix_c_interior_newline_bails() {
+    fn test_fix_c_interior_newline_bails() {
         assert!(
             command_needs_passthrough("git commit -m \"feat: subject\n\nBody paragraph.\""),
             "interior newline must force passthrough"
@@ -1293,7 +1293,7 @@ mod tests {
     /// A clean command with no newline must pass through `command_needs_passthrough`
     /// unaffected — the wrapper must not introduce false positives.
     #[test]
-    fn fix_c_clean_command_passes() {
+    fn test_fix_c_clean_command_passes() {
         assert!(
             !command_needs_passthrough("cargo test"),
             "clean command must not need passthrough"

--- a/crates/rskim/src/cmd/rewrite/hook.rs
+++ b/crates/rskim/src/cmd/rewrite/hook.rs
@@ -9,7 +9,7 @@ use std::process::ExitCode;
 
 use crate::cmd::session::AgentKind;
 
-use super::compound::{rewrite_would_corrupt, split_compound, try_rewrite_compound};
+use super::compound::{command_needs_passthrough, split_compound, try_rewrite_compound};
 use super::engine::try_rewrite;
 use super::types::CompoundSplitResult;
 
@@ -209,7 +209,13 @@ pub(super) fn run_hook_mode(agent: Option<AgentKind>) -> anyhow::Result<ExitCode
     // command substitution, backticks, unmatched quotes, and whitespace that
     // does not survive split+rejoin. The simple path previously ran
     // split_whitespace()+join(" ") with NO checks.
-    if rewrite_would_corrupt(&command) {
+    //
+    // Fix C (fix/rewrite-hook-falseneg): use `command_needs_passthrough`
+    // instead of `rewrite_would_corrupt` directly.  The hook-layer function
+    // trims trailing whitespace first so trailing newlines (commonly added
+    // by agent hooks) are ignored, while interior newlines (multi-line
+    // commands that would corrupt tokenization) still cause a bail-out.
+    if command_needs_passthrough(&command) {
         audit_hook(&command, false, "");
         return Ok(ExitCode::SUCCESS);
     }

--- a/crates/rskim/src/cmd/rewrite/mod.rs
+++ b/crates/rskim/src/cmd/rewrite/mod.rs
@@ -36,8 +36,8 @@ use std::process::ExitCode;
 
 use acknowledge::is_segment_ack;
 use compound::{
-    has_pipe_operator, rewrite_would_corrupt, splice_redirects_back, split_compound,
-    try_rewrite_compound,
+    command_needs_passthrough, has_pipe_operator, rewrite_would_corrupt, splice_redirects_back,
+    split_compound, try_rewrite_compound,
 };
 use engine::try_rewrite;
 use hook::{parse_agent_flag, run_hook_mode};
@@ -371,6 +371,31 @@ pub(crate) fn run(
         .iter()
         .map(|s| s.as_str())
         .collect();
+
+    // Round-trip safety (#317, Fix C — CLI path): check the raw command string
+    // BEFORE `collect_input_tokens` flattens it via `split_whitespace`.
+    //
+    // `collect_input_tokens` uses `flat_map(|s| s.split_whitespace())`, which
+    // treats an interior `\n` as ordinary whitespace and merges two shell
+    // statements into one token list. By the time `run_classify_and_emit` runs
+    // `tokens.join(" ")`, the newline is already gone — so the existing
+    // `rewrite_would_corrupt` guard never sees it and happily rewrites the
+    // corrupt merged command.
+    //
+    // Fix: join `positional_args` first (preserving the raw newline), run
+    // `command_needs_passthrough` (which trims trailing whitespace so a lone
+    // trailing `\n` does NOT bail), and bail before tokenization when the raw
+    // command contains an interior newline or other corruption trigger.
+    //
+    // `positional_args.join(" ")` is correct for both shell invocation shapes:
+    //   `skim rewrite 'git log\nprintf done'`  → one arg with interior `\n` → bail ✓
+    //   `skim rewrite grep -rn x dir`          → multiple args, no `\n` → proceeds ✓
+    if !positional_args.is_empty() {
+        let raw = positional_args.join(" ");
+        if command_needs_passthrough(&raw) {
+            return emit_result(suggest_mode, &raw, None, false);
+        }
+    }
 
     let tokens = match collect_input_tokens(&positional_args)? {
         Some(t) => t,

--- a/crates/rskim/src/cmd/rewrite/mod.rs
+++ b/crates/rskim/src/cmd/rewrite/mod.rs
@@ -488,7 +488,9 @@ fn run_classify_and_emit(suggest_mode: bool, tokens: &[String]) -> anyhow::Resul
     let original = tokens.join(" ");
 
     // Round-trip safety (#317): never emit a rewrite for syntax the pipeline
-    // cannot reconstruct byte-faithfully.
+    // cannot reconstruct byte-faithfully. Interior newlines are already filtered
+    // upstream by `command_needs_passthrough`; this guard catches heredocs, command
+    // substitutions, unmatched quotes, and redirect hazards that survive tokenization.
     if rewrite_would_corrupt(&original) {
         return emit_result(suggest_mode, &original, None, false);
     }

--- a/crates/rskim/src/cmd/rewrite/rules.rs
+++ b/crates/rskim/src/cmd/rewrite/rules.rs
@@ -14,7 +14,8 @@
 //! GLOBALLY in `compound.rs`: `try_rewrite_compound` checks
 //! `has_pipe_operator` on the full segment list and returns `None` immediately
 //! if any pipe operator is present, so the entire pipeline passes through
-//! untouched (lines 543-545 of compound.rs).  No per-rule flag is needed or
+//! untouched (enforced by the `has_pipe_operator` short-circuit in
+//! `try_rewrite_compound`, compound.rs).  No per-rule flag is needed or
 //! used — git diff/log/show as pipe sources are protected by this global
 //! short-circuit, not by any field on `RewriteRule`.  SEE: AD-RW-2.
 
@@ -1816,8 +1817,8 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
     // informational invocations pass through unmodified.
     //
     // Pipe-source passthrough (`ls | head`) is handled GLOBALLY by
-    // `try_rewrite_compound` in compound.rs (has_pipe_operator check,
-    // lines 543-545) — not by any per-rule field.  SEE: AD-RW-2.
+    // `has_pipe_operator` short-circuit in `try_rewrite_compound` (compound.rs)
+    // — not by any per-rule field.  SEE: AD-RW-2.
     RewriteRule {
         prefix: &["ls"],
         rewrite_to: &["skim", "ls"],
@@ -1833,8 +1834,8 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
     // rule (e.g., `grep -rn`, `grep -r`).  Guards on --help/--version/-V.
     //
     // Pipe-source passthrough (`grep pat | head`) is handled GLOBALLY by
-    // `try_rewrite_compound` in compound.rs (has_pipe_operator check,
-    // lines 543-545) — not by any per-rule field.  SEE: AD-RW-2.
+    // `has_pipe_operator` short-circuit in `try_rewrite_compound` (compound.rs)
+    // — not by any per-rule field.  SEE: AD-RW-2.
     RewriteRule {
         prefix: &["grep"],
         rewrite_to: &["skim", "grep"],
@@ -2116,25 +2117,40 @@ mod tests {
     /// `no_rule_silently_drops_prefix_flags` and its negative fixture so the
     /// fixture protects the REAL checker (AC-A4, fix/rewrite-hook-falseneg).
     ///
-    /// Logic: collect `prefix[1..]` tokens that start with `-`; for each, if
-    /// `rewrite_to.contains(flag)` the flag is preserved; else if the prefix
-    /// appears in `allowlist` the whole rule is exempt (return `None`); else
-    /// return `Some(flag)`.  The allowlist check is per-rule: a single entry
-    /// exempts ALL flags in that prefix.
+    /// Logic: compute whether the rule is allowlist-exempt once, then scan
+    /// `prefix[1..]` tokens that start with `-`; for each, if
+    /// `rewrite_to.contains(flag)` the flag is preserved; else if the whole
+    /// rule is exempt return `None`; else return `Some(flag)`.  The allowlist
+    /// check is per-rule: a single entry exempts ALL flags in that prefix.
+    ///
+    /// **Scope note (conservative invariant):** only dash-prefixed tokens are
+    /// checked; bare subcommands consumed by a prefix (e.g. a hypothetical
+    /// `format`/`check` subcommand not prefixed with `-`) would not be caught
+    /// by this helper.  No current rule has that shape, and the guard direction
+    /// is conservative (would over-flag on a false alarm, never under-flag on a
+    /// real drop), so this is safe to leave as a documented limitation rather
+    /// than widen the check.  Similarly, the global-flag branch in the engine
+    /// is not modelled here — the guard is conservative in that direction too.
     fn check_rule_for_flag_drop<'a>(
         prefix: &[&'a str],
         rewrite_to: &[&str],
         allowlist: &[(&[&str], &str)],
     ) -> Option<&'a str> {
-        for flag in prefix[1..].iter().filter(|t| t.starts_with('-')).copied() {
+        // Compute exemption once — allowlist is per-rule, not per-flag.
+        let rule_is_exempt = allowlist
+            .iter()
+            .any(|(allowed_prefix, _comment)| *allowed_prefix == prefix);
+        for flag in prefix
+            .get(1..)
+            .unwrap_or(&[])
+            .iter()
+            .filter(|t| t.starts_with('-'))
+            .copied()
+        {
             if rewrite_to.contains(&flag) {
                 continue; // Flag preserved — OK.
             }
-            // Flag absent from rewrite_to; check allowlist.
-            let in_allowlist = allowlist
-                .iter()
-                .any(|(allowed_prefix, _comment)| *allowed_prefix == prefix);
-            if in_allowlist {
+            if rule_is_exempt {
                 return None; // Entire rule is exempt — no dropped flag.
             }
             return Some(flag); // Dropped flag, not on allowlist.
@@ -2185,14 +2201,13 @@ mod tests {
                 "cmd/lint/mypy.rs:run — tool replacement, -m is dispatch mechanism",
             ),
             // gofmt -l: cmd/lint/gofmt.rs:prepare_args injects `-l` when no
-            // mode flag is present.  Verified: line ~54 in gofmt.rs.
+            // mode flag is present.
             (
                 &["gofmt", "-l"],
                 "cmd/lint/gofmt.rs:prepare_args — injects -l when absent",
             ),
             // prettier --check / npx prettier --check: cmd/lint/prettier.rs:
-            // prepare_check_args injects `--check` when absent.  Verified:
-            // lines ~92-94 in prettier.rs.
+            // prepare_check_args injects `--check` when absent.
             (
                 &["prettier", "--check"],
                 "cmd/lint/prettier.rs:prepare_check_args — injects --check when absent",
@@ -2202,9 +2217,8 @@ mod tests {
                 "cmd/lint/prettier.rs:prepare_check_args — injects --check when absent",
             ),
             // rustfmt --check: cmd/lint/rustfmt.rs:prepare_check_args injects
-            // `--check` when absent.  Verified: lines ~94-97 in rustfmt.rs.
-            // is_format_mode only triggers on --format/-f, so dropping --check
-            // safely defaults to check mode.
+            // `--check` when absent.  is_format_mode only triggers on
+            // --format/-f, so dropping --check safely defaults to check mode.
             (
                 &["rustfmt", "--check"],
                 "cmd/lint/rustfmt.rs:prepare_check_args — injects --check when absent",
@@ -2281,6 +2295,52 @@ mod tests {
             "Allowlisted rule must be exempt; check_rule_for_flag_drop returned {:?}",
             result
         );
+    }
+
+    /// WRAPPER_REINJECTS coupling test (S7, fix/rewrite-hook-falseneg).
+    ///
+    /// Asserts that every allowlist entry in `no_rule_silently_drops_prefix_flags`
+    /// whose dropped flag is re-injected by a lint handler actually has that flag
+    /// present in the handler's `INJECTS` const.  If a handler later removes the
+    /// injection without updating `INJECTS`, this test goes red — turning the
+    /// prose comment into a compiler/test-checked link.
+    ///
+    /// Entries using tool-replacement dispatch (`-m` mechanism for pytest/mypy)
+    /// are excluded: their flag is structurally replaced, not re-injected.
+    #[test]
+    fn wrapper_reinjects_matches_handler_injects() {
+        use crate::cmd::lint::{gofmt, prettier, rustfmt};
+
+        // Map: (prefix_tokens, dropped_flag, handler_INJECTS)
+        // Only entries where a lint handler's prepare_* fn is responsible.
+        let cases: &[(&[&str], &str, &[&str])] = &[
+            (&["gofmt", "-l"], "-l", gofmt::INJECTS),
+            (&["prettier", "--check"], "--check", prettier::INJECTS),
+            (
+                &["npx", "prettier", "--check"],
+                "--check",
+                prettier::INJECTS,
+            ),
+            (&["rustfmt", "--check"], "--check", rustfmt::INJECTS),
+            (&["cargo", "fmt", "--check"], "--check", rustfmt::INJECTS),
+            (
+                &["cargo", "fmt", "--", "--check"],
+                "--check",
+                rustfmt::INJECTS,
+            ),
+        ];
+
+        for (prefix, dropped_flag, handler_injects) in cases {
+            assert!(
+                handler_injects.contains(dropped_flag),
+                "WRAPPER_REINJECTS entry {:?} claims handler re-injects {:?}, \
+                 but that flag is absent from the handler's INJECTS const {:?}. \
+                 Update the handler's INJECTS or fix the allowlist.",
+                prefix,
+                dropped_flag,
+                handler_injects,
+            );
+        }
     }
 
     /// ls --help skips the catch-all rule (passthrough).

--- a/crates/rskim/src/cmd/rewrite/rules.rs
+++ b/crates/rskim/src/cmd/rewrite/rules.rs
@@ -565,9 +565,14 @@ const LINT_RULES: &[RewriteRule] = &[
     // AD-LINT-20 (2026-04-15): `prettier --write` and `-w` are routed through the
     // format-mode parse path in prettier.rs. `is_format_mode` detects `--write`
     // or `-w` in the user arguments. Check-mode rules unchanged.
+    // Fix A (fix/rewrite-hook-falseneg): `--write`/`-w` included in
+    // `rewrite_to`.  prettier.rs:is_format_mode checks args for `--write`/`-w`
+    // to dispatch to run_format; without the flag in args, the handler falls
+    // through to run_check and prepare_check_args injects `--check` instead,
+    // causing check behaviour when the user asked to write files.
     RewriteRule {
         prefix: &["npx", "prettier", "--write"],
-        rewrite_to: &["skim", "prettier"],
+        rewrite_to: &["skim", "prettier", "--write"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -576,7 +581,7 @@ const LINT_RULES: &[RewriteRule] = &[
     },
     RewriteRule {
         prefix: &["npx", "prettier", "-w"],
-        rewrite_to: &["skim", "prettier"],
+        rewrite_to: &["skim", "prettier", "-w"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -585,7 +590,7 @@ const LINT_RULES: &[RewriteRule] = &[
     },
     RewriteRule {
         prefix: &["prettier", "--write"],
-        rewrite_to: &["skim", "prettier"],
+        rewrite_to: &["skim", "prettier", "--write"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -594,7 +599,7 @@ const LINT_RULES: &[RewriteRule] = &[
     },
     RewriteRule {
         prefix: &["prettier", "-w"],
-        rewrite_to: &["skim", "prettier"],
+        rewrite_to: &["skim", "prettier", "-w"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -661,9 +666,15 @@ const LINT_RULES: &[RewriteRule] = &[
         require_flag: &[],
     },
     // black
+    //
+    // Fix A (fix/rewrite-hook-falseneg): `--check` included in `rewrite_to`.
+    // black.rs:is_format_mode returns true when args are non-empty AND lack
+    // `--check`/`--diff`.  Dropping `--check` from the prefix caused the handler
+    // to enter run_format (which rewrites files in place) instead of run_check,
+    // a destructive mode-switch.
     RewriteRule {
         prefix: &["black", "--check"],
-        rewrite_to: &["skim", "black"],
+        rewrite_to: &["skim", "black", "--check"],
         skip_if_flag_prefix: &["--diff"],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -689,9 +700,13 @@ const LINT_RULES: &[RewriteRule] = &[
         global_value_flags: &[],
         require_flag: &[],
     },
+    // Fix A (fix/rewrite-hook-falseneg): `-d` included in `rewrite_to`.
+    // gofmt.rs:prepare_args injects `-l` only when no mode flag is present;
+    // without `-d` in the args the wrapper would inject `-l` instead, silently
+    // switching from diff output to file-list output.
     RewriteRule {
         prefix: &["gofmt", "-d"],
-        rewrite_to: &["skim", "gofmt"],
+        rewrite_to: &["skim", "gofmt", "-d"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -1638,9 +1653,15 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
         require_flag: &[],
     },
     // ls (verbose/recursive only)
+    //
+    // Fix A (fix/rewrite-hook-falseneg): `-la` and `-R` are included in
+    // `rewrite_to` so that the skim handler receives them.  Previously the
+    // prefix consumed the flag tokens and `rewrite_to` only emitted
+    // `["skim", "ls"]`, dropping the flags silently.  The handler needs
+    // `-la`/`-R` to run the right listing mode.
     RewriteRule {
         prefix: &["ls", "-la"],
-        rewrite_to: &["skim", "ls"],
+        rewrite_to: &["skim", "ls", "-la"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::FileOps,
         skip_if_middle_contains_eq: false,
@@ -1649,7 +1670,7 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
     },
     RewriteRule {
         prefix: &["ls", "-R"],
-        rewrite_to: &["skim", "ls"],
+        rewrite_to: &["skim", "ls", "-R"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::FileOps,
         skip_if_middle_contains_eq: false,
@@ -1667,9 +1688,14 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
         require_flag: &[],
     },
     // grep (recursive only)
+    //
+    // Fix A (fix/rewrite-hook-falseneg): `-rn` and `-r` are included in
+    // `rewrite_to` so that the skim handler receives them.  Without them grep
+    // invokes in non-recursive mode, hitting "Is a directory" on the first
+    // directory argument and producing zero matches (silent false-negative).
     RewriteRule {
         prefix: &["grep", "-rn"],
-        rewrite_to: &["skim", "grep"],
+        rewrite_to: &["skim", "grep", "-rn"],
         skip_if_flag_prefix: &["-c", "--count", "-l"],
         category: RewriteCategory::FileOps,
         skip_if_middle_contains_eq: false,
@@ -1678,7 +1704,7 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
     },
     RewriteRule {
         prefix: &["grep", "-r"],
-        rewrite_to: &["skim", "grep"],
+        rewrite_to: &["skim", "grep", "-r"],
         skip_if_flag_prefix: &["-c", "--count", "-l"],
         category: RewriteCategory::FileOps,
         skip_if_middle_contains_eq: false,
@@ -2020,7 +2046,12 @@ mod tests {
         }
     }
 
-    /// Specific grep rules win over catch-all.
+    /// Specific grep rules win over catch-all, and the flag survives the rewrite.
+    ///
+    /// Regression guard for Fix A (fix/rewrite-hook-falseneg): previously the
+    /// rule consumed `-rn` as part of its prefix and `rewrite_to` omitted it,
+    /// so the handler received no recursion flag and silently failed with "Is a
+    /// directory" on directory arguments.
     #[test]
     fn test_specific_grep_still_wins() {
         use crate::cmd::rewrite::engine::try_rewrite;
@@ -2028,6 +2059,193 @@ mod tests {
         let tokens: &[&str] = &["grep", "-rn", "pattern", "src/"];
         let result = try_rewrite(tokens).expect("should rewrite grep -rn");
         assert!(result.tokens.contains(&"skim".to_string()));
+        // Fix A: the `-rn` flag must survive into the rewritten command.
+        assert!(
+            result.tokens.contains(&"-rn".to_string()),
+            "-rn must be preserved in rewrite output; got: {:?}",
+            result.tokens
+        );
+    }
+
+    /// Fix A (fix/rewrite-hook-falseneg): `-r` must survive the grep -r rewrite.
+    #[test]
+    fn test_grep_r_preserves_flag() {
+        use crate::cmd::rewrite::engine::try_rewrite;
+        let result = try_rewrite(&["grep", "-r", "pattern", "src/"])
+            .expect("grep -r must rewrite");
+        assert!(
+            result.tokens.contains(&"-r".to_string()),
+            "-r must be preserved in rewrite output; got: {:?}",
+            result.tokens
+        );
+    }
+
+    /// Fix A (fix/rewrite-hook-falseneg): `-la` must survive the ls -la rewrite.
+    #[test]
+    fn test_ls_la_preserves_flag() {
+        use crate::cmd::rewrite::engine::try_rewrite;
+        let result = try_rewrite(&["ls", "-la"]).expect("ls -la must rewrite");
+        assert!(
+            result.tokens.contains(&"-la".to_string()),
+            "-la must be preserved in rewrite output; got: {:?}",
+            result.tokens
+        );
+    }
+
+    /// Fix A (fix/rewrite-hook-falseneg): `-R` must survive the ls -R rewrite.
+    #[test]
+    fn test_ls_r_preserves_flag() {
+        use crate::cmd::rewrite::engine::try_rewrite;
+        let result = try_rewrite(&["ls", "-R"]).expect("ls -R must rewrite");
+        assert!(
+            result.tokens.contains(&"-R".to_string()),
+            "-R must be preserved in rewrite output; got: {:?}",
+            result.tokens
+        );
+    }
+
+    /// Recurrence guard: no rule may silently drop a flag token from its prefix
+    /// unless the compensating wrapper function is on the WRAPPER_REINJECTS list.
+    ///
+    /// Every flag token (starts with `-`) in `prefix[1..]` must appear in
+    /// `rewrite_to`, OR the rule's prefix must be in `WRAPPER_REINJECTS` with a
+    /// comment naming the exact wrapper fn that compensates.
+    ///
+    /// Fix A (fix/rewrite-hook-falseneg): this test failed before the four
+    /// flag-drop rules were corrected and caused a build failure.  A future
+    /// `foo -X → skim foo` rule that drops a flag will fail this test.
+    ///
+    /// Negative fixture: `synthetic_bad_rule_check` below exercises the checker
+    /// with a known-bad rule and asserts it is detected (AC-A4).
+    #[test]
+    fn no_rule_silently_drops_prefix_flags() {
+        // WRAPPER_REINJECTS: rules whose prefix flags are intentionally absent
+        // from `rewrite_to` because the compensating wrapper fn re-injects them.
+        // Each entry must cite the exact file:fn that compensates.
+        //
+        // Entry format: (prefix_tokens, "comment citing wrapper file:fn")
+        const WRAPPER_REINJECTS: &[(&[&str], &str)] = &[
+            // python3 -m pytest / python -m pytest: the `-m` flag is the Python
+            // module-dispatch mechanism; the entire invocation is replaced by the
+            // pytest handler (cmd/test/pytest.rs:run).
+            (
+                &["python3", "-m", "pytest"],
+                "cmd/test/pytest.rs:run — tool replacement, -m is dispatch mechanism",
+            ),
+            (
+                &["python", "-m", "pytest"],
+                "cmd/test/pytest.rs:run — tool replacement, -m is dispatch mechanism",
+            ),
+            // python3 -m mypy / python -m mypy: same dispatch-mechanism pattern.
+            (
+                &["python3", "-m", "mypy"],
+                "cmd/lint/mypy.rs:run — tool replacement, -m is dispatch mechanism",
+            ),
+            (
+                &["python", "-m", "mypy"],
+                "cmd/lint/mypy.rs:run — tool replacement, -m is dispatch mechanism",
+            ),
+            // gofmt -l: cmd/lint/gofmt.rs:prepare_args injects `-l` when no
+            // mode flag is present.  Verified: line ~54 in gofmt.rs.
+            (
+                &["gofmt", "-l"],
+                "cmd/lint/gofmt.rs:prepare_args — injects -l when absent",
+            ),
+            // prettier --check / npx prettier --check: cmd/lint/prettier.rs:
+            // prepare_check_args injects `--check` when absent.  Verified:
+            // lines ~92-94 in prettier.rs.
+            (
+                &["prettier", "--check"],
+                "cmd/lint/prettier.rs:prepare_check_args — injects --check when absent",
+            ),
+            (
+                &["npx", "prettier", "--check"],
+                "cmd/lint/prettier.rs:prepare_check_args — injects --check when absent",
+            ),
+            // rustfmt --check: cmd/lint/rustfmt.rs:prepare_check_args injects
+            // `--check` when absent.  Verified: lines ~94-97 in rustfmt.rs.
+            // is_format_mode only triggers on --format/-f, so dropping --check
+            // safely defaults to check mode.
+            (
+                &["rustfmt", "--check"],
+                "cmd/lint/rustfmt.rs:prepare_check_args — injects --check when absent",
+            ),
+            // cargo fmt --check: same rustfmt handler via dispatch.
+            (
+                &["cargo", "fmt", "--check"],
+                "cmd/lint/rustfmt.rs:prepare_check_args — injects --check when absent",
+            ),
+            // cargo fmt -- --check: `--` is a separator token that starts with
+            // `-`; it is not a meaningful flag.  The `--check` is compensated by
+            // prepare_check_args as above.
+            (
+                &["cargo", "fmt", "--", "--check"],
+                "cmd/lint/rustfmt.rs:prepare_check_args — injects --check; -- is a separator",
+            ),
+        ];
+
+        for rule in all_rules() {
+            // Collect flag tokens in prefix[1..] (skip the leading tool name).
+            let prefix_flags: Vec<&str> = rule.prefix[1..]
+                .iter()
+                .filter(|t| t.starts_with('-'))
+                .copied()
+                .collect();
+
+            if prefix_flags.is_empty() {
+                continue; // No flags in prefix — nothing to check.
+            }
+
+            for flag in &prefix_flags {
+                if rule.rewrite_to.contains(flag) {
+                    continue; // Flag preserved in rewrite_to — OK.
+                }
+
+                // Flag is absent from rewrite_to — must be in allowlist.
+                let in_allowlist = WRAPPER_REINJECTS
+                    .iter()
+                    .any(|(allowed_prefix, _comment)| *allowed_prefix == rule.prefix);
+
+                assert!(
+                    in_allowlist,
+                    "Rule {:?} drops prefix flag {:?} without re-injecting it in \
+                     rewrite_to and without a WRAPPER_REINJECTS entry. \
+                     Either add {:?} to rewrite_to, or add an allowlist entry \
+                     citing the compensating wrapper fn.",
+                    rule.prefix,
+                    flag,
+                    flag
+                );
+            }
+        }
+    }
+
+    /// Negative fixture for the recurrence guard: a synthetic bad rule that
+    /// drops a prefix flag must be detected by `check_rule_for_flag_drop`
+    /// (AC-A4 from fix/rewrite-hook-falseneg).
+    ///
+    /// This test validates the checker logic itself rather than the rule table.
+    #[test]
+    fn synthetic_bad_rule_check() {
+        // A fake rule: prefix has `-X`, rewrite_to omits it.
+        let bad_prefix: &[&str] = &["mytool", "-X"];
+        let bad_rewrite_to: &[&str] = &["skim", "mytool"];
+
+        let prefix_flags: Vec<&str> = bad_prefix[1..]
+            .iter()
+            .filter(|t| t.starts_with('-'))
+            .copied()
+            .collect();
+
+        let drops_flag = prefix_flags
+            .iter()
+            .any(|flag| !bad_rewrite_to.contains(flag));
+
+        assert!(
+            drops_flag,
+            "The negative fixture must detect that -X is dropped; \
+             if this fails the checker logic itself is broken"
+        );
     }
 
     /// ls --help skips the catch-all rule (passthrough).

--- a/crates/rskim/src/cmd/rewrite/rules.rs
+++ b/crates/rskim/src/cmd/rewrite/rules.rs
@@ -2071,8 +2071,7 @@ mod tests {
     #[test]
     fn test_grep_r_preserves_flag() {
         use crate::cmd::rewrite::engine::try_rewrite;
-        let result = try_rewrite(&["grep", "-r", "pattern", "src/"])
-            .expect("grep -r must rewrite");
+        let result = try_rewrite(&["grep", "-r", "pattern", "src/"]).expect("grep -r must rewrite");
         assert!(
             result.tokens.contains(&"-r".to_string()),
             "-r must be preserved in rewrite output; got: {:?}",
@@ -2212,9 +2211,7 @@ mod tests {
                      rewrite_to and without a WRAPPER_REINJECTS entry. \
                      Either add {:?} to rewrite_to, or add an allowlist entry \
                      citing the compensating wrapper fn.",
-                    rule.prefix,
-                    flag,
-                    flag
+                    rule.prefix, flag, flag
                 );
             }
         }

--- a/crates/rskim/src/cmd/rewrite/rules.rs
+++ b/crates/rskim/src/cmd/rewrite/rules.rs
@@ -7,17 +7,16 @@
 //! v2.8.0: Flat dispatch — `rewrite_to` uses tool names directly
 //! (e.g. `["skim", "cargo", "test"]` instead of `["skim", "test", "cargo"]`).
 //!
-//! # Pipe-source exclusion (AD-RW-2)
+//! # Pipe-source passthrough (AD-RW-2)
 //!
-//! Rules with `exclude_pipe_source: true` are suppressed when the command is
-//! the *source* side of a pipe expression (e.g. `ls | head`, `find . | head`,
-//! `rg pat | head`).  The check is co-located with the rule — adding a new
-//! excluded command only requires setting the flag in the rule struct.
-//!
-//! Current excluded commands: `ls` (catch-all), `grep` (catch-all), `find`,
-//! `rg`.  Catch-alls are also guarded by `skip_if_flag_prefix` for `--help`,
-//! `--version`, and `-V` so that informational invocations pass through
-//! unmodified.  SEE: AD-RW-2.
+//! Commands that appear as the *source* side of a pipe (e.g. `ls | head`,
+//! `git diff | head`, `rg pat | head`) are NEVER rewritten.  This is enforced
+//! GLOBALLY in `compound.rs`: `try_rewrite_compound` checks
+//! `has_pipe_operator` on the full segment list and returns `None` immediately
+//! if any pipe operator is present, so the entire pipeline passes through
+//! untouched (lines 543-545 of compound.rs).  No per-rule flag is needed or
+//! used — git diff/log/show as pipe sources are protected by this global
+//! short-circuit, not by any field on `RewriteRule`.  SEE: AD-RW-2.
 
 use std::sync::LazyLock;
 
@@ -1816,9 +1815,9 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
     // (e.g., `ls -la`, `ls -R`).  Guards on --help/--version/-V so that
     // informational invocations pass through unmodified.
     //
-    // `exclude_pipe_source: true` prevents this rule from rewriting the source
-    // side of a pipe (`ls | head`).  The compound pipeline engine skips rules
-    // with this flag set on the pipe-source segment.  SEE: AD-RW-2.
+    // Pipe-source passthrough (`ls | head`) is handled GLOBALLY by
+    // `try_rewrite_compound` in compound.rs (has_pipe_operator check,
+    // lines 543-545) — not by any per-rule field.  SEE: AD-RW-2.
     RewriteRule {
         prefix: &["ls"],
         rewrite_to: &["skim", "ls"],
@@ -1833,8 +1832,9 @@ const FILE_OPS_RULES: &[RewriteRule] = &[
     // Fires for any `grep` invocation not matched by a more-specific earlier
     // rule (e.g., `grep -rn`, `grep -r`).  Guards on --help/--version/-V.
     //
-    // `exclude_pipe_source: true` prevents `grep | head` from being rewritten on the
-    // source side.  SEE: AD-RW-2.
+    // Pipe-source passthrough (`grep pat | head`) is handled GLOBALLY by
+    // `try_rewrite_compound` in compound.rs (has_pipe_operator check,
+    // lines 543-545) — not by any per-rule field.  SEE: AD-RW-2.
     RewriteRule {
         prefix: &["grep"],
         rewrite_to: &["skim", "grep"],
@@ -2110,6 +2110,38 @@ mod tests {
         );
     }
 
+    /// Returns the first prefix flag that `rewrite_to` drops without an
+    /// allowlist entry, or `None` if the rule preserves all its prefix flags
+    /// (or is exempt via the allowlist). Shared by the structural guard
+    /// `no_rule_silently_drops_prefix_flags` and its negative fixture so the
+    /// fixture protects the REAL checker (AC-A4, fix/rewrite-hook-falseneg).
+    ///
+    /// Logic: collect `prefix[1..]` tokens that start with `-`; for each, if
+    /// `rewrite_to.contains(flag)` the flag is preserved; else if the prefix
+    /// appears in `allowlist` the whole rule is exempt (return `None`); else
+    /// return `Some(flag)`.  The allowlist check is per-rule: a single entry
+    /// exempts ALL flags in that prefix.
+    fn check_rule_for_flag_drop<'a>(
+        prefix: &[&'a str],
+        rewrite_to: &[&str],
+        allowlist: &[(&[&str], &str)],
+    ) -> Option<&'a str> {
+        for flag in prefix[1..].iter().filter(|t| t.starts_with('-')).copied() {
+            if rewrite_to.contains(&flag) {
+                continue; // Flag preserved — OK.
+            }
+            // Flag absent from rewrite_to; check allowlist.
+            let in_allowlist = allowlist
+                .iter()
+                .any(|(allowed_prefix, _comment)| *allowed_prefix == prefix);
+            if in_allowlist {
+                return None; // Entire rule is exempt — no dropped flag.
+            }
+            return Some(flag); // Dropped flag, not on allowlist.
+        }
+        None // All flags preserved or no flags in prefix.
+    }
+
     /// Recurrence guard: no rule may silently drop a flag token from its prefix
     /// unless the compensating wrapper function is on the WRAPPER_REINJECTS list.
     ///
@@ -2121,8 +2153,9 @@ mod tests {
     /// flag-drop rules were corrected and caused a build failure.  A future
     /// `foo -X → skim foo` rule that drops a flag will fail this test.
     ///
-    /// Negative fixture: `synthetic_bad_rule_check` below exercises the checker
-    /// with a known-bad rule and asserts it is detected (AC-A4).
+    /// Negative fixture: `synthetic_bad_rule_check` below calls the SAME
+    /// `check_rule_for_flag_drop` helper so the fixture protects the REAL
+    /// checker rather than a copy (AC-A4).
     #[test]
     fn no_rule_silently_drops_prefix_flags() {
         // WRAPPER_REINJECTS: rules whose prefix flags are intentionally absent
@@ -2191,64 +2224,62 @@ mod tests {
         ];
 
         for rule in all_rules() {
-            // Collect flag tokens in prefix[1..] (skip the leading tool name).
-            let prefix_flags: Vec<&str> = rule.prefix[1..]
-                .iter()
-                .filter(|t| t.starts_with('-'))
-                .copied()
-                .collect();
-
-            if prefix_flags.is_empty() {
-                continue; // No flags in prefix — nothing to check.
-            }
-
-            for flag in &prefix_flags {
-                if rule.rewrite_to.contains(flag) {
-                    continue; // Flag preserved in rewrite_to — OK.
-                }
-
-                // Flag is absent from rewrite_to — must be in allowlist.
-                let in_allowlist = WRAPPER_REINJECTS
-                    .iter()
-                    .any(|(allowed_prefix, _comment)| *allowed_prefix == rule.prefix);
-
-                assert!(
-                    in_allowlist,
+            if let Some(dropped) =
+                check_rule_for_flag_drop(rule.prefix, rule.rewrite_to, WRAPPER_REINJECTS)
+            {
+                panic!(
                     "Rule {:?} drops prefix flag {:?} without re-injecting it in \
                      rewrite_to and without a WRAPPER_REINJECTS entry. \
                      Either add {:?} to rewrite_to, or add an allowlist entry \
                      citing the compensating wrapper fn.",
-                    rule.prefix, flag, flag
+                    rule.prefix, dropped, dropped
                 );
             }
         }
     }
 
-    /// Negative fixture for the recurrence guard: a synthetic bad rule that
-    /// drops a prefix flag must be detected by `check_rule_for_flag_drop`
-    /// (AC-A4 from fix/rewrite-hook-falseneg).
+    /// Negative fixture for `check_rule_for_flag_drop` (AC-A4).
     ///
-    /// This test validates the checker logic itself rather than the rule table.
+    /// Calls the SAME `check_rule_for_flag_drop` helper used by
+    /// `no_rule_silently_drops_prefix_flags`.  This means any regression in the
+    /// checker (e.g. inverting the `rewrite_to.contains` condition) will make
+    /// BOTH tests go red — the fixture protects the REAL guard, not a copy.
+    ///
+    /// Three controls:
+    ///   1. Bad rule (flag dropped, empty allowlist) → must return Some("-X").
+    ///   2. Good rule (flag preserved)               → must return None.
+    ///   3. Allowlist-exempt bad rule                → must return None.
     #[test]
     fn synthetic_bad_rule_check() {
-        // A fake rule: prefix has `-X`, rewrite_to omits it.
         let bad_prefix: &[&str] = &["mytool", "-X"];
         let bad_rewrite_to: &[&str] = &["skim", "mytool"];
+        let good_rewrite_to: &[&str] = &["skim", "mytool", "-X"];
 
-        let prefix_flags: Vec<&str> = bad_prefix[1..]
-            .iter()
-            .filter(|t| t.starts_with('-'))
-            .copied()
-            .collect();
+        // Control 1: dropped flag detected against empty allowlist.
+        let result = check_rule_for_flag_drop(bad_prefix, bad_rewrite_to, &[]);
+        assert_eq!(
+            result,
+            Some("-X"),
+            "Bad rule must be detected; check_rule_for_flag_drop returned {:?}",
+            result
+        );
 
-        let drops_flag = prefix_flags
-            .iter()
-            .any(|flag| !bad_rewrite_to.contains(flag));
+        // Control 2: preserved flag returns None.
+        let result = check_rule_for_flag_drop(bad_prefix, good_rewrite_to, &[]);
+        assert_eq!(
+            result, None,
+            "Good rule must not be flagged; check_rule_for_flag_drop returned {:?}",
+            result
+        );
 
-        assert!(
-            drops_flag,
-            "The negative fixture must detect that -X is dropped; \
-             if this fails the checker logic itself is broken"
+        // Control 3: exempt via allowlist — bad rule with prefix on allowlist returns None.
+        let allowlist: &[(&[&str], &str)] =
+            &[(&["mytool", "-X"], "synthetic: allowlist-exemption control")];
+        let result = check_rule_for_flag_drop(bad_prefix, bad_rewrite_to, allowlist);
+        assert_eq!(
+            result, None,
+            "Allowlisted rule must be exempt; check_rule_for_flag_drop returned {:?}",
+            result
         );
     }
 

--- a/crates/rskim/src/cmd/rewrite/rules.rs
+++ b/crates/rskim/src/cmd/rewrite/rules.rs
@@ -477,9 +477,16 @@ const LINT_RULES: &[RewriteRule] = &[
     // AD-LINT-20 (2026-04-15): `ruff format --check` and `ruff format` (apply mode)
     // are routed through the format-mode parse path in ruff.rs. The ruff parser
     // detects `is_format_mode` from the first user argument (`"format"`).
+    //
+    // Fix A (fix/rewrite-hook-falseneg): rewrite_to must include both "format" and
+    // "--check" because the engine places `middle = prefix_tail..`; the prefix
+    // tokens are consumed and never reach the handler unless they are in rewrite_to.
+    // Dropping --check silently switches ruff format --check (dry-run) to apply
+    // mode, which is destructive.  Dropping "format" routes the call to run_check
+    // instead of run_format — semantically wrong.
     RewriteRule {
         prefix: &["ruff", "format", "--check"],
-        rewrite_to: &["skim", "ruff"],
+        rewrite_to: &["skim", "ruff", "format", "--check"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,
@@ -488,7 +495,7 @@ const LINT_RULES: &[RewriteRule] = &[
     },
     RewriteRule {
         prefix: &["ruff", "format"],
-        rewrite_to: &["skim", "ruff"],
+        rewrite_to: &["skim", "ruff", "format"],
         skip_if_flag_prefix: &[],
         category: RewriteCategory::Lint,
         skip_if_middle_contains_eq: false,

--- a/crates/rskim/src/output/canonical.rs
+++ b/crates/rskim/src/output/canonical.rs
@@ -2180,8 +2180,8 @@ mod tests {
     fn fix_f_ratio_header_present_when_truncated() {
         let result = FileResult::new(
             "ls".to_string(),
-            50,  // shown
             342, // total
+            50,  // shown
             (0..50).map(|i| format!("file{i}")).collect(),
             Some("... and 292 more".to_string()),
         );

--- a/crates/rskim/src/output/canonical.rs
+++ b/crates/rskim/src/output/canonical.rs
@@ -2065,7 +2065,10 @@ mod tests {
         );
         let output = format!("{result}");
         // Fix F: no truncation (shown==total) → plain count, not ratio.
-        assert!(output.starts_with("find 5"), "header must be 'find 5': {output:?}");
+        assert!(
+            output.starts_with("find 5"),
+            "header must be 'find 5': {output:?}"
+        );
         assert!(
             !output.starts_with("find 5/5"),
             "N/N tautology header must be gone (Fix F): {output:?}"
@@ -2122,8 +2125,16 @@ mod tests {
         result.ensure_rendered();
         assert!(!result.rendered.is_empty());
         // Fix F: shown_count==total_count → plain count header.
-        assert!(result.rendered.contains("rg 2"), "header must contain 'rg 2': {:?}", result.rendered);
-        assert!(!result.rendered.contains("rg 2/2"), "N/N tautology must be gone (Fix F): {:?}", result.rendered);
+        assert!(
+            result.rendered.contains("rg 2"),
+            "header must contain 'rg 2': {:?}",
+            result.rendered
+        );
+        assert!(
+            !result.rendered.contains("rg 2/2"),
+            "N/N tautology must be gone (Fix F): {:?}",
+            result.rendered
+        );
     }
 
     #[test]
@@ -2131,8 +2142,14 @@ mod tests {
         let result = FileResult::new("find".to_string(), 0, 0, vec![], None);
         let output = format!("{result}");
         // Fix F: 0/0 is a tautology → plain count "find 0".
-        assert!(output.contains("find 0"), "header must be 'find 0': {output:?}");
-        assert!(!output.contains("find 0/0"), "N/N tautology must be gone (Fix F): {output:?}");
+        assert!(
+            output.contains("find 0"),
+            "header must be 'find 0': {output:?}"
+        );
+        assert!(
+            !output.contains("find 0/0"),
+            "N/N tautology must be gone (Fix F): {output:?}"
+        );
     }
 
     // ========================================================================
@@ -2144,13 +2161,7 @@ mod tests {
     /// show just `N` instead.  `N/N` is a tautology that adds noise.
     #[test]
     fn fix_f_no_ratio_header_when_not_truncated() {
-        let result = FileResult::new(
-            "grep".to_string(),
-            7,
-            7,
-            vec!["entry".to_string()],
-            None,
-        );
+        let result = FileResult::new("grep".to_string(), 7, 7, vec!["entry".to_string()], None);
         let output = format!("{result}");
         assert!(
             output.starts_with("grep 7"),

--- a/crates/rskim/src/output/canonical.rs
+++ b/crates/rskim/src/output/canonical.rs
@@ -1017,7 +1017,17 @@ impl FileResult {
     ) -> String {
         use std::fmt::Write;
 
-        let mut output = format!("{tool} {shown_count}/{total_count}");
+        // Fix F (fix/rewrite-hook-falseneg): only emit a ratio header when
+        // truncation actually occurred (shown_count < total_count).  When all
+        // results fit in the output, `N/N` is a tautology that adds no
+        // information — show just the count instead.  When truncation did
+        // occur, `shown/total` communicates what was omitted.
+        let header = if shown_count < total_count {
+            format!("{tool} {shown_count}/{total_count}")
+        } else {
+            format!("{tool} {total_count}")
+        };
+        let mut output = header;
         for entry in entries {
             let _ = write!(output, "\n {entry}");
         }
@@ -2054,7 +2064,12 @@ mod tests {
             None,
         );
         let output = format!("{result}");
-        assert!(output.starts_with("find 5/5"));
+        // Fix F: no truncation (shown==total) → plain count, not ratio.
+        assert!(output.starts_with("find 5"), "header must be 'find 5': {output:?}");
+        assert!(
+            !output.starts_with("find 5/5"),
+            "N/N tautology header must be gone (Fix F): {output:?}"
+        );
         assert!(output.contains(" ./src/main.rs"));
         assert!(output.contains(" ./Cargo.toml"));
     }
@@ -2106,14 +2121,64 @@ mod tests {
         };
         result.ensure_rendered();
         assert!(!result.rendered.is_empty());
-        assert!(result.rendered.contains("rg 2/2"));
+        // Fix F: shown_count==total_count → plain count header.
+        assert!(result.rendered.contains("rg 2"), "header must contain 'rg 2': {:?}", result.rendered);
+        assert!(!result.rendered.contains("rg 2/2"), "N/N tautology must be gone (Fix F): {:?}", result.rendered);
     }
 
     #[test]
     fn test_file_result_empty_entries() {
         let result = FileResult::new("find".to_string(), 0, 0, vec![], None);
         let output = format!("{result}");
-        assert!(output.contains("find 0/0"));
+        // Fix F: 0/0 is a tautology → plain count "find 0".
+        assert!(output.contains("find 0"), "header must be 'find 0': {output:?}");
+        assert!(!output.contains("find 0/0"), "N/N tautology must be gone (Fix F): {output:?}");
+    }
+
+    // ========================================================================
+    // Fix F: header format — no ratio when not truncated
+    // ========================================================================
+
+    /// Fix F (fix/rewrite-hook-falseneg): when all results are shown
+    /// (shown_count == total_count), the header must NOT emit `N/N` —
+    /// show just `N` instead.  `N/N` is a tautology that adds noise.
+    #[test]
+    fn fix_f_no_ratio_header_when_not_truncated() {
+        let result = FileResult::new(
+            "grep".to_string(),
+            7,
+            7,
+            vec!["entry".to_string()],
+            None,
+        );
+        let output = format!("{result}");
+        assert!(
+            output.starts_with("grep 7"),
+            "header must start with 'grep 7': {output:?}"
+        );
+        assert!(
+            !output.starts_with("grep 7/7"),
+            "N/N ratio header must be absent (Fix F): {output:?}"
+        );
+    }
+
+    /// Fix F: when truncation DID occur (shown_count < total_count),
+    /// the ratio header MUST still be emitted so the agent knows output
+    /// was capped.
+    #[test]
+    fn fix_f_ratio_header_present_when_truncated() {
+        let result = FileResult::new(
+            "ls".to_string(),
+            50,  // shown
+            342, // total
+            (0..50).map(|i| format!("file{i}")).collect(),
+            Some("... and 292 more".to_string()),
+        );
+        let output = format!("{result}");
+        assert!(
+            output.starts_with("ls 50/342"),
+            "truncated header must show ratio 50/342: {output:?}"
+        );
     }
 
     // ========================================================================

--- a/crates/rskim/tests/cli_e2e_exit_codes.rs
+++ b/crates/rskim/tests/cli_e2e_exit_codes.rs
@@ -19,6 +19,8 @@
 //! - **go test**: Does NOT support stdin (always runs `go test`).
 //! - **build parsers**: Do NOT support stdin (always run the real command).
 
+use std::fs;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 
@@ -187,4 +189,74 @@ fn test_exit_code_pytest_passthrough_garbage() {
         .write_stdin("random garbage not pytest output\n")
         .assert()
         .code(predicate::ne(0));
+}
+
+// ============================================================================
+// Fix B — diff exit-1 Full-tier E2E (fix/rewrite-hook-falseneg)
+//
+// These tests exercise the INTEGRATED path that Fix B changes: a real diff on
+// two differing files exits 1 with a non-empty compressed body (Full tier).
+// The pre-existing grep no-match test hits the Passthrough tier (empty body →
+// already silent), so it does NOT exercise the new `!is_benign_exit1` term in
+// `should_emit_compressed_hint`. These tests do.
+//
+// Discriminates against a regression in `RecordReport::program` threading: if
+// `program` were not forwarded correctly into `should_emit_compressed_hint`,
+// the benign guard would not fire and the compressed-output hint would appear
+// in stderr — causing the `.stderr(predicate::str::contains(...).not())`
+// assertion to FAIL, catching the regression.
+// ============================================================================
+
+/// diff exit 1 = files differ — Full-tier compressed body, hint suppressed.
+///
+/// This is the core Fix B integration test: skim compresses the diff output
+/// (non-empty body → Full tier), propagates exit code 1, and does NOT print
+/// the "[skim] compressed output" hint because diff is in BENIGN_EXIT1_PROGRAMS.
+#[test]
+fn test_diff_differing_files_exit1_full_tier_hint_suppressed() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_a = dir.path().join("a.txt");
+    let file_b = dir.path().join("b.txt");
+    fs::write(&file_a, "alpha\nbeta\n").unwrap();
+    fs::write(&file_b, "alpha\ngamma\n").unwrap();
+
+    skim_cmd()
+        .args(["diff", file_a.to_str().unwrap(), file_b.to_str().unwrap()])
+        .assert()
+        // Exit code must be propagated faithfully (files differ = 1).
+        .code(1)
+        // stdout must contain compressed diff body (Full tier, non-empty).
+        // FileResult::render produces "diff 1" header when shown == total.
+        .stdout(predicate::str::contains("diff"))
+        .stdout(predicate::str::contains("changed"))
+        // The hint must NOT appear: diff exit 1 is benign ("files differ"),
+        // not an error. Printing the hint would mislead agents.
+        .stderr(predicate::str::contains("[skim] compressed output").not());
+}
+
+/// diff exit >=2 = read error — hint DOES fire (not benign, real error).
+///
+/// Proves the suppression is exit-code-aware, not blanket: only exit 1 is
+/// benign for diff. A missing-file error exits 2 and SHOULD get the hint so
+/// agents know skim re-encoded the (forwarded-raw) diagnostic output.
+///
+/// Because exit 2 is an unexpected failure (not in expected_exit_codes=[1]),
+/// skim actually raw-forwards the output with the "raw output (not compressed)"
+/// notice, not the "compressed output" hint. Either notice signals the agent
+/// to investigate — the key property is that diff exit 2 does NOT produce a
+/// silent suppression identical to the benign exit-1 path.
+#[test]
+fn test_diff_missing_file_exit2_not_silent() {
+    skim_cmd()
+        .args([
+            "diff",
+            "/nonexistent/skim-fix-b-a",
+            "/nonexistent/skim-fix-b-b",
+        ])
+        .assert()
+        .code(2)
+        // skim must emit SOME diagnostic to stderr for exit 2 — either the
+        // raw-forward notice or (if the parser somehow reaches record_and_report)
+        // the compressed-output hint. Either way it must not be silent.
+        .stderr(predicate::str::is_empty().not());
 }

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -2622,6 +2622,57 @@ fn test_hook_pipe_with_rewritable_producer_passes_through() {
         .stdout(predicate::str::is_empty());
 }
 
+/// Fix E (fix/rewrite-hook-falseneg): `git diff | grep "^+"` must NOT be
+/// rewritten.  Rewiring `git diff` to `skim git diff` in a pipe would change
+/// the byte stream that `grep` sees — the compressed diff format differs from
+/// raw `git diff` output.  The hook must emit empty stdout (passthrough).
+#[test]
+fn fix_e_git_diff_pipe_grep_passes_through() {
+    let input = serde_json::json!({
+        "tool_input": {
+            "command": "git diff | grep \"^+\""
+        }
+    });
+    skim_cmd()
+        .args(["rewrite", "--hook"])
+        .write_stdin(serde_json::to_string(&input).unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// Fix E: `git log | grep feat` must pass through — same pipe-source rule.
+#[test]
+fn fix_e_git_log_pipe_grep_passes_through() {
+    let input = serde_json::json!({
+        "tool_input": {
+            "command": "git log --oneline | grep feat"
+        }
+    });
+    skim_cmd()
+        .args(["rewrite", "--hook"])
+        .write_stdin(serde_json::to_string(&input).unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// Fix E: `git show HEAD:src/lib.rs | wc -l` must pass through.
+#[test]
+fn fix_e_git_show_pipe_passes_through() {
+    let input = serde_json::json!({
+        "tool_input": {
+            "command": "git show HEAD:src/lib.rs | wc -l"
+        }
+    });
+    skim_cmd()
+        .args(["rewrite", "--hook"])
+        .write_stdin(serde_json::to_string(&input).unwrap())
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
 // ============================================================================
 // #317 — the emitted rewrite must EXECUTE (round-trip e2e)
 //

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -841,7 +841,7 @@ fn test_rewrite_ruff_format_check() {
         .args(["rewrite", "ruff", "format", "--check", "."])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim ruff"));
+        .stdout(predicate::str::contains("skim ruff format --check ."));
 }
 
 #[test]
@@ -1143,7 +1143,7 @@ fn test_rewrite_ls_la() {
         .args(["rewrite", "ls", "-la"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim ls"));
+        .stdout(predicate::str::contains("skim ls -la"));
 }
 
 #[test]
@@ -1161,7 +1161,7 @@ fn test_rewrite_grep_r() {
         .args(["rewrite", "grep", "-r", "TODO", "src/"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim grep"));
+        .stdout(predicate::str::contains("skim grep -r TODO src/"));
 }
 
 #[test]
@@ -1726,7 +1726,7 @@ fn test_rewrite_black_check() {
         .args(["rewrite", "black", "--check", "src/"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim black"));
+        .stdout(predicate::str::contains("skim black --check src/"));
 }
 
 #[test]
@@ -1749,11 +1749,14 @@ fn test_rewrite_black_diff_skipped() {
 
 #[test]
 fn test_rewrite_gofmt_l() {
+    // gofmt -l rewrites to `skim gofmt ./...` (no -l in rewrite_to): the
+    // gofmt handler (prepare_args) re-injects -l when no mode flag is present
+    // (WRAPPER_REINJECTS entry in no_rule_silently_drops_prefix_flags).
     skim_cmd()
         .args(["rewrite", "gofmt", "-l", "./..."])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim gofmt"));
+        .stdout(predicate::str::contains("skim gofmt ./..."));
 }
 
 #[test]
@@ -2859,13 +2862,16 @@ fn cli_rewrite_interior_newline_passes_through() {
 #[test]
 fn cli_rewrite_trailing_newline_still_rewrites() {
     // Trailing newline only — command_needs_passthrough trims it, so no bail.
+    // collect_input_tokens then splits on whitespace (stripping the \n), and
+    // the rule prefix=["grep","-rn"] with rewrite_to=["skim","grep","-rn"]
+    // yields the full `skim grep -rn x dir` form.
     let cmd_with_trailing_newline = "grep -rn x dir\n";
 
     skim_cmd()
         .args(["rewrite", cmd_with_trailing_newline])
         .assert()
         .success()
-        .stdout(predicate::str::contains("skim grep"));
+        .stdout(predicate::str::contains("skim grep -rn x dir"));
 }
 
 /// AC-C3 regression: normal multi-word positional args (no newline) still rewrite.

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -2802,3 +2802,81 @@ fn test_hook_safe_redirect_order_still_rewrites() {
         .success()
         .stdout(predicate::str::contains(">log.txt 2>&1"));
 }
+
+// ============================================================================
+// Fix C — CLI path: interior newline must pass through (AC-C1 / AC-C2 / AC-C3)
+//
+// The hook path already bails on interior newlines (via command_needs_passthrough
+// in hook.rs). The CLI positional-args path had a different bug: collect_input_tokens
+// flattened the newline via split_whitespace BEFORE the corruption guard ran,
+// so the guard never saw it and happily emitted a corrupt merged command.
+// Fix: check command_needs_passthrough on the joined raw string BEFORE tokenising.
+// ============================================================================
+
+/// AC-C1 CLI: a single quoted arg containing an INTERIOR newline must NOT
+/// produce a corrupt merged rewrite — the two shell statements must never be
+/// joined into one command line.
+///
+/// Repro: `skim rewrite "$(printf 'git log -1 abc123\nprintf done')"` previously
+/// emitted `skim git log -1 abc123 printf done` (corrupt merged command, exit 0).
+/// Correct behavior: no-match passthrough (empty stdout, exit 1) — the CLI path
+/// uses ExitCode::FAILURE for "no rewrite match", consistent with the existing
+/// rewrite_would_corrupt guard in run_classify_and_emit.
+#[test]
+fn cli_rewrite_interior_newline_passes_through() {
+    // A Rust string literal with a real \n char — matches the shell repro.
+    let cmd_with_interior_newline = "git log -1 abc123\nprintf done";
+
+    let output = skim_cmd()
+        .args(["rewrite", cmd_with_interior_newline])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    // Must NOT emit the corrupt merged form (the regression being fixed).
+    assert!(
+        !stdout.contains("skim git log -1 abc123 printf done"),
+        "interior newline must not produce a merged rewritten command; got: {stdout:?}"
+    );
+    // Must NOT emit any skim-prefixed rewrite — the whole arg is a corruption trigger.
+    assert!(
+        !stdout.contains("skim git log"),
+        "interior newline must not rewrite the first statement in isolation; got: {stdout:?}"
+    );
+    // stdout must be empty (no-match passthrough, per existing convention).
+    assert!(
+        stdout.is_empty(),
+        "interior newline passthrough must produce empty stdout; got: {stdout:?}"
+    );
+}
+
+/// AC-C2 CLI: a single arg with ONLY a trailing newline must still rewrite.
+///
+/// Agent hooks commonly add a trailing `\n` to the command field. That trailing
+/// newline is benign — it survives trim_end in command_needs_passthrough and
+/// does not indicate a multi-statement command. The rewrite must proceed.
+#[test]
+fn cli_rewrite_trailing_newline_still_rewrites() {
+    // Trailing newline only — command_needs_passthrough trims it, so no bail.
+    let cmd_with_trailing_newline = "grep -rn x dir\n";
+
+    skim_cmd()
+        .args(["rewrite", cmd_with_trailing_newline])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skim grep"));
+}
+
+/// AC-C3 regression: normal multi-word positional args (no newline) still rewrite.
+///
+/// Proves that the new early-bail guard did not break the common path where the
+/// user passes the command as separate tokens rather than a single quoted string.
+#[test]
+fn cli_rewrite_no_newline_still_rewrites() {
+    skim_cmd()
+        .args(["rewrite", "grep", "-rn", "x", "dir"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skim grep -rn x dir"));
+}

--- a/crates/rskim/tests/cli_git.rs
+++ b/crates/rskim/tests/cli_git.rs
@@ -526,6 +526,50 @@ fn test_skim_git_show_file_content_unsupported_ext_passthrough() {
     );
 }
 
+/// Fix D (fix/rewrite-hook-falseneg, AD-GIT-SHOW-PSEUDO): `git show <ref>:<file>`
+/// must use Pseudo mode (preserves function bodies), NOT Structure mode (collapses
+/// them to `{...}`).  This drives the real production path (`run_show_file_content`,
+/// show.rs) end-to-end against a committed fixture and is the PF-007 guard for the
+/// mode constant: it FAILS if that site reverts to Structure.
+///
+/// The asserted tokens live ONLY inside function bodies in the fixture (not in any
+/// signature, doc comment, `use`, or struct field), so Structure mode — which keeps
+/// signatures and imports — strips every one of them.  Their presence proves Pseudo
+/// is live in production, not merely at the transform layer.
+#[test]
+fn test_skim_git_show_file_content_pseudo_preserves_bodies() {
+    let output = Command::cargo_bin("skim")
+        .unwrap()
+        .args([
+            "git",
+            "show",
+            "HEAD:crates/rskim/tests/fixtures/cmd/git/show_file.rs",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "skim git show of a committed .rs file should exit 0; got exit code {:?}",
+        output.status.code()
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    for token in [
+        "find_user_by_username",
+        "Invalid credentials",
+        "duration_since",
+    ] {
+        assert!(
+            stdout.contains(token),
+            "Pseudo-mode `git show` must preserve body token {token:?} \
+             (Structure mode would strip it); got: {}",
+            &stdout[..stdout.len().min(600)]
+        );
+    }
+}
+
 // ============================================================================
 // Git dispatcher coverage (MEDIUM-28, #132)
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes a class of **silent false-negatives** in skim's command-rewrite hook. skim rewrites `grep` → `skim grep` (wrapping the real tool); three independent reviewer reports hit the same defect. Empirical reproduction against the built binary showed the trigger was **not** pattern characters (`<`, anchored `+`, quotes) but a small set of root-cause bugs that all produce the same dangerous outcome — output an agent reads as *"no matches / not present."*

Six fixes (A–F) on one branch, spanning the rewrite engine (A/C/E — the agent PreToolUse hook and the `skim rewrite` CLI) and the shared tool handlers that **both** interception surfaces run (B/D/F — the hook/CLI engine **and** the OS-level PATH wrappers). The rewrite engine and the wrapper surface dispatch differently; see `CLAUDE.md` → *Two interception surfaces*.

## Fixes

- **A — Flag-drop root cause + recurrence guard.** Rules baked a required flag into the match `prefix`, then `rewrite_to` replaced the whole prefix with `skim <tool>`, **dropping the flag** (`grep -rn` → `skim grep` lost `-rn` → non-recursive → *"Is a directory"* → false-negative; same for `grep -r`, `ls -la`, `ls -R`). Flags are now preserved in `rewrite_to`. **Generalization:** a structural guard test (`no_rule_silently_drops_prefix_flags`) **fails the build** if any rule drops a prefix flag that isn't on an explicit `WRAPPER_REINJECTS` allowlist (each entry citing the compensating wrapper fn). The guard immediately caught a **pre-existing** bug — `ruff format --check` dropped both `format` and `--check`, silently turning a dry-run into a destructive file rewrite — now fixed too.
- **B — Error visibility.** grep/rg/diff exit **1** (benign "no match"/"differs") no longer prints the misleading `[skim] compressed output (exit 1)` hint, while **still propagating the exit code**; exit **≥2** (a real error) forwards the tool's stderr to our stderr. (Surfacing stderr on error was already provided by #317's `forward_stderr`; this PR makes the hint exit-code-aware per tool via `should_emit_compressed_hint`.)
- **C — Composed-command safety.** Passthrough-unchanged when a command, after trimming trailing whitespace, contains an **interior newline** (statement-merge corruption: `git log -1 SHA⏎printf done` was merging into one command). Applied at **both** engine entry points — the agent hook **and** the `skim rewrite` CLI path (where `split_whitespace` had been silently merging statements). Trailing newlines still rewrite. The deeper composed-command parser gap is tracked in #337.
- **D — git show file-content.** `git show <ref>:<path>` now uses **pseudo** mode (preserves body logic) instead of structure mode (which collapsed bodies to `{...}` and hid the logic). The inflation guardrail still falls back to raw.
- **E — Pipe-source.** `git diff|log|show | grep …` leaves the source **raw** when piped (skim's reformatted lines would break the downstream filter). Enforced globally by the pipe short-circuit in `compound.rs`; misleading per-rule comments corrected.
- **F — Display wording.** `GREP: N matches in M files` — removed the misleading `(showing N)` (N was the *file* count; a reviewer read it as truncation). Truncation wording appears only when a cap actually truncated. **JSON envelope unchanged.**

## Recurrence prevention

1. **Structural guard test (A)** — CI fails if any rule drops a prefix flag.
2. **Error visibility (B)** — any residual failure becomes loud stderr, not an empty "no match."
3. **Bail-don't-corrupt (C)** — the engine passes through anything it can't provably round-trip.

## Testing

- **rskim: 3921 tests pass** (full `--no-fail-fast`); **rskim-core: 470 tests + 15 doctests pass**.
- `cargo clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.
- **AC-A4 is mutation-proven:** the negative fixture drives the *real* shared `check_rule_for_flag_drop` helper — inverting the check turns **both** the guard and the fixture red.
- **Surfaces tested:** the `--hook` JSON path and the `skim rewrite` CLI are tested for flag preservation (A) and the B/D/F behavioral changes. The PATH-wrapper surface (`~/.skim/bin/<tool>` → skim binary) takes a separate dispatch path (`detect_argv0_dispatch` → `cmd::dispatch`) that **bypasses the rewrite engine** — it runs the tool handler directly with the original argv, so rewrite-path flag preservation (A/C/E) does not apply to it. It shares the B/D/F handler code with the tested paths but is not independently exercised by a wrapped-`argv[0]` test. See `CLAUDE.md` → *Two interception surfaces*.

## Scope (deliberately not in this PR)

No full multi-line/quote-aware parser, no engine-level per-rule flag opt-outs, no `--mode` flag on `git show` — all per the plan. Round-tripping constructs (`$()`, backticks, `${}`, `<()`, redirects, `&`, `<<<`, comments, env-prefixes, quoted pipes) are **not** bailed (verified to round-trip — bailing would lose compression for nothing).

## Tracking

- #337 — *rewrite engine: full composed-command support (parse instead of bail)* — the deeper quote-aware tokenization / multi-line / heredoc work.

