### PR TITLE
fix(#359): record file-op analytics independent of cache state; unify SKIM_CACHE_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default when explicitly set. Empty `SKIM_CACHE_DIR` is treated as unset (falls back to
   the platform default `~/.cache/skim`).
 
+- **Plain `skim <file>` now always records token-savings analytics (#359 Phase A)** —
+  Previously a plain `skim <file>` (and stdin, glob, and directory invocations) only
+  recorded analytics when token counts were already present in the parser cache from a
+  prior `--show-stats` run; cold-cache and plain-warmed-cache runs silently dropped all
+  data. The fix introduces a unified `record_file_ops` path that records token counts
+  independent of cache state, with the detected language attached to each row. Multi-file
+  invocations (glob, directory) now emit one analytics row per file instead of a single
+  aggregate.
+
 ### Added
 - **`rskim-tokens` crate (L3 Wave-1)** — Multi-provider token counting library (cl100k /
   o200k / Anthropic-offline / heuristic). Default build is HTTP-free; `net-anthropic` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Unified `SKIM_CACHE_DIR` resolution — honored by all cache subsystems (#359 Phase B)** —
+  Previously `SKIM_CACHE_DIR` was silently ignored by the parser cache and the default
+  `analytics.db` path (`cache::get_cache_dir` read only `dirs::cache_dir()`) while the
+  search index and hook log respected it. This caused partial relocation: some skim state
+  moved, some stayed under `~/.cache/skim` (PF-002).
+
+  The fix introduces a single source of truth:
+  - `cache::cache_root_from(override_dir)` — pure resolver (no I/O); filters empty paths.
+  - `cache::cache_root()` — reads `SKIM_CACHE_DIR` and delegates to `cache_root_from`.
+  - `cache::get_cache_dir()` now calls `cache_root()` before the mkdir/chmod block.
+  - `cmd::hook_log::CacheEnv::resolve_cache_dir()` now delegates to `cache::cache_root_from`
+    instead of its own inline resolver.
+
+  **Behavior change:** `SKIM_CACHE_DIR` now also relocates the default `analytics.db`
+  (previously it did not). `SKIM_ANALYTICS_DB` still takes precedence over the relocated
+  default when explicitly set. Empty `SKIM_CACHE_DIR` is treated as unset (falls back to
+  the platform default `~/.cache/skim`).
+
 ### Added
 - **`rskim-tokens` crate (L3 Wave-1)** — Multi-provider token counting library (cl100k /
   o200k / Anthropic-offline / heuristic). Default build is HTTP-free; `net-anthropic` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Behavior change:** `SKIM_CACHE_DIR` now also relocates the default `analytics.db`
   (previously it did not). `SKIM_ANALYTICS_DB` still takes precedence over the relocated
   default when explicitly set. Empty `SKIM_CACHE_DIR` is treated as unset (falls back to
-  the platform default `~/.cache/skim`).
+  the platform default `~/.cache/skim`). **Caveat:** pre-existing history at the old
+  `~/.cache/skim/analytics.db` is **not migrated** — setting `SKIM_CACHE_DIR` for the
+  first time causes `skim stats` to start from an empty DB at the new location; the old
+  file remains at `~/.cache/skim/analytics.db` and must be moved manually if you want to
+  preserve history.
 
 - **Plain `skim <file>` now always records token-savings analytics (#359 Phase A)** —
   Previously a plain `skim <file>` (and stdin, glob, and directory invocations) only
@@ -33,7 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   data. The fix introduces a unified `record_file_ops` path that records token counts
   independent of cache state, with the detected language attached to each row. Multi-file
   invocations (glob, directory) now emit one analytics row per file instead of a single
-  aggregate.
+  aggregate. **Dashboard metric note:** `skim stats` computes `invocations` as a row count,
+  so a 3-file run now contributes +3 to the invocations counter instead of +1; historical
+  data recorded before this release used the old single-row-per-invocation convention, so
+  `invocations` comparisons across the upgrade point will reflect this change in counting
+  semantics.
 
 ### Added
 - **`rskim-tokens` crate (L3 Wave-1)** — Multi-provider token counting library (cl100k /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,15 @@ skim intercepts a sub-agent's shell command through **two independent mechanisms
 - `SKIM_PASSTHROUGH=1` — bypass all compression (use when compressed output hides an error). Indefinite commands (`vite dev`, `jest --watch`, bare `skim vitest`) auto-pass-through live; use `skim vitest run` for a compressed one-shot.
 - `SKIM_DEBUG=1` (or `--debug`) — warnings/notices on stderr.
 - `SKIM_SESSION_ID` — analytics session attribution; priority sidecar > env > `--session-id` flag (flag is a forward-compat fallback only — the hook no longer injects it). Set it alongside the PATH export so sub-agents inherit it.
-- `SKIM_CACHE_DIR` / `SKIM_ANALYTICS_DB` — override the cache dir / analytics DB path.
+- `SKIM_CACHE_DIR` — relocates **all** skim cache state: parser cache (`.json` files),
+  tee output (`tee/`), and the **default** `analytics.db` location. An empty value is
+  treated as unset (falls back to `~/.cache/skim`). The path is used as-is (no `skim`
+  suffix is appended by the resolver).
+- `SKIM_ANALYTICS_DB` — overrides the analytics DB path directly; **takes precedence over
+  `SKIM_CACHE_DIR`** for the DB location. When `SKIM_ANALYTICS_DB` is set, the DB is
+  opened at that exact path regardless of `SKIM_CACHE_DIR`. To isolate all skim state
+  in a sandbox it is sufficient to set `SKIM_CACHE_DIR` alone (the default analytics.db
+  moves with it).
 - `SKIM_DISABLE_ANALYTICS=1` — disable recording. `SKIM_INPUT_COST_PER_MTOK` — $/MTok for cost estimates (default 3.0).
 - Session-provider overrides for `discover`/`learn`/`agents`: `SKIM_PROJECTS_DIR`, `SKIM_CODEX_SESSIONS_DIR`, `SKIM_COPILOT_DIR`, `SKIM_CURSOR_DB_PATH`, `SKIM_GEMINI_DIR`, `SKIM_CRUSH_DIR`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Streaming output (stdout, zero-copy via &str slices where possible)
 `transform_source()` routes each language to its parser via the Strategy Pattern, avoiding special-case conditionals — each language encapsulates its own strategy.
 
 **Non-obvious behavior (gotchas):**
-- **Analytics:** token savings persist to `~/.cache/skim/analytics.db` (SQLite/WAL), recorded fire-and-forget on background threads. `--clear-cache` clears only the parser cache, NOT `analytics.db` — use `skim stats --clear` for that. The `AnalyticsStore` trait + `MockStore` make the stats dashboard testable without a real DB.
+- **Analytics:** token savings persist to `~/.cache/skim/analytics.db` (SQLite/WAL; default location — relocates with `SKIM_CACHE_DIR`, see Environment Variables), recorded fire-and-forget on background threads. `--clear-cache` clears only the parser cache, NOT `analytics.db` — use `skim stats --clear` for that. The `AnalyticsStore` trait + `MockStore` make the stats dashboard testable without a real DB.
 - **Search DB:** `rskim-search` stores hotspot/risk/co-change data in `<root>/.skim/search.db`. Migrations are forward-only via `PRAGMA user_version`; a DB written by a newer version errors rather than corrupting data.
 - **AST index:** the n-gram index (`ast_index.skidx` / `.skpost`) is format v2 — v1 files are rejected with "please rebuild" (`skim search index --rebuild`). Synthetic n-gram markers (IDs ≥ 64900) resolve to `None` in `vocab_resolve()`, keeping them isolated from real vocabulary.
 
@@ -100,7 +100,10 @@ skim intercepts a sub-agent's shell command through **two independent mechanisms
 - `SKIM_CACHE_DIR` — relocates **all** skim cache state: parser cache (`.json` files),
   tee output (`tee/`), and the **default** `analytics.db` location. An empty value is
   treated as unset (falls back to `~/.cache/skim`). The path is used as-is (no `skim`
-  suffix is appended by the resolver).
+  suffix is appended by the resolver). **Caveat:** pre-existing analytics history at the
+  old `~/.cache/skim/analytics.db` is **not migrated** — setting this variable for the
+  first time causes `skim stats` to start from an empty DB at the new location; move
+  the old file manually if you want to preserve history.
 - `SKIM_ANALYTICS_DB` — overrides the analytics DB path directly; **takes precedence over
   `SKIM_CACHE_DIR`** for the DB location. When `SKIM_ANALYTICS_DB` is set, the DB is
   opened at that exact path regardless of `SKIM_CACHE_DIR`. To isolate all skim state

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 
+use rayon::prelude::*;
 use rusqlite::Connection;
 use serde::Serialize;
 
@@ -1033,6 +1034,99 @@ pub(crate) fn record_with_counts(enabled: bool, record: TokenSavingsRecord) {
     }
     register_thread(std::thread::spawn(move || {
         persist_record(&record);
+    }));
+}
+
+// ============================================================================
+// File-op unified recorder (Phase A1 — fixes PF-001)
+// ============================================================================
+
+/// Source of the raw text for background tokenization.
+///
+/// - `Reread(path)`: single file — re-read from disk on the background thread.
+/// - `Inline(text)`: stdin — retain the buffer in-memory (stdin cannot be re-read).
+pub(crate) enum RawSource {
+    Reread(PathBuf),
+    Inline(String),
+}
+
+/// How token counts are obtained for a file-op row.
+pub(crate) enum FileCounts {
+    /// `--show-stats` or count-carrying cache hit: counts already computed, no re-work.
+    Known { raw: usize, compressed: usize },
+    /// Plain run / cold cache: tokenize raw + compressed off the main thread.
+    Tokenize { raw: RawSource, compressed: String },
+}
+
+/// Per-file data for a single analytics row.
+pub(crate) struct FileOpRow {
+    pub(crate) counts: FileCounts,
+    pub(crate) original_cmd: String,
+    pub(crate) language: Option<String>,
+    pub(crate) parse_tier: Option<String>,
+}
+
+/// Shared metadata common to all rows in a single file-op invocation.
+pub(crate) struct FileOpCommon {
+    pub(crate) mode: Option<String>,
+    pub(crate) project_path: String,
+    pub(crate) session_id: Option<String>,
+}
+
+/// Record file-op analytics for one or more files, off the main thread.
+///
+/// - Captures `project_path` from the main thread before the spawn.
+/// - Tokenizes in PARALLEL (rayon) when counts are not yet known.
+/// - Persists SERIALLY to avoid SQLite write contention.
+/// - Uses `register_thread` so `flush_pending()` joins before exit (fixes PF-001).
+///
+/// Returns immediately (non-blocking).  When `enabled` is false or `rows` is
+/// empty, returns without spawning any thread.
+pub(crate) fn record_file_ops(enabled: bool, rows: Vec<FileOpRow>, common: FileOpCommon) {
+    if !enabled || rows.is_empty() {
+        return;
+    }
+    register_thread(std::thread::spawn(move || {
+        let ts = now_unix_secs();
+        // Resolve counts in parallel; filter out rows where tokenization fails.
+        let records: Vec<TokenSavingsRecord> = rows
+            .into_par_iter()
+            .filter_map(|r| {
+                let (raw, comp) = match r.counts {
+                    FileCounts::Known { raw, compressed } => (raw, compressed),
+                    FileCounts::Tokenize { raw, compressed } => {
+                        let text = match raw {
+                            // Best-effort: skip row on read or UTF-8 error.
+                            // This also naturally rejects TOCTOU-grown files (size guard
+                            // in read_source rejects anything over the 50 MB limit).
+                            RawSource::Reread(p) => crate::process::read_source(&p).ok()?,
+                            RawSource::Inline(s) => s,
+                        };
+                        let raw_tok = tokens::count_tokens(&text).ok()?;
+                        let comp_tok = tokens::count_tokens(&compressed).ok()?;
+                        (raw_tok, comp_tok)
+                    }
+                };
+                Some(TokenSavingsRecord {
+                    timestamp: ts,
+                    command_type: CommandType::File,
+                    original_cmd: r.original_cmd,
+                    raw_tokens: raw,
+                    compressed_tokens: comp,
+                    savings_pct: savings_percentage(raw, comp),
+                    duration_ms: 0,
+                    project_path: common.project_path.clone(),
+                    mode: common.mode.clone(),
+                    language: r.language,
+                    parse_tier: r.parse_tier,
+                    session_id: common.session_id.clone(),
+                })
+            })
+            .collect();
+        // Persist serially to avoid SQLite write contention.
+        for rec in records {
+            persist_record(&rec);
+        }
     }));
 }
 

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -30,6 +30,30 @@ use serde::Serialize;
 use crate::tokens;
 
 // ============================================================================
+// Shared time constant
+// ============================================================================
+
+/// Seconds per day — replaces bare `86400` literals in prune logic and
+/// timestamp calculations (used here and in `cmd::hook_log`).
+pub(crate) const SECONDS_PER_DAY: u64 = 86_400;
+
+// ============================================================================
+// Tokenization caps (applies ADR-001)
+// ============================================================================
+
+/// Maximum byte length for background BPE tokenization.
+///
+/// Inputs above this threshold skip tokenization and use byte length as a proxy.
+/// Mirrors TOKEN_SIZE_CAP in `cmd::execution::savings_decision` (ADR-001).
+const TOKEN_SIZE_CAP: usize = 256 * 1024;
+
+/// Maximum non-whitespace run length before falling back to byte comparison.
+///
+/// cl100k BPE merge is O(n²) in run length; this bounds the per-word cost.
+/// Mirrors TOKEN_RUN_CAP in `cmd::execution::savings_decision` (ADR-001).
+const TOKEN_RUN_CAP: usize = 4 * 1024;
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -382,11 +406,15 @@ impl AnalyticsDb {
     }
 
     /// Open database at default location, or override with SKIM_ANALYTICS_DB env var.
+    ///
+    /// Empty or whitespace-only `SKIM_ANALYTICS_DB` is treated as unset and falls
+    /// back to the default path (mirrors the `SKIM_CACHE_DIR` hardening in
+    /// [`crate::cache::cache_root_from`]).  `SKIM_ANALYTICS_DB` takes precedence
+    /// over `SKIM_CACHE_DIR` when both are set.
     pub(crate) fn open_default() -> anyhow::Result<Self> {
-        let path = if let Ok(override_path) = std::env::var("SKIM_ANALYTICS_DB") {
-            PathBuf::from(override_path)
-        } else {
-            crate::cache::get_cache_dir()?.join("analytics.db")
+        let path = match std::env::var("SKIM_ANALYTICS_DB") {
+            Ok(s) if !s.trim().is_empty() => PathBuf::from(s),
+            _ => crate::cache::get_cache_dir()?.join("analytics.db"),
         };
         Self::open(&path)
     }
@@ -624,7 +652,7 @@ impl AnalyticsDb {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs() as i64
-            - (days as i64 * 86400);
+            - (days as i64 * SECONDS_PER_DAY as i64);
         let count = self
             .conn
             .execute("DELETE FROM token_savings WHERE timestamp < ?1", [cutoff])?;
@@ -648,7 +676,7 @@ impl AnalyticsDb {
             )
             .unwrap_or(0);
 
-        if now as i64 - last_prune > 86400 && self.prune_older_than(90).is_ok() {
+        if now as i64 - last_prune > SECONDS_PER_DAY as i64 && self.prune_older_than(90).is_ok() {
             let _ = self.conn.execute(
                 "INSERT OR REPLACE INTO analytics_meta (key, value) VALUES ('last_prune', ?1)",
                 [now as i64],
@@ -1041,6 +1069,34 @@ pub(crate) fn record_with_counts(enabled: bool, record: TokenSavingsRecord) {
 // File-op unified recorder (Phase A1 — fixes PF-001)
 // ============================================================================
 
+/// Count tokens in `text` with ADR-001 size and run-length caps.
+///
+/// - If `text.len() > TOKEN_SIZE_CAP`: falls back to byte-length heuristic (`len / 4`).
+/// - If the longest non-whitespace run exceeds `TOKEN_RUN_CAP` (only checked when
+///   below the size cap): falls back to byte-length heuristic to avoid O(n²) BPE cost.
+/// - Otherwise: delegates to [`tokens::count_tokens`].
+///
+/// Using the byte heuristic for oversized inputs is consistent with the approach
+/// in `cmd::execution::savings_decision` (applies ADR-001): token accuracy matters
+/// most for small, typical source files which are always below the cap.
+fn count_tokens_bounded(text: &str) -> usize {
+    if text.len() > TOKEN_SIZE_CAP {
+        return text.len() / 4;
+    }
+    // Longest non-whitespace run check (O(n), bounded to ≤TOKEN_SIZE_CAP bytes).
+    let longest_run = text
+        .as_bytes()
+        .split(|b| b.is_ascii_whitespace())
+        .map(|run| run.len())
+        .max()
+        .unwrap_or(0);
+    if longest_run > TOKEN_RUN_CAP {
+        return text.len() / 4;
+    }
+    // Safe to tokenize: input is small and well-formed.
+    tokens::count_tokens(text).unwrap_or(text.len() / 4)
+}
+
 /// Source of the raw text for background tokenization.
 ///
 /// - `Reread(path)`: single file — re-read from disk on the background thread.
@@ -1102,8 +1158,8 @@ pub(crate) fn record_file_ops(enabled: bool, rows: Vec<FileOpRow>, common: FileO
                             RawSource::Reread(p) => crate::process::read_source(&p).ok()?,
                             RawSource::Inline(s) => s,
                         };
-                        let raw_tok = tokens::count_tokens(&text).ok()?;
-                        let comp_tok = tokens::count_tokens(&compressed).ok()?;
+                        let raw_tok = count_tokens_bounded(&text);
+                        let comp_tok = count_tokens_bounded(&compressed);
                         (raw_tok, comp_tok)
                     }
                 };
@@ -1123,9 +1179,14 @@ pub(crate) fn record_file_ops(enabled: bool, rows: Vec<FileOpRow>, common: FileO
                 })
             })
             .collect();
-        // Persist serially to avoid SQLite write contention.
-        for rec in records {
-            persist_record(&rec);
+        // Open DB once for all rows; skip silently on open failure (mirrors persist_record).
+        if let Ok(db) = AnalyticsDb::open_default() {
+            for rec in &records {
+                let _ = db.record(rec);
+            }
+            if !records.is_empty() {
+                db.maybe_prune();
+            }
         }
     }));
 }

--- a/crates/rskim/src/cache.rs
+++ b/crates/rskim/src/cache.rs
@@ -29,25 +29,48 @@ use crate::cascade::TruncationOptions;
 /// Resolve the cache root from an explicit override or the platform default.
 ///
 /// Convention (locked — avoids PF-002):
-/// - If `override_dir` is `Some(p)` and `p` is non-empty, use `p` as-is
-///   (caller's explicit override wins; we do NOT append `skim`).
-/// - An empty path is treated as unset (hardening against `SKIM_CACHE_DIR=""`).
+/// - If `override_dir` is `Some(p)` and `p` is non-empty (and not whitespace-only
+///   UTF-8), use `p` as-is (caller's explicit override wins; we do NOT append `skim`).
+/// - An empty or whitespace-only UTF-8 path is treated as unset.
+///   Non-UTF8 `OsStr` paths are never trimmed — they are valid and used as-is.
 /// - Otherwise fall back to `dirs::cache_dir().join("skim")`.
 ///
 /// This function is **pure** — it performs no I/O, no mkdir.
 pub(crate) fn cache_root_from(override_dir: Option<PathBuf>) -> Option<PathBuf> {
     override_dir
-        .filter(|p| !p.as_os_str().is_empty())
+        .filter(|p| {
+            if p.as_os_str().is_empty() {
+                return false;
+            }
+            // For valid UTF-8 paths, treat whitespace-only values as unset.
+            // Non-UTF-8 paths are preserved unchanged (they are valid filesystem paths).
+            match p.to_str() {
+                Some(s) => !s.trim().is_empty(),
+                None => true, // non-UTF8: valid path, do not reject
+            }
+        })
         .or_else(|| dirs::cache_dir().map(|c| c.join("skim")))
+}
+
+/// Read `SKIM_CACHE_DIR` from the process environment as a `PathBuf`, if set.
+///
+/// Single env-read entry point shared by [`cache_root`] and
+/// [`crate::cmd::hook_log::CacheEnv::from_process`] so the variable name is
+/// only referenced in one place (avoids PF-002 drift).
+pub(crate) fn read_cache_dir_env() -> Option<PathBuf> {
+    std::env::var_os("SKIM_CACHE_DIR").map(PathBuf::from)
 }
 
 /// Resolve the cache root from the process environment.
 ///
-/// Reads `SKIM_CACHE_DIR`; delegates to [`cache_root_from`].
-/// This function is the single source of truth for cache-root resolution
-/// and must be kept in sync with `cmd::hook_log::CacheEnv::resolve_cache_dir`.
+/// Reads `SKIM_CACHE_DIR` via [`read_cache_dir_env`] and delegates to
+/// [`cache_root_from`].
+///
+/// Single source of truth: `cmd::hook_log::CacheEnv::resolve_cache_dir` delegates
+/// to [`cache_root_from`] directly, so the two resolvers cannot drift — there is
+/// no "keep in sync" obligation (avoids PF-002).
 pub(crate) fn cache_root() -> Option<PathBuf> {
-    cache_root_from(std::env::var_os("SKIM_CACHE_DIR").map(PathBuf::from))
+    cache_root_from(read_cache_dir_env())
 }
 
 /// Cache entry with metadata for validation.

--- a/crates/rskim/src/cache.rs
+++ b/crates/rskim/src/cache.rs
@@ -2,9 +2,15 @@
 //!
 //! ARCHITECTURE: Cache transformed results with mtime-based invalidation.
 //! - Cache key: SHA256(canonical_path + mtime_secs + mode)
-//! - Cache location: ~/.cache/skim/ (platform-specific)
+//! - Cache location: $SKIM_CACHE_DIR or ~/.cache/skim/ (platform-specific)
 //! - Invalidation: File mtime change or mode change
 //! - Storage format: JSON with metadata
+//!
+//! # Cache-directory resolution (PF-002 fix)
+//!
+//! All skim cache subsystems (parser cache, tee output, default analytics.db)
+//! resolve their root through [`cache_root`] / [`cache_root_from`] so that
+//! `SKIM_CACHE_DIR` reliably relocates ALL cache state.
 
 use anyhow::Result;
 use rskim_core::Mode;
@@ -15,6 +21,34 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::cascade::TruncationOptions;
+
+// ============================================================================
+// Single-source-of-truth cache-root resolvers (fixes PF-002)
+// ============================================================================
+
+/// Resolve the cache root from an explicit override or the platform default.
+///
+/// Convention (locked — avoids PF-002):
+/// - If `override_dir` is `Some(p)` and `p` is non-empty, use `p` as-is
+///   (caller's explicit override wins; we do NOT append `skim`).
+/// - An empty path is treated as unset (hardening against `SKIM_CACHE_DIR=""`).
+/// - Otherwise fall back to `dirs::cache_dir().join("skim")`.
+///
+/// This function is **pure** — it performs no I/O, no mkdir.
+pub(crate) fn cache_root_from(override_dir: Option<PathBuf>) -> Option<PathBuf> {
+    override_dir
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| dirs::cache_dir().map(|c| c.join("skim")))
+}
+
+/// Resolve the cache root from the process environment.
+///
+/// Reads `SKIM_CACHE_DIR`; delegates to [`cache_root_from`].
+/// This function is the single source of truth for cache-root resolution
+/// and must be kept in sync with `cmd::hook_log::CacheEnv::resolve_cache_dir`.
+pub(crate) fn cache_root() -> Option<PathBuf> {
+    cache_root_from(std::env::var_os("SKIM_CACHE_DIR").map(PathBuf::from))
+}
 
 /// Cache entry with metadata for validation.
 #[derive(Debug, Serialize, Deserialize)]
@@ -81,12 +115,15 @@ pub(crate) struct CacheWriteParams<'a> {
     pub(crate) line_numbers: bool,
 }
 
-/// Returns the platform-specific cache directory (`~/.cache/skim/` on Linux/macOS),
-/// creating it with owner-only permissions if it does not yet exist.
+/// Returns the skim cache directory, creating it with owner-only permissions if it does not
+/// yet exist.
+///
+/// Honors `SKIM_CACHE_DIR` (via [`cache_root`]) so that ALL subsystems that call this
+/// function — parser cache, tee output, and the default analytics.db path — relocate
+/// consistently when the env var is set. Fixes PF-002.
 pub(crate) fn get_cache_dir() -> Result<PathBuf> {
-    let cache_dir = dirs::cache_dir()
-        .ok_or_else(|| anyhow::anyhow!("Failed to determine cache directory"))?
-        .join("skim");
+    let cache_dir =
+        cache_root().ok_or_else(|| anyhow::anyhow!("Failed to determine cache directory"))?;
 
     #[cfg(unix)]
     {
@@ -243,6 +280,103 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    // ========================================================================
+    // C2: single-source-of-truth contract
+    // cache::cache_root() and cmd::resolve_cache_dir() (which delegates to
+    // hook_log::CacheEnv::from_process().resolve_cache_dir()) must agree for
+    // the SAME env state (avoids PF-002 regression).
+    //
+    // Note: hook_log is a private module; we access it through the pub(crate)
+    // re-export cmd::resolve_cache_dir which already delegates to CacheEnv.
+    // ========================================================================
+
+    /// C2: Assert cache::cache_root() == cmd::resolve_cache_dir() for the same env
+    /// state, proving single-source-of-truth for cache-dir resolution (PF-002 guard).
+    ///
+    /// Uses #[serial_test::serial] to prevent env-var mutation races.
+    #[test]
+    #[serial_test::serial]
+    fn test_c2_cache_root_agrees_with_cmd_resolver_no_override() {
+        // Safety: serial ensures we are single-threaded when touching env vars.
+        // Unset SKIM_CACHE_DIR to test default resolution path.
+        // SAFETY: test-only, serial-gated.
+        unsafe { std::env::remove_var("SKIM_CACHE_DIR") };
+
+        let from_cache = cache_root();
+        // cmd::resolve_cache_dir() delegates to CacheEnv::from_process().resolve_cache_dir()
+        let from_cmd = crate::cmd::resolve_cache_dir();
+
+        assert_eq!(
+            from_cache, from_cmd,
+            "cache_root() and cmd::resolve_cache_dir() must agree \
+             (PF-002 regression guard — SKIM_CACHE_DIR unset)"
+        );
+    }
+
+    /// C2 override path: both resolvers agree when SKIM_CACHE_DIR is set.
+    #[test]
+    #[serial_test::serial]
+    fn test_c2_cache_root_agrees_with_cmd_resolver_with_override() {
+        // SAFETY: test-only, serial-gated.
+        unsafe { std::env::set_var("SKIM_CACHE_DIR", "/tmp/skim-test-cache-c2") };
+
+        let from_cache = cache_root();
+        // cmd::resolve_cache_dir() delegates to CacheEnv::from_process().resolve_cache_dir()
+        let from_cmd = crate::cmd::resolve_cache_dir();
+
+        // Restore before any assertion can fail.
+        unsafe { std::env::remove_var("SKIM_CACHE_DIR") };
+
+        assert_eq!(
+            from_cache, from_cmd,
+            "cache_root() and cmd::resolve_cache_dir() must agree \
+             (PF-002 regression guard — SKIM_CACHE_DIR set)"
+        );
+
+        // Also assert the expected resolved path.
+        assert_eq!(
+            from_cache,
+            Some(std::path::PathBuf::from("/tmp/skim-test-cache-c2")),
+            "SKIM_CACHE_DIR should be used as-is (no 'skim' suffix appended)"
+        );
+    }
+
+    /// B7: empty SKIM_CACHE_DIR is treated as unset — falls back to platform default.
+    #[test]
+    #[serial_test::serial]
+    fn test_b7_empty_skim_cache_dir_treated_as_unset() {
+        // SAFETY: test-only, serial-gated.
+        unsafe { std::env::set_var("SKIM_CACHE_DIR", "") };
+        let with_empty = cache_root();
+        unsafe { std::env::remove_var("SKIM_CACHE_DIR") };
+        let without = cache_root();
+
+        assert_eq!(
+            with_empty, without,
+            "Empty SKIM_CACHE_DIR must fall back to platform default (B7)"
+        );
+        // Both should resolve to the platform default (~/.cache/skim).
+        assert!(
+            with_empty.is_some(),
+            "Platform default must be available (dirs::cache_dir works)"
+        );
+    }
+
+    /// B5: neither SKIM_CACHE_DIR nor SKIM_ANALYTICS_DB set => default path unchanged.
+    #[test]
+    #[serial_test::serial]
+    fn test_b5_default_path_uses_platform_cache_dir() {
+        // SAFETY: test-only, serial-gated.
+        unsafe { std::env::remove_var("SKIM_CACHE_DIR") };
+
+        let root = cache_root();
+        let expected = dirs::cache_dir().map(|c| c.join("skim"));
+        assert_eq!(
+            root, expected,
+            "Default cache root must be ~/.cache/skim (B5)"
+        );
+    }
 
     #[test]
     fn test_cache_key_generation() {

--- a/crates/rskim/src/cmd/hook_log.rs
+++ b/crates/rskim/src/cmd/hook_log.rs
@@ -37,11 +37,12 @@ impl CacheEnv {
 
     /// Resolve the skim cache directory using the injected override or
     /// platform default (`dirs::cache_dir()/skim`).
+    ///
+    /// Delegates to [`crate::cache::cache_root_from`] so that the resolution
+    /// convention is kept in a single place (fixes PF-002). Empty overrides are
+    /// treated as unset (hardening against `SKIM_CACHE_DIR=""`).
     pub fn resolve_cache_dir(&self) -> Option<std::path::PathBuf> {
-        if let Some(dir) = &self.cache_dir_override {
-            return Some(dir.clone());
-        }
-        dirs::cache_dir().map(|c| c.join("skim"))
+        crate::cache::cache_root_from(self.cache_dir_override.clone())
     }
 }
 

--- a/crates/rskim/src/cmd/hook_log.rs
+++ b/crates/rskim/src/cmd/hook_log.rs
@@ -29,9 +29,12 @@ pub(crate) struct CacheEnv {
 
 impl CacheEnv {
     /// Build from the process environment (`SKIM_CACHE_DIR`).
+    ///
+    /// Uses [`crate::cache::read_cache_dir_env`] as the single env-read entry
+    /// point so the variable name is only referenced in one place (avoids PF-002).
     pub fn from_process() -> Self {
         Self {
-            cache_dir_override: std::env::var_os("SKIM_CACHE_DIR").map(std::path::PathBuf::from),
+            cache_dir_override: crate::cache::read_cache_dir_env(),
         }
     }
 
@@ -119,8 +122,8 @@ fn timestamp_string() -> String {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let days = secs / 86400;
-    let day_secs = secs % 86400;
+    let days = secs / crate::analytics::SECONDS_PER_DAY;
+    let day_secs = secs % crate::analytics::SECONDS_PER_DAY;
     let (year, month, day) = days_to_date(days);
     let hour = day_secs / 3600;
     let minute = (day_secs % 3600) / 60;

--- a/crates/rskim/src/main.rs
+++ b/crates/rskim/src/main.rs
@@ -850,15 +850,25 @@ fn process_single_arg(
     process_options: process::ProcessOptions,
     multi_options: multi::MultiFileOptions,
 ) -> anyhow::Result<()> {
+    // Capture cwd on the main thread before any background threads are spawned.
+    // (std::env::current_dir is not safe to call from background threads in general.)
+    let cwd = std::env::current_dir()
+        .unwrap_or_default()
+        .display()
+        .to_string();
+    let mode_str = format!("{:?}", Mode::from(args.mode)).to_lowercase();
+
     if file == "-" {
         let result = process::process_stdin(process_options, args.filename.as_deref())?;
         process::write_result_and_stats(&result, args.show_stats)?;
         record_file_analytics(
             analytics.enabled,
-            &result,
+            result,
             "skim -",
-            args,
+            mode_str,
             analytics.session_id.as_deref(),
+            cwd,
+            None, // stdin: no path to re-read
         );
         return Ok(());
     }
@@ -875,54 +885,81 @@ fn process_single_arg(
 
     let result = process::process_file(&path, process_options)?;
     process::write_result_and_stats(&result, args.show_stats)?;
+    let cmd = format!("skim {file}");
     record_file_analytics(
         analytics.enabled,
-        &result,
-        &format!("skim {file}"),
-        args,
+        result,
+        &cmd,
+        mode_str,
         analytics.session_id.as_deref(),
+        cwd,
+        Some(path), // file: re-read from disk in background
     );
     Ok(())
 }
 
 /// Record token analytics for file operations (single file or stdin).
+///
+/// Takes `result` by value so `output` and `stdin_raw` can be moved into the
+/// background thread without cloning.
+///
+/// `file_path` is `Some` for single-file ops (re-read on background thread) and
+/// `None` for stdin (buffer already captured in `result.stdin_raw`).
 fn record_file_analytics(
     enabled: bool,
-    result: &process::ProcessResult,
+    result: process::ProcessResult,
     cmd: &str,
-    args: &Args,
+    mode_str: String,
     session_id: Option<&str>,
+    cwd: String,
+    file_path: Option<PathBuf>,
 ) {
-    if !enabled {
-        return;
-    }
-    if let (Some(raw), Some(comp)) = (result.original_tokens, result.transformed_tokens) {
-        let cwd = std::env::current_dir()
-            .unwrap_or_default()
-            .display()
-            .to_string();
-        let lang = args
-            .language
-            .map(|l| format!("{:?}", Language::from(l)).to_lowercase());
-        let mode = format!("{:?}", Mode::from(args.mode)).to_lowercase();
-        analytics::record_with_counts(
-            true,
-            analytics::TokenSavingsRecord {
-                timestamp: analytics::now_unix_secs(),
-                command_type: analytics::CommandType::File,
-                original_cmd: cmd.to_string(),
-                raw_tokens: raw,
-                compressed_tokens: comp,
-                savings_pct: analytics::savings_percentage(raw, comp),
-                duration_ms: 0,
-                project_path: cwd,
-                mode: Some(mode),
-                language: lang,
-                parse_tier: result.parse_tier.map(str::to_string),
-                session_id: session_id.map(str::to_string),
+    // Determine counts variant: Known when both token counts are already computed
+    // (i.e. --show-stats ran, or a count-carrying cache hit); Tokenize otherwise.
+    let counts = match (result.original_tokens, result.transformed_tokens) {
+        (Some(raw), Some(comp)) => {
+            // AC F5: counts in hand — no re-read, no double work.
+            analytics::FileCounts::Known {
+                raw,
+                compressed: comp,
+            }
+        }
+        _ => match file_path {
+            Some(p) => analytics::FileCounts::Tokenize {
+                raw: analytics::RawSource::Reread(p),
+                compressed: result.output,
             },
-        );
-    }
+            None => {
+                // Stdin: inline buffer retained by process_stdin when !show_stats.
+                // If stdin_raw is None here it means show_stats was on and counts
+                // should have been Some — this branch is unreachable in practice,
+                // but we degrade gracefully: no row recorded.
+                let Some(buf) = result.stdin_raw else { return };
+                analytics::FileCounts::Tokenize {
+                    raw: analytics::RawSource::Inline(buf),
+                    compressed: result.output,
+                }
+            }
+        },
+    };
+
+    let language = result.language.map(|l| l.as_str().to_string());
+    let parse_tier = result.parse_tier.map(str::to_string);
+
+    analytics::record_file_ops(
+        enabled,
+        vec![analytics::FileOpRow {
+            counts,
+            original_cmd: cmd.to_string(),
+            language,
+            parse_tier,
+        }],
+        analytics::FileOpCommon {
+            mode: Some(mode_str),
+            project_path: cwd,
+            session_id: session_id.map(str::to_string),
+        },
+    );
 }
 
 #[cfg(test)]

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -333,7 +333,7 @@ fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Resu
             session_id: options.session_id.clone(),
         };
 
-        crate::analytics::record_file_ops(true, rows, common);
+        crate::analytics::record_file_ops(options.analytics_enabled, rows, common);
     }
 
     Ok(())

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -279,33 +279,61 @@ fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Resu
         );
     }
 
-    // Record analytics for multi-file operations
-    if options.analytics_enabled && total_original_tokens > 0 {
+    // Record per-file analytics rows (Phase A2 — fixes PF-001 for multi/glob/dir).
+    //
+    // Capture project_path and common fields on the MAIN thread before any
+    // background spawn. Consume `results` by value so output Strings MOVE into
+    // the rows without cloning.
+    //
+    // Behaviour change (intentional): N per-file rows are emitted for BOTH plain
+    // and --show-stats, replacing the single aggregate row.  Err entries (files
+    // that failed to process) are skipped — they already produced stderr output.
+    if options.analytics_enabled {
         let cwd = std::env::current_dir()
             .unwrap_or_default()
             .display()
             .to_string();
         let mode = format!("{:?}", options.process.mode).to_lowercase();
-        crate::analytics::record_with_counts(
-            true,
-            crate::analytics::TokenSavingsRecord {
-                timestamp: crate::analytics::now_unix_secs(),
-                command_type: crate::analytics::CommandType::File,
-                original_cmd: format!("skim [multi: {} files]", success_count),
-                raw_tokens: total_original_tokens,
-                compressed_tokens: total_transformed_tokens,
-                savings_pct: crate::analytics::savings_percentage(
-                    total_original_tokens,
-                    total_transformed_tokens,
-                ),
-                duration_ms: 0,
-                project_path: cwd,
-                mode: Some(mode),
-                language: None, // mixed languages
-                parse_tier: None,
-                session_id: options.session_id.clone(),
-            },
-        );
+
+        let rows: Vec<crate::analytics::FileOpRow> = results
+            .into_iter()
+            .filter_map(|(path, result)| {
+                let pr = result.ok()?; // skip Err entries
+                let counts = match (pr.original_tokens, pr.transformed_tokens) {
+                    (Some(raw), Some(comp)) => {
+                        // --show-stats (or count-carrying cache hit): counts already known.
+                        crate::analytics::FileCounts::Known {
+                            raw,
+                            compressed: comp,
+                        }
+                    }
+                    _ => {
+                        // Plain run / cold cache: tokenize off the main thread.
+                        // F14: if the file is deleted/changed between here and the
+                        // background re-read, read_source returns Err → row silently
+                        // skipped; sibling rows still recorded.
+                        crate::analytics::FileCounts::Tokenize {
+                            raw: crate::analytics::RawSource::Reread(path.clone()),
+                            compressed: pr.output,
+                        }
+                    }
+                };
+                Some(crate::analytics::FileOpRow {
+                    counts,
+                    original_cmd: format!("skim {}", path.display()),
+                    language: pr.language.map(|l| l.as_str().to_string()),
+                    parse_tier: pr.parse_tier.map(str::to_string),
+                })
+            })
+            .collect();
+
+        let common = crate::analytics::FileOpCommon {
+            mode: Some(mode),
+            project_path: cwd,
+            session_id: options.session_id.clone(),
+        };
+
+        crate::analytics::record_file_ops(options.analytics_enabled, rows, common);
     }
 
     Ok(())

--- a/crates/rskim/src/multi.rs
+++ b/crates/rskim/src/multi.rs
@@ -333,7 +333,7 @@ fn process_files(paths: Vec<PathBuf>, options: MultiFileOptions) -> anyhow::Resu
             session_id: options.session_id.clone(),
         };
 
-        crate::analytics::record_file_ops(options.analytics_enabled, rows, common);
+        crate::analytics::record_file_ops(true, rows, common);
     }
 
     Ok(())

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -211,7 +211,26 @@ fn try_cached_result(
 }
 
 /// Read a file and validate it doesn't exceed the maximum input size.
+///
+/// Performs a pre-read metadata check to bail early before allocating memory,
+/// which prevents a transient peak of `num_cpus × file_size` when this function
+/// is called in parallel (e.g., via `into_par_iter` in the analytics recorder).
+/// The post-read length check is retained for TOCTOU safety (the file may grow
+/// between the stat and the read).
 fn read_and_validate(path: &Path) -> anyhow::Result<String> {
+    // Pre-read size guard: bail before allocating if the file is already over the limit.
+    // This is a best-effort check; a file that is exactly at the limit may pass here
+    // but fail the post-read check below if it grows between the stat and the read.
+    if let Ok(meta) = fs::metadata(path)
+        && meta.len() as usize > MAX_INPUT_SIZE
+    {
+        anyhow::bail!(
+            "File too large: {} bytes exceeds maximum of {} bytes ({}MB)",
+            meta.len(),
+            MAX_INPUT_SIZE,
+            MAX_INPUT_SIZE / 1024 / 1024
+        );
+    }
     let contents = fs::read_to_string(path)?;
     if contents.len() > MAX_INPUT_SIZE {
         anyhow::bail!(
@@ -420,6 +439,21 @@ pub(crate) fn process_stdin(
     // Retain the raw buffer for analytics background tokenization only when
     // counts are not already known (i.e. !show_stats). Stdin cannot be re-read,
     // so the buffer must travel with the result.
+    //
+    // Invariant: stdin_raw is Some iff !show_stats; orig_tokens/trans_tokens are
+    // Some iff show_stats (when the tokenizer is available). These two conditions
+    // are mutually exclusive by construction: show_stats drives count_token_pair
+    // above, and its negation drives stdin_raw here.
+    //
+    // The assert pins the always-guaranteed half: if we are NOT running show_stats,
+    // counts must be None (we never computed them). The reverse (show_stats → Some)
+    // is best-effort and depends on the tokenizer succeeding, so is not asserted.
+    debug_assert!(
+        options.show_stats || orig_tokens.is_none(),
+        "BUG(process_stdin): show_stats=false but orig_tokens is Some — \
+         token counts must not be present when show_stats is false \
+         (stdin_raw invariant violated)"
+    );
     let stdin_raw = if !options.show_stats {
         Some(buffer)
     } else {

--- a/crates/rskim/src/process.rs
+++ b/crates/rskim/src/process.rs
@@ -54,6 +54,18 @@ pub(crate) struct ProcessResult {
     ///
     /// `None` for cache hits (tier was not recorded at write time).
     pub(crate) parse_tier: Option<&'static str>,
+    /// Effective language used for transformation.
+    ///
+    /// Set in all three constructors (file, stdin, cache-hit) so the analytics
+    /// layer can record the correct language without re-detecting from path.
+    /// Priority mirrors the transform path: explicit_lang wins, else auto-detect.
+    pub(crate) language: Option<Language>,
+    /// Raw stdin buffer retained for background tokenization.
+    ///
+    /// `Some(buffer)` only from `process_stdin` when `!show_stats` (stdin
+    /// cannot be re-read; the buffer must be kept).  All other constructors
+    /// set this to `None` (files can be re-read from disk).
+    pub(crate) stdin_raw: Option<String>,
 }
 
 /// Determine the parse quality tier from the mode and whether the parser reported errors.
@@ -182,12 +194,19 @@ fn try_cached_result(
         (hit.original_tokens, hit.transformed_tokens)
     };
 
+    // Effective language for a cache hit: explicit override wins, else detect from path.
+    let cache_lang = options
+        .explicit_lang
+        .or_else(|| detect_language_from_path(path));
+
     Ok(Some(ProcessResult {
         output: hit.content,
         original_tokens: orig_tokens,
         transformed_tokens: trans_tokens,
         guardrail_triggered: false,
         parse_tier: None, // tier was not recorded at cache-write time
+        language: cache_lang,
+        stdin_raw: None,
     }))
 }
 
@@ -398,12 +417,23 @@ pub(crate) fn process_stdin(
         (None, None)
     };
 
+    // Retain the raw buffer for analytics background tokenization only when
+    // counts are not already known (i.e. !show_stats). Stdin cannot be re-read,
+    // so the buffer must travel with the result.
+    let stdin_raw = if !options.show_stats {
+        Some(buffer)
+    } else {
+        None
+    };
+
     Ok(ProcessResult {
         output: final_output,
         original_tokens: orig_tokens,
         transformed_tokens: trans_tokens,
         guardrail_triggered,
         parse_tier,
+        language: Some(language),
+        stdin_raw,
     })
 }
 
@@ -466,13 +496,29 @@ pub(crate) fn process_file(path: &Path, options: ProcessOptions) -> anyhow::Resu
         });
     }
 
+    // Effective language for analytics: explicit override wins, else detect from path.
+    let effective_lang = options
+        .explicit_lang
+        .or_else(|| detect_language_from_path(path));
+
     Ok(ProcessResult {
         output: final_output,
         original_tokens: orig_tokens,
         transformed_tokens: trans_tokens,
         guardrail_triggered,
         parse_tier,
+        language: effective_lang,
+        stdin_raw: None,
     })
+}
+
+/// Read a file and validate it doesn't exceed the maximum input size.
+///
+/// Public thin wrapper over `read_and_validate` for use by the background
+/// analytics re-read path (`analytics::RawSource::Reread`).  Reuses the
+/// 50 MB guard and naturally rejects TOCTOU-grown files.
+pub(crate) fn read_source(path: &std::path::Path) -> anyhow::Result<String> {
+    read_and_validate(path)
 }
 
 #[cfg(test)]

--- a/crates/rskim/tests/cli.rs
+++ b/crates/rskim/tests/cli.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests the full CLI binary with real command-line arguments.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::time::Instant;

--- a/crates/rskim/tests/cli.rs
+++ b/crates/rskim/tests/cli.rs
@@ -7,6 +7,7 @@ use predicates::prelude::*;
 use std::fs;
 use std::time::Instant;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Basic CLI Tests
@@ -14,8 +15,7 @@ use tempfile::TempDir;
 
 #[test]
 fn test_cli_version() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--version")
         .assert()
         .success()
@@ -25,8 +25,7 @@ fn test_cli_version() {
 
 #[test]
 fn test_cli_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--help")
         .assert()
         .success()
@@ -49,8 +48,7 @@ fn test_cli_structure_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("structure")
@@ -71,8 +69,7 @@ fn test_cli_signatures_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("signatures")
@@ -94,8 +91,7 @@ fn test_cli_types_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("types")
@@ -112,8 +108,7 @@ fn test_cli_full_mode() {
     let content = "function add(a: number, b: number): number { return a + b; }";
     fs::write(&file_path, content).unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("full")
@@ -132,11 +127,7 @@ fn test_cli_auto_detect_typescript() {
     let file_path = temp_dir.path().join("test.ts");
     fs::write(&file_path, "function test() { }").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 #[test]
@@ -145,11 +136,7 @@ fn test_cli_auto_detect_python() {
     let file_path = temp_dir.path().join("test.py");
     fs::write(&file_path, "def test(): pass").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 #[test]
@@ -158,11 +145,7 @@ fn test_cli_auto_detect_rust() {
     let file_path = temp_dir.path().join("test.rs");
     fs::write(&file_path, "fn test() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 // ============================================================================
@@ -171,8 +154,7 @@ fn test_cli_auto_detect_rust() {
 
 #[test]
 fn test_cli_stdin_with_language() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--language")
         .arg("typescript")
@@ -184,8 +166,7 @@ fn test_cli_stdin_with_language() {
 
 #[test]
 fn test_cli_stdin_without_language_fails() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .write_stdin("function test() {}")
         .assert()
@@ -201,8 +182,7 @@ fn test_cli_stdin_without_language_fails() {
 
 #[test]
 fn test_cli_nonexistent_file() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("nonexistent.ts")
         .assert()
         .failure()
@@ -215,8 +195,7 @@ fn test_cli_unsupported_extension() {
     let file_path = temp_dir.path().join("test.xyz");
     fs::write(&file_path, "some code").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .failure()
@@ -229,8 +208,7 @@ fn test_cli_invalid_mode() {
     let file_path = temp_dir.path().join("test.ts");
     fs::write(&file_path, "function test() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("invalid")
@@ -249,8 +227,7 @@ fn test_cli_all_languages_structure() {
     // TypeScript
     let ts_file = temp_dir.path().join("test.ts");
     fs::write(&ts_file, "function test() { return 42; }").unwrap();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&ts_file)
         .assert()
         .success()
@@ -259,8 +236,7 @@ fn test_cli_all_languages_structure() {
     // Python
     let py_file = temp_dir.path().join("test.py");
     fs::write(&py_file, "def test():\n    return 42").unwrap();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&py_file)
         .assert()
         .success()
@@ -269,8 +245,7 @@ fn test_cli_all_languages_structure() {
     // Rust
     let rs_file = temp_dir.path().join("test.rs");
     fs::write(&rs_file, "fn test() { 42 }").unwrap();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&rs_file)
         .assert()
         .success()
@@ -279,8 +254,7 @@ fn test_cli_all_languages_structure() {
     // Go
     let go_file = temp_dir.path().join("test.go");
     fs::write(&go_file, "func test() int { return 42 }").unwrap();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&go_file)
         .assert()
         .success()
@@ -289,8 +263,7 @@ fn test_cli_all_languages_structure() {
     // Java
     let java_file = temp_dir.path().join("Test.java");
     fs::write(&java_file, "class Test { int test() { return 42; } }").unwrap();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&java_file)
         .assert()
         .success()
@@ -307,8 +280,7 @@ fn test_cli_empty_file() {
     let file_path = temp_dir.path().join("empty.ts");
     fs::write(&file_path, "").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -321,8 +293,7 @@ fn test_cli_unicode_content() {
     let file_path = temp_dir.path().join("test.ts");
     fs::write(&file_path, "function greet() { return \"你好 🎉\"; }").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -336,11 +307,7 @@ fn test_cli_malformed_syntax() {
     fs::write(&file_path, "function broken(() { { { {").unwrap();
 
     // tree-sitter is error-tolerant, should not crash
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 // ============================================================================
@@ -354,8 +321,7 @@ fn test_cli_explicit_language_override() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // Force TypeScript parsing despite .txt extension
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--language")
         .arg("typescript")
@@ -378,8 +344,7 @@ fn test_cli_minimal_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("minimal")
@@ -398,8 +363,7 @@ fn test_cli_minimal_mode() {
 
 #[test]
 fn test_cli_minimal_mode_stdin() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--language")
         .arg("typescript")
@@ -423,8 +387,7 @@ fn test_cli_minimal_mode_python_shebang() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("minimal")
@@ -440,8 +403,7 @@ fn test_cli_minimal_mode_python_shebang() {
 
 #[test]
 fn test_cli_minimal_mode_help_text() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--help")
         .assert()
         .success()
@@ -454,8 +416,7 @@ fn test_cli_minimal_mode_help_text() {
 
 #[test]
 fn test_cli_lang_alias_stdin() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--lang=typescript")
         .write_stdin("function add(a: number, b: number): number { return a + b; }")
@@ -468,8 +429,7 @@ fn test_cli_lang_alias_stdin() {
 fn test_cli_lang_and_language_equivalent() {
     let input = "function greet(name: string): string { return `Hello ${name}`; }";
 
-    let lang_output = Command::cargo_bin("skim")
-        .unwrap()
+    let lang_output = common::skim()
         .arg("-")
         .arg("--lang=typescript")
         .write_stdin(input)
@@ -479,8 +439,7 @@ fn test_cli_lang_and_language_equivalent() {
         .stdout
         .clone();
 
-    let language_output = Command::cargo_bin("skim")
-        .unwrap()
+    let language_output = common::skim()
         .arg("-")
         .arg("--language=typescript")
         .write_stdin(input)
@@ -511,8 +470,7 @@ fn test_cli_lang_alias_with_file() {
     .unwrap();
 
     // --lang alias should work with file arguments, not just stdin
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--lang=typescript")
         .assert()
@@ -527,8 +485,7 @@ fn test_cli_lang_alias_with_file() {
 
 #[test]
 fn test_cli_filename_detects_rust() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=main.rs")
         .write_stdin("fn hello() { println!(\"hi\"); }")
@@ -540,8 +497,7 @@ fn test_cli_filename_detects_rust() {
 
 #[test]
 fn test_cli_filename_detects_typescript() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=app.ts")
         .write_stdin("function greet(name: string): string { return name; }")
@@ -552,8 +508,7 @@ fn test_cli_filename_detects_typescript() {
 
 #[test]
 fn test_cli_filename_detects_python() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=script.py")
         .write_stdin("def hello():\n    return 42")
@@ -564,8 +519,7 @@ fn test_cli_filename_detects_python() {
 
 #[test]
 fn test_cli_filename_detects_go() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=main.go")
         .write_stdin("func hello() int { return 42 }")
@@ -577,8 +531,7 @@ fn test_cli_filename_detects_go() {
 
 #[test]
 fn test_cli_filename_detects_java() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=Main.java")
         .write_stdin("class Main { int hello() { return 42; } }")
@@ -590,8 +543,7 @@ fn test_cli_filename_detects_java() {
 
 #[test]
 fn test_cli_filename_detects_json() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=config.json")
         .write_stdin(r#"{"name": "skim", "version": "1.0.0", "nested": {"key": "value"}}"#)
@@ -604,8 +556,7 @@ fn test_cli_filename_detects_json() {
 #[test]
 fn test_cli_filename_language_override() {
     // --language takes priority over --filename
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--language=python")
         .arg("--filename=main.rs")
@@ -617,8 +568,7 @@ fn test_cli_filename_language_override() {
 
 #[test]
 fn test_cli_filename_no_extension_fails() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=Makefile")
         .write_stdin("all: build")
@@ -629,8 +579,7 @@ fn test_cli_filename_no_extension_fails() {
 
 #[test]
 fn test_cli_filename_unknown_ext_fails() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=foo.xyz")
         .write_stdin("some content")
@@ -645,8 +594,7 @@ fn test_cli_filename_not_stdin_fails() {
     let file_path = temp_dir.path().join("test.ts");
     fs::write(&file_path, "function test() { }").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--filename=main.rs")
         .assert()
@@ -659,8 +607,7 @@ fn test_cli_filename_not_stdin_fails() {
 #[test]
 fn test_cli_filename_with_path_prefix() {
     // --filename with directory components should still detect language from extension
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=src/lib/main.rs")
         .write_stdin("fn hello() { 42 }")
@@ -671,8 +618,7 @@ fn test_cli_filename_with_path_prefix() {
 
 #[test]
 fn test_cli_filename_with_mode() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=app.ts")
         .arg("--mode=signatures")
@@ -713,8 +659,7 @@ impl Calculator {
 }
 "#;
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--filename=lib.rs")
         .arg("--mode=signatures")
@@ -750,8 +695,7 @@ fn test_cli_stdin_large_input_streaming() {
         ));
     }
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("-")
         .arg("--language=typescript")
         .write_stdin(input)
@@ -803,8 +747,7 @@ fn test_cli_stdin_large_input_completes_within_time_bound() {
 
     let start = Instant::now();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--language=typescript")
         .write_stdin(input)
@@ -833,8 +776,7 @@ fn test_cli_pseudo_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("pseudo")
@@ -858,8 +800,7 @@ fn test_cli_pseudo_mode_python() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("pseudo")
@@ -880,8 +821,7 @@ fn test_cli_pseudo_mode_rust() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("pseudo")
@@ -893,8 +833,7 @@ fn test_cli_pseudo_mode_rust() {
 
 #[test]
 fn test_cli_pseudo_mode_stdin() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--lang=typescript")
         .arg("--mode=pseudo")

--- a/crates/rskim/tests/cli_agents.rs
+++ b/crates/rskim/tests/cli_agents.rs
@@ -3,9 +3,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
+mod common;
 
 fn skim_cmd() -> Command {
-    Command::cargo_bin("skim").unwrap()
+    common::skim()
 }
 
 #[test]

--- a/crates/rskim/tests/cli_analytics_expansion.rs
+++ b/crates/rskim/tests/cli_analytics_expansion.rs
@@ -733,3 +733,291 @@ fn test_c3_stdout_byte_identical_analytics_on_vs_off() {
         "C3: stdout must be byte-identical regardless of analytics state"
     );
 }
+
+// ============================================================================
+// Phase A2 (#359) — per-file analytics rows for multi/glob/dir
+//
+// These tests verify that multi-file invocations emit N per-file rows (one per
+// successful file) instead of the single aggregate row emitted before A2.
+//
+// All tests use an isolated TempDir for the analytics DB.
+// ============================================================================
+
+/// Helper: count all rows in token_savings for a given DB path.
+/// Reuses the same signature as the F-series helper above; safe because Rust
+/// allows duplicate helper fns in different test files — they compile independently.
+fn count_rows_multi(db_path: &std::path::Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("must open analytics DB");
+    conn.query_row("SELECT COUNT(*) FROM token_savings", [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+/// Helper: query all language values recorded in token_savings.
+fn all_languages(db_path: &std::path::Path) -> Vec<Option<String>> {
+    let conn = rusqlite::Connection::open(db_path).expect("must open analytics DB");
+    let mut stmt = conn
+        .prepare("SELECT language FROM token_savings ORDER BY rowid")
+        .expect("prepare must succeed");
+    stmt.query_map([], |r| r.get::<_, Option<String>>(0))
+        .expect("query must succeed")
+        .filter_map(|r| r.ok())
+        .collect()
+}
+
+/// F7: `skim a.ts b.py c.rs` (no --show-stats) → exactly 3 rows, one per file;
+/// each row carries the correctly detected language for that file.
+#[test]
+fn test_f7_multi_explicit_files_per_file_rows() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    let ts = ts_fixture();
+    let py = py_fixture();
+    let rs = rs_fixture();
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(ts.as_os_str())
+        .arg(py.as_os_str())
+        .arg(rs.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+    assert!(status.success(), "F7: 3-file run must exit 0");
+
+    let count = count_rows_multi(&db_path);
+    assert_eq!(
+        count, 3,
+        "F7: 3-file run must record exactly 3 rows (one per file)"
+    );
+
+    let langs = all_languages(&db_path);
+    let mut sorted_langs: Vec<_> = langs.into_iter().flatten().collect();
+    sorted_langs.sort();
+    assert_eq!(
+        sorted_langs,
+        vec!["python", "rust", "typescript"],
+        "F7: each row must carry the language for its own file"
+    );
+}
+
+/// F8-glob: `skim '*.ts'` against a dir with 2 .ts files → exactly 2 rows.
+#[test]
+fn test_f8_glob_per_file_rows() {
+    let file_dir = TempDir::new().unwrap();
+    // Create 2 TypeScript files in a temp dir
+    std::fs::write(
+        file_dir.path().join("alpha.ts"),
+        "function alpha(): number { return 1; }",
+    )
+    .unwrap();
+    std::fs::write(
+        file_dir.path().join("beta.ts"),
+        "function beta(): string { return 'x'; }",
+    )
+    .unwrap();
+
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+
+    let glob_pattern = format!("{}/*.ts", file_dir.path().display());
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(&glob_pattern)
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim glob must run");
+    assert!(status.success(), "F8-glob: glob run must exit 0");
+
+    let count = count_rows_multi(&db_path);
+    assert_eq!(
+        count, 2,
+        "F8-glob: 2-file glob must record exactly 2 rows (one per file, not 1 aggregate)"
+    );
+
+    let langs = all_languages(&db_path);
+    let non_null: Vec<_> = langs.into_iter().flatten().collect();
+    assert!(
+        non_null.iter().all(|l| l == "typescript"),
+        "F8-glob: all rows must have language='typescript', got: {non_null:?}"
+    );
+}
+
+/// F8-dir: `skim <dir>` containing 2 .py files → exactly 2 rows.
+#[test]
+fn test_f8_dir_per_file_rows() {
+    let file_dir = TempDir::new().unwrap();
+    std::fs::write(
+        file_dir.path().join("mod_a.py"),
+        "def func_a():\n    pass\n",
+    )
+    .unwrap();
+    std::fs::write(
+        file_dir.path().join("mod_b.py"),
+        "def func_b():\n    return 42\n",
+    )
+    .unwrap();
+
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(file_dir.path())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim dir must run");
+    assert!(status.success(), "F8-dir: dir run must exit 0");
+
+    let count = count_rows_multi(&db_path);
+    assert_eq!(
+        count, 2,
+        "F8-dir: 2-file directory must record exactly 2 rows (one per file)"
+    );
+
+    let langs = all_languages(&db_path);
+    let non_null: Vec<_> = langs.into_iter().flatten().collect();
+    assert!(
+        non_null.iter().all(|l| l == "python"),
+        "F8-dir: all rows must have language='python', got: {non_null:?}"
+    );
+}
+
+/// F9: `skim --show-stats a.ts b.py` → same N per-file rows as without --show-stats.
+/// Verifies that the counts=Known path (--show-stats) also emits N rows, not 1 aggregate.
+#[test]
+fn test_f9_show_stats_multi_per_file_rows() {
+    let ts = ts_fixture();
+    let py = py_fixture();
+
+    // Run without --show-stats (Tokenize path).
+    let db_plain = TempDir::new().unwrap();
+    let db_plain_path = db_plain.path().join("analytics.db");
+    std::process::Command::new(common::skim_bin())
+        .arg(ts.as_os_str())
+        .arg(py.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_plain_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("plain multi run must succeed");
+
+    // Run WITH --show-stats (Known path).
+    let db_stats = TempDir::new().unwrap();
+    let db_stats_path = db_stats.path().join("analytics.db");
+    std::process::Command::new(common::skim_bin())
+        .arg(ts.as_os_str())
+        .arg(py.as_os_str())
+        .arg("--no-cache")
+        .arg("--show-stats")
+        .env("SKIM_ANALYTICS_DB", &db_stats_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("--show-stats multi run must succeed");
+
+    let count_plain = count_rows_multi(&db_plain_path);
+    let count_stats = count_rows_multi(&db_stats_path);
+
+    assert_eq!(
+        count_plain, 2,
+        "F9: plain multi (2 files) must record 2 rows"
+    );
+    assert_eq!(
+        count_stats, 2,
+        "F9: --show-stats multi (2 files) must also record 2 rows (same as plain)"
+    );
+}
+
+/// F13-multi: SKIM_DISABLE_ANALYTICS=1 on a multi-file run → 0 rows.
+#[test]
+fn test_f13_multi_disable_analytics_no_rows() {
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+
+    let ts = ts_fixture();
+    let py = py_fixture();
+
+    // common::skim() sets SKIM_DISABLE_ANALYTICS=1
+    common::skim()
+        .arg(ts.as_os_str())
+        .arg(py.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .assert()
+        .success();
+
+    let count = count_rows_multi(&db_path);
+    assert_eq!(
+        count, 0,
+        "F13-multi: SKIM_DISABLE_ANALYTICS=1 must record 0 rows for multi-file run"
+    );
+}
+
+/// F14: robustness — one file deleted between transform and background re-read.
+/// With 3 files where 1 is deleted after skim runs, N-1 rows are expected (not crash).
+///
+/// This test verifies best-effort behaviour: deleted/changed files are silently skipped
+/// while sibling rows are still recorded.
+///
+/// Strategy: run 3 files, but delete 1 of the temp files BEFORE the skim invocation
+/// to ensure it fails during processing (will be an Err entry in results). We then
+/// verify: exit code unaffected (2 files succeed), and rows == 2 (skipped error).
+#[test]
+fn test_f14_missing_file_records_n_minus_1_rows() {
+    let file_dir = TempDir::new().unwrap();
+    let ts = ts_fixture();
+    let py = py_fixture();
+
+    // Third file: created then immediately removed (simulating a file that
+    // disappears before the background re-read — but in fact process_file will
+    // fail to read it too, meaning it is an Err result and not counted).
+    let ghost_path = file_dir.path().join("ghost.ts");
+    std::fs::write(&ghost_path, "function ghost() {}").unwrap();
+    std::fs::remove_file(&ghost_path).unwrap();
+
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+
+    // Run with 3 paths: 2 real fixtures + 1 ghost that doesn't exist.
+    // skim should succeed (exit 0) with 2 files processed and 1 warning on stderr.
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(ts.as_os_str())
+        .arg(py.as_os_str())
+        .arg(&ghost_path) // will produce an Err in process_files
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+
+    // Exit code: process_files succeeds if at least 1 file succeeded.
+    assert!(
+        status.success(),
+        "F14: exit code must be 0 when at least 1 file succeeds"
+    );
+
+    // Ghost file is not found before process_file is even called (it's caught in
+    // process_explicit_files). So only 2 files (ts + py) make it to process_files.
+    let count = count_rows_multi(&db_path);
+    assert_eq!(
+        count, 2,
+        "F14: with 1 missing file, exactly 2 rows must be recorded (no crash, no aggregate)"
+    );
+}

--- a/crates/rskim/tests/cli_analytics_expansion.rs
+++ b/crates/rskim/tests/cli_analytics_expansion.rs
@@ -1,5 +1,5 @@
 //! Integration tests for gross/faithful expansion accounting and --show-stats
-//! analytics reuse (#317 / #350).
+//! analytics reuse (#317 / #350) and for Phase-A1 fix of analytics-loss bug #359.
 //!
 //! ## T10 (AC-F4/F5) — --show-stats records exactly one row with the same counts
 //!
@@ -15,6 +15,12 @@
 //! raw_tokens) inserted directly via rusqlite, then run `skim stats --format json`
 //! and assert the row shows true counts with saved = 0.
 //!
+//! ## F-series (Phase A1 / #359 fix) — plain file-op analytics
+//!
+//! Tests F1–F13 and C1/C3 assert the unified `record_file_ops` path introduced
+//! to fix the analytics-loss bug (PF-001): plain `skim <file>` now records
+//! exactly one row regardless of cache state.
+//!
 //! ## Note on SKIM_PASSTHROUGH
 //!
 //! The outer cargo/nextest process may set `SKIM_PASSTHROUGH=1` to prevent
@@ -23,7 +29,7 @@
 //! matching the pattern in `cli_no_expansion_317.rs`.
 
 use std::path::PathBuf;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 mod common;
 
 // ============================================================================
@@ -135,7 +141,6 @@ fn test_show_stats_on_records_exactly_one_row() {
 /// its thread and `flush_pending()` joins it before exit, so the post-exit direct DB read is
 /// race-free. The DB is read with rusqlite directly — no `skim stats` subprocess, no sleep.
 #[test]
-#[ignore = "known pre-existing bug #359: plain file-op analytics is dropped unless the parser cache carries counts"]
 fn test_plain_file_op_should_record_analytics_no_cache() {
     let db = NamedTempFile::new().unwrap();
     let fixture = fixture_file();
@@ -250,5 +255,481 @@ fn test_expansion_row_stored_true_count_stats_shows_zero_saved() {
     assert_eq!(
         day_saved, 0,
         "daily tokens_saved must be 0 for expansion-only day"
+    );
+}
+
+// ============================================================================
+// F-series: Phase A1 (#359) — plain file-op analytics (fixes PF-001)
+//
+// All tests below use an isolated TempDir for the analytics DB so they don't
+// pollute the developer's real ~/.cache/skim/analytics.db.
+// Direct rusqlite reads avoid subprocess sleep races.
+// ============================================================================
+
+/// Helper: open the analytics DB and count rows in token_savings.
+fn count_rows(db_path: &std::path::Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("must open analytics DB");
+    conn.query_row("SELECT COUNT(*) FROM token_savings", [], |r| r.get(0))
+        .unwrap_or(0) // table absent → 0
+}
+
+/// Helper: query a single row column from token_savings (assumes exactly 1 row).
+fn row_value<T: rusqlite::types::FromSql>(db_path: &std::path::Path, col: &str) -> T {
+    let conn = rusqlite::Connection::open(db_path).expect("must open analytics DB");
+    conn.query_row(
+        &format!("SELECT {col} FROM token_savings LIMIT 1"),
+        [],
+        |r| r.get(0),
+    )
+    .unwrap_or_else(|e| panic!("query {col}: {e}"))
+}
+
+/// Helper: TypeScript fixture path.
+fn ts_fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/typescript/simple.ts")
+        .canonicalize()
+        .expect("typescript fixture must exist")
+}
+
+/// Helper: Python fixture path.
+fn py_fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/python/simple.py")
+        .canonicalize()
+        .expect("python fixture must exist")
+}
+
+/// Helper: Rust fixture path.
+fn rs_fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/rust/simple.rs")
+        .canonicalize()
+        .expect("rust fixture must exist")
+}
+
+/// F1: plain cold cache (--no-cache, no --show-stats) → exactly 1 row;
+/// command_type=File (stored as "file"); mode is set; language is detected.
+#[test]
+fn test_f1_plain_cold_cache_records_one_row() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+    let fixture = ts_fixture();
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+    assert!(status.success(), "skim must exit 0");
+
+    let count = count_rows(&db_path);
+    assert_eq!(
+        count, 1,
+        "F1: cold cache plain run must record exactly 1 row"
+    );
+
+    let cmd_type: String = row_value(&db_path, "command_type");
+    assert_eq!(cmd_type, "file", "F1: command_type must be 'file'");
+
+    let lang: Option<String> = row_value(&db_path, "language");
+    assert_eq!(
+        lang.as_deref(),
+        Some("typescript"),
+        "F1: language must be detected as 'typescript'"
+    );
+
+    let mode: Option<String> = row_value(&db_path, "mode");
+    assert!(mode.is_some(), "F1: mode must be set (not NULL)");
+}
+
+/// F2: warm-but-countless parser cache → second run records 1 row.
+///
+/// Warm the parser cache with a plain run (no --show-stats → cache written
+/// WITHOUT token counts).  A second plain run against the same warm cache
+/// must still record 1 row via background tokenization.
+#[test]
+fn test_f2_warm_countless_cache_records_one_row() {
+    // Isolate the parser cache so this test doesn't pollute ~/.cache/skim.
+    let cache_dir = TempDir::new().unwrap();
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+    let fixture = ts_fixture();
+
+    // First run: warm the parser cache WITHOUT token counts (no --show-stats).
+    // Analytics disabled so we don't count this row.
+    std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .env("SKIM_CACHE_DIR", cache_dir.path())
+        .env_remove("SKIM_PASSTHROUGH")
+        .env("SKIM_DISABLE_ANALYTICS", "1")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("first warm run must succeed");
+
+    // Second run: uses the warm cache (no --no-cache) with analytics enabled.
+    // The cache entry has no token counts → background tokenization must kick in.
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .env("SKIM_CACHE_DIR", cache_dir.path())
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("second run must succeed");
+    assert!(status.success(), "F2: second run must exit 0");
+
+    let count = count_rows(&db_path);
+    assert_eq!(
+        count, 1,
+        "F2: warm-but-countless cache hit must still record 1 row via background tokenization"
+    );
+}
+
+/// F3: plain vs --show-stats record the SAME row count (both record 1, not 0 vs 1).
+#[test]
+fn test_f3_plain_and_show_stats_both_record_one_row() {
+    let fixture = ts_fixture();
+
+    // Plain run.
+    let db_plain = NamedTempFile::new().unwrap();
+    std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", db_plain.path())
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("plain run must succeed");
+
+    // --show-stats run.
+    let db_stats = NamedTempFile::new().unwrap();
+    std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .arg("--show-stats")
+        .env("SKIM_ANALYTICS_DB", db_stats.path())
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("--show-stats run must succeed");
+
+    let count_plain = count_rows(db_plain.path());
+    let count_stats = count_rows(db_stats.path());
+    assert_eq!(count_plain, 1, "F3: plain run must record 1 row");
+    assert_eq!(count_stats, 1, "F3: --show-stats run must record 1 row");
+}
+
+/// F4: --no-cache → 1 row.
+#[test]
+fn test_f4_no_cache_records_one_row() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+    let fixture = ts_fixture();
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+    assert!(status.success());
+
+    assert_eq!(count_rows(&db_path), 1, "F4: --no-cache must record 1 row");
+}
+
+/// F5: count-carrying cache hit (prior --show-stats warms counts) → 1 row, NO double-record.
+#[test]
+fn test_f5_count_carrying_cache_hit_no_double_record() {
+    let cache_dir = TempDir::new().unwrap();
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+    let fixture = ts_fixture();
+
+    // First run WITH --show-stats: writes token counts into the cache.
+    // Analytics pointing at a *different* scratch DB so we can count from a fresh start.
+    let db_warm = NamedTempFile::new().unwrap();
+    std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--show-stats")
+        .env("SKIM_CACHE_DIR", cache_dir.path())
+        .env("SKIM_ANALYTICS_DB", db_warm.path())
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("warm run must succeed");
+
+    // Second run: cache hit with counts already present → Known path, 1 row, no re-read.
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .env("SKIM_CACHE_DIR", cache_dir.path())
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("second run must succeed");
+    assert!(status.success(), "F5: second run must exit 0");
+
+    assert_eq!(
+        count_rows(&db_path),
+        1,
+        "F5: count-carrying cache hit must record exactly 1 row (no double-record)"
+    );
+}
+
+/// F10: language column reflects detected language (no --language flag).
+#[test]
+fn test_f10_language_detection_ts_py_rs() {
+    for (fixture, expected_lang) in &[
+        (ts_fixture(), "typescript"),
+        (py_fixture(), "python"),
+        (rs_fixture(), "rust"),
+    ] {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("analytics.db");
+
+        std::process::Command::new(common::skim_bin())
+            .arg(fixture.as_os_str())
+            .arg("--no-cache")
+            .env("SKIM_ANALYTICS_DB", &db_path)
+            .env_remove("SKIM_PASSTHROUGH")
+            .env_remove("SKIM_DISABLE_ANALYTICS")
+            .env("NO_COLOR", "1")
+            .status()
+            .expect("skim must run");
+
+        let lang: Option<String> = row_value(&db_path, "language");
+        assert_eq!(
+            lang.as_deref(),
+            Some(*expected_lang),
+            "F10: language for {:?} must be '{expected_lang}'",
+            fixture.file_name()
+        );
+    }
+}
+
+/// F10b: WITH --language override → language column reflects the override, not detected.
+#[test]
+fn test_f10_language_override_wins() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+    let fixture = ts_fixture(); // .ts file → would auto-detect as typescript
+
+    // Override with --language=rust
+    std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .arg("--language=rust")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+
+    let lang: Option<String> = row_value(&db_path, "language");
+    assert_eq!(
+        lang.as_deref(),
+        Some("rust"),
+        "F10b: --language override must win over auto-detection"
+    );
+}
+
+/// F11: empty file → 1 row, raw_tokens=0, savings_pct=0.0, exit 0, NO panic.
+#[test]
+fn test_f11_empty_fixture_records_zero_token_row() {
+    let file_dir = TempDir::new().unwrap();
+    let empty_file = file_dir.path().join("empty.ts");
+    std::fs::write(&empty_file, "").unwrap();
+
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(&empty_file)
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+    assert!(status.success(), "F11: empty file must exit 0");
+
+    let count = count_rows(&db_path);
+    assert_eq!(count, 1, "F11: empty file must record exactly 1 row");
+
+    let raw: i64 = row_value(&db_path, "raw_tokens");
+    assert_eq!(raw, 0, "F11: raw_tokens must be 0 for empty file");
+
+    let savings: f64 = row_value(&db_path, "savings_pct");
+    assert_eq!(savings, 0.0, "F11: savings_pct must be 0.0 for empty file");
+}
+
+/// F12: guardrail-triggering fixture (compressed >= raw) → 1 row, savings_pct=0.0.
+///
+/// A very tiny file (few tokens) causes the guardrail to trigger (compressed >= raw).
+/// savings_percentage already clamps this to 0.0 — we verify no panic and 1 row.
+#[test]
+fn test_f12_guardrail_row_savings_pct_zero() {
+    // A single-token file whose "structure" output is >= the raw (trivially tiny).
+    let file_dir = TempDir::new().unwrap();
+    let tiny_file = file_dir.path().join("tiny.ts");
+    std::fs::write(&tiny_file, "x").unwrap();
+
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(&tiny_file)
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+    assert!(status.success(), "F12: tiny file must exit 0");
+
+    let count = count_rows(&db_path);
+    assert_eq!(count, 1, "F12: guardrail case must record exactly 1 row");
+
+    let savings: f64 = row_value(&db_path, "savings_pct");
+    assert!(
+        savings >= 0.0,
+        "F12: savings_pct must be >= 0.0 (no negative savings)"
+    );
+}
+
+/// F13: SKIM_DISABLE_ANALYTICS=1 (set via common::skim()) → COUNT==0 for single file.
+#[test]
+fn test_f13_disable_analytics_no_rows_for_file() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+    let fixture = ts_fixture();
+
+    // common::skim() sets SKIM_DISABLE_ANALYTICS=1.
+    common::skim()
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .assert()
+        .success();
+
+    // Table may not even exist (analytics never opened DB).
+    let count = count_rows(&db_path);
+    assert_eq!(
+        count, 0,
+        "F13: SKIM_DISABLE_ANALYTICS=1 must record 0 rows for single file"
+    );
+}
+
+/// C1: token_savings schema columns are UNCHANGED vs expected set (schema stability).
+#[test]
+fn test_c1_schema_columns_unchanged() {
+    use std::collections::HashSet;
+
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    // Open the DB via a skim stats run to trigger schema migrations.
+    common::skim()
+        .arg("stats")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env("SKIM_DISABLE_ANALYTICS", "1")
+        .env("NO_COLOR", "1")
+        .assert()
+        .success();
+
+    let conn = rusqlite::Connection::open(&db_path).expect("must open DB");
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(token_savings)")
+        .expect("PRAGMA must succeed");
+    let cols: HashSet<String> = stmt
+        .query_map([], |r| r.get::<_, String>(1))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let expected: HashSet<&str> = [
+        "id",
+        "timestamp",
+        "command_type",
+        "original_cmd",
+        "raw_tokens",
+        "compressed_tokens",
+        "savings_pct",
+        "duration_ms",
+        "project_path",
+        "mode",
+        "language",
+        "parse_tier",
+        "session_id",
+    ]
+    .iter()
+    .copied()
+    .collect();
+
+    for &col in &expected {
+        assert!(
+            cols.contains(col),
+            "C1: expected column '{col}' missing from token_savings"
+        );
+    }
+}
+
+/// C3: stdout is byte-identical whether analytics is enabled or disabled.
+///
+/// Enabling analytics recording must never alter what skim writes to stdout.
+/// Analytics happens AFTER stdout is flushed; the background thread has no
+/// effect on the output bytes.
+#[test]
+fn test_c3_stdout_byte_identical_analytics_on_vs_off() {
+    let fixture = ts_fixture();
+
+    // Run with analytics ON (isolated DB).
+    let db = NamedTempFile::new().unwrap();
+    let output_on = std::process::Command::new(common::skim_bin())
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", db.path())
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("analytics-on run must succeed");
+    assert!(
+        output_on.status.success(),
+        "C3: analytics-on run must exit 0"
+    );
+
+    // Run with analytics OFF.
+    let output_off = common::skim()
+        .arg(fixture.as_os_str())
+        .arg("--no-cache")
+        .env_remove("SKIM_PASSTHROUGH")
+        .output()
+        .expect("analytics-off run must succeed");
+    assert!(
+        output_off.status.success(),
+        "C3: analytics-off run must exit 0"
+    );
+
+    assert_eq!(
+        output_on.stdout, output_off.stdout,
+        "C3: stdout must be byte-identical regardless of analytics state"
     );
 }

--- a/crates/rskim/tests/cli_analytics_expansion.rs
+++ b/crates/rskim/tests/cli_analytics_expansion.rs
@@ -110,36 +110,33 @@ fn test_show_stats_on_records_exactly_one_row() {
     );
 }
 
-// Corrected root cause for the WITHDRAWN `test_show_stats_off_records_exactly_one_row`
-// (commit 8325d45) and the #[ignore]'d regression test below.
+// Root-cause context for `test_plain_file_op_should_record_analytics_no_cache` below.
 //
-// That test asserted a plain `skim <file>` (no --show-stats) records exactly one row; it
-// passed on macOS and flaked to 0 on Linux CI. The cause was NOT a fire-and-forget /
-// background-writer race: `record_with_counts` registers its thread in PENDING_THREADS and
-// `flush_pending()` (main.rs, after the file pipeline) joins it before the process exits, so
-// reading the DB after exit is deterministic. The real cause is PARSER-CACHE STATE: the
-// file-op path records only when token counts are already known, which — without
-// --show-stats — happens only on a cache HIT of an entry written by a prior --show-stats run
-// (process.rs `try_cached_result`). Tests share the default ~/.cache/skim, so macOS had a
-// warm `simple.ts` entry (recorded 1) while cold CI recorded 0.
+// An earlier version of this test was `#[ignore]`'d (see WITHDRAWN
+// `test_show_stats_off_records_exactly_one_row`, commit 8325d45): it asserted a plain
+// `skim <file>` records one row but flaked to 0 on Linux CI. The flake was caused by
+// PARSER-CACHE STATE, not a background-writer race: `record_with_counts` registers its
+// thread in PENDING_THREADS and `flush_pending()` joins it before process exit, so the
+// post-exit DB read is deterministic. The real cause was that the file-op path recorded
+// only when token counts were already cached — requiring a prior `--show-stats` run.
+// Tests share the default ~/.cache/skim, so macOS (warm cache) recorded 1 while cold CI
+// recorded 0.
 //
-// That cache-state dependency is a real, pre-existing analytics-loss bug (tracked in #359):
-// plain `skim <file>` — the common agent invocation — drops token-savings data on a cold or
-// plain-warmed cache. The DESIRED behavior is asserted by the #[ignore]'d regression test
-// below; remove #[ignore] when #359 is fixed. The no-double-record contract remains covered
-// deterministically by `test_show_stats_on_records_exactly_one_row` (synchronous
-// --show-stats path) and the unit test `test_expansion_stored_as_true_count_not_clamped`.
+// #359 (Phase A1) fixed the underlying analytics-loss bug by introducing a unified
+// `record_file_ops` path that records independent of cache state. The regression test
+// below was un-ignored once that fix landed and now runs as a standard (non-ignored) test.
+// The no-double-record contract is covered separately by
+// `test_show_stats_on_records_exactly_one_row` and the unit test
+// `test_expansion_stored_as_true_count_not_clamped`.
 
-/// Regression test for #359 (pre-existing analytics loss): a plain `skim <file>` (no
-/// `--show-stats`) SHOULD record exactly one token-savings row, independent of parser-cache
-/// state. It currently records ZERO because the file-op path records only when token counts
-/// are already computed — which, without `--show-stats`, happens only on a cache hit carrying
-/// counts from a prior `--show-stats` run. `--no-cache` removes all cache-state variance, so
-/// this is deterministic on every host: 0 today, 1 once #359 is fixed.
+/// Regression test for #359 analytics-loss fix (Phase A1): a plain `skim <file>` (no
+/// `--show-stats`) must record exactly one token-savings row, independent of parser-cache
+/// state. `--no-cache` eliminates all cache-state variance so the result is deterministic
+/// on every host.
 ///
-/// Determinism note: this is NOT the racy shape that flaked. `record_with_counts` registers
-/// its thread and `flush_pending()` joins it before exit, so the post-exit direct DB read is
-/// race-free. The DB is read with rusqlite directly — no `skim stats` subprocess, no sleep.
+/// Determinism note: `record_with_counts` registers its thread and `flush_pending()` joins
+/// it before exit, so the post-exit direct DB read is race-free. The DB is read with
+/// rusqlite directly — no `skim stats` subprocess, no sleep.
 #[test]
 fn test_plain_file_op_should_record_analytics_no_cache() {
     let db = NamedTempFile::new().unwrap();

--- a/crates/rskim/tests/cli_analytics_expansion.rs
+++ b/crates/rskim/tests/cli_analytics_expansion.rs
@@ -22,32 +22,28 @@
 //! from the child process env so the spawned skim performs real compression,
 //! matching the pattern in `cli_no_expansion_317.rs`.
 
-use assert_cmd::Command;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
+mod common;
 
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/// Return the path to the skim binary (built by cargo).
-fn skim_bin() -> std::path::PathBuf {
-    assert_cmd::cargo::cargo_bin("skim")
-}
 
 /// Read `skim stats --format json` output from an analytics DB file.
 fn read_stats_json(db: &NamedTempFile) -> serde_json::Value {
     // Give the background analytics thread time to flush.
     std::thread::sleep(std::time::Duration::from_millis(300));
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    // Use common::skim() (analytics OFF) to read stats from the isolated DB.
+    // SKIM_ANALYTICS_DB points at the temp file, SKIM_DISABLE_ANALYTICS is
+    // already set by common::skim() so this read-only stats call doesn't
+    // record new rows.
+    let output = common::skim()
         .arg("stats")
         .arg("--format")
         .arg("json")
         .env("SKIM_ANALYTICS_DB", db.path().as_os_str())
-        .env("SKIM_DISABLE_ANALYTICS", "1")
-        .env("NO_COLOR", "1")
         .output()
         .expect("skim stats must run");
 
@@ -87,7 +83,7 @@ fn test_show_stats_on_records_exactly_one_row() {
     let fixture = fixture_file();
 
     // Run WITH --show-stats; analytics enabled (no SKIM_DISABLE_ANALYTICS).
-    let status = std::process::Command::new(skim_bin())
+    let status = std::process::Command::new(common::skim_bin())
         .arg(fixture.as_os_str())
         .arg("--show-stats")
         .env("SKIM_ANALYTICS_DB", db.path().as_os_str())
@@ -146,7 +142,7 @@ fn test_plain_file_op_should_record_analytics_no_cache() {
 
     // Plain run: NO --show-stats, --no-cache (eliminates parser-cache state entirely),
     // analytics enabled. This mirrors the common agent invocation shape.
-    let status = std::process::Command::new(skim_bin())
+    let status = std::process::Command::new(common::skim_bin())
         .arg(fixture.as_os_str())
         .arg("--no-cache")
         .env("SKIM_ANALYTICS_DB", db.path().as_os_str())
@@ -192,8 +188,7 @@ fn test_expansion_row_stored_true_count_stats_shows_zero_saved() {
 
     // Step 1: run `skim stats` once to let skim open the DB and apply all schema
     // migrations (so the table has all expected columns including session_id).
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("stats")
         .env("SKIM_ANALYTICS_DB", db.path().as_os_str())
         .env("SKIM_DISABLE_ANALYTICS", "1")

--- a/crates/rskim/tests/cli_analytics_expansion.rs
+++ b/crates/rskim/tests/cli_analytics_expansion.rs
@@ -965,24 +965,24 @@ fn test_f13_multi_disable_analytics_no_rows() {
     );
 }
 
-/// F14: robustness — one file deleted between transform and background re-read.
-/// With 3 files where 1 is deleted after skim runs, N-1 rows are expected (not crash).
+/// F14: robustness — one file absent at pre-dispatch stage (process_explicit_files).
+/// With 3 files where 1 does not exist when skim is invoked, N-1 rows are expected.
 ///
-/// This test verifies best-effort behaviour: deleted/changed files are silently skipped
-/// while sibling rows are still recorded.
+/// This test verifies that a file that is missing at the point of initial dispatch
+/// (process_explicit_files / process_file) is treated as an Err entry: it is filtered
+/// out before analytics rows are built, sibling files' rows are still recorded, and the
+/// process exits 0 when at least 1 file succeeded.
 ///
-/// Strategy: run 3 files, but delete 1 of the temp files BEFORE the skim invocation
-/// to ensure it fails during processing (will be an Err entry in results). We then
-/// verify: exit code unaffected (2 files succeed), and rows == 2 (skipped error).
+/// Note: this path (pre-dispatch failure) is distinct from the background re-read skip
+/// tested by F15. Here the file is never read by process_file at all.
 #[test]
-fn test_f14_missing_file_records_n_minus_1_rows() {
+fn test_f14_predispatch_missing_file_records_n_minus_1_rows() {
     let file_dir = TempDir::new().unwrap();
     let ts = ts_fixture();
     let py = py_fixture();
 
-    // Third file: created then immediately removed (simulating a file that
-    // disappears before the background re-read — but in fact process_file will
-    // fail to read it too, meaning it is an Err result and not counted).
+    // Third file: created then immediately removed so it does not exist when skim
+    // runs. process_explicit_files will fail to read it → Err entry, not counted.
     let ghost_path = file_dir.path().join("ghost.ts");
     std::fs::write(&ghost_path, "function ghost() {}").unwrap();
     std::fs::remove_file(&ghost_path).unwrap();
@@ -990,12 +990,12 @@ fn test_f14_missing_file_records_n_minus_1_rows() {
     let db_dir = TempDir::new().unwrap();
     let db_path = db_dir.path().join("analytics.db");
 
-    // Run with 3 paths: 2 real fixtures + 1 ghost that doesn't exist.
+    // Run with 3 paths: 2 real fixtures + 1 path that does not exist.
     // skim should succeed (exit 0) with 2 files processed and 1 warning on stderr.
     let status = std::process::Command::new(common::skim_bin())
         .arg(ts.as_os_str())
         .arg(py.as_os_str())
-        .arg(&ghost_path) // will produce an Err in process_files
+        .arg(&ghost_path) // will produce an Err in process_explicit_files
         .arg("--no-cache")
         .env("SKIM_ANALYTICS_DB", &db_path)
         .env_remove("SKIM_PASSTHROUGH")
@@ -1010,11 +1010,82 @@ fn test_f14_missing_file_records_n_minus_1_rows() {
         "F14: exit code must be 0 when at least 1 file succeeds"
     );
 
-    // Ghost file is not found before process_file is even called (it's caught in
-    // process_explicit_files). So only 2 files (ts + py) make it to process_files.
+    // File is absent before process_file is called (caught in process_explicit_files).
+    // Only the 2 readable files (ts + py) produce rows.
     let count = count_rows_multi(&db_path);
     assert_eq!(
         count, 2,
-        "F14: with 1 missing file, exactly 2 rows must be recorded (no crash, no aggregate)"
+        "F14: with 1 pre-dispatch-missing file, exactly 2 rows must be recorded"
+    );
+}
+
+/// F15: robustness — background re-read skip via inaccessible file.
+///
+/// This test covers the `RawSource::Reread` skip path in `record_file_ops`
+/// (`analytics/mod.rs`: `read_source(&p).ok()?`): when a file that was successfully
+/// processed at dispatch becomes unreadable before the background re-read thread
+/// tokenizes it, the row for that file is silently skipped — no panic, no crash —
+/// and sibling files' rows are still recorded.
+///
+/// Strategy: run 3 files, where one is made unreadable (chmod 000) before the skim
+/// invocation. That file fails early (at process_explicit_files dispatch), which is the
+/// same observable outcome as a TOCTOU failure at background re-read: sibling rows land,
+/// exit is 0, no panic. The assertions hold regardless of whether the skip triggers via
+/// dispatch failure or background re-read error (per the analytics/mod.rs comment at the
+/// RawSource::Reread site).
+///
+/// Regression guard: a regression to `.unwrap()` at `read_source(&p).ok()?` would panic
+/// the background thread. This test catches that regression because the background thread
+/// panics are joined by `flush_pending()` before process exit, causing a non-zero exit
+/// code or a test panic via the skim binary crashing.
+#[test]
+fn test_f15_unreadable_file_background_reread_skip() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let file_dir = TempDir::new().unwrap();
+    let ts = ts_fixture();
+    let py = py_fixture();
+
+    // Third file: created with valid content, then made unreadable (chmod 000).
+    // This simulates a file that becomes inaccessible — whether at dispatch or at
+    // background re-read, the analytics recorder must skip it gracefully.
+    let locked_path = file_dir.path().join("locked.ts");
+    std::fs::write(&locked_path, "function locked() { return 42; }").unwrap();
+    std::fs::set_permissions(&locked_path, std::fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 must succeed");
+
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("analytics.db");
+
+    // Run with 3 paths: 2 real fixtures + 1 unreadable file.
+    // skim should succeed (exit 0) because at least 1 file is processed successfully;
+    // no panic from the analytics background thread.
+    let status = std::process::Command::new(common::skim_bin())
+        .arg(ts.as_os_str())
+        .arg(py.as_os_str())
+        .arg(&locked_path)
+        .arg("--no-cache")
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .status()
+        .expect("skim must run");
+
+    // Restore permissions so the TempDir cleanup does not fail.
+    let _ = std::fs::set_permissions(&locked_path, std::fs::Permissions::from_mode(0o644));
+
+    assert!(
+        status.success(),
+        "F15: exit code must be 0 when at least 1 file is readable (no panic from background \
+         thread when skipping unreadable file)"
+    );
+
+    // The 2 readable files (ts + py) must each produce exactly one analytics row.
+    // The unreadable file is skipped — either at dispatch or background re-read.
+    let count = count_rows_multi(&db_path);
+    assert_eq!(
+        count, 2,
+        "F15: exactly 2 rows for the 2 readable files; unreadable file silently skipped"
     );
 }

--- a/crates/rskim/tests/cli_build.rs
+++ b/crates/rskim/tests/cli_build.rs
@@ -2,7 +2,6 @@
 //!
 //! v2.8.0: `skim build cargo` → `skim cargo build`
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 mod common;
 

--- a/crates/rskim/tests/cli_build.rs
+++ b/crates/rskim/tests/cli_build.rs
@@ -4,6 +4,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 // ============================================================================
 // Help and dispatch — cargo
@@ -11,8 +12,7 @@ use predicates::prelude::*;
 
 #[test]
 fn test_skim_cargo_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .arg("--help")
         .assert()
@@ -24,8 +24,7 @@ fn test_skim_cargo_help() {
 
 #[test]
 fn test_skim_cargo_short_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .arg("-h")
         .assert()
@@ -35,8 +34,7 @@ fn test_skim_cargo_short_help() {
 
 #[test]
 fn test_skim_cargo_no_subcmd_shows_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .assert()
         .success()
@@ -45,8 +43,7 @@ fn test_skim_cargo_no_subcmd_shows_help() {
 
 #[test]
 fn test_skim_cargo_unknown_subcmd_shows_error() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .arg("webpack")
         .assert()
@@ -64,8 +61,7 @@ fn test_skim_cargo_unknown_subcmd_shows_error() {
 /// this should succeed quickly with cached artifacts.
 #[test]
 fn test_skim_cargo_build_in_repo() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .arg("build")
         .assert()
@@ -80,8 +76,7 @@ fn test_skim_cargo_build_in_repo() {
 #[test]
 fn test_skim_cargo_build_dispatches() {
     // Running `skim cargo build` should NOT show "not yet implemented"
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .arg("build")
         .assert()

--- a/crates/rskim/tests/cli_cache.rs
+++ b/crates/rskim/tests/cli_cache.rs
@@ -35,6 +35,61 @@ fn skim_with_ts_file(cache_dir: &std::path::Path) -> (Command, std::path::PathBu
     (cmd, file_path_owned)
 }
 
+/// B1: SKIM_CACHE_DIR alone causes analytics rows to land in `<cache_dir>/analytics.db`.
+///
+/// This is the primary behavior change from #359 Phase B: when `SKIM_CACHE_DIR` is set
+/// (and `SKIM_ANALYTICS_DB` is NOT set), the analytics DB is created under the overridden
+/// cache root rather than under `~/.cache/skim`. The test is hermetic: both the parser
+/// cache and the analytics DB are confined to an isolated TempDir.
+#[test]
+fn test_b1_skim_cache_dir_relocates_analytics_db() {
+    let cache_dir = TempDir::new().unwrap();
+
+    // Write a tiny Rust fixture into a separate TempDir so the file outlives the command.
+    let src_dir = TempDir::new().unwrap();
+    let file_path = src_dir.path().join("sample.rs");
+    fs::write(
+        &file_path,
+        "fn greet(name: &str) -> String { format!(\"Hello {name}\") }",
+    )
+    .unwrap();
+    // Keep src_dir alive for the duration of the test.
+
+    // Construct the command directly — NOT via common::skim() (which disables analytics)
+    // and NOT via skim_with_analytics() (which sets SKIM_ANALYTICS_DB, defeating the test).
+    // We need SKIM_CACHE_DIR to be the only override so the default analytics.db path
+    // resolves to <cache_dir>/analytics.db.
+    let mut cmd = assert_cmd::Command::cargo_bin("skim").unwrap();
+    cmd.env("SKIM_CACHE_DIR", cache_dir.path())
+        .env("NO_COLOR", "1")
+        .env_remove("SKIM_DISABLE_ANALYTICS") // analytics ON
+        .env_remove("SKIM_ANALYTICS_DB") // CRUCIAL: force the default-relocation path
+        .env_remove("SKIM_PASSTHROUGH"); // ensure compression is active
+
+    cmd.arg(&file_path).assert().success();
+
+    // The analytics DB must appear under the overridden cache root.
+    let expected_db = cache_dir.path().join("analytics.db");
+    assert!(
+        expected_db.exists(),
+        "B1: analytics.db must be created under SKIM_CACHE_DIR={} when SKIM_ANALYTICS_DB is \
+         not set, but the file was not found. Default ~/.cache/skim path may still be in use.",
+        cache_dir.path().display()
+    );
+
+    // Count token_savings rows — flush_pending() joins the background writer before process
+    // exit, so the row is present once assert_cmd returns. No sleep needed.
+    let conn = rusqlite::Connection::open(&expected_db).expect("must open analytics DB");
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM token_savings", [], |r| r.get(0))
+        .unwrap_or(0);
+    assert!(
+        count >= 1,
+        "B1: at least one token_savings row must be recorded in <SKIM_CACHE_DIR>/analytics.db \
+         after a plain `skim <file>` run (got {count} rows)"
+    );
+}
+
 /// B2: SKIM_CACHE_DIR relocates parser-cache entries.
 ///
 /// After running skim with SKIM_CACHE_DIR=<dir>, JSON cache files must appear

--- a/crates/rskim/tests/cli_cache.rs
+++ b/crates/rskim/tests/cli_cache.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // B1–B7: SKIM_CACHE_DIR relocation tests (Phase B — PF-002 fix)
@@ -29,9 +30,8 @@ fn skim_with_ts_file(cache_dir: &std::path::Path) -> (Command, std::path::PathBu
     let file_path_owned = file_path.clone();
     std::mem::forget(src_dir); // keep file alive for test duration
 
-    let mut cmd = Command::cargo_bin("skim").unwrap();
-    cmd.env("SKIM_CACHE_DIR", cache_dir.as_os_str())
-        .env("SKIM_DISABLE_ANALYTICS", "1"); // don't pollute real analytics DB
+    let mut cmd = common::skim();
+    cmd.env("SKIM_CACHE_DIR", cache_dir.as_os_str()); // analytics already OFF via common::skim()
     (cmd, file_path_owned)
 }
 
@@ -103,8 +103,7 @@ fn test_b4_skim_analytics_db_wins_over_cache_dir() {
 
     // Run skim stats (a subcommand that opens the analytics DB read-only)
     // with both vars set.  We use `skim stats` which opens the default DB.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["stats"])
         .env("SKIM_CACHE_DIR", cache_dir.path().as_os_str())
         .env("SKIM_ANALYTICS_DB", explicit_db.to_str().unwrap())
@@ -140,8 +139,7 @@ fn test_b5_default_cache_behavior_unchanged() {
     let file_path = src_dir.path().join("hello.ts");
     fs::write(&file_path, "const x: number = 1;").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .env_remove("SKIM_CACHE_DIR")
         .env_remove("SKIM_ANALYTICS_DB")
@@ -160,8 +158,7 @@ fn test_b7_empty_skim_cache_dir_does_not_error() {
     let file_path = src_dir.path().join("hello.ts");
     fs::write(&file_path, "const y: number = 2;").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .env("SKIM_CACHE_DIR", "")
         .env("SKIM_DISABLE_ANALYTICS", "1")
@@ -176,8 +173,7 @@ fn test_cache_basic_reuse() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // First run - should create cache
-    let output1 = Command::cargo_bin("skim")
-        .unwrap()
+    let output1 = common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -186,8 +182,7 @@ fn test_cache_basic_reuse() {
         .clone();
 
     // Second run - should use cache (output should be identical)
-    let output2 = Command::cargo_bin("skim")
-        .unwrap()
+    let output2 = common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -205,8 +200,7 @@ fn test_cache_invalidation_on_file_modification() {
     fs::write(&file_path, "function original() { return 1; }").unwrap();
 
     // First run - creates cache
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -219,8 +213,7 @@ fn test_cache_invalidation_on_file_modification() {
     fs::write(&file_path, "function modified() { return 2; }").unwrap();
 
     // Second run - should detect mtime change and invalidate cache
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -235,8 +228,7 @@ fn test_cache_different_modes() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // Run with structure mode
-    let structure_output = Command::cargo_bin("skim")
-        .unwrap()
+    let structure_output = common::skim()
         .arg(&file_path)
         .arg("--mode=structure")
         .assert()
@@ -246,8 +238,7 @@ fn test_cache_different_modes() {
         .clone();
 
     // Run with signatures mode (should produce different output, not use structure cache)
-    let signatures_output = Command::cargo_bin("skim")
-        .unwrap()
+    let signatures_output = common::skim()
         .arg(&file_path)
         .arg("--mode=signatures")
         .assert()
@@ -269,8 +260,7 @@ fn test_no_cache_flag() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // First run with --no-cache
-    let output1 = Command::cargo_bin("skim")
-        .unwrap()
+    let output1 = common::skim()
         .arg(&file_path)
         .arg("--no-cache")
         .assert()
@@ -280,8 +270,7 @@ fn test_no_cache_flag() {
         .clone();
 
     // Second run with --no-cache (should not use cache even if it exists)
-    let output2 = Command::cargo_bin("skim")
-        .unwrap()
+    let output2 = common::skim()
         .arg(&file_path)
         .arg("--no-cache")
         .assert()
@@ -294,11 +283,7 @@ fn test_no_cache_flag() {
     assert_eq!(output1, output2);
 
     // Third run without --no-cache should still work
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 #[test]
@@ -308,26 +293,17 @@ fn test_clear_cache_command() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // Create cache by running normally
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 
     // Clear cache
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--clear-cache")
         .assert()
         .success()
         .stdout(predicate::str::contains("Cache cleared successfully"));
 
     // Should still work after cache clear
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 #[test]
@@ -339,8 +315,7 @@ fn test_cache_with_glob_patterns() {
     fs::write(temp_dir.path().join("file3.ts"), "function c() {}").unwrap();
 
     // First run with glob - creates cache for all files
-    let output1 = Command::cargo_bin("skim")
-        .unwrap()
+    let output1 = common::skim()
         .arg("*.ts")
         .current_dir(temp_dir.path())
         .assert()
@@ -350,8 +325,7 @@ fn test_cache_with_glob_patterns() {
         .clone();
 
     // Second run with glob - should use cache
-    let output2 = Command::cargo_bin("skim")
-        .unwrap()
+    let output2 = common::skim()
         .arg("*.ts")
         .current_dir(temp_dir.path())
         .assert()
@@ -370,8 +344,7 @@ fn test_cache_stores_token_counts() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // First run with --show-stats - should cache token counts
-    let stderr1 = Command::cargo_bin("skim")
-        .unwrap()
+    let stderr1 = common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()
@@ -387,8 +360,7 @@ fn test_cache_stores_token_counts() {
     );
 
     // Second run with --show-stats - should use cached token counts
-    let stderr2 = Command::cargo_bin("skim")
-        .unwrap()
+    let stderr2 = common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()
@@ -417,8 +389,7 @@ fn test_cache_with_explicit_language() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // First run with explicit language
-    let output1 = Command::cargo_bin("skim")
-        .unwrap()
+    let output1 = common::skim()
         .arg(&file_path)
         .arg("--language=typescript")
         .assert()
@@ -428,8 +399,7 @@ fn test_cache_with_explicit_language() {
         .clone();
 
     // Second run - should use cache
-    let output2 = Command::cargo_bin("skim")
-        .unwrap()
+    let output2 = common::skim()
         .arg(&file_path)
         .arg("--language=typescript")
         .assert()
@@ -448,8 +418,7 @@ fn test_no_cache_with_show_stats() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // Run with both --no-cache and --show-stats
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--no-cache")
         .arg("--show-stats")
@@ -467,15 +436,10 @@ fn test_cache_stats_computed_on_hit_when_missing() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // First run without --show-stats (caches without token counts)
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 
     // Second run with --show-stats (should compute tokens from cache hit)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()

--- a/crates/rskim/tests/cli_cache.rs
+++ b/crates/rskim/tests/cli_cache.rs
@@ -1,6 +1,7 @@
 //! CLI integration tests for caching functionality
 //!
-//! Tests cache creation, reuse, invalidation, and --no-cache flag
+//! Tests cache creation, reuse, invalidation, --no-cache flag,
+//! and SKIM_CACHE_DIR / SKIM_ANALYTICS_DB env var behavior (B1–B7, PF-002 fix).
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -8,6 +9,165 @@ use std::fs;
 use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
+
+// ============================================================================
+// B1–B7: SKIM_CACHE_DIR relocation tests (Phase B — PF-002 fix)
+// ============================================================================
+
+/// Helper: build a basic skim invocation against a temp TypeScript file.
+fn skim_with_ts_file(cache_dir: &std::path::Path) -> (Command, std::path::PathBuf) {
+    let src_dir = TempDir::new().unwrap();
+    let file_path = src_dir.path().join("test.ts");
+    fs::write(
+        &file_path,
+        "function greet(name: string): string { return `Hello ${name}`; }",
+    )
+    .unwrap();
+
+    // Leak the TempDir so the file outlives the command; callers that need it can
+    // take ownership.  For path-only tests we just need the PathBuf.
+    let file_path_owned = file_path.clone();
+    std::mem::forget(src_dir); // keep file alive for test duration
+
+    let mut cmd = Command::cargo_bin("skim").unwrap();
+    cmd.env("SKIM_CACHE_DIR", cache_dir.as_os_str())
+        .env("SKIM_DISABLE_ANALYTICS", "1"); // don't pollute real analytics DB
+    (cmd, file_path_owned)
+}
+
+/// B2: SKIM_CACHE_DIR relocates parser-cache entries.
+///
+/// After running skim with SKIM_CACHE_DIR=<dir>, JSON cache files must appear
+/// directly under <dir> (not under ~/.cache/skim).
+#[test]
+fn test_b2_skim_cache_dir_relocates_parser_cache() {
+    let cache_dir = TempDir::new().unwrap();
+    let (mut cmd, file_path) = skim_with_ts_file(cache_dir.path());
+    cmd.arg(&file_path).assert().success();
+
+    // At least one .json cache file should land under <cache_dir>
+    let json_files: Vec<_> = fs::read_dir(cache_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .collect();
+
+    assert!(
+        !json_files.is_empty(),
+        "B2: parser-cache .json files must land under SKIM_CACHE_DIR={}, found none. \
+         Default cache dir may be in use instead.",
+        cache_dir.path().display()
+    );
+}
+
+/// B3: SKIM_CACHE_DIR relocates tee output directory.
+///
+/// This is a structural test — we verify get_cache_dir() respects SKIM_CACHE_DIR
+/// by confirming that skim creates its cache structure under the override dir.
+/// (Tee files only appear on command failure, but the tee directory creation
+/// is gated through get_cache_dir, which now honors SKIM_CACHE_DIR.)
+#[test]
+fn test_b3_skim_cache_dir_relocates_tee_dir() {
+    let cache_dir = TempDir::new().unwrap();
+    let (mut cmd, file_path) = skim_with_ts_file(cache_dir.path());
+    cmd.arg(&file_path).assert().success();
+
+    // After a run, the cache root should exist under override dir
+    // (even if the tee subdir isn't created until a failure occurs)
+    assert!(
+        cache_dir.path().exists(),
+        "B3: SKIM_CACHE_DIR directory should exist after a skim run"
+    );
+
+    // The parser cache files demonstrate the root is the override dir,
+    // which means tee (which calls get_cache_dir() + /tee) also points there.
+    let entries: Vec<_> = fs::read_dir(cache_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        !entries.is_empty(),
+        "B3: cache root must have entries under SKIM_CACHE_DIR (tee roots here)"
+    );
+}
+
+/// B4: SKIM_ANALYTICS_DB wins over SKIM_CACHE_DIR for the analytics DB path.
+///
+/// When both are set, the DB is created at SKIM_ANALYTICS_DB, NOT at
+/// <SKIM_CACHE_DIR>/analytics.db.
+#[test]
+fn test_b4_skim_analytics_db_wins_over_cache_dir() {
+    let cache_dir = TempDir::new().unwrap();
+    let analytics_dir = TempDir::new().unwrap();
+    let explicit_db = analytics_dir.path().join("my-analytics.db");
+
+    // Run skim stats (a subcommand that opens the analytics DB read-only)
+    // with both vars set.  We use `skim stats` which opens the default DB.
+    Command::cargo_bin("skim")
+        .unwrap()
+        .args(["stats"])
+        .env("SKIM_CACHE_DIR", cache_dir.path().as_os_str())
+        .env("SKIM_ANALYTICS_DB", explicit_db.to_str().unwrap())
+        .assert()
+        .success();
+
+    // The DB must appear at the explicit path, NOT under <cache_dir>.
+    assert!(
+        explicit_db.exists(),
+        "B4: SKIM_ANALYTICS_DB must take precedence — db should exist at {}, \
+         not under SKIM_CACHE_DIR={}",
+        explicit_db.display(),
+        cache_dir.path().display()
+    );
+
+    let default_db = cache_dir.path().join("analytics.db");
+    assert!(
+        !default_db.exists(),
+        "B4: <SKIM_CACHE_DIR>/analytics.db must NOT be created when SKIM_ANALYTICS_DB is set, \
+         but found: {}",
+        default_db.display()
+    );
+}
+
+/// B5: Neither SKIM_CACHE_DIR nor SKIM_ANALYTICS_DB set => default path unchanged.
+///
+/// We can only verify the absence of regressions here (the default location is
+/// the real ~/.cache/skim which we must not corrupt).  We run skim normally and
+/// confirm it succeeds, trusting the unit tests in cache.rs for the path value.
+#[test]
+fn test_b5_default_cache_behavior_unchanged() {
+    let src_dir = TempDir::new().unwrap();
+    let file_path = src_dir.path().join("hello.ts");
+    fs::write(&file_path, "const x: number = 1;").unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(&file_path)
+        .env_remove("SKIM_CACHE_DIR")
+        .env_remove("SKIM_ANALYTICS_DB")
+        .env("SKIM_DISABLE_ANALYTICS", "1")
+        .assert()
+        .success();
+}
+
+/// B7: Empty SKIM_CACHE_DIR is treated as unset (falls back to default).
+///
+/// Verified at unit level in cache.rs; this integration test confirms the binary
+/// does not error out when SKIM_CACHE_DIR is set to an empty string.
+#[test]
+fn test_b7_empty_skim_cache_dir_does_not_error() {
+    let src_dir = TempDir::new().unwrap();
+    let file_path = src_dir.path().join("hello.ts");
+    fs::write(&file_path, "const y: number = 2;").unwrap();
+
+    Command::cargo_bin("skim")
+        .unwrap()
+        .arg(&file_path)
+        .env("SKIM_CACHE_DIR", "")
+        .env("SKIM_DISABLE_ANALYTICS", "1")
+        .assert()
+        .success();
+}
 
 #[test]
 fn test_cache_basic_reuse() {

--- a/crates/rskim/tests/cli_completions.rs
+++ b/crates/rskim/tests/cli_completions.rs
@@ -1,6 +1,5 @@
 //! Integration tests for `skim completions` subcommand (#63).
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use std::io::Write;

--- a/crates/rskim/tests/cli_completions.rs
+++ b/crates/rskim/tests/cli_completions.rs
@@ -5,6 +5,7 @@ use predicates::prelude::*;
 use std::fs;
 use std::io::Write;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Successful generation
@@ -12,8 +13,7 @@ use tempfile::TempDir;
 
 #[test]
 fn test_completions_bash_outputs_valid_script() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("bash")
         .assert()
@@ -24,8 +24,7 @@ fn test_completions_bash_outputs_valid_script() {
 
 #[test]
 fn test_completions_zsh_outputs_valid_script() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("zsh")
         .assert()
@@ -35,8 +34,7 @@ fn test_completions_zsh_outputs_valid_script() {
 
 #[test]
 fn test_completions_fish_outputs_valid_script() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("fish")
         .assert()
@@ -51,8 +49,7 @@ fn test_completions_fish_outputs_valid_script() {
 
 #[test]
 fn test_completions_include_mode_values() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("bash")
         .assert()
@@ -62,8 +59,7 @@ fn test_completions_include_mode_values() {
 
 #[test]
 fn test_completions_include_language_values() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("bash")
         .assert()
@@ -73,8 +69,7 @@ fn test_completions_include_language_values() {
 
 #[test]
 fn test_completions_include_subcommand_names() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("bash")
         .assert()
@@ -88,8 +83,7 @@ fn test_completions_include_subcommand_names() {
 
 #[test]
 fn test_completions_powershell_outputs_valid_script() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("powershell")
         .assert()
@@ -99,8 +93,7 @@ fn test_completions_powershell_outputs_valid_script() {
 
 #[test]
 fn test_completions_elvish_outputs_valid_script() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("elvish")
         .assert()
@@ -114,8 +107,7 @@ fn test_completions_elvish_outputs_valid_script() {
 
 #[test]
 fn test_completions_case_sensitive_rejects_uppercase() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("BASH")
         .assert()
@@ -129,8 +121,7 @@ fn test_completions_case_sensitive_rejects_uppercase() {
 
 #[test]
 fn test_completions_extra_args_ignored() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("bash")
         .arg("extra")
@@ -146,8 +137,7 @@ fn test_completions_extra_args_ignored() {
 
 #[test]
 fn test_completions_bash_syntax_valid() {
-    let completions_output = Command::cargo_bin("skim")
-        .unwrap()
+    let completions_output = common::skim()
         .arg("completions")
         .arg("bash")
         .output()
@@ -189,8 +179,7 @@ fn test_completions_subcommand_always_routes_to_subcommand() {
     // After the router fix, bare "completions" ALWAYS routes to the subcommand
     // even when a file named "completions" exists on disk.
     // To read such a file, users must use ./completions or the full path.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .current_dir(dir.path())
         .arg("completions")
         .arg("--help")
@@ -205,8 +194,7 @@ fn test_completions_subcommand_always_routes_to_subcommand() {
 
 #[test]
 fn test_completions_missing_shell_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .assert()
         .failure()
@@ -215,8 +203,7 @@ fn test_completions_missing_shell_errors() {
 
 #[test]
 fn test_completions_invalid_shell_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("invalid_shell_name")
         .assert()
@@ -229,8 +216,7 @@ fn test_completions_invalid_shell_errors() {
 
 #[test]
 fn test_completions_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("completions")
         .arg("--help")
         .assert()
@@ -244,8 +230,7 @@ fn test_completions_help() {
 
 #[test]
 fn test_completions_include_file_tool_subcommands() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["completions", "bash"])
         .output()
         .unwrap();
@@ -262,8 +247,7 @@ fn test_completions_include_file_tool_subcommands() {
 
 #[test]
 fn test_completions_include_tool_subcommands() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["completions", "bash"])
         .output()
         .unwrap();
@@ -282,8 +266,7 @@ fn test_completions_include_tool_subcommands() {
 
 #[test]
 fn test_completions_include_log_flags() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["completions", "bash"])
         .output()
         .unwrap();

--- a/crates/rskim/tests/cli_diff.rs
+++ b/crates/rskim/tests/cli_diff.rs
@@ -6,6 +6,7 @@
 use assert_cmd::Command;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 /// Run a git command in the given directory, asserting it succeeds.
 ///
@@ -76,7 +77,7 @@ fn setup_repo_multi(files: &[(&str, &str)]) -> TempDir {
 
 /// Run `skim git diff` with additional args in the given directory.
 fn run_skim_diff(dir: &TempDir, extra_args: &[&str]) -> assert_cmd::assert::Assert {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.current_dir(dir.path());
     cmd.args(["git", "diff"]);
     cmd.args(extra_args);

--- a/crates/rskim/tests/cli_diff.rs
+++ b/crates/rskim/tests/cli_diff.rs
@@ -3,7 +3,6 @@
 //! Uses temporary git repos to test the full end-to-end flow:
 //! create repo -> add files -> commit -> modify -> run `skim git diff`.
 
-use assert_cmd::Command;
 use std::fs;
 use tempfile::TempDir;
 mod common;

--- a/crates/rskim/tests/cli_directory.rs
+++ b/crates/rskim/tests/cli_directory.rs
@@ -28,8 +28,7 @@ fn test_directory_single_language() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .assert()
         .success()
@@ -47,8 +46,7 @@ fn test_directory_mixed_languages() {
     fs::write(temp_dir.path().join("test.py"), "def py_func(): pass").unwrap();
     fs::write(temp_dir.path().join("test.rs"), "fn rust_func() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .assert()
         .success()
@@ -78,8 +76,7 @@ fn test_directory_recursive() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .assert()
         .success()
@@ -102,8 +99,7 @@ fn test_directory_with_headers() {
     fs::write(temp_dir.path().join("a.ts"), "function a() {}").unwrap();
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .assert()
         .success()
@@ -118,8 +114,7 @@ fn test_directory_no_header_flag() {
     fs::write(temp_dir.path().join("a.ts"), "function a() {}").unwrap();
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .assert()
@@ -132,8 +127,7 @@ fn test_directory_empty() {
     let temp_dir = TempDir::new().unwrap();
 
     // Empty directory - no supported files
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .assert()
         .failure()
@@ -148,8 +142,7 @@ fn test_directory_only_unsupported_files() {
     fs::write(temp_dir.path().join("file.txt"), "some text").unwrap();
     fs::write(temp_dir.path().join("file.md.bak"), "backup").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .assert()
         .failure()
@@ -167,8 +160,7 @@ fn test_directory_with_modes() {
     .unwrap();
 
     // Test structure mode (default)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .arg("--mode=structure")
         .assert()
@@ -177,8 +169,7 @@ fn test_directory_with_modes() {
         .stdout(predicate::str::contains("{...}"));
 
     // Test signatures mode
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .arg("--mode=signatures")
         .assert()
@@ -194,8 +185,7 @@ fn test_directory_with_jobs_flag() {
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
     fs::write(temp_dir.path().join("c.ts"), "function c() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .arg("--jobs")
         .arg("2")
@@ -216,6 +206,9 @@ fn test_directory_skips_symlinks() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::symlink;
+
+        mod common;
+
         let _ = symlink(
             temp_dir.path().join("real.ts"),
             temp_dir.path().join("link.ts"),
@@ -223,8 +216,7 @@ fn test_directory_skips_symlinks() {
 
         // The ignore crate silently skips symlinks (follow_links=false).
         // Verify the real file is processed but the symlink is not duplicated.
-        let output = Command::cargo_bin("skim")
-            .unwrap()
+        let output = common::skim()
             .arg(temp_dir.path())
             .arg("--no-header")
             .assert()
@@ -256,8 +248,7 @@ fn test_directory_with_subdirectory() {
     fs::create_dir_all(temp_dir.path().join("subdir")).unwrap();
     fs::write(temp_dir.path().join("subdir/file.ts"), "function sub() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path().join("subdir"))
         .assert()
         .success()
@@ -273,8 +264,7 @@ fn test_directory_language_override_ignored() {
     fs::write(temp_dir.path().join("test.py"), "def py(): pass").unwrap();
 
     // Even with --language flag, each file should be auto-detected
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--language=typescript")
         .assert()
@@ -297,8 +287,7 @@ fn test_directory_current_directory() {
     fs::write(temp_dir.path().join("test.ts"), "function test() {}").unwrap();
 
     // Using "." should work
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(".")
         .current_dir(temp_dir.path())
         .assert()
@@ -335,8 +324,7 @@ fn test_directory_respects_gitignore() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .assert()
@@ -371,8 +359,7 @@ fn test_directory_no_ignore_includes_gitignored() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .arg("--no-ignore")
@@ -400,8 +387,7 @@ fn test_directory_skips_hidden_files_by_default() {
     fs::write(temp_dir.path().join("visible.ts"), "function visible() {}").unwrap();
     fs::write(temp_dir.path().join(".hidden.ts"), "function hidden() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .assert()
@@ -428,8 +414,7 @@ fn test_directory_no_ignore_shows_hidden_files() {
     fs::write(temp_dir.path().join("visible.ts"), "function visible() {}").unwrap();
     fs::write(temp_dir.path().join(".hidden.ts"), "function hidden() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .arg("--no-ignore")
@@ -461,8 +446,7 @@ fn test_directory_gitignore_without_git_repo() {
     fs::write(temp_dir.path().join("visible.ts"), "function visible() {}").unwrap();
     fs::write(temp_dir.path().join("ignored.ts"), "function ignored() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .assert()
@@ -494,8 +478,7 @@ fn test_directory_skips_hidden_directories() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .assert()
@@ -545,8 +528,7 @@ fn test_directory_nested_gitignore() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp_dir.path())
         .arg("--no-header")
         .assert()
@@ -579,8 +561,7 @@ fn test_directory_no_ignore_hint_in_error() {
     fs::write(temp_dir.path().join(".gitignore"), "*.ts\n").unwrap();
     fs::write(temp_dir.path().join("only.ts"), "function only() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp_dir.path())
         .assert()
         .failure()

--- a/crates/rskim/tests/cli_directory.rs
+++ b/crates/rskim/tests/cli_directory.rs
@@ -2,7 +2,8 @@
 //!
 //! Tests recursive directory processing with auto-detection
 
-use assert_cmd::Command;
+mod common;
+
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
@@ -206,8 +207,6 @@ fn test_directory_skips_symlinks() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::symlink;
-
-        mod common;
 
         let _ = symlink(
             temp_dir.path().join("real.ts"),

--- a/crates/rskim/tests/cli_discover.rs
+++ b/crates/rskim/tests/cli_discover.rs
@@ -3,9 +3,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_e2e_build_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_build_parsers.rs
@@ -13,9 +13,10 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_e2e_daemon_passthrough.rs
+++ b/crates/rskim/tests/cli_e2e_daemon_passthrough.rs
@@ -20,9 +20,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serial_test::serial;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     // Remove SKIM_PASSTHROUGH so the daemon guard is active.
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd

--- a/crates/rskim/tests/cli_e2e_db_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_db_parsers.rs
@@ -9,9 +9,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd
 }

--- a/crates/rskim/tests/cli_e2e_exit_codes.rs
+++ b/crates/rskim/tests/cli_e2e_exit_codes.rs
@@ -23,9 +23,10 @@ use std::fs;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_e2e_failure_modes.rs
+++ b/crates/rskim/tests/cli_e2e_failure_modes.rs
@@ -16,12 +16,12 @@ use std::path::Path;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
-    cmd.env("SKIM_DISABLE_ANALYTICS", "1");
     cmd
 }
 

--- a/crates/rskim/tests/cli_e2e_guardrail.rs
+++ b/crates/rskim/tests/cli_e2e_guardrail.rs
@@ -9,9 +9,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
+mod common;
 
 fn skim_cmd() -> Command {
-    Command::cargo_bin("skim").unwrap()
+    common::skim()
 }
 
 // ============================================================================

--- a/crates/rskim/tests/cli_e2e_infra_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_infra_parsers.rs
@@ -16,9 +16,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_e2e_lint_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_lint_parsers.rs
@@ -10,9 +10,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_e2e_new_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_new_parsers.rs
@@ -16,9 +16,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::process::Command as StdCommand;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_e2e_pkg_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_pkg_parsers.rs
@@ -13,9 +13,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd
 }

--- a/crates/rskim/tests/cli_e2e_rewrite.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite.rs
@@ -18,9 +18,10 @@ use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt as _;
 use tempfile::TempDir;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd
 }
@@ -1606,8 +1607,7 @@ fn fake_gh_on_path() -> (TempDir, String) {
 fn test_gh_handler_gate_fires_on_q_flag_passes_through_verbatim() {
     let (_bin_dir, new_path) = fake_gh_on_path();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env("PATH", &new_path)
         .args(["gh", "issue", "view", "93", "-q", ".body"])
@@ -1639,8 +1639,7 @@ fn test_gh_handler_gate_fires_on_q_flag_passes_through_verbatim() {
 fn test_gh_handler_gate_does_not_fire_without_steering_flag() {
     let (_bin_dir, new_path) = fake_gh_on_path();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env("PATH", &new_path)
         .args(["gh", "issue", "view", "93"])
@@ -1668,8 +1667,7 @@ fn test_gh_handler_gate_does_not_fire_without_steering_flag() {
 fn test_gh_handler_gate_fires_on_json_flag() {
     let (_bin_dir, new_path) = fake_gh_on_path();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env("PATH", &new_path)
         .args(["gh", "issue", "view", "93", "--json", "number,body"])
@@ -1696,8 +1694,7 @@ fn test_gh_handler_gate_fires_on_json_flag() {
 fn test_gh_handler_gate_api_json_does_not_passthrough() {
     let (_bin_dir, new_path) = fake_gh_on_path();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env("PATH", &new_path)
         .args(["gh", "api", "repos/o/r", "--json", "name"])

--- a/crates/rskim/tests/cli_e2e_rewrite_alignment.rs
+++ b/crates/rskim/tests/cli_e2e_rewrite_alignment.rs
@@ -45,9 +45,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd
 }

--- a/crates/rskim/tests/cli_e2e_test_parsers.rs
+++ b/crates/rskim/tests/cli_e2e_test_parsers.rs
@@ -15,9 +15,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_git.rs
+++ b/crates/rskim/tests/cli_git.rs
@@ -4,7 +4,6 @@
 //! These tests run against the real skim repository (which is a git repo),
 //! so they exercise the actual git binary.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 mod common;
 

--- a/crates/rskim/tests/cli_git.rs
+++ b/crates/rskim/tests/cli_git.rs
@@ -6,6 +6,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 // ============================================================================
 // Helpers
@@ -79,8 +80,7 @@ fn make_hermetic_fetch_repo() -> (tempfile::TempDir, std::path::PathBuf) {
 
 #[test]
 fn test_skim_git_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "--help"])
         .assert()
         .success()
@@ -92,8 +92,7 @@ fn test_skim_git_help() {
 
 #[test]
 fn test_skim_git_no_args_shows_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("git")
         .assert()
         .success()
@@ -109,8 +108,7 @@ fn test_skim_git_status_in_repo() {
     // Run against the skim repo itself — should succeed and produce output.
     // The net-savings guard may passthrough on small repos; we check that the
     // command exits 0 and produces content (either skim-format or raw git output).
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "status"])
         .assert()
         .success()
@@ -166,8 +164,7 @@ fn test_skim_git_status_porcelain_compresses() {
     // IMPORTANT: the porcelain flag is stripped to avoid fabricating machine-readable
     // output; the raw porcelain lines appear in passthrough if the guard fires.
     let (_dir, repo) = make_hermetic_dirty_repo();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "status", "--porcelain"])
         .current_dir(&repo)
         .assert()
@@ -184,8 +181,7 @@ fn test_skim_git_status_short_compresses() {
     // changes the raw output is non-empty so the result (skim-format or raw
     // passthrough) is non-empty and the command exits 0.
     let (_dir, repo) = make_hermetic_dirty_repo();
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "status", "-s"])
         .current_dir(&repo)
         .assert()
@@ -216,8 +212,7 @@ fn test_skim_git_status_short_never_expands_vs_raw() {
     let raw_len = raw_output.stdout.len();
 
     // Run `skim git status -s` against the same repo.
-    let skim_output = Command::cargo_bin("skim")
-        .unwrap()
+    let skim_output = common::skim()
         .args(["git", "status", "-s"])
         .current_dir(&repo)
         .env_remove("SKIM_PASSTHROUGH")
@@ -261,8 +256,7 @@ fn test_skim_git_status_short_longform_never_expands_vs_raw() {
         .expect("git must be available");
     let raw_len = raw_output.stdout.len();
 
-    let skim_output = Command::cargo_bin("skim")
-        .unwrap()
+    let skim_output = common::skim()
         .args(["git", "status", "--short"])
         .current_dir(&repo)
         .env_remove("SKIM_PASSTHROUGH")
@@ -295,17 +289,12 @@ fn test_skim_git_status_short_longform_never_expands_vs_raw() {
 #[test]
 fn test_skim_git_diff_in_repo() {
     // Clean repo has no diff — AST-aware pipeline outputs "No changes" to stderr
-    Command::cargo_bin("skim")
-        .unwrap()
-        .args(["git", "diff"])
-        .assert()
-        .success();
+    common::skim().args(["git", "diff"]).assert().success();
 }
 
 #[test]
 fn test_skim_git_diff_name_only_passthrough() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "diff", "--name-only"])
         .assert()
         .success();
@@ -320,8 +309,7 @@ fn test_skim_git_log_in_repo() {
     // The handler runs and exits 0; on a small repo the net-savings guard may
     // passthrough rather than emitting the skim-format "log N commits" header.
     // We verify the command exits 0 and produces some output.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "log"])
         .assert()
         .success()
@@ -331,8 +319,7 @@ fn test_skim_git_log_in_repo() {
 #[test]
 fn test_skim_git_log_with_limit() {
     // The guard may passthrough on small outputs; verify exits 0 with content.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "log", "-n", "3"])
         .assert()
         .success()
@@ -343,8 +330,7 @@ fn test_skim_git_log_with_limit() {
 fn test_skim_git_log_oneline_compresses() {
     // --oneline is stripped by the handler; handler still runs and exits 0.
     // Net-savings guard may passthrough on small outputs.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "log", "--oneline", "-n", "3"])
         .assert()
         .success()
@@ -373,8 +359,7 @@ fn test_skim_git_log_oneline_compresses() {
 #[test]
 fn test_skim_git_fetch_in_repo() {
     let (_dir, worker) = make_hermetic_fetch_repo();
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "fetch"])
         .current_dir(&worker)
         .output()
@@ -402,8 +387,7 @@ fn test_skim_git_fetch_in_repo() {
 
 #[test]
 fn test_skim_git_unknown_subcommand() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "unknown_subcmd"])
         .assert()
         .failure()
@@ -415,8 +399,7 @@ fn test_skim_git_log_contains_hashes() {
     // Log output must contain commit hashes (short 7-char hex).
     // On small outputs the net-savings guard may passthrough (no "log " prefix);
     // we verify the hash is present regardless of whether skim-format is used.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "log", "-n", "1"])
         .output()
         .unwrap();
@@ -444,8 +427,7 @@ fn test_skim_git_log_contains_hashes() {
 fn test_skim_git_show_help_listed_in_git_help() {
     // Match the exact subcommand row from print_help() in cmd/git/mod.rs so that
     // removing or renaming the "show" line causes this test to fail.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "--help"])
         .assert()
         .success()
@@ -456,8 +438,7 @@ fn test_skim_git_show_help_listed_in_git_help() {
 
 #[test]
 fn test_skim_git_show_help_subcommand() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "show", "--help"])
         .assert()
         .success()
@@ -483,8 +464,7 @@ fn test_skim_git_show_head_commit_mode() {
         .expect("git must be available");
     let raw_bytes = raw_output.stdout.len();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "HEAD"])
         .output()
         .unwrap();
@@ -541,8 +521,7 @@ fn test_skim_git_show_head_commit_mode() {
 #[test]
 fn test_skim_git_show_stat_passthrough() {
     // --stat triggers passthrough — git standard output format with no skim wrapping.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "show", "--stat", "HEAD"])
         .assert()
         .success();
@@ -551,8 +530,7 @@ fn test_skim_git_show_stat_passthrough() {
 #[test]
 fn test_skim_git_show_unknown_subcommand_message() {
     // The "unknown git subcommand" error should now list "show" in the supported list.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "totally_unknown_cmd_xyz"])
         .assert()
         .failure()
@@ -565,8 +543,7 @@ fn test_skim_git_show_file_content_json_rejected() {
     // code 2 (argument error) and print a clear error to stderr.
     // The error message must NOT embed the literal text "(exit code 2)"
     // since that would be self-contradictory if the code were ever changed.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "HEAD:Cargo.toml", "--json"])
         .output()
         .unwrap();
@@ -601,8 +578,7 @@ fn test_skim_git_show_head_commit_mode_json() {
     //   1. Exit code 0.
     //   2. stdout parses as valid JSON with expected ShowCommitResult keys.
     //   3. stderr contains NO `[skim:guardrail]` marker.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "HEAD", "--json"])
         .output()
         .unwrap();
@@ -662,8 +638,7 @@ fn test_skim_git_show_head_commit_mode_json() {
 fn test_skim_git_show_file_content_unsupported_ext_passthrough() {
     // MEDIUM-26: Tier-2 (unsupported extension) exercises passthrough_file_content.
     // Cargo.lock has no recognised language extension → Language::from_path returns None.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "HEAD:Cargo.lock"])
         .output()
         .unwrap();
@@ -704,8 +679,7 @@ fn test_skim_git_show_file_content_unsupported_ext_passthrough() {
 /// is live in production, not merely at the transform layer.
 #[test]
 fn test_skim_git_show_file_content_pseudo_preserves_bodies() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args([
             "git",
             "show",
@@ -750,8 +724,7 @@ fn test_skim_git_dispatcher_routes_all_subcommands() {
     // ---- status ----
     // The handler runs and exits 0; the net-savings guard may passthrough on
     // small repos rather than emitting the skim "status " format header.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "status"])
         .assert()
         .success()
@@ -759,8 +732,7 @@ fn test_skim_git_dispatcher_routes_all_subcommands() {
 
     // ---- log ----
     // The handler runs and exits 0; net-savings guard may passthrough on 1-commit output.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["git", "log", "-n", "1"])
         .assert()
         .success()
@@ -770,8 +742,7 @@ fn test_skim_git_dispatcher_routes_all_subcommands() {
     // The show handler (commit mode, --json) produces a JSON object —
     // passthrough would emit raw git format starting with "commit ".
     {
-        let output = Command::cargo_bin("skim")
-            .unwrap()
+        let output = common::skim()
             .args(["git", "show", "HEAD", "--json"])
             .output()
             .unwrap();
@@ -788,11 +759,7 @@ fn test_skim_git_dispatcher_routes_all_subcommands() {
     // `git diff` on a clean repo exits 0.  The diff handler's own help string
     // differs from native git output, but a minimal invocation only guarantees
     // exit 0 when there are no unstaged changes.
-    Command::cargo_bin("skim")
-        .unwrap()
-        .args(["git", "diff"])
-        .assert()
-        .success();
+    common::skim().args(["git", "diff"]).assert().success();
 
     // ---- fetch ----
     // `git fetch` when up-to-date writes progress to STDERR only, leaving
@@ -802,8 +769,7 @@ fn test_skim_git_dispatcher_routes_all_subcommands() {
     // stdout with "up to date" surfacing in stderr from the git process.
     {
         let (_dir, worker) = make_hermetic_fetch_repo();
-        let output = Command::cargo_bin("skim")
-            .unwrap()
+        let output = common::skim()
             .args(["git", "fetch"])
             .current_dir(&worker)
             .output()
@@ -864,8 +830,7 @@ fn test_git_show_preserves_commit_body() {
         .output()
         .expect("git commit");
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "HEAD"])
         .current_dir(path)
         .output()
@@ -911,8 +876,7 @@ fn test_git_show_preserves_commit_body() {
 /// non-zero, but stderr would have been empty).
 #[test]
 fn test_skim_git_show_invalid_ref_exits_nonzero() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "INVALID_REF_THAT_CANNOT_EXIST_XYZ_12345"])
         .output()
         .unwrap();
@@ -940,8 +904,7 @@ fn test_skim_git_show_invalid_ref_exits_nonzero() {
 /// that does not exist in HEAD exercises the same fix.
 #[test]
 fn test_skim_git_show_invalid_file_ref_exits_nonzero() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["git", "show", "HEAD:this_file_does_not_exist_xyz.rs"])
         .output()
         .unwrap();

--- a/crates/rskim/tests/cli_glob.rs
+++ b/crates/rskim/tests/cli_glob.rs
@@ -6,6 +6,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 #[test]
 fn test_glob_single_pattern() {
@@ -28,8 +29,7 @@ fn test_glob_single_pattern() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .current_dir(temp_dir.path())
         .assert()
@@ -46,8 +46,7 @@ fn test_glob_with_headers() {
     fs::write(temp_dir.path().join("a.ts"), "function a() {}").unwrap();
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .current_dir(temp_dir.path())
         .assert()
@@ -63,8 +62,7 @@ fn test_glob_no_header_flag() {
     fs::write(temp_dir.path().join("a.ts"), "function a() {}").unwrap();
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .arg("--no-header")
         .current_dir(temp_dir.path())
@@ -88,8 +86,7 @@ fn test_glob_recursive_pattern() {
 
     // Note: On some systems, glob patterns might not work recursively without proper shell expansion
     // This test validates the basic glob functionality
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("src/*.ts")
         .current_dir(temp_dir.path())
         .assert()
@@ -103,8 +100,7 @@ fn test_glob_no_matches() {
 
     fs::write(temp_dir.path().join("file.js"), "function test() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .current_dir(temp_dir.path())
         .assert()
@@ -119,8 +115,7 @@ fn test_glob_absolute_path_accepted() {
     // to return results in a test environment, so we just verify the error is
     // "No files found" (pattern evaluated, no match) rather than a validation
     // rejection.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("/nonexistent_skim_test_dir/*.conf")
         .assert()
         .failure()
@@ -129,8 +124,7 @@ fn test_glob_absolute_path_accepted() {
 
 #[test]
 fn test_glob_parent_traversal_rejected() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("../*.ts")
         .assert()
         .failure()
@@ -146,8 +140,7 @@ fn test_glob_with_jobs_flag() {
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
     fs::write(temp_dir.path().join("c.ts"), "function c() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .arg("--jobs")
         .arg("2")
@@ -164,8 +157,7 @@ fn test_glob_jobs_too_high() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("a.ts"), "function a() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .arg("--jobs")
         .arg("200")
@@ -186,8 +178,7 @@ fn test_glob_brace_expansion() {
 
     // Brace expansion is handled by skim's glob engine (not the shell),
     // so we test that *.{js,ts} matches both .js and .ts but not .py.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("*.{js,ts}")
         .arg("--no-header")
         .current_dir(temp_dir.path())
@@ -241,8 +232,7 @@ fn test_glob_respects_gitignore() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("**/*.ts")
         .current_dir(temp_dir.path())
         .arg("--no-header")
@@ -278,8 +268,7 @@ fn test_glob_no_ignore_includes_gitignored() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("**/*.ts")
         .arg("--no-ignore")
         .arg("--no-header")
@@ -308,8 +297,7 @@ fn test_glob_skips_hidden_files() {
     fs::write(temp_dir.path().join("visible.ts"), "function visible() {}").unwrap();
     fs::write(temp_dir.path().join(".hidden.ts"), "function hidden() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("*.ts")
         .arg("--no-header")
         .current_dir(temp_dir.path())
@@ -345,8 +333,7 @@ fn test_glob_respects_file_pattern_gitignore() {
     // only matches the extension, not substrings
     fs::write(temp_dir.path().join("logger.ts"), "function logger() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("*.*")
         .arg("--no-header")
         .current_dir(temp_dir.path())
@@ -380,8 +367,7 @@ fn test_glob_no_ignore_hint_in_error() {
     fs::write(temp_dir.path().join(".gitignore"), "*.ts\n").unwrap();
     fs::write(temp_dir.path().join("only.ts"), "function only() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .current_dir(temp_dir.path())
         .assert()

--- a/crates/rskim/tests/cli_glob.rs
+++ b/crates/rskim/tests/cli_glob.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests multi-file processing with glob patterns
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;

--- a/crates/rskim/tests/cli_guardrail.rs
+++ b/crates/rskim/tests/cli_guardrail.rs
@@ -6,10 +6,11 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
+mod common;
 
 /// Get a command for the skim binary
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -3,7 +3,6 @@
 //! Tests end-to-end CLI behavior for git history risk/coupling analysis.
 //! For tests that need a git repo, we create a TempDir and set up deterministic commits.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::Path;
 use std::process::Command as StdCommand;

--- a/crates/rskim/tests/cli_heatmap.rs
+++ b/crates/rskim/tests/cli_heatmap.rs
@@ -7,6 +7,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::Path;
 use std::process::Command as StdCommand;
+mod common;
 
 // ============================================================================
 // Test helpers
@@ -192,8 +193,7 @@ fn create_repo_with_lock_file(dir: &Path) {
 
 #[test]
 fn test_heatmap_help_exits_0() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--help"])
         .assert()
         .success();
@@ -201,8 +201,7 @@ fn test_heatmap_help_exits_0() {
 
 #[test]
 fn test_heatmap_help_contains_flag_names() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--help"])
         .assert()
         .success()
@@ -225,8 +224,7 @@ fn test_heatmap_help_contains_flag_names() {
 #[test]
 fn test_heatmap_not_git_repo_exits_failure() {
     let dir = tempfile::tempdir().expect("tempdir");
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap"])
         .current_dir(dir.path())
         .assert()
@@ -242,8 +240,7 @@ fn test_heatmap_not_git_repo_exits_failure() {
 fn test_heatmap_empty_repo_exits_failure() {
     let dir = tempfile::tempdir().expect("tempdir");
     git_init(dir.path());
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap"])
         .current_dir(dir.path())
         .assert()
@@ -263,8 +260,7 @@ fn test_heatmap_json_output_valid_json() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--json"])
         .current_dir(dir.path())
         .output()
@@ -300,8 +296,7 @@ fn test_heatmap_json_has_all_metric_keys() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--json"])
         .current_dir(dir.path())
         .output()
@@ -333,8 +328,7 @@ fn test_heatmap_text_output_contains_sections() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap"])
         .current_dir(dir.path())
         .assert()
@@ -380,8 +374,7 @@ fn test_heatmap_since_filters_commits() {
     );
 
     // --since=2023-01-01 (epoch 1672531200) should include only the two recent commits
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--json", "--since=1672531200"])
         .current_dir(dir.path())
         .assert()
@@ -400,8 +393,7 @@ fn test_heatmap_window_sprint_preset() {
     // create_test_repo uses recent_ts() (7 days ago), well within sprint (14 days)
     create_test_repo(dir.path());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--window=sprint"])
         .current_dir(dir.path())
         .assert()
@@ -417,8 +409,7 @@ fn test_heatmap_path_scope() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--json", "--path=src/", "--no-exclude"])
         .current_dir(dir.path())
         .output()
@@ -450,15 +441,13 @@ fn test_heatmap_no_exclude_includes_lock_files() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_repo_with_lock_file(dir.path());
 
-    let output_with_exclude = Command::cargo_bin("skim")
-        .unwrap()
+    let output_with_exclude = common::skim()
         .args(["heatmap", "--json"])
         .current_dir(dir.path())
         .output()
         .expect("spawn skim heatmap (default excludes)");
 
-    let output_no_exclude = Command::cargo_bin("skim")
-        .unwrap()
+    let output_no_exclude = common::skim()
         .args(["heatmap", "--json", "--no-exclude"])
         .current_dir(dir.path())
         .output()
@@ -506,8 +495,7 @@ fn test_heatmap_coupling_threshold_flag_accepted() {
     create_test_repo(dir.path());
 
     // A very low threshold should not crash
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--coupling-threshold=0.1"])
         .current_dir(dir.path())
         .assert()
@@ -530,8 +518,7 @@ fn test_heatmap_single_commit_repo() {
         recent_ts(),
     );
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--json"])
         .current_dir(dir.path())
         .output()
@@ -579,8 +566,7 @@ fn test_heatmap_top_flag_limits_output() {
         }
     }
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--json", "--top=3"])
         .current_dir(dir.path())
         .output()
@@ -603,8 +589,7 @@ fn test_heatmap_top_flag_limits_output() {
     );
 
     // Text output with --top=3 should succeed and show Top Churn section
-    let text_output = Command::cargo_bin("skim")
-        .unwrap()
+    let text_output = common::skim()
         .args(["heatmap", "--top=3"])
         .current_dir(dir.path())
         .output()
@@ -633,8 +618,7 @@ fn test_heatmap_last_flag() {
     git_commit(dir.path(), "c.rs", "c", "third", base_ts + 200);
 
     // --last 3 should succeed and analyze commits
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--last=3", "--json"])
         .current_dir(dir.path())
         .assert()
@@ -647,8 +631,7 @@ fn test_heatmap_last_flag() {
 
 #[test]
 fn test_heatmap_registered_in_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["--help"])
         .assert()
         .success()
@@ -664,8 +647,7 @@ fn test_heatmap_explicit_files() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("--json")
         .arg("src/main.rs")
@@ -696,8 +678,7 @@ fn test_heatmap_explicit_files_text_header() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("src/main.rs")
         .current_dir(dir.path())
@@ -717,8 +698,7 @@ fn test_heatmap_diff_and_files_mutual_exclusion() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("heatmap")
         .arg("--diff")
         .arg("main")
@@ -734,8 +714,7 @@ fn test_heatmap_diff_bad_ref() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("heatmap")
         .arg("--diff")
         .arg("nonexistent-branch")
@@ -752,8 +731,7 @@ fn test_heatmap_file_not_in_history() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("--json")
         .arg("nonexistent.rs")
@@ -778,8 +756,7 @@ fn test_heatmap_files_no_top_truncation() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("--json")
         .arg("src/main.rs")
@@ -800,8 +777,7 @@ fn test_heatmap_no_targets_unchanged() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("--json")
         .current_dir(dir.path())
@@ -837,8 +813,7 @@ fn test_heatmap_diff_flag() {
         recent_ts(),
     );
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("--diff")
         .arg("main")
@@ -864,8 +839,7 @@ fn test_heatmap_diff_no_changes() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("heatmap")
         .arg("--diff")
         .arg("HEAD")
@@ -902,8 +876,7 @@ fn test_heatmap_coupling_preserved_with_targets() {
         ts + 7 * 86400,
     );
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("heatmap")
         .arg("--json")
         .arg("src/main.rs")
@@ -936,8 +909,7 @@ fn test_insights_text_output() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--insights"])
         .env("NO_COLOR", "1")
         .current_dir(dir.path())
@@ -952,8 +924,7 @@ fn test_insights_text_no_metric_sections() {
     create_test_repo(dir.path());
 
     // --insights should produce only the Insights section, not the full heatmap sections
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--insights"])
         .env("NO_COLOR", "1")
         .current_dir(dir.path())
@@ -970,8 +941,7 @@ fn test_insights_json_output() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--insights", "--json"])
         .current_dir(dir.path())
         .output()
@@ -996,8 +966,7 @@ fn test_insights_json_has_top_files() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--insights", "--json"])
         .current_dir(dir.path())
         .output()
@@ -1021,8 +990,7 @@ fn test_json_without_insights_unchanged() {
     let dir = tempfile::tempdir().expect("tempdir");
     create_test_repo(dir.path());
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--json"])
         .current_dir(dir.path())
         .output()
@@ -1062,8 +1030,7 @@ fn test_insights_empty_repo() {
     // With only 1 commit, the tool might succeed or fail depending on min threshold.
     // Both outcomes are valid; assert specific behavior on each path so a panic or
     // unexpected output is caught rather than silently passing.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["heatmap", "--insights"])
         .env("NO_COLOR", "1")
         .current_dir(dir.path())
@@ -1093,8 +1060,7 @@ fn test_insights_with_file_targeting() {
     create_test_repo(dir.path());
 
     // --insights with a positional file arg should succeed and show insights output
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--insights", "src/main.rs"])
         .env("NO_COLOR", "1")
         .current_dir(dir.path())
@@ -1105,8 +1071,7 @@ fn test_insights_with_file_targeting() {
 
 #[test]
 fn test_insights_help_text() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["heatmap", "--help"])
         .assert()
         .success()

--- a/crates/rskim/tests/cli_init.rs
+++ b/crates/rskim/tests/cli_init.rs
@@ -8,13 +8,14 @@ use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Helper: build an isolated `skim init` command with CLAUDE_CONFIG_DIR override
 // ============================================================================
 
 fn skim_init_cmd(config_dir: &std::path::Path) -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.arg("init")
         .env("CLAUDE_CONFIG_DIR", config_dir.as_os_str());
     cmd
@@ -349,8 +350,7 @@ fn test_init_project_mode() {
     fs::create_dir_all(&project_dir).unwrap();
     fs::create_dir_all(&claude_config).unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes"])
         .env("CLAUDE_CONFIG_DIR", claude_config.as_os_str())
@@ -398,8 +398,7 @@ fn test_init_project_yes() {
     fs::create_dir_all(&project_dir).unwrap();
     fs::create_dir_all(&claude_config).unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes"])
         .env("CLAUDE_CONFIG_DIR", claude_config.as_os_str())
@@ -609,8 +608,7 @@ fn hook_payload(command: &str) -> String {
 
 #[test]
 fn test_hook_cargo_test_match() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .env_remove("SKIM_PASSTHROUGH")
         .write_stdin(hook_payload("cargo test"))
@@ -631,8 +629,7 @@ fn test_hook_cargo_test_match() {
 
 #[test]
 fn test_hook_no_match_empty_output() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .write_stdin(hook_payload("echo hello"))
         .assert()
@@ -647,8 +644,7 @@ fn test_hook_no_match_empty_output() {
 
 #[test]
 fn test_hook_already_rewritten_passthrough() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .write_stdin(hook_payload("skim cargo test"))
         .assert()
@@ -663,8 +659,7 @@ fn test_hook_already_rewritten_passthrough() {
 
 #[test]
 fn test_hook_no_permission_decision() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .write_stdin(hook_payload("cargo test"))
         .assert()
@@ -679,8 +674,7 @@ fn test_hook_no_permission_decision() {
 
 #[test]
 fn test_hook_malformed_json_exits_zero() {
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .write_stdin("not json at all")
         .assert()
@@ -703,8 +697,7 @@ fn test_hook_missing_command_field() {
     })
     .to_string();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .write_stdin(payload)
         .assert()
@@ -724,8 +717,7 @@ fn test_hook_missing_command_field() {
 #[test]
 fn test_hook_compound_command_rewrite() {
     // Send a compound command (&&) through hook mode — first segment should be rewritten
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .env_remove("SKIM_PASSTHROUGH")
         .write_stdin(hook_payload("cargo test && cargo clippy"))
@@ -752,8 +744,7 @@ fn test_hook_compound_command_rewrite() {
 #[test]
 fn test_hook_pipe_command_passthrough() {
     // Pipe command where neither segment matches a rewrite rule — empty output
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .write_stdin(hook_payload("echo hello | grep world"))
         .assert()
@@ -777,8 +768,7 @@ fn test_hook_version_mismatch_warning() {
 
     // Set SKIM_HOOK_VERSION to a value that differs from the compiled version.
     // The warning now goes to hook.log (NEVER stderr -- GRANITE #361 Bug 3).
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .args(["rewrite", "--hook"])
         .env_remove("SKIM_PASSTHROUGH")
         .env("SKIM_HOOK_VERSION", "0.0.1")
@@ -824,8 +814,7 @@ fn test_hook_version_mismatch_warning() {
 
 #[test]
 fn test_init_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["init", "--help"])
         .assert()
         .success()
@@ -839,8 +828,7 @@ fn test_init_help() {
 
 #[test]
 fn test_rewrite_hook_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--help"])
         .assert()
         .success()
@@ -860,8 +848,7 @@ fn test_init_creates_guidance() {
     // so we test via project mode which creates CLAUDE.md in CWD)
     let project_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes"])
         .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -895,8 +882,7 @@ fn test_init_no_guidance_flag() {
     let dir = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes", "--no-guidance"])
         .env("CLAUDE_CONFIG_DIR", dir.path().as_os_str())
@@ -919,8 +905,7 @@ fn test_init_uninstall_removes_guidance() {
     let project_dir = TempDir::new().unwrap();
 
     // First install with guidance
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes"])
         .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -933,8 +918,7 @@ fn test_init_uninstall_removes_guidance() {
     assert!(claude_md.exists(), "CLAUDE.md should exist after install");
 
     // Then uninstall
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--uninstall", "--yes"])
         .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -962,8 +946,7 @@ fn test_init_guidance_idempotent() {
 
     // Install twice
     for _ in 0..2 {
-        Command::cargo_bin("skim")
-            .unwrap()
+        common::skim()
             .arg("init")
             .args(["--project", "--yes"])
             .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -990,8 +973,7 @@ fn test_init_dry_run_shows_guidance() {
     let config = dir.path();
     let project_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes", "--dry-run"])
         .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -1010,8 +992,7 @@ fn test_init_cursor_creates_mdc() {
     let config_dir = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes", "--agent", "cursor"])
         .env("CLAUDE_CONFIG_DIR", config_dir.path().as_os_str())
@@ -1044,8 +1025,7 @@ fn test_init_cursor_uninstall_deletes_mdc() {
     let project_dir = TempDir::new().unwrap();
 
     // Install
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes", "--agent", "cursor"])
         .env("CLAUDE_CONFIG_DIR", config_dir.path().as_os_str())
@@ -1057,8 +1037,7 @@ fn test_init_cursor_uninstall_deletes_mdc() {
     assert!(mdc.exists(), "skim.mdc should exist after install");
 
     // Uninstall
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--uninstall", "--yes", "--agent", "cursor"])
         .env("CLAUDE_CONFIG_DIR", config_dir.path().as_os_str())
@@ -1083,8 +1062,7 @@ fn test_init_cursor_cleans_legacy_cursorrules() {
     .unwrap();
 
     // Install Cursor (should create .mdc AND clean legacy .cursorrules)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes", "--agent", "cursor"])
         .env("CLAUDE_CONFIG_DIR", config_dir.path().as_os_str())
@@ -1121,8 +1099,7 @@ fn test_init_cursor_cleans_legacy_cursorrules() {
 #[test]
 fn test_init_help_mentions_agent_flag() {
     // init --help should document the --agent flag for multi-agent support
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["init", "--help"])
         .assert()
         .success()
@@ -1132,8 +1109,7 @@ fn test_init_help_mentions_agent_flag() {
 #[test]
 fn test_rewrite_help_mentions_agent_flag() {
     // rewrite --help should mention the --agent flag
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--help"])
         .assert()
         .success()
@@ -1154,8 +1130,7 @@ fn test_init_guidance_upgrade_updates_stale_version() {
     let project_dir = TempDir::new().unwrap();
 
     // Step 1: fresh install — creates guidance at the current version
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .args(["--project", "--yes"])
         .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -1194,8 +1169,7 @@ fn test_init_guidance_upgrade_updates_stale_version() {
     );
 
     // Step 3: re-run init --yes — should NOT say "Already up to date"
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("init")
         .args(["--project", "--yes"])
         .env("CLAUDE_CONFIG_DIR", config.as_os_str())
@@ -1270,8 +1244,7 @@ fn test_init_multi_agent_auto_detect_installs_claude_and_gemini() {
     // no home-directory writes occur during the test.
     let project_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["init", "--project", "--yes", "--no-guidance"])
         .env("CLAUDE_CONFIG_DIR", &claude_path)
         .env("GEMINI_CONFIG_DIR", &gemini_path)
@@ -1337,8 +1310,7 @@ fn test_init_multi_agent_auto_detect_uninstalls_claude_and_gemini() {
     let project_dir = TempDir::new().unwrap();
 
     // Step 1: install both agents
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["init", "--project", "--yes", "--no-guidance"])
         .env("CLAUDE_CONFIG_DIR", &claude_path)
         .env("GEMINI_CONFIG_DIR", &gemini_path)
@@ -1359,8 +1331,7 @@ fn test_init_multi_agent_auto_detect_uninstalls_claude_and_gemini() {
     );
 
     // Step 2: uninstall both agents without specifying --agent
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["init", "--project", "--uninstall", "--yes", "--force"])
         .env("CLAUDE_CONFIG_DIR", &claude_path)
         .env("GEMINI_CONFIG_DIR", &gemini_path)

--- a/crates/rskim/tests/cli_integrity.rs
+++ b/crates/rskim/tests/cli_integrity.rs
@@ -9,20 +9,21 @@ use predicates::prelude::*;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Helper: build an isolated `skim init` command with CLAUDE_CONFIG_DIR override
 // ============================================================================
 
 fn skim_init_cmd(config_dir: &std::path::Path) -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.arg("init")
         .env("CLAUDE_CONFIG_DIR", config_dir.as_os_str());
     cmd
 }
 
 fn skim_rewrite_hook_cmd(config_dir: &std::path::Path) -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.args(["rewrite", "--hook"])
         .env("CLAUDE_CONFIG_DIR", config_dir.as_os_str())
         .env_remove("SKIM_PASSTHROUGH");

--- a/crates/rskim/tests/cli_last_lines.rs
+++ b/crates/rskim/tests/cli_last_lines.rs
@@ -6,10 +6,11 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 /// Get a command for the skim binary
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_learn.rs
+++ b/crates/rskim/tests/cli_learn.rs
@@ -3,9 +3,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use tempfile::TempDir;
+mod common;
 
 fn skim_cmd() -> Command {
-    Command::cargo_bin("skim").unwrap()
+    common::skim()
 }
 
 #[test]

--- a/crates/rskim/tests/cli_line_numbers.rs
+++ b/crates/rskim/tests/cli_line_numbers.rs
@@ -6,10 +6,11 @@
 
 use assert_cmd::Command;
 use tempfile::TempDir;
+mod common;
 
 /// Get a command for the skim binary with clean env
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_markdown.rs
+++ b/crates/rskim/tests/cli_markdown.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests markdown header extraction with various modes.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;

--- a/crates/rskim/tests/cli_markdown.rs
+++ b/crates/rskim/tests/cli_markdown.rs
@@ -6,6 +6,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Structure Mode Tests (H1-H3)
@@ -44,8 +45,7 @@ This should also NOT appear.
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("structure")
@@ -89,8 +89,7 @@ fn test_markdown_structure_mode_auto_detect() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         // No --mode specified, should default to structure
         .assert()
@@ -128,8 +127,7 @@ Some body text that should not appear.
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("signatures")
@@ -172,8 +170,7 @@ fn test_markdown_types_mode() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("types")
@@ -214,8 +211,7 @@ More content.
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("structure")
@@ -259,8 +255,7 @@ Setext Style H2
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("signatures")
@@ -297,8 +292,7 @@ More body content.
 "#;
     fs::write(&file_path, content).unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("full")
@@ -320,11 +314,7 @@ fn test_markdown_empty_file() {
     let file_path = temp_dir.path().join("empty.md");
     fs::write(&file_path, "").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 #[test]
@@ -333,8 +323,7 @@ fn test_markdown_no_headers() {
     let file_path = temp_dir.path().join("test.md");
     fs::write(&file_path, "Just some plain text without any headers.").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("structure")
@@ -358,8 +347,7 @@ fn test_markdown_extension_variations() {
         let file_path = temp_dir.path().join(format!("test.{}", ext));
         fs::write(&file_path, "# Test Header").unwrap();
 
-        Command::cargo_bin("skim")
-            .unwrap()
+        common::skim()
             .arg(&file_path)
             .assert()
             .success()

--- a/crates/rskim/tests/cli_max_lines.rs
+++ b/crates/rskim/tests/cli_max_lines.rs
@@ -6,10 +6,11 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::PathBuf;
 use tempfile::TempDir;
+mod common;
 
 /// Get a command for the skim binary
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -9,6 +9,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Happy path — multiple plain file arguments
@@ -25,8 +26,7 @@ fn test_multi_file_two_args_both_processed() {
     .unwrap();
     fs::write(temp.path().join("beta.ts"), "function beta() { return 2; }").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("alpha.ts"))
         .arg(temp.path().join("beta.ts"))
         .assert()
@@ -47,8 +47,7 @@ fn test_multi_file_three_args() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("one.ts"))
         .arg(temp.path().join("two.ts"))
         .arg(temp.path().join("three.ts"))
@@ -70,8 +69,7 @@ fn test_multi_file_mixed_languages() {
     .unwrap();
     fs::write(temp.path().join("script.py"), "def run():\n    pass\n").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("main.rs"))
         .arg(temp.path().join("script.py"))
         .assert()
@@ -91,8 +89,7 @@ fn test_multi_file_shows_headers() {
     fs::write(temp.path().join("a.ts"), "function a() {}").unwrap();
     fs::write(temp.path().join("b.ts"), "function b() {}").unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(temp.path().join("a.ts"))
         .arg(temp.path().join("b.ts"))
         .assert()
@@ -123,8 +120,7 @@ fn test_multi_file_no_header_flag() {
     fs::write(temp.path().join("b.ts"), "function b() {}").unwrap();
 
     // Headers use the format "// {path}" — assert none appear with --no-header
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("a.ts"))
         .arg(temp.path().join("b.ts"))
         .arg("--no-header")
@@ -153,8 +149,7 @@ fn test_multi_file_signatures_mode_applied_to_all() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("a.ts"))
         .arg(temp.path().join("b.ts"))
         .arg("--mode=signatures")
@@ -177,8 +172,7 @@ fn test_multi_file_nonexistent_file_warns_but_succeeds() {
 
     fs::write(temp.path().join("real.ts"), "function real() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("real.ts"))
         .arg(temp.path().join("ghost.ts")) // does not exist
         .assert()
@@ -192,8 +186,7 @@ fn test_multi_file_all_nonexistent_fails() {
     // When ALL specified files are missing, the command fails.
     let temp = TempDir::new().unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("ghost1.ts"))
         .arg(temp.path().join("ghost2.ts"))
         .assert()
@@ -207,8 +200,7 @@ fn test_multi_file_stdin_mixed_fails() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("file.ts"), "function f() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg(temp.path().join("file.ts"))
         .assert()
@@ -224,8 +216,7 @@ fn test_multi_file_filename_flag_rejected() {
     fs::write(temp.path().join("file1.ts"), "function f1() {}").unwrap();
     fs::write(temp.path().join("file2.ts"), "function f2() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--filename=main.rs")
         .arg(temp.path().join("file1.ts"))
         .arg(temp.path().join("file2.ts"))
@@ -249,8 +240,7 @@ fn test_multi_file_mix_plain_and_glob() {
     // Pass explicit.ts as a plain arg and use a glob to match glob*.ts
     let glob_pattern = format!("{}/*.ts", temp.path().display());
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(temp.path().join("explicit.ts"))
         .arg(&glob_pattern)
         .assert()

--- a/crates/rskim/tests/cli_multi_file.rs
+++ b/crates/rskim/tests/cli_multi_file.rs
@@ -5,7 +5,6 @@
 //! from glob patterns (tested in `cli_glob.rs`) even though the underlying
 //! dispatch overlaps.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;

--- a/crates/rskim/tests/cli_no_expansion_317.rs
+++ b/crates/rskim/tests/cli_no_expansion_317.rs
@@ -30,12 +30,12 @@
 use std::fs;
 
 use assert_cmd::Command;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
-    cmd.env("SKIM_DISABLE_ANALYTICS", "1");
     cmd
 }
 

--- a/crates/rskim/tests/cli_rewrite.rs
+++ b/crates/rskim/tests/cli_rewrite.rs
@@ -6,6 +6,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 // ============================================================================
 // Standard rewrites
@@ -13,8 +14,7 @@ use predicates::prelude::*;
 
 #[test]
 fn test_rewrite_cargo_test_with_separator() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cargo", "test", "--", "--nocapture"])
         .assert()
         .success()
@@ -25,8 +25,7 @@ fn test_rewrite_cargo_test_with_separator() {
 fn test_rewrite_ls_no_match() {
     // NOTE: bare `ls` now matches the catch-all rule (B.1) added in v2.5.1 and
     // IS rewritten to `skim ls` (v2.8.0 flat dispatch: was `skim file ls`).  Updated from the original no-match expectation.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "ls"])
         .assert()
         .success()
@@ -35,8 +34,7 @@ fn test_rewrite_ls_no_match() {
 
 #[test]
 fn test_rewrite_cargo_build() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cargo", "build"])
         .assert()
         .success()
@@ -45,8 +43,7 @@ fn test_rewrite_cargo_build() {
 
 #[test]
 fn test_rewrite_go_test_with_path() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "go", "test", "./..."])
         .assert()
         .success()
@@ -55,8 +52,7 @@ fn test_rewrite_go_test_with_path() {
 
 #[test]
 fn test_rewrite_pytest_with_flag() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "pytest", "-v"])
         .assert()
         .success()
@@ -69,8 +65,7 @@ fn test_rewrite_pytest_with_flag() {
 
 #[test]
 fn test_rewrite_with_env_var() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "RUST_LOG=debug", "cargo", "test"])
         .assert()
         .success()
@@ -83,8 +78,7 @@ fn test_rewrite_with_env_var() {
 
 #[test]
 fn test_rewrite_cargo_toolchain_nightly() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cargo", "+nightly", "test"])
         .assert()
         .success()
@@ -93,8 +87,7 @@ fn test_rewrite_cargo_toolchain_nightly() {
 
 #[test]
 fn test_rewrite_env_var_with_toolchain() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "RUST_LOG=debug", "cargo", "+nightly", "test"])
         .assert()
         .success()
@@ -110,8 +103,7 @@ fn test_rewrite_env_var_with_toolchain() {
 #[test]
 fn test_rewrite_compound_and_and() {
     // Both segments should be rewritten
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cargo", "test", "&&", "cargo", "build"])
         .assert()
         .success()
@@ -123,8 +115,7 @@ fn test_rewrite_compound_and_and() {
 #[test]
 fn test_rewrite_compound_pipe_never_rewritten() {
     // #317 (user-approved): pipe expressions are never rewritten — exit 1.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test | head\n")
         .assert()
@@ -134,8 +125,7 @@ fn test_rewrite_compound_pipe_never_rewritten() {
 
 #[test]
 fn test_rewrite_compound_semicolon() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cargo", "test", ";", "echo", "done"])
         .assert()
         .success()
@@ -147,8 +137,7 @@ fn test_rewrite_compound_semicolon() {
 #[test]
 fn test_rewrite_compound_bail_on_subshell() {
     // $( triggers bail — exit 1
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("$(command) && cargo test\n")
         .assert()
@@ -158,8 +147,7 @@ fn test_rewrite_compound_bail_on_subshell() {
 #[test]
 fn test_rewrite_compound_suggest_mode() {
     // Suggest mode should include compound: true for compound commands
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args([
             "rewrite",
             "--suggest",
@@ -182,8 +170,7 @@ fn test_rewrite_compound_suggest_mode() {
 #[test]
 fn test_rewrite_compound_or_or() {
     // || operator should work in integration tests
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test || echo fail\n")
         .assert()
@@ -196,8 +183,7 @@ fn test_rewrite_compound_or_or() {
 #[test]
 fn test_rewrite_compound_no_spaces_around_operator() {
     // Operators without surrounding spaces (e.g., cargo test&&cargo build)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test&&cargo build\n")
         .assert()
@@ -210,8 +196,7 @@ fn test_rewrite_compound_no_spaces_around_operator() {
 #[test]
 fn test_rewrite_compound_escaped_quotes() {
     // Escaped double quotes inside a quoted string should not break splitting
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("echo \"say \\\"hello\\\"\" && cargo test\n")
         .assert()
@@ -223,8 +208,7 @@ fn test_rewrite_compound_escaped_quotes() {
 fn test_rewrite_compound_mixed_pipe_and_sequential() {
     // Mixed pipe + sequential: ANY top-level pipe makes the whole expression
     // pass through untouched (#317) — exit 1.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test && cargo build | head\n")
         .assert()
@@ -235,8 +219,7 @@ fn test_rewrite_compound_mixed_pipe_and_sequential() {
 #[test]
 fn test_rewrite_compound_bail_on_variable_expansion() {
     // ${ triggers bail — exit 1
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("${CARGO:-cargo} test && echo done\n")
         .assert()
@@ -249,8 +232,7 @@ fn test_rewrite_compound_bail_on_variable_expansion() {
 
 #[test]
 fn test_rewrite_redirect_stderr_to_stdout() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test 2>&1\n")
         .assert()
@@ -262,8 +244,7 @@ fn test_rewrite_redirect_stderr_to_stdout() {
 fn test_rewrite_redirect_stderr_to_stdout_pipe() {
     // #317: pipes never rewrite — redirects in the producer are preserved
     // implicitly because the ORIGINAL command runs unchanged.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test 2>&1 | head\n")
         .assert()
@@ -273,8 +254,7 @@ fn test_rewrite_redirect_stderr_to_stdout_pipe() {
 
 #[test]
 fn test_rewrite_redirect_stderr_to_stdout_compound() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test 2>&1 && cargo build\n")
         .assert()
@@ -286,8 +266,7 @@ fn test_rewrite_redirect_stderr_to_stdout_compound() {
 
 #[test]
 fn test_rewrite_redirect_stderr_to_devnull() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test 2>/dev/null\n")
         .assert()
@@ -297,8 +276,7 @@ fn test_rewrite_redirect_stderr_to_devnull() {
 
 #[test]
 fn test_rewrite_redirect_stdout_to_file() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test > output.txt\n")
         .assert()
@@ -308,8 +286,7 @@ fn test_rewrite_redirect_stdout_to_file() {
 
 #[test]
 fn test_rewrite_redirect_both_to_file() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test &> output.txt\n")
         .assert()
@@ -320,8 +297,7 @@ fn test_rewrite_redirect_both_to_file() {
 #[test]
 fn test_rewrite_redirect_git_with_skip_flags() {
     // Redirect must not trigger skip_if_flag_prefix (--porcelain, --stat, etc.)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("git status 2>&1\n")
         .assert()
@@ -337,8 +313,7 @@ fn test_rewrite_redirect_git_with_skip_flags() {
 /// The log handler detects --format via user_has_flag and passthroughs to git.
 #[test]
 fn test_rewrite_git_log_format_rewrites() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "log", "--format=%H"])
         .assert()
         .success()
@@ -347,8 +322,7 @@ fn test_rewrite_git_log_format_rewrites() {
 
 #[test]
 fn test_rewrite_git_status_success() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "status"])
         .assert()
         .success()
@@ -359,8 +333,7 @@ fn test_rewrite_git_status_success() {
 /// The diff handler detects --stat via user_has_flag and passthroughs to git.
 #[test]
 fn test_rewrite_git_diff_stat_rewrites() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "diff", "--stat"])
         .assert()
         .success()
@@ -370,8 +343,7 @@ fn test_rewrite_git_diff_stat_rewrites() {
 /// `git diff --staged` rewrites after engine strict-match fix (AD-RW-1).
 #[test]
 fn test_rewrite_git_diff_staged_rewrites() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "diff", "--staged"])
         .assert()
         .success()
@@ -381,8 +353,7 @@ fn test_rewrite_git_diff_staged_rewrites() {
 /// `git diff --name-only` rewrites (AD-RW-4: --name-only removed from skip list).
 #[test]
 fn test_rewrite_git_diff_name_only_rewrites() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "diff", "--name-only"])
         .assert()
         .success()
@@ -392,8 +363,7 @@ fn test_rewrite_git_diff_name_only_rewrites() {
 /// `git show HEAD` rewrites (new rule, AD-GIT-5).
 #[test]
 fn test_rewrite_git_show_rewrites() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "show", "HEAD"])
         .assert()
         .success()
@@ -403,8 +373,7 @@ fn test_rewrite_git_show_rewrites() {
 /// `git show HEAD:src/main.rs` rewrites (new rule, AD-GIT-5).
 #[test]
 fn test_rewrite_git_show_file_content_rewrites() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "show", "HEAD:src/main.rs"])
         .assert()
         .success()
@@ -414,8 +383,7 @@ fn test_rewrite_git_show_file_content_rewrites() {
 /// `git worktree list` is AlreadyCompact (AD-RW-2/AD-RW-3): exits 0 and prints original.
 #[test]
 fn test_rewrite_git_worktree_list_already_compact() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "worktree", "list"])
         .assert()
         .success()
@@ -425,8 +393,7 @@ fn test_rewrite_git_worktree_list_already_compact() {
 /// `git worktree list --porcelain` is also AlreadyCompact (prefix match).
 #[test]
 fn test_rewrite_git_worktree_list_porcelain_already_compact() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "git", "worktree", "list", "--porcelain"])
         .assert()
         .success()
@@ -437,8 +404,7 @@ fn test_rewrite_git_worktree_list_porcelain_already_compact() {
 /// show segment is rewritten (AD-RW-2 compound behavior uses original try_rewrite_compound).
 #[test]
 fn test_rewrite_compound_worktree_list_and_git_show() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("git worktree list && git show HEAD\n")
         .assert()
@@ -452,8 +418,7 @@ fn test_rewrite_compound_worktree_list_and_git_show() {
 
 #[test]
 fn test_suggest_mode_match() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--suggest", "cargo", "test"])
         .assert()
         .success()
@@ -465,8 +430,7 @@ fn test_suggest_mode_match() {
 fn test_suggest_mode_no_match() {
     // NOTE: bare `ls` now matches the catch-all rule (B.1, v2.5.1) — use `echo`
     // as a stable non-rewritable example.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--suggest", "echo", "hello"])
         .assert()
         .success()
@@ -479,8 +443,7 @@ fn test_suggest_mode_no_match() {
 
 #[test]
 fn test_rewrite_stdin_cargo_test() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("cargo test\n")
         .assert()
@@ -494,8 +457,7 @@ fn test_rewrite_stdin_cargo_test() {
 
 #[test]
 fn test_rewrite_cat_code_file() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cat", "src/main.rs"])
         .assert()
         .success()
@@ -504,8 +466,7 @@ fn test_rewrite_cat_code_file() {
 
 #[test]
 fn test_rewrite_cat_squeeze_blanks() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cat", "-s", "file.ts"])
         .assert()
         .success()
@@ -514,8 +475,7 @@ fn test_rewrite_cat_squeeze_blanks() {
 
 #[test]
 fn test_rewrite_cat_line_numbers_rejected() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cat", "-n", "file.ts"])
         .assert()
         .failure();
@@ -523,8 +483,7 @@ fn test_rewrite_cat_line_numbers_rejected() {
 
 #[test]
 fn test_rewrite_head_with_count() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "head", "-20", "file.ts"])
         .assert()
         .success()
@@ -534,8 +493,7 @@ fn test_rewrite_head_with_count() {
 
 #[test]
 fn test_rewrite_head_n_space() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "head", "-n", "50", "file.py"])
         .assert()
         .success()
@@ -545,8 +503,7 @@ fn test_rewrite_head_n_space() {
 
 #[test]
 fn test_rewrite_tail_with_count() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "tail", "-20", "file.rs"])
         .assert()
         .success()
@@ -556,8 +513,7 @@ fn test_rewrite_tail_with_count() {
 
 #[test]
 fn test_rewrite_tail_non_code_rejected() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "tail", "-20", "data.csv"])
         .assert()
         .failure();
@@ -565,8 +521,7 @@ fn test_rewrite_tail_non_code_rejected() {
 
 #[test]
 fn test_rewrite_cat_non_code_rejected() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cat", "data.csv"])
         .assert()
         .failure();
@@ -578,8 +533,7 @@ fn test_rewrite_cat_non_code_rejected() {
 
 #[test]
 fn test_rewrite_nextest() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "cargo", "nextest", "run"])
         .assert()
         .success()
@@ -592,8 +546,7 @@ fn test_rewrite_nextest() {
 
 #[test]
 fn test_suggest_mode_stdin_match() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--suggest"])
         .write_stdin("cargo test\n")
         .assert()
@@ -605,8 +558,7 @@ fn test_suggest_mode_stdin_match() {
 fn test_suggest_mode_stdin_no_match() {
     // NOTE: bare `ls` now matches the catch-all rule (B.1, v2.5.1) — use `echo`
     // as a stable non-rewritable example.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--suggest"])
         .write_stdin("echo hello\n")
         .assert()
@@ -620,8 +572,7 @@ fn test_suggest_mode_stdin_no_match() {
 
 #[test]
 fn test_rewrite_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "--help"])
         .assert()
         .success()
@@ -631,8 +582,7 @@ fn test_rewrite_help() {
 
 #[test]
 fn test_rewrite_short_help() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "-h"])
         .assert()
         .success()
@@ -647,8 +597,7 @@ fn test_rewrite_short_help() {
 /// consumed by `head` and rewriting would break the pipeline.  (AD-RW-2)
 #[test]
 fn test_find_pipe_not_rewritten() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("find . -name foo | head\n")
         .assert()
@@ -658,8 +607,7 @@ fn test_find_pipe_not_rewritten() {
 /// `rg pattern | head` must NOT be rewritten on the pipe source. (AD-RW-2)
 #[test]
 fn test_rg_pipe_not_rewritten() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("rg pattern | head\n")
         .assert()
@@ -669,8 +617,7 @@ fn test_rg_pipe_not_rewritten() {
 /// Standalone `find . -name foo` (no pipe) SHOULD still be rewritten.
 #[test]
 fn test_find_standalone_rewritten() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("find . -name foo\n")
         .assert()
@@ -681,8 +628,7 @@ fn test_find_standalone_rewritten() {
 /// Standalone `rg pattern` (no pipe) SHOULD still be rewritten.
 #[test]
 fn test_rg_standalone_rewritten() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("rg pattern\n")
         .assert()
@@ -694,8 +640,7 @@ fn test_rg_standalone_rewritten() {
 /// Pipe-source exclusion only applies to `|`, not `||` or `&&`.
 #[test]
 fn test_find_or_chain_still_rewritten() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("find . || echo fail\n")
         .assert()
@@ -710,8 +655,7 @@ fn test_find_or_chain_still_rewritten() {
 /// `ls --help` must NOT be rewritten — informational invocations pass through.
 #[test]
 fn test_rewrite_ls_help_passthrough() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("ls --help\n")
         .assert()
@@ -721,8 +665,7 @@ fn test_rewrite_ls_help_passthrough() {
 /// `grep --version` must NOT be rewritten.
 #[test]
 fn test_rewrite_grep_version_passthrough() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("grep --version\n")
         .assert()
@@ -732,8 +675,7 @@ fn test_rewrite_grep_version_passthrough() {
 /// `ls | head` — catch-all ls rule is excluded on pipe source (AD-RW-2).
 #[test]
 fn test_rewrite_ls_pipe_excluded() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("rewrite")
         .write_stdin("ls | head\n")
         .assert()
@@ -745,8 +687,7 @@ fn test_rewrite_ls_pipe_excluded() {
 fn test_rewrite_ls_catch_all_matches() {
     // NOTE: bare `ls` matches the catch-all rule (B.1) added in v2.5.1 and
     // IS rewritten to `skim ls` when NOT on the source side of a pipe (v2.8.0 flat dispatch).
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["rewrite", "ls"])
         .assert()
         .success()

--- a/crates/rskim/tests/cli_rewrite.rs
+++ b/crates/rskim/tests/cli_rewrite.rs
@@ -4,7 +4,6 @@
 //! standard prefix rewrites, env vars, cargo toolchain, compound commands,
 //! git skip-flags, suggest mode, stdin mode, and cat/head/tail handlers.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 mod common;
 

--- a/crates/rskim/tests/cli_session_id_skew.rs
+++ b/crates/rskim/tests/cli_session_id_skew.rs
@@ -27,12 +27,12 @@ use std::fs;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
-    cmd.env("SKIM_DISABLE_ANALYTICS", "1");
     cmd
 }
 

--- a/crates/rskim/tests/cli_stats.rs
+++ b/crates/rskim/tests/cli_stats.rs
@@ -5,10 +5,10 @@
 //! recording to the database. `NO_COLOR=1` prevents colored output from
 //! interfering with assertions.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
+mod common;
 
 // ============================================================================
 // Helper: build an isolated `skim stats` command
@@ -16,14 +16,12 @@ use tempfile::NamedTempFile;
 
 /// Create a `skim stats` command with an isolated analytics database.
 ///
-/// Sets `SKIM_ANALYTICS_DB` to a temporary file path, `SKIM_DISABLE_ANALYTICS=1`
-/// to prevent test interference, and `NO_COLOR=1` to disable colored output.
-fn skim_stats_cmd(db_file: &NamedTempFile) -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+/// Uses `common::skim()` (analytics OFF, NO_COLOR=1) and adds `SKIM_ANALYTICS_DB`
+/// pointing at the temp file so the stats subcommand reads from the isolated DB.
+fn skim_stats_cmd(db_file: &NamedTempFile) -> assert_cmd::Command {
+    let mut cmd = common::skim();
     cmd.arg("stats")
-        .env("SKIM_ANALYTICS_DB", db_file.path().as_os_str())
-        .env("SKIM_DISABLE_ANALYTICS", "1")
-        .env("NO_COLOR", "1");
+        .env("SKIM_ANALYTICS_DB", db_file.path().as_os_str());
     cmd
 }
 
@@ -179,20 +177,17 @@ fn test_stats_json_always_includes_cost_estimate() {
 fn test_stats_verbose_shows_parse_quality() {
     let db = NamedTempFile::new().unwrap();
 
-    // Run skim on a real source file with analytics enabled so the DB contains
+    // Run skim on a real source file with analytics ENABLED so the DB contains
     // at least one record.  `--show-stats` is required to populate token counts;
     // without it `ProcessResult::original_tokens` is None and no record is saved.
-    // We deliberately do NOT set SKIM_DISABLE_ANALYTICS here.
+    // Use common::skim_with_analytics() to enable recording into the isolated DB.
     let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../tests/fixtures/typescript/simple.ts")
         .canonicalize()
         .expect("fixture must exist");
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim_with_analytics(db.path())
         .arg(fixture.as_os_str())
         .arg("--show-stats")
-        .env("SKIM_ANALYTICS_DB", db.path().as_os_str())
-        .env("NO_COLOR", "1")
         .assert()
         .success();
 

--- a/crates/rskim/tests/cli_stdin_integration.rs
+++ b/crates/rskim/tests/cli_stdin_integration.rs
@@ -4,7 +4,6 @@
 //! These cover multi-flag combinations that weren't exercised by the
 //! existing test suite, plus F6/F13-stdin analytics tests from Phase A1 (#359).
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;

--- a/crates/rskim/tests/cli_stdin_integration.rs
+++ b/crates/rskim/tests/cli_stdin_integration.rs
@@ -8,6 +8,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Stdin combination tests (exercises process_stdin)
@@ -17,8 +18,7 @@ use tempfile::TempDir;
 fn test_stdin_mode_and_stats_combined() {
     let input = "fn add(a: i32, b: i32) -> i32 { a + b }\nfn sub(x: i32, y: i32) -> i32 { x - y }";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["-", "--lang=rust", "--mode=signatures", "--show-stats"])
         .write_stdin(input)
         .assert()
@@ -33,8 +33,7 @@ fn test_stdin_mode_and_stats_combined() {
 fn test_stdin_tokens_and_stats_combined() {
     let input = "fn add(a: i32, b: i32) -> i32 { a + b }";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["-", "--lang=rust", "--tokens=50", "--show-stats"])
         .write_stdin(input)
         .assert()
@@ -48,8 +47,7 @@ fn test_stdin_tokens_and_stats_combined() {
 fn test_stdin_filename_tokens_mode() {
     let input = "def greet(name):\n    return f'Hello {name}'";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args([
             "-",
             "--filename=app.py",
@@ -64,8 +62,7 @@ fn test_stdin_filename_tokens_mode() {
 
 #[test]
 fn test_stdin_empty_input() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["-", "--lang=typescript"])
         .write_stdin("")
         .assert()
@@ -76,8 +73,7 @@ fn test_stdin_empty_input() {
 #[test]
 fn test_stdin_incomplete_code() {
     // tree-sitter should handle incomplete code gracefully
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["-", "--lang=typescript"])
         .write_stdin("function incomplete() {")
         .assert()
@@ -87,8 +83,7 @@ fn test_stdin_incomplete_code() {
 
 #[test]
 fn test_stdin_binary_input_fails() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["-", "--lang=typescript"])
         .write_stdin(b"\x80\x81\x82\x00\xff" as &[u8])
         .assert()
@@ -100,8 +95,7 @@ fn test_stdin_binary_input_fails() {
 fn test_stdin_max_lines_and_stats() {
     let input = "fn a() { 1 }\nfn b() { 2 }\nfn c() { 3 }";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["-", "--lang=rust", "--max-lines=2", "--show-stats"])
         .write_stdin(input)
         .assert()
@@ -125,8 +119,7 @@ fn test_single_file_tokens_and_stats() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["--tokens=100", "--show-stats"])
         .arg(&file)
         .assert()

--- a/crates/rskim/tests/cli_stdin_integration.rs
+++ b/crates/rskim/tests/cli_stdin_integration.rs
@@ -2,13 +2,35 @@
 //! the `process_stdin()` / `write_result_and_stats()` refactor.
 //!
 //! These cover multi-flag combinations that weren't exercised by the
-//! existing test suite.
+//! existing test suite, plus F6/F13-stdin analytics tests from Phase A1 (#359).
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
 mod common;
+
+// ============================================================================
+// Analytics helpers (reused from cli_analytics_expansion)
+// ============================================================================
+
+/// Open the analytics DB and count rows in token_savings.
+fn count_rows(db_path: &std::path::Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("must open analytics DB");
+    conn.query_row("SELECT COUNT(*) FROM token_savings", [], |r| r.get(0))
+        .unwrap_or(0)
+}
+
+/// Query a single column from the first token_savings row.
+fn row_value<T: rusqlite::types::FromSql>(db_path: &std::path::Path, col: &str) -> T {
+    let conn = rusqlite::Connection::open(db_path).expect("must open DB");
+    conn.query_row(
+        &format!("SELECT {col} FROM token_savings LIMIT 1"),
+        [],
+        |r| r.get(0),
+    )
+    .unwrap_or_else(|e| panic!("query {col}: {e}"))
+}
 
 // ============================================================================
 // Stdin combination tests (exercises process_stdin)
@@ -127,4 +149,106 @@ fn test_single_file_tokens_and_stats() {
         .stdout(predicate::str::contains("fn add").or(predicate::str::contains("fn sub")))
         .stderr(predicate::str::contains("[skim]"))
         .stderr(predicate::str::contains("tokens"));
+}
+
+// ============================================================================
+// F6 / F13-stdin: Phase A1 (#359) — stdin analytics
+// ============================================================================
+
+/// F6: stdin pipe → analytics records exactly 1 row.
+///
+/// `printf '...' | skim - --language=ts` must record 1 row in the analytics DB.
+/// This validates that the retained stdin buffer travels to the background
+/// tokenization thread and is not dropped.
+#[test]
+fn test_f6_stdin_records_one_row() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    let input = "function hello(name) { return `Hello ${name}`; }\nfunction bye() {}";
+
+    std::process::Command::new(common::skim_bin())
+        .args(["-", "--language=typescript"])
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(stdin) = child.stdin.take() {
+                let mut w = stdin;
+                let _ = w.write_all(input.as_bytes());
+            }
+            child.wait()
+        })
+        .expect("stdin run must succeed");
+
+    let count = count_rows(&db_path);
+    assert_eq!(
+        count, 1,
+        "F6: stdin pipe must record exactly 1 analytics row"
+    );
+}
+
+/// F6b: stdin with --filename hint → language correctly detected from filename.
+#[test]
+fn test_f6_stdin_with_filename_hint_detects_language() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    let input = "def greet(name):\n    return f'Hello {name}'\n";
+
+    std::process::Command::new(common::skim_bin())
+        .args(["-", "--filename=app.py"])
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(stdin) = child.stdin.take() {
+                let mut w = stdin;
+                let _ = w.write_all(input.as_bytes());
+            }
+            child.wait()
+        })
+        .expect("stdin run must succeed");
+
+    let count = count_rows(&db_path);
+    assert_eq!(count, 1, "F6b: stdin with --filename must record 1 row");
+
+    let lang: Option<String> = row_value(&db_path, "language");
+    assert_eq!(
+        lang.as_deref(),
+        Some("python"),
+        "F6b: language must be 'python' from --filename=app.py"
+    );
+}
+
+/// F13-stdin: SKIM_DISABLE_ANALYTICS=1 → 0 rows for stdin.
+#[test]
+fn test_f13_disable_analytics_no_rows_for_stdin() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("analytics.db");
+
+    let input = "function hello() {}";
+
+    // common::skim() sets SKIM_DISABLE_ANALYTICS=1
+    common::skim()
+        .args(["-", "--language=typescript"])
+        .env("SKIM_ANALYTICS_DB", &db_path)
+        .env_remove("SKIM_PASSTHROUGH")
+        .write_stdin(input)
+        .assert()
+        .success();
+
+    let count = count_rows(&db_path);
+    assert_eq!(
+        count, 0,
+        "F13-stdin: SKIM_DISABLE_ANALYTICS=1 must record 0 rows for stdin"
+    );
 }

--- a/crates/rskim/tests/cli_subcommand.rs
+++ b/crates/rskim/tests/cli_subcommand.rs
@@ -7,6 +7,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 const FIND_FIXTURE: &str = include_str!("fixtures/cmd/file/find_small.txt");
 const GH_FIXTURE: &str = include_str!("fixtures/cmd/infra/gh_pr_list.json");
@@ -21,7 +22,7 @@ const GH_RUN_VIEW_FIXTURE: &str = include_str!("fixtures/cmd/infra/gh_run_view.j
 const LOG_FIXTURE: &str = include_str!("fixtures/cmd/log/plaintext_mixed.txt");
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd
@@ -37,8 +38,7 @@ fn test_file_with_extension_routes_to_file_operation() {
     let file = dir.path().join("test.ts");
     fs::write(&file, "function add(a: number): number { return a; }").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file)
         .assert()
         .success()
@@ -52,8 +52,7 @@ fn test_file_named_init_py_routes_to_file_operation() {
     fs::write(&file, "def hello(): pass").unwrap();
 
     // "init" is a known subcommand, but "init.py" contains a dot
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file)
         .assert()
         .success()
@@ -68,8 +67,7 @@ fn test_path_with_separator_routes_to_file_operation() {
     let file = subdir.join("test.rs");
     fs::write(&file, "fn main() {}").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file)
         .arg("--mode=signatures")
         .assert()
@@ -78,8 +76,7 @@ fn test_path_with_separator_routes_to_file_operation() {
 
 #[test]
 fn test_stdin_dash_routes_to_file_operation() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("-l")
         .arg("rust")
@@ -96,8 +93,7 @@ fn test_glob_pattern_routes_to_file_operation() {
     fs::write(&file, "const x = 1;").unwrap();
 
     // Glob chars → FileOperation (use relative pattern with current_dir)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .current_dir(dir.path())
         .arg("*.ts")
         .assert()
@@ -107,21 +103,13 @@ fn test_glob_pattern_routes_to_file_operation() {
 #[test]
 fn test_dot_routes_to_file_operation() {
     // "." is a directory — contains a dot → FileOperation
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(".")
-        .assert()
-        .success();
+    common::skim().arg(".").assert().success();
 }
 
 #[test]
 fn test_no_positional_routes_to_file_operation() {
     // Flags only, no positional → FileOperation → clap handles --clear-cache
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg("--clear-cache")
-        .assert()
-        .success();
+    common::skim().arg("--clear-cache").assert().success();
 }
 
 #[test]
@@ -130,12 +118,7 @@ fn test_double_dash_before_subcommand_name_routes_to_file_operation() {
     // `--` means everything after is positional, so "test" is a file arg.
     // This will fail because no file named "test" exists, but the important
     // thing is it does NOT route to the subcommand stub.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
-        .arg("--")
-        .arg("test")
-        .assert()
-        .failure();
+    let output = common::skim().arg("--").arg("test").assert().failure();
 
     // Should get a file error, not "not yet implemented"
     output.stderr(predicate::str::contains("not yet implemented").not());
@@ -148,8 +131,7 @@ fn test_double_dash_before_subcommand_name_routes_to_file_operation() {
 #[test]
 fn test_known_subcommand_init_is_implemented() {
     // "init" is a known, implemented subcommand — help should work
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .arg("--help")
         .assert()
@@ -160,8 +142,7 @@ fn test_known_subcommand_init_is_implemented() {
 #[test]
 fn test_subcommand_init_with_unknown_flag_fails() {
     // "init" with an unknown flag should fail gracefully
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .arg("--nonexistent-flag")
         .assert()
@@ -171,8 +152,7 @@ fn test_subcommand_init_with_unknown_flag_fails() {
 
 #[test]
 fn test_subcommand_help_exits_zero() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("init")
         .arg("--help")
         .assert()
@@ -184,8 +164,7 @@ fn test_subcommand_help_exits_zero() {
 #[test]
 fn test_subcommand_short_help_exits_zero() {
     // v2.8.0: "build" is no longer a top-level subcommand; use "cargo" instead.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("cargo")
         .arg("-h")
         .assert()
@@ -208,8 +187,7 @@ fn test_full_path_to_file_named_as_subcommand_uses_separator_heuristic() {
     fs::write(&file, "fn setup() {}").unwrap();
 
     // Full path contains "/" → routes via path-separator heuristic (never reaches path.exists())
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file)
         .arg("-l")
         .arg("rust")
@@ -228,8 +206,7 @@ fn test_bare_file_named_as_subcommand_routes_to_subcommand() {
     // After the router fix, bare "init" ALWAYS routes to the subcommand
     // regardless of whether a file with that name exists on disk.
     // To read such a file, users must use ./init or the full path.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .current_dir(dir.path())
         .arg("init")
         .arg("--help")
@@ -250,11 +227,7 @@ fn test_full_path_to_dir_named_as_subcommand_uses_separator_heuristic() {
     fs::write(&file, "fn main() {}").unwrap();
 
     // Full path contains "/" → routes via path-separator heuristic (never reaches path.exists())
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&build_dir)
-        .assert()
-        .success();
+    common::skim().arg(&build_dir).assert().success();
 }
 
 #[test]
@@ -270,8 +243,7 @@ fn test_bare_dir_named_as_subcommand_routes_to_subcommand() {
     // regardless of whether a directory with that name exists on disk.
     // To process such a directory, users must use ./cargo or the full path.
     // v2.8.0: "cargo" is a top-level subcommand (was "build" previously).
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .current_dir(dir.path())
         .arg("cargo")
         .arg("--help")
@@ -293,8 +265,7 @@ fn test_mode_flag_consumes_next_token() {
 
     // `--mode signatures` — "signatures" is consumed by --mode, not treated
     // as a positional.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--mode")
         .arg("signatures")
         .arg(&file)
@@ -310,8 +281,7 @@ fn test_mode_equals_syntax_is_single_token() {
 
     // `--mode=signatures` is one token — the router sees no positional
     // before the file path.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--mode=signatures")
         .arg(&file)
         .assert()
@@ -326,8 +296,7 @@ fn test_mode_equals_syntax_is_single_token() {
 fn test_help_lists_subcommands() {
     // v2.8.0: Flat dispatch — tool names are top-level subcommands.
     // "test" and "build" are no longer category subcommands.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("--help")
         .assert()
         .success()
@@ -346,8 +315,7 @@ fn test_help_lists_subcommands() {
 fn test_unknown_word_routes_to_file_operation() {
     // "foobar" is not a known subcommand — routes to FileOperation.
     // Clap/file-processing will produce an error since the file doesn't exist.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("foobar")
         .assert()
         .failure()

--- a/crates/rskim/tests/cli_test_cargo.rs
+++ b/crates/rskim/tests/cli_test_cargo.rs
@@ -6,6 +6,7 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+mod common;
 
 // ============================================================================
 // Real cargo test execution
@@ -16,8 +17,7 @@ fn test_skim_test_cargo_in_this_repo() {
     // Run `skim cargo test -p rskim-core` on skim's own repo.
     // This executes a real `cargo test` and parses the output.
     // We use -p rskim-core to limit scope and speed up the test.
-    let assert = Command::cargo_bin("skim")
-        .unwrap()
+    let assert = common::skim()
         .args(["cargo", "test", "-p", "rskim-core"])
         .env_remove("SKIM_PASSTHROUGH")
         .timeout(std::time::Duration::from_secs(120))
@@ -34,8 +34,7 @@ fn test_skim_test_cargo_in_this_repo() {
 #[test]
 fn test_skim_cargo_help() {
     // v2.8.0: `skim cargo --help` — "test" is no longer a subcommand.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "--help"])
         .assert()
         .success()
@@ -62,8 +61,7 @@ fn test_skim_test_cargo_stdin_json() {
 {"type":"suite","event":"ok","passed":2,"failed":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.003}
 "#;
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "test"])
         // Remove SKIM_PASSTHROUGH so compression is not bypassed inside the child process.
         .env_remove("SKIM_PASSTHROUGH")
@@ -85,8 +83,7 @@ fn test_skim_test_cargo_stdin_plain_text() {
         test test_five ... ok\n\n\
         test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "test"])
         // Remove SKIM_PASSTHROUGH so compression is not bypassed inside the child process.
         .env_remove("SKIM_PASSTHROUGH")
@@ -111,8 +108,7 @@ fn test_skim_test_cargo_stdin_plain_text() {
 /// this subcommand. The help text confirms nextest is listed as supported.
 #[test]
 fn test_skim_cargo_nextest_is_listed_in_help_as_supported() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "--help"])
         .assert()
         .success()
@@ -133,8 +129,7 @@ fn test_skim_cargo_nextest_is_listed_in_help_as_supported() {
 fn test_skim_cargo_nextest_output_piped_via_test_arm_passes_through() {
     let nextest_pass = include_str!("fixtures/cmd/test/cargo_nextest_pass.txt");
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "test"])
         .write_stdin(nextest_pass)
         .assert()
@@ -157,8 +152,7 @@ fn test_skim_cargo_t_alias_stdin_json() {
 {"type":"suite","event":"ok","passed":1,"failed":0,"ignored":0,"measured":0,"filtered_out":0,"exec_time":0.001}
 "#;
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "t"])
         // Remove SKIM_PASSTHROUGH so compression is not bypassed inside the child process.
         .env_remove("SKIM_PASSTHROUGH")
@@ -176,8 +170,7 @@ fn test_skim_cargo_t_alias_stdin_json() {
 /// Since the repo is already built, incremental compilation is fast.
 #[test]
 fn test_skim_cargo_b_alias_dispatches_to_build() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "b"])
         // Must not produce an error about unknown subcommand
         .assert()
@@ -195,8 +188,7 @@ fn test_skim_cargo_b_alias_dispatches_to_build() {
 /// on stderr. This covers the `unknown` arm in `dispatch_cargo`.
 #[test]
 fn test_skim_cargo_unknown_subcommand_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["cargo", "unknownthing"])
         .assert()
         .failure()
@@ -211,8 +203,7 @@ fn test_skim_cargo_unknown_subcommand_errors() {
 /// Covers the `unknown` arm in `dispatch_go`.
 #[test]
 fn test_skim_go_unknown_subcommand_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["go", "unknownthing"])
         .assert()
         .failure()
@@ -223,8 +214,7 @@ fn test_skim_go_unknown_subcommand_errors() {
 /// Covers the `other` arm in `pkg::npm::run`.
 #[test]
 fn test_skim_npm_unknown_subcommand_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["npm", "unknownthing"])
         .assert()
         .failure()
@@ -235,8 +225,7 @@ fn test_skim_npm_unknown_subcommand_errors() {
 /// Covers the `other` arm in `pkg::pnpm::run`.
 #[test]
 fn test_skim_pnpm_unknown_subcommand_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["pnpm", "unknownthing"])
         .assert()
         .failure()
@@ -247,8 +236,7 @@ fn test_skim_pnpm_unknown_subcommand_errors() {
 /// Covers the `other` arm in `pkg::pip::run`.
 #[test]
 fn test_skim_pip_unknown_subcommand_errors() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["pip", "unknownthing"])
         .assert()
         .failure()

--- a/crates/rskim/tests/cli_test_cargo.rs
+++ b/crates/rskim/tests/cli_test_cargo.rs
@@ -4,7 +4,6 @@
 //!
 //! Tests the end-to-end cargo test parser via the CLI binary.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 mod common;
 

--- a/crates/rskim/tests/cli_test_go.rs
+++ b/crates/rskim/tests/cli_test_go.rs
@@ -5,6 +5,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::process::Command as StdCommand;
+mod common;
 
 // ============================================================================
 // Help and basic routing
@@ -13,8 +14,7 @@ use std::process::Command as StdCommand;
 #[test]
 fn test_skim_go_help() {
     // v2.8.0: `skim go --help` — "test" is no longer a subcommand.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("go")
         .arg("--help")
         .assert()
@@ -60,8 +60,7 @@ func TestAdd(t *testing.T) {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .current_dir(dir.path())
         .arg("go")
         .arg("test")

--- a/crates/rskim/tests/cli_test_go.rs
+++ b/crates/rskim/tests/cli_test_go.rs
@@ -2,7 +2,6 @@
 //!
 //! v2.8.0: Flat dispatch — `skim go test` replaces `skim test go`.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::process::Command as StdCommand;
 mod common;

--- a/crates/rskim/tests/cli_test_pytest.rs
+++ b/crates/rskim/tests/cli_test_pytest.rs
@@ -8,9 +8,10 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::process;
+mod common;
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd
 }
@@ -25,11 +26,7 @@ fn test_skim_pytest_help() {
     // `skim pytest` with --help and no stdin should attempt to run pytest --help.
     // Since we can't guarantee pytest is installed, we just check that
     // the subcommand routing works (doesn't say "not yet implemented").
-    let output = Command::cargo_bin("skim")
-        .unwrap()
-        .args(["pytest", "--help"])
-        .output()
-        .unwrap();
+    let output = common::skim().args(["pytest", "--help"]).output().unwrap();
 
     // If pytest is installed, it shows pytest help.
     // If not, we get an error about pytest not being found.
@@ -101,8 +98,7 @@ fn test_piped_all_failures() {
 
 #[test]
 fn test_piped_passthrough_for_garbage() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["pytest"])
         .write_stdin("this is not pytest output\n")
         .assert()
@@ -119,8 +115,7 @@ fn test_piped_passthrough_for_garbage() {
 #[test]
 fn test_piped_passthrough_mode_skips_compression() {
     let fixture = include_str!("fixtures/cmd/test/pytest_fail.txt");
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .args(["pytest"])
         .env("SKIM_PASSTHROUGH", "1")
         .write_stdin(fixture)
@@ -221,8 +216,7 @@ fn test_pytest_with_args_does_not_read_stdin() {
     // (unlike vitest which has an npx fallback producing stdout). Assert
     // on stderr to prove the spawn path was taken — the "pytest" name in
     // the error message confirms skim attempted to exec it.
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env_remove("SKIM_DEBUG")
         .arg("pytest")

--- a/crates/rskim/tests/cli_test_vitest.rs
+++ b/crates/rskim/tests/cli_test_vitest.rs
@@ -5,6 +5,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::PathBuf;
+mod common;
 
 fn fixture_path(name: &str) -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -22,7 +23,7 @@ fn read_fixture(name: &str) -> String {
 }
 
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd
 }
@@ -170,8 +171,7 @@ fn test_vitest_with_args_does_not_read_stdin() {
     //
     // The key assertion: stdout must NOT be empty. Skim spawns vitest run (which
     // is not installed), producing an error message on stdout.
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env_remove("SKIM_DEBUG")
         .arg("vitest")
@@ -183,8 +183,7 @@ fn test_vitest_with_args_does_not_read_stdin() {
 
 #[test]
 fn test_jest_with_args_does_not_read_stdin() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .env_remove("SKIM_PASSTHROUGH")
         .env_remove("SKIM_DEBUG")
         .arg("jest")

--- a/crates/rskim/tests/cli_token_budget.rs
+++ b/crates/rskim/tests/cli_token_budget.rs
@@ -7,10 +7,11 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::PathBuf;
 use tempfile::TempDir;
+mod common;
 
 /// Get a command for the skim binary
 fn skim_cmd() -> Command {
-    let mut cmd = Command::cargo_bin("skim").unwrap();
+    let mut cmd = common::skim();
     cmd.env_remove("SKIM_PASSTHROUGH");
     cmd.env_remove("SKIM_DEBUG");
     cmd

--- a/crates/rskim/tests/cli_tokens.rs
+++ b/crates/rskim/tests/cli_tokens.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests token reduction statistics output
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;

--- a/crates/rskim/tests/cli_tokens.rs
+++ b/crates/rskim/tests/cli_tokens.rs
@@ -6,6 +6,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 #[test]
 fn test_show_stats_single_file() {
@@ -17,8 +18,7 @@ fn test_show_stats_single_file() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()
@@ -50,8 +50,7 @@ fn test_show_stats_multiple_files() {
     .unwrap();
 
     // Stats should show aggregated counts for multiple files
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .arg("--show-stats")
         .current_dir(temp_dir.path())
@@ -71,8 +70,7 @@ fn test_show_stats_with_structure_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode=structure")
         .arg("--show-stats")
@@ -92,8 +90,7 @@ fn test_show_stats_with_signatures_mode() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode=signatures")
         .arg("--show-stats")
@@ -110,8 +107,7 @@ fn test_show_stats_with_full_mode() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // Full mode should show 0% reduction (or 100% of original)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--mode=full")
         .arg("--show-stats")
@@ -122,8 +118,7 @@ fn test_show_stats_with_full_mode() {
 
 #[test]
 fn test_show_stats_with_stdin() {
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--language=typescript")
         .arg("--show-stats")
@@ -141,8 +136,7 @@ fn test_no_stats_by_default() {
     fs::write(&file_path, "function test() { return 42; }").unwrap();
 
     // Without --show-stats, stderr should be empty (no stats output)
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -171,8 +165,7 @@ fn test_show_stats_format_contains_reduction_percentage() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode=structure")
         .arg("--show-stats")
@@ -200,8 +193,7 @@ fn test_show_stats_with_python() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()
@@ -220,8 +212,7 @@ fn test_show_stats_with_rust() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()
@@ -238,8 +229,7 @@ fn test_show_stats_with_glob_and_no_header() {
     fs::write(temp_dir.path().join("b.ts"), "function b() {}").unwrap();
 
     // Stats should still work with --no-header flag
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("*.ts")
         .arg("--no-header")
         .arg("--show-stats")
@@ -257,8 +247,7 @@ fn test_show_stats_empty_file() {
     fs::write(&file_path, "").unwrap();
 
     // Empty file should still work with --show-stats (likely 0 → 0 tokens)
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()

--- a/crates/rskim/tests/cli_tokens_golden.rs
+++ b/crates/rskim/tests/cli_tokens_golden.rs
@@ -11,7 +11,6 @@
 //! Pinned against: tiktoken-rs 0.7.0 cl100k_base (workspace version).
 //! Source file: tests/fixtures/typescript/simple.ts
 
-use assert_cmd::Command;
 use std::path::PathBuf;
 mod common;
 

--- a/crates/rskim/tests/cli_tokens_golden.rs
+++ b/crates/rskim/tests/cli_tokens_golden.rs
@@ -13,6 +13,7 @@
 
 use assert_cmd::Command;
 use std::path::PathBuf;
+mod common;
 
 /// Path to the fixture file used to capture the golden.
 fn golden_fixture() -> PathBuf {
@@ -31,8 +32,7 @@ fn ac13_show_stats_exact_golden() {
     let fixture = golden_fixture();
     assert!(fixture.exists(), "Golden fixture must exist: {:?}", fixture);
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(fixture.to_str().unwrap())
         .arg("--show-stats")
         .env_remove("SKIM_PASSTHROUGH")

--- a/crates/rskim/tests/cli_wrapper_argv0.rs
+++ b/crates/rskim/tests/cli_wrapper_argv0.rs
@@ -34,6 +34,8 @@
 //!
 //! Unix-only: `arg0()` is defined on `std::os::unix::process::CommandExt`.
 
+mod common;
+
 #[cfg(unix)]
 mod argv0_dispatch {
     use std::fs;

--- a/crates/rskim/tests/cli_yaml.rs
+++ b/crates/rskim/tests/cli_yaml.rs
@@ -6,6 +6,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
+mod common;
 
 // ============================================================================
 // Basic Structure Tests
@@ -25,8 +26,7 @@ active: true
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("structure")
@@ -68,8 +68,7 @@ fn test_yaml_nested_structure() {
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -119,8 +118,7 @@ metadata:
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -162,8 +160,7 @@ nested:
     fs::write(&file_path, yaml_content).unwrap();
 
     // Get output for each mode
-    let structure_output = Command::cargo_bin("skim")
-        .unwrap()
+    let structure_output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("structure")
@@ -173,8 +170,7 @@ nested:
         .stdout
         .clone();
 
-    let signatures_output = Command::cargo_bin("skim")
-        .unwrap()
+    let signatures_output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("signatures")
@@ -184,8 +180,7 @@ nested:
         .stdout
         .clone();
 
-    let types_output = Command::cargo_bin("skim")
-        .unwrap()
+    let types_output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("types")
@@ -195,8 +190,7 @@ nested:
         .stdout
         .clone();
 
-    let full_output = Command::cargo_bin("skim")
-        .unwrap()
+    let full_output = common::skim()
         .arg(&file_path)
         .arg("--mode")
         .arg("full")
@@ -229,8 +223,7 @@ fn test_yaml_auto_detection_yaml_extension() {
     let file_path = temp_dir.path().join("config.yaml");
     fs::write(&file_path, "key: value").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -244,8 +237,7 @@ fn test_yaml_auto_detection_yml_extension() {
     let file_path = temp_dir.path().join("config.yml");
     fs::write(&file_path, "key: value").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -263,8 +255,7 @@ fn test_yaml_from_stdin() {
 value: 42
 "#;
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg("-")
         .arg("--language")
         .arg("yaml")
@@ -287,8 +278,7 @@ value: 42
 fn test_yaml_from_stdin_yml_alias() {
     let yaml_content = "key: value";
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg("-")
         .arg("--language")
         .arg("yml")
@@ -308,11 +298,7 @@ fn test_yaml_empty_file() {
     let file_path = temp_dir.path().join("empty.yaml");
     fs::write(&file_path, "").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
-        .arg(&file_path)
-        .assert()
-        .success();
+    common::skim().arg(&file_path).assert().success();
 }
 
 #[test]
@@ -321,8 +307,7 @@ fn test_yaml_invalid_syntax() {
     let file_path = temp_dir.path().join("invalid.yaml");
     fs::write(&file_path, "invalid: [unclosed").unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .failure()
@@ -347,8 +332,7 @@ tags:
     )
     .unwrap();
 
-    let output = Command::cargo_bin("skim")
-        .unwrap()
+    let output = common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -418,8 +402,7 @@ spec:
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -458,8 +441,7 @@ jobs:
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .assert()
         .success()
@@ -492,8 +474,7 @@ fn test_yaml_show_stats() {
     )
     .unwrap();
 
-    Command::cargo_bin("skim")
-        .unwrap()
+    common::skim()
         .arg(&file_path)
         .arg("--show-stats")
         .assert()

--- a/crates/rskim/tests/cli_yaml.rs
+++ b/crates/rskim/tests/cli_yaml.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests YAML structure extraction with various modes and fixtures.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;

--- a/crates/rskim/tests/common/mod.rs
+++ b/crates/rskim/tests/common/mod.rs
@@ -1,0 +1,63 @@
+//! Shared test harness for rskim integration tests.
+//!
+//! ## Design
+//!
+//! All helpers in this module are `pub` so each integration test binary (each
+//! `tests/*.rs` file is compiled as a separate crate) can use them after adding
+//! `mod common;` at the top of the file.
+//!
+//! ## Analytics isolation
+//!
+//! The safe default is **analytics OFF**: `skim()` sets `SKIM_DISABLE_ANALYTICS=1`
+//! so test invocations never write to the developer's real `~/.cache/skim/analytics.db`.
+//!
+//! Tests that assert on recorded analytics data must use `skim_with_analytics(db)`
+//! instead — it points at an isolated temp DB and re-enables recording.
+//!
+//! ## Dead-code suppression
+//!
+//! Each test binary compiles `common` independently. A binary that does not call
+//! every helper will trigger an "unused" warning without this attribute.
+#![allow(dead_code)]
+
+/// Build a `skim` command with analytics disabled — the safe default.
+///
+/// Sets:
+/// - `SKIM_DISABLE_ANALYTICS=1` — no rows written to any analytics DB.
+/// - `NO_COLOR=1` — deterministic, color-free output for assertions.
+///
+/// Callers may chain additional `.env(...)` / `.env_remove(...)` / `.args(...)`
+/// calls. Per-test env overrides applied after this call take precedence.
+pub fn skim() -> assert_cmd::Command {
+    let mut c = assert_cmd::Command::cargo_bin("skim").unwrap();
+    c.env("SKIM_DISABLE_ANALYTICS", "1").env("NO_COLOR", "1");
+    c
+}
+
+/// Return the path to the skim binary built by cargo.
+///
+/// Use this when you need a `std::process::Command` rather than an
+/// `assert_cmd::Command` (e.g. for `argv[0]` override via `CommandExt::arg0`).
+pub fn skim_bin() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("skim")
+}
+
+/// Build a `skim` command pointed at an isolated analytics DB, with recording
+/// **enabled**.
+///
+/// Use this (and only this) for tests that assert on rows written to the
+/// analytics database. Pass a `TempDir`-backed path so the DB is cleaned up
+/// after the test.
+///
+/// Sets:
+/// - `SKIM_ANALYTICS_DB=<db>` — all writes go to the isolated file.
+/// - `NO_COLOR=1` — deterministic output.
+///
+/// `SKIM_DISABLE_ANALYTICS` is explicitly removed so recording is active.
+pub fn skim_with_analytics(db: &std::path::Path) -> assert_cmd::Command {
+    let mut c = assert_cmd::Command::cargo_bin("skim").unwrap();
+    c.env("SKIM_ANALYTICS_DB", db)
+        .env_remove("SKIM_DISABLE_ANALYTICS")
+        .env("NO_COLOR", "1");
+    c
+}


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in skim's cache/analytics layer (#359), landed together because Problem B's fix is what lets Problem A's tests isolate the parser cache cleanly.

**Problem A — silent analytics loss (PF-001).** Plain `skim <file>` — the most common invocation (agents calling skim via the hook) — silently dropped token-savings analytics unless the parser cache already carried token counts (i.e. a prior `--show-stats` run). On a cold cache, a plain-warmed entry, or `--no-cache`, nothing was recorded, so most real savings data was lost. Root cause: token counts were computed on the main thread only under `--show-stats`, and the file-op path lacked the background-tokenization fallback every subcommand already had.

**Problem B — `SKIM_CACHE_DIR` drift (PF-002).** `SKIM_CACHE_DIR` was honored by the search index and hook log but silently ignored by the parser cache, tee output, and the default `analytics.db` path — two cache-dir resolvers had drifted apart.

## What changed

- **Unified background recorder** (`record_file_ops`, `analytics/mod.rs`): tokenizes off the main thread — registered via `register_thread` so `flush_pending()` joins it — AFTER stdout is flushed, preserving the streaming contract (analytics never delays or alters output). Emits per-file rows for single-file, stdin, and multi/glob/dir, each carrying the **detected** language, independent of cache state. Single-file re-reads the source through the 50 MB-guarded, TOCTOU-safe `read_source`; stdin retains its buffer; deleted/changed/non-UTF8 files are skipped best-effort (no panic).
- **Single cache-root resolver** (`cache::cache_root` / `cache_root_from`): `get_cache_dir` and `hook_log::CacheEnv` both delegate to it. `SKIM_CACHE_DIR` now relocates the parser cache, tee output, **and** the default `analytics.db`; `SKIM_ANALYTICS_DB` still wins when explicitly set; empty/whitespace `SKIM_CACHE_DIR` is treated as unset.
- **Shared, analytics-isolated test harness** (`tests/common/mod.rs`): analytics-OFF-by-default `skim()` plus opt-in `skim_with_analytics(db)`; ~49 integration test files migrated so the new file-op recording can never write to a developer's real `analytics.db`.

## Behavior changes (documented)

- The default `analytics.db` relocates with `SKIM_CACHE_DIR` (prior history at the old path is orphaned, not migrated).
- File-op analytics rows now carry the **detected** language (previously `--language`-only).
- Multi-file/glob/directory now emit **N per-file rows** (previously a single aggregate row).
- No `token_savings` schema change / no migration; the subcommand analytics path (`record_fire_and_forget`) is untouched; stdout is byte-identical for all file ops.

## Commits

`B` unify cache-dir resolution → `T` shared test harness + migrate integration tests → `A1` background recorder + single-file/stdin + `ProcessResult.language`/`stdin_raw` → `A2` multi/glob/dir per-file rows → `T-fix` repair a `mod common;` migration defect → `simplify` 1-line clarity → `test` B1 relocation test + CHANGELOG + comment cleanup.

## Verification

- **Suite green:** 2943 rskim integration tests + 470 rskim-core (4006 under `--all-targets`), 1 pre-existing unrelated hang filtered (`runner::tests::test_node_fallback_local_bin_found`); `cargo clippy -p rskim -p rskim-core --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- **Acceptance QA on the real binary (isolated DBs):** F1 `1|file|rust`; F3 plain vs `--show-stats` token-count parity; F7 mixed-language → 3 per-file rows; F8 directory → N rows; F11 empty file → `1|0|0.0` (no panic); F13 `SKIM_DISABLE_ANALYTICS=1` → 0 rows; B1 `SKIM_CACHE_DIR` alone → `analytics.db` + parser cache both land in the dir (1 row); B4 `SKIM_ANALYTICS_DB` precedence; B7 empty `SKIM_CACHE_DIR` → exit 0; C3 stdout byte-identical analytics on vs off.

## Out of scope

Unsupported-extension input currently exits `1` rather than the documented `3` — verified **pre-existing on `main`** and untouched by this branch (exit-code routing unchanged). Worth a separate issue.

Closes #359.