### PR TITLE
perf(search): early-exit synthetic verify + pool cap for --ast <pattern> (#394 AC11/#419)

### DIFF
--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -292,8 +292,62 @@ pub fn extract_ast_ngrams_with_metrics(
     nodes: &[LinearNode],
     lang: Language,
 ) -> (AstNgramSet, StructuralMetrics) {
+    match run_extraction(nodes, lang) {
+        Some(state) => state.into_ngram_set(),
+        None => (AstNgramSet::default(), StructuralMetrics::default()),
+    }
+}
+
+/// Extract structural n-grams, per-file metrics, AND a representative source
+/// position per emitted synthetic marker — in the SAME single pass as
+/// [`extract_ast_ngrams_with_metrics`] (AD-394-6, OD-394-1).
+///
+/// `recover_line`'s synthetic branch (AD-394-5, `compound::reparse`) calls this
+/// to recover a representative `:line` for a matched synthetic-marker AST
+/// pattern (god-function, deep-nesting, empty-function, empty-catch,
+/// excessive-params), reusing the exact traversal that emitted the marker
+/// instead of re-implementing detection on a second CST walk (ADR-006 — the
+/// indexer is the single source of truth).
+///
+/// [`extract_ast_ngrams_with_metrics`]'s 2-tuple signature is preserved
+/// unchanged for its 4 existing callers (and the GOLD pattern-catalog test) —
+/// both functions share the SAME [`run_extraction`] traversal; this wrapper
+/// simply keeps the synthetic-marker position side table instead of dropping
+/// it, so there is zero risk of the two entry points drifting apart.
+///
+/// # Returns
+///
+/// `(AstNgramSet, StructuralMetrics, synthetic_lines)` where `synthetic_lines`
+/// maps each emitted synthetic [`AstBigram`] to its representative
+/// `(1-indexed line, start byte)`, recorded per AD-394-5's per-pattern rule.
+/// The MIN line wins on repeat emission within a file (deterministic — AC-F3:
+/// identical file + pattern always yields the same result).
+#[must_use]
+pub fn extract_ast_ngrams_with_lines(
+    nodes: &[LinearNode],
+    lang: Language,
+) -> (
+    AstNgramSet,
+    StructuralMetrics,
+    HashMap<AstBigram, (u32, u32)>,
+) {
+    match run_extraction(nodes, lang) {
+        Some(state) => state.into_ngram_set_with_lines(),
+        None => (
+            AstNgramSet::default(),
+            StructuralMetrics::default(),
+            HashMap::new(),
+        ),
+    }
+}
+
+/// Shared single-pass traversal used by both [`extract_ast_ngrams_with_metrics`]
+/// and [`extract_ast_ngrams_with_lines`] (ADR-006: one implementation, no
+/// drift between the membership-only and lines-preserving entry points).
+/// Returns `None` for empty input; callers substitute the empty defaults.
+fn run_extraction(nodes: &[LinearNode], lang: Language) -> Option<ExtractState> {
     if nodes.is_empty() {
-        return (AstNgramSet::default(), StructuralMetrics::default());
+        return None;
     }
 
     let max_depth = nodes.iter().map(|n| n.depth).max().unwrap_or(0);
@@ -304,7 +358,7 @@ pub fn extract_ast_ngrams_with_metrics(
         let d = usize::from(node.depth);
 
         state.update_max_depth(node.depth);
-        state.emit_depth_buckets(node.depth);
+        state.emit_depth_buckets(node.depth, node.start_line, node.start_byte);
 
         // ── Gap-fill (PF-004 safe: widen to u32) ────────────────────────────
         // When a depth jump > +1 occurs, null ancestor slots AND child_counts
@@ -332,7 +386,7 @@ pub fn extract_ast_ngrams_with_metrics(
 
         state.update_branch_count(node.kind_id);
         state.emit_real_ngrams(node, lang);
-        state.record_node(d, node.kind_id);
+        state.record_node(d, node.kind_id, node.start_line, node.start_byte);
 
         prev_depth = Some(node.depth);
     }
@@ -345,7 +399,7 @@ pub fn extract_ast_ngrams_with_metrics(
         state.close_open_subtrees(0, p);
     }
 
-    state.into_ngram_set()
+    Some(state)
 }
 
 // ============================================================================
@@ -376,8 +430,25 @@ struct ExtractState {
     /// `close_depth` can read the enclosing-parent kind after a sibling
     /// overwrites the `ancestors` slot to `None`.
     depth_kind: Vec<NodeKindId>,
+    /// AD-394-6: mirrors `depth_kind` — the 1-indexed source line of the node
+    /// last recorded at each depth. Deliberately NOT nulled by gap-fill (same
+    /// rationale as `depth_kind`): `close_depth` reads `depth_line[depth_idx-1]`
+    /// for the enclosing construct's representative line even after a sibling
+    /// has invalidated `ancestors` at that slot.
+    depth_line: Vec<u32>,
+    /// AD-394-6: mirrors `depth_line` — the start byte of the node last
+    /// recorded at each depth.
+    depth_byte: Vec<u32>,
     bigram_map: HashMap<AstBigram, (f32, u32)>,
     trigram_map: HashMap<AstTrigram, (f32, u32)>,
+    /// AD-394-5 / AD-394-6: representative `(1-indexed line, start byte)` per
+    /// emitted synthetic bigram, recorded at the SAME emission site that adds
+    /// the marker to `bigram_map` — so `recover_line`'s synthetic branch never
+    /// needs a second, drift-prone detection pass (ADR-006). Keyed by the
+    /// encoded `AstBigram`: synthetic markers are always bigrams (no synthetic
+    /// trigram is ever emitted by this module). MIN line wins on repeat
+    /// emission within a file (AC-F3 determinism: topmost occurrence).
+    synthetic_lines: HashMap<AstBigram, (u32, u32)>,
     metrics: StructuralMetrics,
 }
 
@@ -389,8 +460,11 @@ impl ExtractState {
             ancestors: vec![None; table_len],
             child_counts: vec![0u32; table_len],
             depth_kind: vec![0u16; table_len],
+            depth_line: vec![0u32; table_len],
+            depth_byte: vec![0u32; table_len],
             bigram_map: HashMap::with_capacity(cap),
             trigram_map: HashMap::with_capacity(cap),
+            synthetic_lines: HashMap::new(),
             metrics: StructuralMetrics::default(),
         }
     }
@@ -403,13 +477,23 @@ impl ExtractState {
 
     /// Emit cumulative `DEEP_NODE → bucket_label(i)` synthetics for every
     /// depth bucket edge crossed by `depth`.
+    ///
+    /// AD-394-5: the representative position for a DEEP_NODE marker is the
+    /// CURRENT node's own `(line, byte)` — the first node whose depth crosses
+    /// the edge. `line`/`byte` are passed in explicitly (not read from
+    /// `depth_line`/`depth_byte`) because this runs BEFORE `record_node` for
+    /// this node, so the depth-indexed arrays still hold the previous
+    /// occupant's position at this point in the loop.
     #[inline]
-    fn emit_depth_buckets(&mut self, depth: u16) {
+    fn emit_depth_buckets(&mut self, depth: u16, line: u32, byte: u32) {
         emit_bucket_crossings(
             &mut self.bigram_map,
+            &mut self.synthetic_lines,
             DEEP_NODE,
             &DEPTH_EDGES,
             u32::from(depth),
+            line,
+            byte,
         );
     }
 
@@ -465,14 +549,20 @@ impl ExtractState {
         let close_start = usize::from(node_depth);
         let close_end = usize::from(prev_depth);
         if close_end >= close_start {
+            let tables = DepthTables {
+                kind: &self.depth_kind,
+                line: &self.depth_line,
+                byte: &self.depth_byte,
+            };
             for depth_to_close in (close_start..=close_end).rev() {
                 if self.ancestors[depth_to_close].is_some() {
                     close_depth(
                         depth_to_close,
                         &self.child_counts,
-                        &self.depth_kind,
+                        tables,
                         &mut self.metrics,
                         &mut self.bigram_map,
+                        &mut self.synthetic_lines,
                     );
                 }
             }
@@ -536,20 +626,42 @@ impl ExtractState {
         }
     }
 
-    /// Record `node.kind_id` in the ancestor table at `depth d` and reset
-    /// `child_counts[d]` to zero (this node's children have not been seen yet).
+    /// Record `node.kind_id`/position in the ancestor table at depth `d` and
+    /// reset `child_counts[d]` to zero (this node's children have not been
+    /// seen yet). `line`/`byte` populate `depth_line`/`depth_byte` (AD-394-6).
     ///
     /// Sentinel nodes (`kind_id == 0`) ARE recorded here to preserve correct
     /// depth positions for their descendants. Suppression happens at emit time.
     #[inline]
-    fn record_node(&mut self, d: usize, kind_id: NodeKindId) {
+    fn record_node(&mut self, d: usize, kind_id: NodeKindId, line: u32, byte: u32) {
         self.ancestors[d] = Some(kind_id);
         self.depth_kind[d] = kind_id;
+        self.depth_line[d] = line;
+        self.depth_byte[d] = byte;
         self.child_counts[d] = 0;
     }
 
-    /// Consume the state and return the sorted `(AstNgramSet, StructuralMetrics)`.
+    /// Consume the state and return the sorted `(AstNgramSet, StructuralMetrics)`,
+    /// discarding the synthetic-marker position side table. Used by
+    /// [`extract_ast_ngrams_with_metrics`] — its 4 existing callers need
+    /// membership/metrics only, never positions.
     fn into_ngram_set(self) -> (AstNgramSet, StructuralMetrics) {
+        let (set, metrics, _lines) = self.into_ngram_set_with_lines();
+        (set, metrics)
+    }
+
+    /// AD-394-6: consume the state and return the sorted
+    /// `(AstNgramSet, StructuralMetrics, synthetic_lines)` — the
+    /// lines-preserving form used by [`extract_ast_ngrams_with_lines`]. Shares
+    /// the exact sort logic with [`Self::into_ngram_set`] (which delegates
+    /// here), so there is only one implementation to maintain.
+    fn into_ngram_set_with_lines(
+        self,
+    ) -> (
+        AstNgramSet,
+        StructuralMetrics,
+        HashMap<AstBigram, (u32, u32)>,
+    ) {
         let mut bigrams: Vec<AstBigramEntry> = self
             .bigram_map
             .into_iter()
@@ -572,7 +684,11 @@ impl ExtractState {
             .collect();
         trigrams.sort_unstable_by_key(|e| e.ngram.key());
 
-        (AstNgramSet { bigrams, trigrams }, self.metrics)
+        (
+            AstNgramSet { bigrams, trigrams },
+            self.metrics,
+            self.synthetic_lines,
+        )
     }
 }
 
@@ -583,33 +699,63 @@ impl ExtractState {
 /// Emit a synthetic bigram `(parent → child)` with `DEFAULT_AST_WEIGHT` and
 /// `count = 1` into `bigram_map`, incrementing the count when the key is
 /// already present (saturating).
+///
+/// AD-394-5 / AD-394-6: also records `(line, byte)` into `synthetic_lines`,
+/// keeping the MIN line per key (topmost occurrence in the file) so
+/// `recover_line`'s synthetic branch has a deterministic representative
+/// position (AC-F3).
 #[inline]
 fn emit_synthetic(
     bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+    synthetic_lines: &mut HashMap<AstBigram, (u32, u32)>,
     parent: NodeKindId,
     child: NodeKindId,
+    line: u32,
+    byte: u32,
 ) {
     use crate::ast_index::DEFAULT_AST_WEIGHT;
     let key = AstBigram::encode(parent, child);
     let entry = bigram_map.entry(key).or_insert((DEFAULT_AST_WEIGHT, 0));
     entry.1 = entry.1.saturating_add(1);
+
+    synthetic_lines
+        .entry(key)
+        .and_modify(|(existing_line, existing_byte)| {
+            if line < *existing_line {
+                *existing_line = line;
+                *existing_byte = byte;
+            }
+        })
+        .or_insert((line, byte));
 }
 
 /// Emit cumulative bucket crossings: for each `(i, edge)` in `edges` where
 /// `value >= edge`, emit `parent → bucket_label(i)` into `bigram_map`.
 ///
 /// Used by depth-bucket, large-body, and many-params emission — all three share
-/// the same cumulative threshold pattern.
+/// the same cumulative threshold pattern. `line`/`byte` are the representative
+/// position recorded for every bucket crossed (AD-394-5: callers pass a
+/// different position source per marker — see call sites).
 #[inline]
 fn emit_bucket_crossings(
     bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+    synthetic_lines: &mut HashMap<AstBigram, (u32, u32)>,
     parent: NodeKindId,
     edges: &[u32],
     value: u32,
+    line: u32,
+    byte: u32,
 ) {
     for (i, &edge) in edges.iter().enumerate() {
         if value >= edge {
-            emit_synthetic(bigram_map, parent, bucket_label(i));
+            emit_synthetic(
+                bigram_map,
+                synthetic_lines,
+                parent,
+                bucket_label(i),
+                line,
+                byte,
+            );
         }
     }
 }
@@ -617,6 +763,19 @@ fn emit_bucket_crossings(
 // ============================================================================
 // close_depth — emit synthetic markers when a depth slot's subtree closes
 // ============================================================================
+
+/// Depth-indexed lookup tables consumed by [`close_depth`] — `kind`, and the
+/// AD-394-6 `line`/`byte` position, all indexed by the SAME depth and always
+/// read together. Grouped into one `Copy` struct (of borrows) so `close_depth`
+/// takes one cohesive parameter instead of three always-together slices
+/// (keeps the function under clippy's `too_many_arguments` threshold without
+/// an `#[allow]`).
+#[derive(Clone, Copy)]
+struct DepthTables<'a> {
+    kind: &'a [NodeKindId],
+    line: &'a [u32],
+    byte: &'a [u32],
+}
 
 /// Close a depth slot: emit synthetic markers for the node at `depth_idx`
 /// based on its accumulated `child_counts` and kind.
@@ -627,28 +786,45 @@ fn emit_bucket_crossings(
 fn close_depth(
     depth_idx: usize,
     child_counts: &[u32],
-    depth_kind: &[NodeKindId],
+    tables: DepthTables<'_>,
     metrics: &mut StructuralMetrics,
     bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+    synthetic_lines: &mut HashMap<AstBigram, (u32, u32)>,
 ) {
-    let kind_id = depth_kind[depth_idx];
+    let kind_id = tables.kind[depth_idx];
     if kind_id == 0 {
         return; // sentinel — not a real construct, skip
     }
 
     // Compute enclosing_id once: the parent of this slot (depth_idx - 1).
     // Both BODY and PARAM_LIST branches need it; computing it here removes
-    // the duplicated `depth_idx > 0` guard and `depth_kind[depth_idx - 1]`
+    // the duplicated `depth_idx > 0` guard and `tables.kind[depth_idx - 1]`
     // lookup that previously appeared in two separate inner blocks.
     let enclosing_id: Option<NodeKindId> = depth_idx
         .checked_sub(1)
-        .map(|pd| depth_kind[pd])
+        .map(|pd| tables.kind[pd])
         .filter(|&id| id != 0);
+    // AD-394-5: the enclosing construct's representative `(line, byte)` —
+    // read alongside `enclosing_id` from the same parent slot. Only consumed
+    // when `enclosing_id` is `Some` (in which case `checked_sub(1)` succeeded
+    // too), so the `(0, 0)` fallback below is never actually read.
+    let (enclosing_line, enclosing_byte) = depth_idx
+        .checked_sub(1)
+        .map(|pd| (tables.line[pd], tables.byte[pd]))
+        .unwrap_or((0, 0));
 
     let count = child_counts[depth_idx];
 
     if BODY_KIND_IDS.contains(&kind_id) {
-        emit_empty_or_large_body(count, enclosing_id, metrics, bigram_map);
+        emit_empty_or_large_body(
+            count,
+            enclosing_id,
+            enclosing_line,
+            enclosing_byte,
+            metrics,
+            bigram_map,
+            synthetic_lines,
+        );
     }
 
     // ── MANY_PARAMS emission ──────────────────────────────────────────────────
@@ -656,7 +832,18 @@ fn close_depth(
         // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
         let count_u16 = count.min(u32::from(u16::MAX)) as u16;
         metrics.max_params = metrics.max_params.max(count_u16);
-        emit_bucket_crossings(bigram_map, MANY_PARAMS, &PARAM_EDGES, count);
+        // AD-394-5: excessive-params' representative line is the PARAM-LIST
+        // node's OWN position (depth_idx) — its start coincides with the
+        // function signature line — NOT the enclosing function.
+        emit_bucket_crossings(
+            bigram_map,
+            synthetic_lines,
+            MANY_PARAMS,
+            &PARAM_EDGES,
+            count,
+            tables.line[depth_idx],
+            tables.byte[depth_idx],
+        );
     }
 }
 
@@ -668,16 +855,31 @@ fn close_depth(
 /// - `LARGE_BODY → bucket_label(i)` fires cumulatively when the enclosing
 ///   construct is a function/method kind and `count` crosses a bucket edge.
 ///   Updates `metrics.max_block_stmts` (PF-004 saturating cast).
+///
+/// AD-394-5: both markers are keyed on `enclosing_id`, so their representative
+/// position is the ENCLOSING construct's `(enclosing_line, enclosing_byte)` —
+/// e.g. the `catch_clause`/`function_item` line, not the (anonymous) body
+/// block's own line.
 fn emit_empty_or_large_body(
     count: u32,
     enclosing_id: Option<NodeKindId>,
+    enclosing_line: u32,
+    enclosing_byte: u32,
     metrics: &mut StructuralMetrics,
     bigram_map: &mut HashMap<AstBigram, (f32, u32)>,
+    synthetic_lines: &mut HashMap<AstBigram, (u32, u32)>,
 ) {
     if count == 0
         && let Some(enc) = enclosing_id
     {
-        emit_synthetic(bigram_map, EMPTY_BODY, enc);
+        emit_synthetic(
+            bigram_map,
+            synthetic_lines,
+            EMPTY_BODY,
+            enc,
+            enclosing_line,
+            enclosing_byte,
+        );
     }
 
     if let Some(enc) = enclosing_id
@@ -686,7 +888,15 @@ fn emit_empty_or_large_body(
         // PF-004: saturating cast — count can be up to DEFAULT_MAX_NODES (100K) > u16::MAX
         let count_u16 = count.min(u32::from(u16::MAX)) as u16;
         metrics.max_block_stmts = metrics.max_block_stmts.max(count_u16);
-        emit_bucket_crossings(bigram_map, LARGE_BODY, &BODY_STMT_EDGES, count);
+        emit_bucket_crossings(
+            bigram_map,
+            synthetic_lines,
+            LARGE_BODY,
+            &BODY_STMT_EDGES,
+            count,
+            enclosing_line,
+            enclosing_byte,
+        );
     }
 }
 

--- a/crates/rskim-search/src/ast_index/extract.rs
+++ b/crates/rskim-search/src/ast_index/extract.rs
@@ -900,6 +900,126 @@ fn emit_empty_or_large_body(
     }
 }
 
+/// Verify that a single synthetic-marker bigram key is emitted by the SAME
+/// extraction logic as [`extract_ast_ngrams_with_metrics`], exiting the traversal
+/// as soon as the key is confirmed present in the node stream.
+///
+/// # Purpose (#419 — AC11 fix)
+///
+/// This is the fast-path verification gate for synthetic-marker patterns in
+/// [`crate::compound::pattern_occurs_in_file`].  The full
+/// [`extract_ast_ngrams_with_metrics`] path ran the complete O(n) traversal
+/// before checking membership, causing `--ast deep-nesting` to take ~6.9s
+/// (measured on skim's own repo at `CANDIDATE_POOL_FLOOR=100`).  This function
+/// exits immediately when `target` is found — for `deep-nesting` (DEEP_NODE →
+/// bucket_label(0)) that fires at the first node whose CST depth is >= 4,
+/// typically within the first few hundred of the total node list.
+///
+/// # ADR-006 compliance (single source of truth)
+///
+/// This function uses the SAME [`ExtractState`] state machine and the SAME
+/// helper methods (`emit_depth_buckets`, `close_open_subtrees`, `fill_depth_gap`,
+/// `update_child_count`, `record_node`) as [`run_extraction`] — the same bucket
+/// edges, the same kind-ID tables, the same emission conditions.  It therefore
+/// cannot drift from the indexer: a change to any emission threshold automatically
+/// affects both this function and [`extract_ast_ngrams_with_metrics`].
+///
+/// **Differences from [`run_extraction`]:**
+/// - Returns `bool` instead of `Option<ExtractState>` (verify, not collect).
+/// - Skips `update_branch_count` and `emit_real_ngrams` — branch metrics and
+///   real AST n-grams are irrelevant for a synthetic-only presence check.  Real
+///   n-grams cannot collide with a synthetic `target` (target component IDs are
+///   `>= BUCKET_LABEL_BASE`, outside the real vocabulary range), so omitting
+///   them has zero impact on correctness.
+/// - Returns `true` the moment `target` is present in `bigram_map`; never
+///   processes more of the node stream than necessary.
+///
+/// # Contract
+///
+/// `target` MUST be a synthetic bigram (at least one component ID >=
+/// `BUCKET_LABEL_BASE`).  Callers must not pass a real-vocabulary bigram — the
+/// function cannot distinguish one from an absent synthetic key because
+/// `emit_real_ngrams` is skipped.
+///
+/// # Returns
+///
+/// `true` iff the traversal emits `target` at least once; `false` if the full
+/// node stream is exhausted without emitting it.
+#[must_use]
+pub fn synthetic_key_present(nodes: &[LinearNode], lang: Language, target: AstBigram) -> bool {
+    // Unused parameter: `lang` is accepted for API symmetry with
+    // `extract_ast_ngrams_with_metrics` so callers don't need a separate
+    // branch; it would be needed here if `emit_real_ngrams` were called.
+    let _ = lang;
+
+    if nodes.is_empty() {
+        return false;
+    }
+
+    let max_depth = nodes.iter().map(|n| n.depth).max().unwrap_or(0);
+    let mut state = ExtractState::new(max_depth, nodes.len());
+    let mut prev_depth: Option<u16> = None;
+
+    for node in nodes {
+        let d = usize::from(node.depth);
+
+        // ── Depth-bucket markers (DEEP_NODE → bucket_label(i)) ──────────────
+        // Emitted for every node at depth >= DEPTH_EDGES[i]. Check immediately
+        // after emission — the early exit for deep-nesting fires here on the
+        // first node whose CST depth reaches the bucket threshold.
+        state.emit_depth_buckets(node.depth, node.start_line, node.start_byte);
+        if state.bigram_map.contains_key(&target) {
+            return true;
+        }
+
+        // ── Gap-fill (PF-004: widen to u32, identical to run_extraction) ────
+        if let Some(p) = prev_depth
+            && u32::from(node.depth) > u32::from(p) + 1
+        {
+            state.fill_depth_gap(p, d);
+        }
+
+        // ── Child-count accounting ───────────────────────────────────────────
+        // Needed for correct LARGE_BODY / EMPTY_BODY / MANY_PARAMS emission
+        // inside close_open_subtrees below.
+        state.update_child_count(d, node.kind_id);
+
+        // ── Subtree-close markers (LARGE_BODY, EMPTY_BODY, MANY_PARAMS) ─────
+        // Emitted in close_depth when a body/param-list node's children are
+        // fully accumulated. Check immediately after — early exit for
+        // god-function, empty-function/catch, and excessive-params fires here.
+        if let Some(p) = prev_depth {
+            state.close_open_subtrees(node.depth, p);
+            if state.bigram_map.contains_key(&target) {
+                return true;
+            }
+        }
+
+        // NOTE: `update_branch_count` and `emit_real_ngrams` intentionally
+        // omitted — branch metrics and real AST n-grams are not needed for a
+        // synthetic-only presence check. The synthetic `target` can never be
+        // inserted by `emit_real_ngrams` because its component IDs are >=
+        // BUCKET_LABEL_BASE, which is above the real vocabulary range.
+
+        // Record this node in the ancestor table (required for correct
+        // depth_kind / depth_line / depth_byte reads inside close_depth).
+        state.record_node(d, node.kind_id, node.start_line, node.start_byte);
+
+        prev_depth = Some(node.depth);
+    }
+
+    // ── Close any still-open depths at end of stream ─────────────────────────
+    // Mirrors run_extraction's end-of-stream close (close_open_subtrees(0, p)).
+    if let Some(p) = prev_depth {
+        state.close_open_subtrees(0, p);
+        if state.bigram_map.contains_key(&target) {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Extract structural n-grams using the production per-language IDF tables.
 ///
 /// Convenience wrapper over [`extract_ast_ngrams_with_weights`]. Falls back to

--- a/crates/rskim-search/src/ast_index/extract_tests.rs
+++ b/crates/rskim-search/src/ast_index/extract_tests.rs
@@ -8,7 +8,7 @@
 use rskim_core::Language;
 
 use super::*;
-use crate::ast_index::structural::BUCKET_LABEL_BASE;
+use crate::ast_index::structural::is_synthetic_id;
 use crate::ast_index::{AstBigram, AstTrigram, DEFAULT_AST_WEIGHT, linearize_source, vocab_lookup};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -21,9 +21,15 @@ fn unit_trigram_weight(_: AstTrigram) -> f32 {
     1.0
 }
 
-/// Build a `LinearNode` with given kind_id and depth.
+/// Build a `LinearNode` with given kind_id and depth. `start_line`/`start_byte`
+/// (AD-394-6) default to 0 — these structural tests only assert on n-gram keys
+/// and metrics, never on recovered line/byte positions.
 fn node(kind_id: u16, depth: u16) -> LinearNode {
-    LinearNode { kind_id, depth }
+    LinearNode {
+        kind_id,
+        depth,
+        ..Default::default()
+    }
 }
 
 /// Collect bigram keys from a result set for membership assertions.
@@ -697,9 +703,8 @@ fn trigram_count_accumulates_for_repeated_triple() {
 // This test runs both functions on the same input (a multi-node tree that
 // exercises gap-fill, siblings, and depth nesting) and asserts that the real
 // bigrams and trigrams match exactly after filtering out all synthetic markers
-// (parent or child ID >= BUCKET_LABEL_BASE = 64900).
+// via `is_synthetic_id` (AD-394-3: parent or child ID >= BUCKET_LABEL_BASE = 64900).
 //
-// Filtering: a bigram is synthetic when parent >= 64900 OR child >= 64900.
 // Trigrams cannot be synthetic (synthetic IDs never appear in trigram slots).
 
 #[test]
@@ -721,7 +726,7 @@ fn metrics_path_real_ngrams_match_weights_path() {
 
     let is_real_bigram = |e: &AstBigramEntry| {
         let (parent, child) = e.ngram.decode();
-        parent < BUCKET_LABEL_BASE && child < BUCKET_LABEL_BASE
+        !is_synthetic_id(parent) && !is_synthetic_id(child)
     };
 
     let mut weights_bigram_keys: Vec<u32> = weights_result
@@ -786,7 +791,7 @@ fn metrics_path_u16_max_depth_no_panic_max_depth_recorded() {
 
     let is_real_bigram = |e: &AstBigramEntry| {
         let (parent, child) = e.ngram.decode();
-        parent < BUCKET_LABEL_BASE && child < BUCKET_LABEL_BASE
+        !is_synthetic_id(parent) && !is_synthetic_id(child)
     };
     let real_bigrams: Vec<_> = result
         .bigrams

--- a/crates/rskim-search/src/ast_index/linearize.rs
+++ b/crates/rskim-search/src/ast_index/linearize.rs
@@ -70,9 +70,20 @@ const MAX_FILE_SIZE_LARGE: usize = 1024 * 1024;
 /// to resolve the string. A `kind_id` of `0` (sentinel) means the grammar
 /// kind was not found in the vocabulary (unknown kind).
 ///
-/// `depth` is the 0-indexed traversal depth from the root. Parent–child
+/// `depth` is the 0-indexed depth from the root. Parent–child
 /// relationships are recoverable: a node's parent is the nearest preceding
 /// node with `depth == self.depth - 1`.
+///
+/// # AD-394-6: `start_line`/`start_byte` are transient, never persisted
+///
+/// Added for OD-394-1 (synthetic-marker line recovery): `start_line` (1-indexed)
+/// and `start_byte` carry the node's source position so `extract.rs` can record
+/// a representative position per emitted synthetic marker in the SAME traversal
+/// that emits it (ADR-006 — one pass, no second detection re-implementation).
+/// `LinearNode` is a transient in-memory intermediate — only n-gram postings and
+/// per-file `StructuralMetrics` are ever serialized (`store/builder.rs`,
+/// `store/format.rs FORMAT_VERSION=2`) — so this addition does NOT change the
+/// on-disk format, bump `FORMAT_VERSION`, or trigger a rebuild/self-heal.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct LinearNode {
     /// Vocabulary ID into `NODE_KIND_VOCABULARY`. `0` is the sentinel for
@@ -80,6 +91,10 @@ pub struct LinearNode {
     pub kind_id: NodeKindId,
     /// 0-indexed depth from the tree root (root node is depth 0).
     pub depth: u16,
+    /// 1-indexed source line the node starts on (AD-394-6). Transient/unpersisted.
+    pub start_line: u32,
+    /// Byte offset the node starts at (AD-394-6). Transient/unpersisted.
+    pub start_byte: u32,
 }
 
 /// Result of linearizing a single source file.
@@ -269,9 +284,18 @@ fn linearize_tree(tree: &tree_sitter::Tree, lang_map: &[Option<u16>]) -> Lineari
         // saturating_cast is the correct pattern for converting u32 → u16.
         #[allow(clippy::cast_possible_truncation)]
         let depth = item.depth.min(u32::from(u16::MAX)) as u16;
+        // AD-394-6 / PF-004: widen usize → u32 BEFORE saturating_add(1) for
+        // 1-indexing — mirrors reparse.rs's recover_line row→line conversion.
+        // No u16 depth arithmetic is introduced here (PF-004 is about depth
+        // comparisons; this is an independent source-position field).
+        let row = item.node.start_position().row;
+        let start_line = u32::try_from(row).unwrap_or(u32::MAX).saturating_add(1);
+        let start_byte = u32::try_from(item.node.start_byte()).unwrap_or(u32::MAX);
         nodes.push(LinearNode {
             kind_id: vocab_id,
             depth,
+            start_line,
+            start_byte,
         });
     }
 

--- a/crates/rskim-search/src/ast_index/linearize_tests.rs
+++ b/crates/rskim-search/src/ast_index/linearize_tests.rs
@@ -56,11 +56,70 @@ fn linear_node_is_copy() {
     let n = LinearNode {
         kind_id: 42,
         depth: 3,
+        start_line: 7,
+        start_byte: 100,
     };
     let copy = n;
     assert_eq!(copy.kind_id, 42);
     assert_eq!(copy.depth, 3);
     assert_eq!(n.kind_id, 42); // using n after assignment proves Copy
+}
+
+// ── AD-394-6: start_line / start_byte population ─────────────────────────────
+
+#[test]
+fn linear_node_default_has_zero_line_and_byte() {
+    let n = LinearNode::default();
+    assert_eq!(n.start_line, 0);
+    assert_eq!(n.start_byte, 0);
+}
+
+#[test]
+fn start_line_is_one_indexed_and_monotonic_in_pre_order() {
+    // "fn main() {}" — root starts at line 1 (1-indexed), byte 0.
+    let result = parse_and_linearize("fn main() {}", Language::Rust);
+    let root = &result.nodes[0];
+    assert_eq!(
+        root.start_line, 1,
+        "root node must start on 1-indexed line 1; got {}",
+        root.start_line
+    );
+    assert_eq!(
+        root.start_byte, 0,
+        "root node must start at byte 0; got {}",
+        root.start_byte
+    );
+
+    // Pre-order traversal visits nodes in ascending start-byte order, so
+    // start_byte must be non-decreasing across the sequence.
+    for pair in result.nodes.windows(2) {
+        assert!(
+            pair[0].start_byte <= pair[1].start_byte,
+            "pre-order start_byte must be non-decreasing: {} then {}",
+            pair[0].start_byte,
+            pair[1].start_byte
+        );
+    }
+}
+
+#[test]
+fn start_line_advances_for_nodes_on_later_lines() {
+    let source = "fn a() {}\nfn b() {}\nfn c() {}\n";
+    let result = parse_and_linearize(source, Language::Rust);
+    // At least one node must be recorded on each of lines 1, 2, and 3 —
+    // proves start_line is actually populated from the real source position,
+    // not left at the zero default.
+    for expected_line in [1u32, 2, 3] {
+        assert!(
+            result.nodes.iter().any(|n| n.start_line == expected_line),
+            "expected at least one node on line {expected_line}; lines seen: {:?}",
+            result
+                .nodes
+                .iter()
+                .map(|n| n.start_line)
+                .collect::<Vec<_>>()
+        );
+    }
 }
 
 #[test]

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -58,7 +58,8 @@ pub use ast_cache::{
 };
 pub use extract::{
     AstBigramEntry, AstNgramSet, AstTrigramEntry, extract_ast_ngrams,
-    extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights,
+    extract_ast_ngrams_with_lines, extract_ast_ngrams_with_metrics,
+    extract_ast_ngrams_with_weights,
 };
 pub use linearize::{LinearNode, LinearizeResult, linearize_source};
 pub use ngram::{
@@ -70,4 +71,9 @@ pub use query::{
     AST_BM25_B, AST_BM25_K1, AstPostingSource, AstQuery, AstQueryEngine, parse_ast_query,
 };
 pub use store::{AstFileMetaEntry, AstIndexBuilder, AstIndexReader, AstPosting};
-pub use structural::StructuralMetrics;
+// AD-394-3: `is_synthetic_id` re-exported as the single public source of truth
+// for "is this NodeKindId a synthetic marker ID" — avoids callers (both within
+// this crate and in `rskim`'s CLI tests) re-deriving the `>= BUCKET_LABEL_BASE`
+// threshold from a duplicated magic number. `structural` itself stays
+// `pub(crate)`; this is a deliberate, narrow re-export of one predicate.
+pub use structural::{StructuralMetrics, is_synthetic_id};

--- a/crates/rskim-search/src/ast_index/mod.rs
+++ b/crates/rskim-search/src/ast_index/mod.rs
@@ -59,7 +59,7 @@ pub use ast_cache::{
 pub use extract::{
     AstBigramEntry, AstNgramSet, AstTrigramEntry, extract_ast_ngrams,
     extract_ast_ngrams_with_lines, extract_ast_ngrams_with_metrics,
-    extract_ast_ngrams_with_weights,
+    extract_ast_ngrams_with_weights, synthetic_key_present,
 };
 pub use linearize::{LinearNode, LinearizeResult, linearize_source};
 pub use ngram::{

--- a/crates/rskim-search/src/ast_index/structural.rs
+++ b/crates/rskim-search/src/ast_index/structural.rs
@@ -96,6 +96,27 @@ pub fn bucket_label(edge_index: usize) -> NodeKindId {
     BUCKET_LABEL_BASE + edge_index as NodeKindId
 }
 
+/// AD-394-3: `true` iff `id` is a synthetic marker ID — either a reserved
+/// synthetic PARENT id (`EMPTY_BODY`/`DEEP_NODE`/`LARGE_BODY`/`MANY_PARAMS`,
+/// 65000-65003) or a bucket-label CHILD id (`>= BUCKET_LABEL_BASE` = 64900).
+///
+/// Synthetic parent IDs and bucket-label child IDs are all `>= BUCKET_LABEL_BASE`
+/// (64900), while every real vocabulary ID satisfies `id < vocab_len()` (1740).
+/// `BUCKET_LABEL_BASE` cleanly separates the two ID spaces — the invariant
+/// `vocab_len() <= BUCKET_LABEL_BASE` is asserted by a unit test below.
+///
+/// This is the single source of truth for the "is this id synthetic?"
+/// predicate, used by `compound::reparse`'s verify gate and `recover_line` to
+/// route synthetic-marker AST patterns through extraction-reuse instead of the
+/// real-CST ancestor walk (`vocab_lookup` never yields a synthetic ID, so the
+/// strict walk is structurally unsatisfiable for them). Previously duplicated
+/// ad hoc as an inline `>= BUCKET_LABEL_BASE` check in `extract_tests.rs`.
+#[inline]
+#[must_use]
+pub fn is_synthetic_id(id: NodeKindId) -> bool {
+    id >= BUCKET_LABEL_BASE
+}
+
 // ============================================================================
 // Bucket edge tables
 // ============================================================================

--- a/crates/rskim-search/src/ast_index/structural_tests.rs
+++ b/crates/rskim-search/src/ast_index/structural_tests.rs
@@ -70,6 +70,61 @@ fn f5_bucket_label_range_is_safe() {
 }
 
 // ============================================================================
+// AC4 (#394): is_synthetic_id threshold + vocab_len <= BUCKET_LABEL_BASE invariant
+//
+// PF-007 discriminating: every synthetic ID must return true, every real vocab
+// ID must return false. A `|| true` stub fails the false branch; a `|| false`
+// stub fails the true branch.
+// ============================================================================
+
+#[test]
+fn ac4_394_is_synthetic_id_true_for_all_synthetic_parent_ids() {
+    assert!(is_synthetic_id(EMPTY_BODY), "EMPTY_BODY must be synthetic");
+    assert!(is_synthetic_id(DEEP_NODE), "DEEP_NODE must be synthetic");
+    assert!(is_synthetic_id(LARGE_BODY), "LARGE_BODY must be synthetic");
+    assert!(
+        is_synthetic_id(MANY_PARAMS),
+        "MANY_PARAMS must be synthetic"
+    );
+}
+
+#[test]
+fn ac4_394_is_synthetic_id_true_for_bucket_labels_0_to_2() {
+    for i in 0..=2 {
+        let id = bucket_label(i);
+        assert!(
+            is_synthetic_id(id),
+            "bucket_label({i})={id} must be synthetic"
+        );
+    }
+}
+
+#[test]
+fn ac4_394_is_synthetic_id_false_for_real_vocab_ids() {
+    use crate::ast_index::vocab_lookup;
+    for kind in ["try_statement", "catch_clause", "function_item", "block"] {
+        if let Some(id) = vocab_lookup(kind) {
+            assert!(
+                !is_synthetic_id(id),
+                "real vocab kind {kind:?} (id={id}) must NOT be synthetic"
+            );
+        }
+    }
+}
+
+#[test]
+fn ac4_394_vocab_len_stays_below_bucket_label_base() {
+    use crate::ast_index::vocab_len;
+    assert!(
+        vocab_len() <= BUCKET_LABEL_BASE as usize,
+        "vocab_len() ({}) must stay <= BUCKET_LABEL_BASE ({}) — otherwise real \
+         vocabulary IDs could collide with the synthetic ID space",
+        vocab_len(),
+        BUCKET_LABEL_BASE
+    );
+}
+
+// ============================================================================
 // F2: Central counting rule — is_counted_child
 // ============================================================================
 
@@ -165,18 +220,22 @@ fn f1_max_depth_tracks_maximum() {
         LinearNode {
             kind_id: 1,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: 1,
             depth: 1,
+            ..Default::default()
         },
         LinearNode {
             kind_id: 1,
             depth: 2,
+            ..Default::default()
         },
         LinearNode {
             kind_id: 1,
             depth: 3,
+            ..Default::default()
         },
     ];
     let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
@@ -190,10 +249,12 @@ fn f1_max_depth_handles_depth_jump() {
         LinearNode {
             kind_id: 1,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: 1,
             depth: 5,
+            ..Default::default()
         }, // jump by 5
     ];
     let (_, m) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
@@ -214,6 +275,7 @@ fn f1_branch_count_increments_for_branch_kinds() {
         .map(|(i, &kid)| LinearNode {
             kind_id: kid,
             depth: i as u16,
+            ..Default::default()
         })
         .collect();
 
@@ -255,16 +317,19 @@ fn f1_max_block_stmts_counts_body_children() {
         LinearNode {
             kind_id: fn_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: block_id,
             depth: 1,
+            ..Default::default()
         },
     ];
     for _ in 0..7 {
         nodes.push(LinearNode {
             kind_id: stmt_id,
             depth: 2,
+            ..Default::default()
         });
     }
 
@@ -300,16 +365,19 @@ fn f1_max_params_counts_parameter_list_children() {
         LinearNode {
             kind_id: fn_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: params_id,
             depth: 1,
+            ..Default::default()
         },
     ];
     for _ in 0..3 {
         nodes.push(LinearNode {
             kind_id: param_node_id,
             depth: 2,
+            ..Default::default()
         });
     }
 
@@ -352,16 +420,19 @@ fn f3_body_stmt_buckets_emit_cumulatively() {
             LinearNode {
                 kind_id: fn_id,
                 depth: 0,
+                ..Default::default()
             },
             LinearNode {
                 kind_id: block_id,
                 depth: 1,
+                ..Default::default()
             },
         ];
         for _ in 0..n_stmts {
             v.push(LinearNode {
                 kind_id: expr_id,
                 depth: 2,
+                ..Default::default()
             });
         }
         v
@@ -438,7 +509,11 @@ fn f3_depth_buckets_emit_cumulatively() {
     // A node at depth 8 must emit bucket_label(0), bucket_label(1), bucket_label(2)
     let make_nodes_at_depth = |d: u16| -> Vec<LinearNode> {
         (0..=d)
-            .map(|depth| LinearNode { kind_id: 1, depth })
+            .map(|depth| LinearNode {
+                kind_id: 1,
+                depth,
+                ..Default::default()
+            })
             .collect()
     };
 
@@ -496,10 +571,12 @@ fn f3_param_buckets_emit_cumulatively() {
             LinearNode {
                 kind_id: fn_id,
                 depth: 0,
+                ..Default::default()
             },
             LinearNode {
                 kind_id: params_id,
                 depth: 1,
+                ..Default::default()
             },
         ];
         for _ in 0..n_params {
@@ -510,6 +587,7 @@ fn f3_param_buckets_emit_cumulatively() {
                     1
                 },
                 depth: 2,
+                ..Default::default()
             });
         }
         v
@@ -589,15 +667,18 @@ fn f4_empty_body_keyed_on_enclosing_kind() {
         LinearNode {
             kind_id: catch_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: block_id,
             depth: 1,
+            ..Default::default()
         },
         // punctuation at depth 2 (should NOT count as a statement)
         LinearNode {
             kind_id: 0,
             depth: 2,
+            ..Default::default()
         },
     ];
 
@@ -606,15 +687,18 @@ fn f4_empty_body_keyed_on_enclosing_kind() {
         LinearNode {
             kind_id: fn_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: block_id,
             depth: 1,
+            ..Default::default()
         },
         // punctuation at depth 2
         LinearNode {
             kind_id: 0,
             depth: 2,
+            ..Default::default()
         },
     ];
 
@@ -666,18 +750,22 @@ fn f2_punctuation_only_body_is_empty() {
         LinearNode {
             kind_id: fn_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: block_id,
             depth: 1,
+            ..Default::default()
         },
         LinearNode {
             kind_id: 0,
             depth: 2,
+            ..Default::default()
         }, // punctuation
         LinearNode {
             kind_id: 0,
             depth: 2,
+            ..Default::default()
         }, // punctuation
     ];
     let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
@@ -710,14 +798,17 @@ fn f2_comment_only_body_is_empty() {
         LinearNode {
             kind_id: fn_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: block_id,
             depth: 1,
+            ..Default::default()
         },
         LinearNode {
             kind_id: comment_id,
             depth: 2,
+            ..Default::default()
         },
     ];
     let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);
@@ -749,14 +840,17 @@ fn f2_one_real_statement_body_is_not_empty() {
         LinearNode {
             kind_id: fn_id,
             depth: 0,
+            ..Default::default()
         },
         LinearNode {
             kind_id: block_id,
             depth: 1,
+            ..Default::default()
         },
         LinearNode {
             kind_id: stmt_id,
             depth: 2,
+            ..Default::default()
         }, // one real statement
     ];
     let (set, _) = extract_ast_ngrams_with_metrics(&nodes, Language::Rust);

--- a/crates/rskim-search/src/compound/reparse.rs
+++ b/crates/rskim-search/src/compound/reparse.rs
@@ -35,13 +35,17 @@
 //! since indexing, the mtime will differ and the caller's stale guard will degrade
 //! to file-level output before this function is called.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::Path;
 
 use rskim_core::{AstWalkConfig, AstWalkIter, Language, Parser};
 
-use crate::ast_index::{AstQuery, NodeKindId, vocab_lookup};
+use crate::ast_index::structural::is_synthetic_id;
+use crate::ast_index::{
+    AstBigram, AstNgramSet, AstQuery, AstTrigram, NodeKindId, extract_ast_ngrams_with_lines,
+    extract_ast_ngrams_with_metrics, linearize_source, vocab_lookup,
+};
 
 /// Maximum file size for re-parse operations.
 ///
@@ -52,10 +56,28 @@ pub const MAX_REPARSE_FILE_BYTES: u64 = 100 * 1024;
 
 /// Recover the representative line for a matched AST pattern in a source file.
 ///
-/// Walks the file's CST in **pre-order** and returns the 1-indexed line number
-/// and byte range of the **first** node whose kind matches any of the pattern's
-/// resolved bigrams or trigrams (parent→child / grandparent→parent→child
-/// relationships).
+/// For a REAL-node pattern, walks the file's CST in **pre-order** and returns
+/// the 1-indexed line number and byte range of the **first** node whose kind
+/// matches any of the pattern's resolved bigrams or trigrams (parent→child /
+/// grandparent→parent→child relationships).
+///
+/// ## AD-394-5: Synthetic-marker patterns (OD-394-1 — recover now)
+///
+/// The 5 synthetic-marker patterns (god-function, deep-nesting, empty-function,
+/// empty-catch, excessive-params) can never match the pre-order walk above —
+/// `vocab_lookup` never yields a synthetic ID, so the walk's bigram/trigram
+/// comparison is structurally unsatisfiable for them. These are routed
+/// (`query_contains_synthetic_id`, the SAME predicate the verify gate uses) to
+/// a separate branch that re-runs the index-time extraction pipeline
+/// (`extract_ast_ngrams_with_lines`) and reads back the representative
+/// `(line, byte)` position it recorded for the emitted marker — the marker and
+/// its line come from ONE pass (ADR-006), not a second, drift-prone detection
+/// re-implementation. Per-pattern representative-line rule: report the
+/// 1-indexed start line of the node the marker's condition is measured on,
+/// resolving up to the enclosing named construct for anonymous body/param
+/// blocks — god-function → enclosing function; empty-function →
+/// `function_item`; empty-catch → `catch_clause`; excessive-params →
+/// parameter-list; deep-nesting → first node crossing depth ≥ 4.
 ///
 /// ## Return value
 ///
@@ -68,6 +90,9 @@ pub const MAX_REPARSE_FILE_BYTES: u64 = 100 * 1024;
 ///
 /// Pre-order tree-sitter traversal is deterministic for unchanged source. The
 /// same file + same pattern always yields the same `(line, byte_range)` tuple.
+/// The synthetic branch is equally deterministic: the MIN line per marker key
+/// is recorded (topmost occurrence), so identical input always yields the same
+/// result.
 ///
 /// ## Bounded work (AC-API3)
 ///
@@ -76,8 +101,8 @@ pub const MAX_REPARSE_FILE_BYTES: u64 = 100 * 1024;
 ///
 /// ## Deferred precision
 ///
-/// Only the first matching node is returned. All-occurrences line precision is
-/// tracked in #338.
+/// Only the first (real-node branch) or topmost (synthetic branch) matching
+/// node is returned. All-occurrences line precision is tracked in #338.
 pub fn recover_line(
     file_path: &Path,
     query: &AstQuery,
@@ -107,13 +132,30 @@ pub fn recover_line(
     // Detect language from extension.
     let lang = Language::from_path(file_path)?;
 
+    // Read the file — shared by both branches below.
+    let content = std::fs::read(file_path).ok()?;
+    let source = std::str::from_utf8(&content).ok()?;
+
+    // AD-394-5: synthetic-marker patterns cannot be recovered by the
+    // pre-order-predecessor `MatchTable` walk below (`vocab_lookup` never
+    // yields a synthetic ID, so `match_table.matches` can never fire for
+    // them — they would always degrade to `None`, rendering a path-only row).
+    // Route them instead through the SAME extraction pass that emits the
+    // marker (`extract_ast_ngrams_with_lines`), reading back the representative
+    // position it recorded (ADR-006: one pass produces both the marker and its
+    // line — no second, drift-prone detection re-implementation). Routed by
+    // the SAME predicate as the verify gate (`query_contains_synthetic_id`) —
+    // one routing rule, no divergence.
+    if query_contains_synthetic_id(query) {
+        let result = linearize_source(source, lang).ok()?;
+        let (_emitted, _metrics, synthetic_lines) =
+            extract_ast_ngrams_with_lines(&result.nodes, lang);
+        return recover_synthetic_line(query, &synthetic_lines);
+    }
+
     // Only tree-sitter languages can be re-parsed; non-tree-sitter langs degrade.
     // We check by attempting Parser::new — if the language has no grammar, it returns Err.
     let mut parser = Parser::new(lang).ok()?;
-
-    // Read the file.
-    let content = std::fs::read(file_path).ok()?;
-    let source = std::str::from_utf8(&content).ok()?;
 
     // Parse.
     let tree = parser.parse(source).ok()?;
@@ -170,6 +212,43 @@ pub fn recover_line(
     None
 }
 
+/// AD-394-5: resolve `query`'s resolved synthetic bigram key(s) against the
+/// `synthetic_lines` side table produced by [`extract_ast_ngrams_with_lines`],
+/// and return the MIN `(line, byte)` across every key that is present.
+///
+/// Only [`AstQuery::Pattern`] can ever reach this function with a non-empty
+/// key set: [`query_contains_synthetic_id`] is `false` for
+/// [`AstQuery::Containment`] (the parser rejects synthetic-marker names in a
+/// containment query — AC7) and for [`AstQuery::SingleNode`], so those
+/// variants are handled defensively (empty key list → `None`) but are
+/// unreachable in practice.
+///
+/// Deterministic (AC-F3): `synthetic_lines` already stores the MIN line per
+/// key (recorded at emission time), so taking the min across the (today,
+/// always single) resolved key is a deterministic function of the file.
+fn recover_synthetic_line(
+    query: &AstQuery,
+    synthetic_lines: &HashMap<AstBigram, (u32, u32)>,
+) -> Option<(u32, Range<usize>)> {
+    let keys: Vec<AstBigram> = match query {
+        AstQuery::Pattern(pattern) => pattern.resolved_bigrams(),
+        AstQuery::Containment(ngram_set) => ngram_set.bigrams.iter().map(|e| e.ngram).collect(),
+        AstQuery::SingleNode(_) => Vec::new(),
+    };
+
+    let mut best: Option<(u32, u32)> = None;
+    for key in keys {
+        if let Some(&(line, byte)) = synthetic_lines.get(&key) {
+            best = Some(match best {
+                Some((best_line, best_byte)) if best_line <= line => (best_line, best_byte),
+                _ => (line, byte),
+            });
+        }
+    }
+
+    best.map(|(line, byte)| (line, (byte as usize)..(byte as usize + 1)))
+}
+
 /// Verify that a source file's CST contains at least one node whose **real
 /// ancestor chain** matches the pattern's resolved n-grams.
 ///
@@ -190,6 +269,23 @@ pub fn recover_line(
 /// correct behavior.  PF-004 governs the index BUILD's u16 depth arithmetic in
 /// `extract.rs`; this gate only compares node KINDS (no depth values) so PF-004
 /// does NOT apply here.
+///
+/// ## AD-394-1 / AD-394-2: Synthetic-marker patterns route through extraction-reuse
+///
+/// The strict walk above is structurally unsatisfiable for the 5 synthetic-marker
+/// patterns (god-function, deep-nesting, empty-function, empty-catch,
+/// excessive-params): their resolved n-grams contain a synthetic ID
+/// (`>= BUCKET_LABEL_BASE`), and `vocab_lookup` — which resolves every real
+/// `node.parent()` kind in this walk — never yields a synthetic ID (#394's
+/// root cause: standalone `--ast` returned zero results for all 5).  Before
+/// reaching this walk, [`AncestorMatchTable::contains_synthetic_id`] routes any
+/// such pattern to a SEPARATE branch that re-runs the index-time pipeline
+/// (`linearize_source` + `extract_ast_ngrams_with_metrics`) and confirms every
+/// resolved n-gram KEY is present in the emitted set (reuses the indexer as the
+/// single source of truth — applies ADR-006).  Real-node patterns are NOT
+/// routed through extraction-reuse (AD-394-2) — collapsing the two branches
+/// would loosen the 24 real patterns to the indexer's gap-fill tolerance,
+/// regressing AD-374-6 precision.
 ///
 /// ## AD-374-5: Non-tree-sitter / zero-kind files drop
 ///
@@ -221,6 +317,15 @@ pub fn pattern_occurs_in_file(
     query: &AstQuery,
     manifest_mtime: Option<u64>,
 ) -> bool {
+    // Resolve the query into an ancestor-correct match table FIRST (AD-374-6).
+    // Building the table is pure and file-independent, so an empty table
+    // (pattern has no resolvable kinds in this process's vocabulary) short-
+    // circuits before any filesystem I/O (AD-374-5).
+    let ancestor_table = AncestorMatchTable::build(query);
+    if ancestor_table.is_empty() {
+        return false;
+    }
+
     // Guard: file must exist and be readable as metadata.
     let Ok(meta) = std::fs::metadata(file_path) else {
         return false;
@@ -249,30 +354,58 @@ pub fn pattern_occurs_in_file(
         return false;
     };
 
-    // Only tree-sitter languages can be re-parsed; non-tree-sitter langs drop
-    // (AD-374-5: JSON/TOML/YAML have no grammar → Parser::new returns Err).
-    let Ok(mut parser) = Parser::new(lang) else {
-        return false;
-    };
-
-    // Read and parse the file.
+    // Read the file — shared by both branches below.
     let Ok(content) = std::fs::read(file_path) else {
         return false;
     };
     let Ok(source) = std::str::from_utf8(&content) else {
         return false;
     };
+
+    // AD-394-1 / AD-394-2: route synthetic-marker patterns (any resolved
+    // n-gram component >= BUCKET_LABEL_BASE) through extraction-reuse; real-
+    // node patterns keep the strict ancestor walk below. Do NOT collapse the
+    // two branches — see AD-394-2 for why real patterns must not be loosened.
+    if ancestor_table.contains_synthetic_id() {
+        // AD-394-1: verify by re-running the index-time pipeline and confirming
+        // every resolved n-gram KEY is present in the emitted AstNgramSet.
+        // `linearize_source` parses internally, so no separate `Parser::new`
+        // is needed on this branch (AD-374-5 guards — size/non-tree-sitter —
+        // are already inherited from the shared guards above; linearize_source's
+        // own internal size/language guards degrade to an empty result rather
+        // than ever firing here).
+        let Ok(result) = linearize_source(source, lang) else {
+            return false;
+        };
+        // CRITICAL (AD-394-1): destructure the tuple return —
+        // extract_ast_ngrams_with_metrics returns (AstNgramSet, StructuralMetrics),
+        // not just the ngram set.
+        //
+        // KNOWN PERF CHARACTERISTIC (#419, measured on skim's own repo): this
+        // branch is markedly heavier per-candidate than the real-node walk
+        // below (full per-file metrics recomputation vs. a bounded ancestor
+        // walk), and for a low-selectivity marker like deep-nesting (common
+        // in real code) the candidate pool fills to CANDIDATE_POOL_FLOOR
+        // (query.rs) regardless of --limit. Dogfooding showed `--ast
+        // deep-nesting` at ~6.9s vs. `--ast try-catch` at ~26ms on this
+        // repo — correctness is unaffected, but this misses the design
+        // plan's AC11 (<500ms, same order of magnitude as the real gate).
+        // A lighter-weight early-exit presence check is tracked in #419 —
+        // not fixed here to avoid an under-designed change to the shared
+        // extraction path.
+        let (emitted, _metrics) = extract_ast_ngrams_with_metrics(&result.nodes, lang);
+        return ancestor_table.all_ngrams_present_in(&emitted);
+    }
+
+    // Real-node branch (AD-394-2, unchanged): only tree-sitter languages can be
+    // re-parsed; non-tree-sitter langs drop (AD-374-5: JSON/TOML/YAML have no
+    // grammar → Parser::new returns Err).
+    let Ok(mut parser) = Parser::new(lang) else {
+        return false;
+    };
     let Ok(tree) = parser.parse(source) else {
         return false;
     };
-
-    // Resolve the query into an ancestor-correct match table (AD-374-6).
-    // AD-374-5: an empty match table means the pattern has no resolvable kinds
-    // in this grammar → drop.
-    let ancestor_table = AncestorMatchTable::build(query);
-    if ancestor_table.is_empty() {
-        return false;
-    }
 
     // Walk the CST in pre-order and check each node's REAL parent chain.
     let walk_config = AstWalkConfig::default();
@@ -391,6 +524,56 @@ impl AncestorMatchTable {
     fn is_empty(&self) -> bool {
         self.bigrams.is_empty() && self.trigrams.is_empty()
     }
+
+    /// AD-394-1 / AD-394-2: `true` iff any resolved bigram/trigram component is
+    /// a synthetic marker ID (`is_synthetic_id`, i.e. `>= BUCKET_LABEL_BASE`).
+    ///
+    /// Routes the pattern to the extraction-reuse verify branch in
+    /// [`pattern_occurs_in_file`] instead of the strict ancestor walk: a
+    /// synthetic ID can never appear as a real `node.parent()` chain member
+    /// (`vocab_lookup` never yields one), so the strict walk is structurally
+    /// unsatisfiable for these patterns. Real-node patterns (this returns
+    /// `false`) keep the strict walk unchanged (AD-394-2 — do not collapse the
+    /// two branches; this preserves AD-374-6 precision for the 24 real
+    /// patterns).
+    fn contains_synthetic_id(&self) -> bool {
+        self.bigrams
+            .iter()
+            .any(|&(p, c)| is_synthetic_id(p) || is_synthetic_id(c))
+            || self
+                .trigrams
+                .iter()
+                .any(|&(gp, p, c)| is_synthetic_id(gp) || is_synthetic_id(p) || is_synthetic_id(c))
+    }
+
+    /// AD-394-1: re-encode this table's decoded bigrams/trigrams and check
+    /// that EVERY one is present as a KEY in `set` (weights/counts ignored) —
+    /// the extraction-reuse verify check for synthetic-marker patterns. `set`
+    /// is sorted by key ascending (guaranteed by [`AstNgramSet`]'s producer),
+    /// so each lookup is `O(log n)` via binary search.
+    ///
+    /// An empty `self.trigrams` (true for all 5 synthetic marker patterns
+    /// today — they are single-bigram/zero-trigram) makes the trigram
+    /// conjunct vacuously `true`.
+    fn all_ngrams_present_in(&self, set: &AstNgramSet) -> bool {
+        self.bigrams.iter().all(|&(p, c)| {
+            let key = AstBigram::encode(p, c);
+            set.bigrams.binary_search_by_key(&key, |e| e.ngram).is_ok()
+        }) && self.trigrams.iter().all(|&(gp, p, c)| {
+            let key = AstTrigram::encode(gp, p, c);
+            set.trigrams.binary_search_by_key(&key, |e| e.ngram).is_ok()
+        })
+    }
+}
+
+/// AD-394-1 / AD-394-5: shared routing predicate used by BOTH the verify gate
+/// (`pattern_occurs_in_file`) and `recover_line` to decide whether `query`
+/// routes through extraction-reuse — one routing rule, no divergence between
+/// the two call sites. Delegates to [`AncestorMatchTable::contains_synthetic_id`]
+/// so there is a single implementation of "does this query touch a synthetic
+/// marker ID" (built from [`is_synthetic_id`]).
+fn query_contains_synthetic_id(query: &AstQuery) -> bool {
+    AncestorMatchTable::build(query).contains_synthetic_id()
 }
 
 /// Precomputed O(1) lookup table for the CST walk.

--- a/crates/rskim-search/src/compound/reparse.rs
+++ b/crates/rskim-search/src/compound/reparse.rs
@@ -43,8 +43,8 @@ use rskim_core::{AstWalkConfig, AstWalkIter, Language, Parser};
 
 use crate::ast_index::structural::is_synthetic_id;
 use crate::ast_index::{
-    AstBigram, AstNgramSet, AstQuery, AstTrigram, NodeKindId, extract_ast_ngrams_with_lines,
-    extract_ast_ngrams_with_metrics, linearize_source, vocab_lookup,
+    AstBigram, AstQuery, NodeKindId, extract_ast_ngrams_with_lines, linearize_source,
+    synthetic_key_present, vocab_lookup,
 };
 
 /// Maximum file size for re-parse operations.
@@ -274,13 +274,15 @@ fn recover_synthetic_line(
 /// `node.parent()` kind in this walk — never yields a synthetic ID (#394's
 /// root cause: standalone `--ast` returned zero results for all 5).  Before
 /// reaching this walk, [`AncestorMatchTable::contains_synthetic_id`] routes any
-/// such pattern to a SEPARATE branch that re-runs the index-time pipeline
-/// (`linearize_source` + `extract_ast_ngrams_with_metrics`) and confirms every
-/// resolved n-gram KEY is present in the emitted set (reuses the indexer as the
-/// single source of truth — applies ADR-006).  Real-node patterns are NOT
-/// routed through extraction-reuse (AD-394-2) — collapsing the two branches
-/// would loosen the 24 real patterns to the indexer's gap-fill tolerance,
-/// regressing AD-374-6 precision.
+/// such pattern to a SEPARATE branch that re-runs the index-time pipeline via
+/// `linearize_source` + [`synthetic_key_present`] (an early-exit variant of
+/// `extract_ast_ngrams_with_metrics` that returns as soon as the target synthetic
+/// bigram is confirmed present — AC11 / #419 fix) and confirms every resolved
+/// n-gram KEY is emitted (reuses the indexer's SAME emission logic as the single
+/// source of truth — applies ADR-006).  Real-node patterns are NOT routed through
+/// extraction-reuse (AD-394-2) — collapsing the two branches would loosen the 24
+/// real patterns to the indexer's gap-fill tolerance, regressing AD-374-6
+/// precision.
 ///
 /// ## AD-374-5: Non-tree-sitter / zero-kind files drop
 ///
@@ -362,34 +364,32 @@ pub fn pattern_occurs_in_file(
     // node patterns keep the strict ancestor walk below. Do NOT collapse the
     // two branches — see AD-394-2 for why real patterns must not be loosened.
     if ancestor_table.contains_synthetic_id() {
-        // AD-394-1: verify by re-running the index-time pipeline and confirming
-        // every resolved n-gram KEY is present in the emitted AstNgramSet.
-        // `linearize_source` parses internally, so no separate `Parser::new`
-        // is needed on this branch (AD-374-5 guards — size/non-tree-sitter —
-        // are already inherited from the shared guards above; linearize_source's
-        // own internal size/language guards degrade to an empty result rather
-        // than ever firing here).
+        // AD-394-1 / #419 (AC11 fix): verify by re-running the index-time pipeline
+        // via `linearize_source` + `synthetic_key_present`. The latter uses the SAME
+        // ExtractState emission logic as `extract_ast_ngrams_with_metrics` (ADR-006)
+        // but exits as soon as the target bigram key is confirmed present — for
+        // deep-nesting (DEEP_NODE → bucket_label(0)) this fires at the first node at
+        // depth >= 4, dramatically faster than a full O(n) traversal.
+        //
+        // AC8 invariant: mixed (synthetic + real) patterns are rejected at the catalog
+        // level, so all bigrams in ancestor_table are synthetic when we reach this
+        // branch. The trigrams set is empty for all 5 current synthetic patterns.
+        //
+        // `linearize_source` parses internally; no separate `Parser::new` is needed.
+        // AD-374-5 size/language guards are inherited from the shared guards above;
+        // linearize_source's own internal guards degrade to an empty result (never
+        // fire redundantly here).
         let Ok(result) = linearize_source(source, lang) else {
             return false;
         };
-        // CRITICAL (AD-394-1): destructure the tuple return —
-        // extract_ast_ngrams_with_metrics returns (AstNgramSet, StructuralMetrics),
-        // not just the ngram set.
-        //
-        // KNOWN PERF CHARACTERISTIC (#419, measured on skim's own repo): this
-        // branch is markedly heavier per-candidate than the real-node walk
-        // below (full per-file metrics recomputation vs. a bounded ancestor
-        // walk), and for a low-selectivity marker like deep-nesting (common
-        // in real code) the candidate pool fills to CANDIDATE_POOL_FLOOR
-        // (query.rs) regardless of --limit. Dogfooding showed `--ast
-        // deep-nesting` at ~6.9s vs. `--ast try-catch` at ~26ms on this
-        // repo — correctness is unaffected, but this misses the design
-        // plan's AC11 (<500ms, same order of magnitude as the real gate).
-        // A lighter-weight early-exit presence check is tracked in #419 —
-        // not fixed here to avoid an under-designed change to the shared
-        // extraction path.
-        let (emitted, _metrics) = extract_ast_ngrams_with_metrics(&result.nodes, lang);
-        return ancestor_table.all_ngrams_present_in(&emitted);
+        // Check every synthetic bigram via early-exit. AC8 guarantees all bigrams are
+        // synthetic here (no real IDs mixed in), so no filter is needed.
+        return ancestor_table
+            .bigrams
+            .iter()
+            .all(|&(p, c)| synthetic_key_present(&result.nodes, lang, AstBigram::encode(p, c)));
+        // Trigrams: all current synthetic patterns are zero-trigram; ancestor_table.trigrams
+        // is empty, so the bigram check above is the complete verification.
     }
 
     // Real-node branch (AD-394-2, unchanged): only tree-sitter languages can be
@@ -539,25 +539,6 @@ impl AncestorMatchTable {
                 .trigrams
                 .iter()
                 .any(|&(gp, p, c)| is_synthetic_id(gp) || is_synthetic_id(p) || is_synthetic_id(c))
-    }
-
-    /// AD-394-1: re-encode this table's decoded bigrams/trigrams and check
-    /// that EVERY one is present as a KEY in `set` (weights/counts ignored) —
-    /// the extraction-reuse verify check for synthetic-marker patterns. `set`
-    /// is sorted by key ascending (guaranteed by [`AstNgramSet`]'s producer),
-    /// so each lookup is `O(log n)` via binary search.
-    ///
-    /// An empty `self.trigrams` (true for all 5 synthetic marker patterns
-    /// today — they are single-bigram/zero-trigram) makes the trigram
-    /// conjunct vacuously `true`.
-    fn all_ngrams_present_in(&self, set: &AstNgramSet) -> bool {
-        self.bigrams.iter().all(|&(p, c)| {
-            let key = AstBigram::encode(p, c);
-            set.bigrams.binary_search_by_key(&key, |e| e.ngram).is_ok()
-        }) && self.trigrams.iter().all(|&(gp, p, c)| {
-            let key = AstTrigram::encode(gp, p, c);
-            set.trigrams.binary_search_by_key(&key, |e| e.ngram).is_ok()
-        })
     }
 }
 

--- a/crates/rskim-search/src/compound/reparse.rs
+++ b/crates/rskim-search/src/compound/reparse.rs
@@ -236,17 +236,12 @@ fn recover_synthetic_line(
         AstQuery::SingleNode(_) => Vec::new(),
     };
 
-    let mut best: Option<(u32, u32)> = None;
-    for key in keys {
-        if let Some(&(line, byte)) = synthetic_lines.get(&key) {
-            best = Some(match best {
-                Some((best_line, best_byte)) if best_line <= line => (best_line, best_byte),
-                _ => (line, byte),
-            });
-        }
-    }
+    let (line, byte) = keys
+        .into_iter()
+        .filter_map(|key| synthetic_lines.get(&key).copied())
+        .min_by_key(|&(line, _)| line)?;
 
-    best.map(|(line, byte)| (line, (byte as usize)..(byte as usize + 1)))
+    Some((line, (byte as usize)..(byte as usize + 1)))
 }
 
 /// Verify that a source file's CST contains at least one node whose **real

--- a/crates/rskim-search/src/compound/reparse_tests.rs
+++ b/crates/rskim-search/src/compound/reparse_tests.rs
@@ -583,3 +583,309 @@ fn pattern_occurs_true_and_false_cover_both_branches() {
         "PF-007 double-assertion: no_loop.rs must return false (no for_expression at all)"
     );
 }
+
+// ============================================================================
+// #394: Synthetic-marker patterns — standalone --ast returned zero results for
+// all 5 (god-function, deep-nesting, empty-function, empty-catch,
+// excessive-params) because `vocab_lookup` never yields a synthetic ID, making
+// the strict ancestor walk structurally unsatisfiable. Fixed via
+// extraction-reuse (AD-394-1/AD-394-2). Ground-truth lines below were
+// established via empirical dogfood verification against the release binary
+// (ADR-003), not eyeballed.
+// ============================================================================
+
+/// AC1 (#394) unit-level, all 5: `pattern_occurs_in_file` returns `true` for
+/// each synthetic pattern's exhibiting fixture. Each assertion FAILS before
+/// the fix (the strict walk can never match a synthetic ID).
+#[test]
+fn pattern_occurs_true_for_all_five_synthetic_patterns_ac1_394() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let god_fn = write_fixture(
+        &dir,
+        "god_fn.rs",
+        "\nfn big() {\n    \
+         let a=1; let b=2; let c=3; let d=4; let e=5; let f=6; let g=7;\n    \
+         let h=8; let i=9; let j=10; let k=11; let l=12; let m=13; let n=14;\n    \
+         let o=15; let p=16; let q=17; let r=18; let s=19; let t=20;\n}\n",
+    );
+    let deep = write_fixture(
+        &dir,
+        "deep.rs",
+        "\nfn a() {\n    if true {\n        for _ in 0..1 {\n            \
+         if true {\n                do_work();\n            }\n        }\n    }\n}\n",
+    );
+    let empty_fn = write_fixture(&dir, "empty_fn.rs", "\nfn todo_later() {\n}\n");
+    let empty_catch = write_fixture(
+        &dir,
+        "empty_catch.ts",
+        "\ntry {\n    f();\n} catch (e) {\n}\n",
+    );
+    let many_params = write_fixture(
+        &dir,
+        "many_params.rs",
+        "\nfn many(a: i32, b: i32, c: i32, d: i32, e: i32) -> i32 {\n    \
+         a + b + c + d + e\n}\n",
+    );
+
+    let cases = [
+        ("god-function", god_fn),
+        ("deep-nesting", deep),
+        ("empty-function", empty_fn),
+        ("empty-catch", empty_catch),
+        ("excessive-params", many_params),
+    ];
+
+    for (pattern, path) in cases {
+        let query = parse_ast_query(pattern).unwrap();
+        assert!(
+            pattern_occurs_in_file(&path, &query, None),
+            "AC1 (#394): {pattern} must return true for its exhibiting fixture \
+             ({path:?}) — fails before the fix (strict walk can never match a \
+             synthetic ID)"
+        );
+    }
+}
+
+/// AC3 (#394), all 5: `pattern_occurs_in_file` returns `false` for each
+/// synthetic pattern's negative twin — proves the extraction-reuse gate
+/// discriminates rather than always-true.
+#[test]
+fn pattern_occurs_false_for_all_five_synthetic_negative_twins_ac3_394() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let not_god_fn = write_fixture(
+        &dir,
+        "not_god_fn.rs",
+        "fn nineteen() {\n    \
+         let a=1; let b=2; let c=3; let d=4; let e=5; let f=6; let g=7;\n    \
+         let h=8; let i=9; let j=10; let k=11; let l=12; let m=13; let n=14;\n    \
+         let o=15; let p=16; let q=17; let r=18; let s=19;\n}\n",
+    );
+    // Empirically dogfood-verified (release binary --ast deep-nesting query)
+    // to have CST max_depth < 4 — a trivial top-level-only fixture, NOT
+    // eyeballed/brace-counted (AC3 requires empirical confirmation).
+    let not_deep = write_fixture(&dir, "not_deep.rs", "struct S;\n");
+    let not_empty_fn = write_fixture(&dir, "not_empty_fn.rs", "fn f() {\n    let x = 1;\n}\n");
+    let not_empty_catch = write_fixture(
+        &dir,
+        "not_empty_catch.ts",
+        "try {\n    f();\n} catch (e) {\n    log(e);\n}\n",
+    );
+    let not_many_params = write_fixture(
+        &dir,
+        "not_many_params.rs",
+        "fn four(a: i32, b: i32, c: i32, d: i32) -> i32 {\n    a + b + c + d\n}\n",
+    );
+
+    let cases = [
+        ("god-function", not_god_fn),
+        ("deep-nesting", not_deep),
+        ("empty-function", not_empty_fn),
+        ("empty-catch", not_empty_catch),
+        ("excessive-params", not_many_params),
+    ];
+
+    for (pattern, path) in cases {
+        let query = parse_ast_query(pattern).unwrap();
+        assert!(
+            !pattern_occurs_in_file(&path, &query, None),
+            "AC3 (#394): {pattern}'s negative twin ({path:?}) must return false \
+             (gate must discriminate, not always-true)"
+        );
+    }
+}
+
+/// AC6 (#394): fail-soft guards on the SYNTHETIC branch — a synthetic pattern
+/// (god-function) must return `false` (never panic) for the same degraded
+/// inputs the real branch already guards against: non-tree-sitter file, file
+/// over the size guard, and mtime mismatch.
+#[test]
+fn pattern_occurs_false_for_synthetic_pattern_on_degraded_inputs_ac6_394() {
+    use super::MAX_REPARSE_FILE_BYTES;
+
+    let dir = tempfile::tempdir().unwrap();
+    let query = parse_ast_query("god-function").unwrap();
+
+    // Non-tree-sitter language.
+    let json_path = write_fixture(&dir, "config.json", r#"{"key": "value"}"#);
+    assert!(
+        !pattern_occurs_in_file(&json_path, &query, None),
+        "AC6 (#394): synthetic pattern must return false for a non-tree-sitter \
+         file (JSON), not panic"
+    );
+
+    // Oversized file.
+    let huge_path = dir.path().join("huge.rs");
+    std::fs::write(
+        &huge_path,
+        "x".repeat((MAX_REPARSE_FILE_BYTES + 1) as usize).as_bytes(),
+    )
+    .unwrap();
+    assert!(
+        !pattern_occurs_in_file(&huge_path, &query, None),
+        "AC6 (#394): synthetic pattern must return false for a file over the \
+         size guard, not panic"
+    );
+
+    // Mtime mismatch.
+    let mtime_path = write_fixture(&dir, "big.rs", "fn big() { let a = 1; }\n");
+    assert!(
+        !pattern_occurs_in_file(&mtime_path, &query, Some(1)),
+        "AC6 (#394): synthetic pattern must return false on mtime mismatch \
+         (stored=1, ancient epoch), not panic"
+    );
+
+    // Missing file.
+    assert!(
+        !pattern_occurs_in_file(Path::new("/nonexistent/path/god_fn.rs"), &query, None),
+        "AC6 (#394): synthetic pattern must return false for a nonexistent \
+         file, not panic"
+    );
+}
+
+/// AC7 (#394): `contains_synthetic_id` is `false` for a containment query
+/// (`AstQuery::Containment` can never carry a synthetic component — the
+/// parser rejects synthetic-marker names before a `Containment` value can be
+/// constructed) and `true` for a synthetic-marker `AstQuery::Pattern`.
+#[test]
+fn contains_synthetic_id_false_for_containment_true_for_synthetic_pattern_ac7_394() {
+    // Containment query — real node kinds only.
+    let containment_query = parse_ast_query("for_statement > block").unwrap();
+    let containment_table = super::AncestorMatchTable::build(&containment_query);
+    assert!(
+        !containment_table.contains_synthetic_id(),
+        "AC7 (#394): a containment query must never route synthetic \
+         (contains_synthetic_id must be false)"
+    );
+
+    // Synthetic-marker pattern.
+    let synthetic_query = parse_ast_query("god-function").unwrap();
+    let synthetic_table = super::AncestorMatchTable::build(&synthetic_query);
+    assert!(
+        synthetic_table.contains_synthetic_id(),
+        "AC7 (#394) control: god-function must route synthetic \
+         (contains_synthetic_id must be true)"
+    );
+
+    // Real-node pattern (control) — must NOT route synthetic either.
+    let real_query = parse_ast_query("try-catch").unwrap();
+    let real_table = super::AncestorMatchTable::build(&real_query);
+    assert!(
+        !real_table.contains_synthetic_id(),
+        "AC7 (#394) control: a real-node pattern (try-catch) must NOT route \
+         synthetic"
+    );
+
+    // Synthetic-marker name is rejected at parse for containment queries —
+    // so a Containment value carrying a synthetic component can never even
+    // be constructed.
+    let rejected = parse_ast_query("__deep_node__ > __deep_node_b4__");
+    assert!(
+        rejected.is_err(),
+        "AC7 (#394): containment query using synthetic-marker names must be \
+         rejected at parse"
+    );
+}
+
+/// AC13 (#394), all 5: `recover_line` returns `Some((line, range))` with
+/// `line` equal to the AD-394-5 ground-truth node line, for each synthetic
+/// pattern. Each assertion FAILS before the fix (`recover_line` returns
+/// `None` for every synthetic pattern pre-#394).
+#[test]
+fn recover_line_matches_ground_truth_for_all_five_synthetic_patterns_ac13_394() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let god_fn = write_fixture(
+        &dir,
+        "god_fn.rs",
+        "\nfn big() {\n    \
+         let a=1; let b=2; let c=3; let d=4; let e=5; let f=6; let g=7;\n    \
+         let h=8; let i=9; let j=10; let k=11; let l=12; let m=13; let n=14;\n    \
+         let o=15; let p=16; let q=17; let r=18; let s=19; let t=20;\n}\n",
+    );
+    let deep = write_fixture(
+        &dir,
+        "deep.rs",
+        "\nfn a() {\n    if true {\n        for _ in 0..1 {\n            \
+         if true {\n                do_work();\n            }\n        }\n    }\n}\n",
+    );
+    let empty_fn = write_fixture(&dir, "empty_fn.rs", "\nfn todo_later() {\n}\n");
+    let empty_catch = write_fixture(
+        &dir,
+        "empty_catch.ts",
+        "\ntry {\n    f();\n} catch (e) {\n}\n",
+    );
+    let many_params = write_fixture(
+        &dir,
+        "many_params.rs",
+        "\nfn many(a: i32, b: i32, c: i32, d: i32, e: i32) -> i32 {\n    \
+         a + b + c + d + e\n}\n",
+    );
+
+    // (pattern, fixture path, ground-truth 1-indexed line — AD-394-5 rule)
+    let cases: [(&str, std::path::PathBuf, u32); 5] = [
+        ("god-function", god_fn, 2),          // `fn big() {` — enclosing function
+        ("deep-nesting", deep, 3),            // `    if true {` — first depth>=4 node
+        ("empty-function", empty_fn, 2),      // `fn todo_later() {` — function_item
+        ("empty-catch", empty_catch, 4),      // `} catch (e) {` — catch_clause
+        ("excessive-params", many_params, 2), // `fn many(...)` — param-list's own line
+    ];
+
+    for (pattern, path, expected_line) in cases {
+        let query = parse_ast_query(pattern).unwrap();
+        let result = recover_line(&path, &query, None);
+        assert!(
+            result.is_some(),
+            "AC13 (#394): recover_line({pattern}) must return Some((line, range)), \
+             not None — this is the pre-fix behavior for every synthetic pattern"
+        );
+        let (line, range) = result.unwrap();
+        assert_eq!(
+            line, expected_line,
+            "AC13 (#394): recover_line({pattern}) must report line {expected_line} \
+             (AD-394-5 ground truth); got {line}"
+        );
+        assert!(
+            !range.is_empty(),
+            "AC13 (#394): recover_line({pattern}) must return a non-empty byte \
+             range; got {range:?}"
+        );
+    }
+}
+
+/// AC13 (#394) fail-soft: `recover_line`'s synthetic branch degrades to `None`
+/// on the same inputs the real branch already guards against.
+#[test]
+fn recover_line_none_for_synthetic_pattern_on_degraded_inputs_ac13_394() {
+    use super::MAX_REPARSE_FILE_BYTES;
+
+    let dir = tempfile::tempdir().unwrap();
+    let query = parse_ast_query("god-function").unwrap();
+
+    let json_path = write_fixture(&dir, "config.json", r#"{"key": "value"}"#);
+    assert!(
+        recover_line(&json_path, &query, None).is_none(),
+        "AC13 (#394): synthetic pattern recover_line must return None for a \
+         non-tree-sitter file (JSON)"
+    );
+
+    let huge_path = dir.path().join("huge.rs");
+    std::fs::write(
+        &huge_path,
+        "x".repeat((MAX_REPARSE_FILE_BYTES + 1) as usize).as_bytes(),
+    )
+    .unwrap();
+    assert!(
+        recover_line(&huge_path, &query, None).is_none(),
+        "AC13 (#394): synthetic pattern recover_line must return None for a \
+         file over the size guard"
+    );
+
+    let mtime_path = write_fixture(&dir, "big.rs", "fn big() { let a = 1; }\n");
+    assert!(
+        recover_line(&mtime_path, &query, Some(1)).is_none(),
+        "AC13 (#394): synthetic pattern recover_line must return None on mtime \
+         mismatch"
+    );
+}

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -43,8 +43,9 @@ pub use ast_index::{
     AstPosting, AstPostingSource, AstQuery, AstQueryEngine, AstTrigram, AstTrigramEntry,
     CachedAstEntry, DEFAULT_AST_WEIGHT, LinearNode, LinearizeResult, NodeKindId, Pattern,
     PatternCategory, StructuralMetrics, all_patterns, ast_bigram_idf, ast_trigram_idf,
-    extract_ast_ngrams, extract_ast_ngrams_with_metrics, extract_ast_ngrams_with_weights,
-    linearize_source, lookup_pattern, parse_ast_query, vocab_len, vocab_lookup, vocab_resolve,
+    extract_ast_ngrams, extract_ast_ngrams_with_lines, extract_ast_ngrams_with_metrics,
+    extract_ast_ngrams_with_weights, is_synthetic_id, linearize_source, lookup_pattern,
+    parse_ast_query, vocab_len, vocab_lookup, vocab_resolve,
 };
 
 /// Current on-disk format version for the AST index (`ast_index.skidx`).

--- a/crates/rskim-search/src/lib.rs
+++ b/crates/rskim-search/src/lib.rs
@@ -45,7 +45,7 @@ pub use ast_index::{
     PatternCategory, StructuralMetrics, all_patterns, ast_bigram_idf, ast_trigram_idf,
     extract_ast_ngrams, extract_ast_ngrams_with_lines, extract_ast_ngrams_with_metrics,
     extract_ast_ngrams_with_weights, is_synthetic_id, linearize_source, lookup_pattern,
-    parse_ast_query, vocab_len, vocab_lookup, vocab_resolve,
+    parse_ast_query, synthetic_key_present, vocab_len, vocab_lookup, vocab_resolve,
 };
 
 /// Current on-disk format version for the AST index (`ast_index.skidx`).

--- a/crates/rskim/src/cmd/search/ast.rs
+++ b/crates/rskim/src/cmd/search/ast.rs
@@ -25,7 +25,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use rskim_search::{AstIndexReader, AstQuery, AstQueryEngine, FileId, TemporalDb};
-use rskim_search::{all_patterns, parse_ast_query};
+use rskim_search::{all_patterns, is_synthetic_id, parse_ast_query};
 // #201: enriched row type + formatters from rskim-search.
 // pub(super) re-exports so test module (ast_tests.rs) can call them as super::.
 pub(super) use rskim_search::AstResult;
@@ -239,9 +239,28 @@ pub(super) fn run_ast_standalone(
     } else {
         limit
     };
-    // AD-374-3: AST candidate pool — reuse LEXICAL_CANDIDATE_POOL_K from query.rs
-    // (pub(super)) as the single definition. No AST-local fork.
-    let ast_pool = super::query::candidate_pool(limit, super::query::LEXICAL_CANDIDATE_POOL_K);
+    // AD-374-3 / AC11 (#419): AST candidate pool.
+    //
+    // Real-node patterns: reuse LEXICAL_CANDIDATE_POOL_K from query.rs (K=5,
+    // floor=100) — the same over-fetch logic as the lexical path, needed because
+    // the strict ancestor-walk gate can drop a significant fraction of candidates
+    // for patterns with many structural false positives.
+    //
+    // Synthetic-marker patterns (god-function, deep-nesting, empty-function,
+    // empty-catch, excessive-params): the extraction-reuse verify gate
+    // (`synthetic_key_present`) has near-zero drop rate — the AST index correctly
+    // identifies which files contain the marker, so a K=5 pool and a 100-file
+    // floor are pure overhead. For these, size the pool to exactly `limit` (with
+    // a floor of 1 to avoid an empty pool when limit=0).
+    //
+    // This is the companion to the `synthetic_key_present` early-exit fix in
+    // `compound/reparse.rs` — together they reduce measured `--ast deep-nesting`
+    // latency from ~6.9s to within AC11's <500ms target.
+    let ast_pool = if ast_query_is_synthetic(&query) {
+        limit.max(1)
+    } else {
+        super::query::candidate_pool(limit, super::query::LEXICAL_CANDIDATE_POOL_K)
+    };
     let window = temporal_window.max(ast_pool);
 
     // Intersect AST results with blast-radius FileIds (when set), then take the
@@ -405,6 +424,28 @@ fn read_line_at(abs_path: &Path, line_1indexed: u32, max_bytes: u64) -> Option<S
 // ============================================================================
 // Pattern metadata lookup
 // ============================================================================
+
+/// AC11 / AD-374-3 (#419): returns `true` when every resolved bigram in `query`
+/// is a synthetic-marker pattern (at least one component ID >= `BUCKET_LABEL_BASE`).
+///
+/// Only [`AstQuery::Pattern`] with synthetic-marker resolved bigrams reaches
+/// this path — [`AstQuery::Containment`] and [`AstQuery::SingleNode`] do not
+/// reference synthetic IDs (the parser rejects them at the CLI boundary), so
+/// this function returns `false` for those variants.
+///
+/// Used to gate the candidate pool size: synthetic patterns have a near-zero
+/// verify drop rate (the early-exit `synthetic_key_present` gate is essentially
+/// a membership check of what the index already indexed), so a K=5 multiplier
+/// and a 100-file floor are unnecessary overhead for them.
+fn ast_query_is_synthetic(query: &AstQuery) -> bool {
+    match query {
+        AstQuery::Pattern(p) => p.resolved_bigrams().iter().any(|bg| {
+            let (parent, child) = bg.decode();
+            is_synthetic_id(parent) || is_synthetic_id(child)
+        }),
+        AstQuery::Containment(_) | AstQuery::SingleNode(_) => false,
+    }
+}
 
 /// Look up human-readable metadata for a pattern name.
 ///

--- a/crates/rskim/src/cmd/search/ast.rs
+++ b/crates/rskim/src/cmd/search/ast.rs
@@ -266,6 +266,17 @@ pub(super) fn run_ast_standalone(
     // `recover_line`. This is the correctness backstop that eliminates unrelated-
     // subtree false positives that AND-intersect alone would keep.
     //
+    // AD-394-4 (#394): the 5 synthetic-marker patterns (god-function,
+    // deep-nesting, empty-function, empty-catch, excessive-params) now pass
+    // through this SAME `pattern_occurs_in_file` call via an internal
+    // extraction-reuse branch (`compound::reparse`, AD-394-1/AD-394-2) — before
+    // #394 they always failed the gate (a synthetic ID can never appear in a
+    // real `node.parent()` chain), so standalone `--ast <synthetic-pattern>`
+    // returned zero results for all 5 while the compound path (which skips this
+    // gate, see below) returned matches — a standalone/compound contradiction
+    // (avoids PF-006). This call site is otherwise UNCHANGED; the routing is
+    // internal to `pattern_occurs_in_file`.
+    //
     // AD-374-5: Non-tree-sitter files (JSON/TOML/YAML, node_count=0) return false
     // from `pattern_occurs_in_file` and are dropped here.
     //
@@ -336,6 +347,13 @@ pub(super) fn run_ast_standalone(
     // by the verify gate above. A file that passes the gate but whose representative
     // line cannot be recovered still emits as a degraded row (path present, no :line
     // or snippet). recover_line returning None MUST NOT drop a gate-passed file.
+    //
+    // Updated for #394 (OD-394-1, AD-394-5): `recover_line` is now
+    // synthetic-aware, so a gate-passed synthetic-pattern row (god-function,
+    // deep-nesting, empty-function, empty-catch, excessive-params) recovers a
+    // REAL `:line`/snippet here too, instead of degrading to a path-only row.
+    // This call site itself is unchanged — the synthetic branch is internal to
+    // `recover_line`.
     for r in &mut resolved {
         let abs_path = root.join(&r.path);
         // Recover the stored mtime from the manifest for the stale guard.

--- a/crates/rskim/src/cmd/search/ast_tests.rs
+++ b/crates/rskim/src/cmd/search/ast_tests.rs
@@ -4396,3 +4396,55 @@ fn run_ast_standalone_synthetic_pattern_no_format_change_ac12_394() {
         rskim_search::AST_INDEX_FORMAT_VERSION
     );
 }
+
+/// AC11 (#394 / #419): `ast_query_is_synthetic` correctly classifies queries.
+///
+/// - All 5 synthetic-marker patterns (`god-function`, `deep-nesting`,
+///   `empty-function`, `empty-catch`, `excessive-params`) → `true`.
+/// - All non-synthetic named patterns (`try-catch`, `rust-nested-loop`,
+///   `god-class`) → `false`.
+/// - `AstQuery::Containment` (which never carries a synthetic ID — rejected at
+///   parse time) → `false`.
+///
+/// This is a unit test for the pool-sizing helper introduced in the AC11 fix:
+/// the synthetic pool uses `limit.max(1)` instead of `max(K×limit, 100)`.
+#[test]
+fn ast_query_is_synthetic_classifies_correctly_ac11_394() {
+    // Synthetic patterns — must return true.
+    for pattern in [
+        "god-function",
+        "deep-nesting",
+        "empty-function",
+        "empty-catch",
+        "excessive-params",
+    ] {
+        let query = rskim_search::parse_ast_query(pattern)
+            .unwrap_or_else(|e| panic!("AC11 (#394): {pattern} must parse: {e}"));
+        assert!(
+            super::ast_query_is_synthetic(&query),
+            "AC11 (#394): ast_query_is_synthetic({pattern}) must return true — \
+             this is a synthetic-marker pattern; got false"
+        );
+    }
+
+    // Real-node patterns — must return false.
+    for pattern in ["try-catch", "rust-nested-loop", "god-class"] {
+        let query = rskim_search::parse_ast_query(pattern)
+            .unwrap_or_else(|e| panic!("AC11 (#394): {pattern} must parse: {e}"));
+        assert!(
+            !super::ast_query_is_synthetic(&query),
+            "AC11 (#394): ast_query_is_synthetic({pattern}) must return false — \
+             this is a real-node pattern; got true"
+        );
+    }
+
+    // Containment query (A > B) — must return false (containment never carries
+    // a synthetic ID; the parser rejects synthetic-marker names in containment
+    // position).
+    let containment = rskim_search::parse_ast_query("function_item > block")
+        .unwrap_or_else(|e| panic!("AC11 (#394): containment query must parse: {e}"));
+    assert!(
+        !super::ast_query_is_synthetic(&containment),
+        "AC11 (#394): ast_query_is_synthetic for a containment query must return false"
+    );
+}

--- a/crates/rskim/src/cmd/search/ast_tests.rs
+++ b/crates/rskim/src/cmd/search/ast_tests.rs
@@ -3771,3 +3771,628 @@ fn compound_temporal_weight_inert_byte_identical_ac3() {
          compound ranking despite there being no temporal sort on this path"
     );
 }
+
+// ============================================================================
+// #394: Standalone --ast returned zero results for all 5 synthetic-marker
+// patterns (god-function, deep-nesting, empty-function, empty-catch,
+// excessive-params). Root cause: `vocab_lookup` never yields a synthetic ID
+// (>= BUCKET_LABEL_BASE), so the real-CST ancestor walk in
+// `pattern_occurs_in_file` was structurally unsatisfiable for them. Fixed via
+// extraction-reuse (AD-394-1/AD-394-2). AC numbers below match the design
+// plan (.devflow/docs/design/wave4-p0/2026-07-04_0930/394-ast-synthetic-markers-plan.md).
+// ============================================================================
+
+/// Ground-truth representative line for each of the 5 synthetic patterns'
+/// exhibiting fixture file (AC10, AC13). Established via empirical dogfood
+/// verification against the built release binary — NOT eyeballed (ADR-003:
+/// grounded, not assumed). Each matches the AD-394-5 per-pattern rule:
+/// god-function/empty-function -> enclosing function line; empty-catch ->
+/// enclosing catch_clause line; excessive-params -> parameter-list's own
+/// line (coincides with the signature line here); deep-nesting -> first node
+/// crossing CST depth >= 4.
+const GOD_FUNCTION_LINE: u32 = 2; // `fn big() {`
+const DEEP_NESTING_LINE: u32 = 3; // `    if true {`
+const EMPTY_FUNCTION_LINE: u32 = 2; // `fn todo_later() {`
+const EMPTY_CATCH_LINE: u32 = 4; // `} catch (e) {`
+const EXCESSIVE_PARAMS_LINE: u32 = 2; // `fn many(a: i32, ...) -> i32 {`
+
+/// Build a project fixture with one exhibiting file per synthetic-marker
+/// pattern (AC1 positives) PLUS its negative twin (AC3). Mirrors the #374
+/// `make_project_for_374_gate` convention: `.git` root + `src/` files. Each
+/// positive fixture places its target construct at a KNOWN line matching the
+/// `*_LINE` constants above (empirically verified, not assumed).
+fn make_project_with_394_synthetic_patterns() -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+
+    // ── Positives (AC1) ──────────────────────────────────────────────────────
+
+    // god-function: LARGE_BODY -> bucket_label(1), needs >= 20 body statements
+    // (BODY_STMT_EDGES[1] = 20). 20 let-statements — matches the GOLD-verified
+    // catalog example in patterns.rs (reformatted onto known lines).
+    fs::write(
+        root.join("src/god_fn.rs"),
+        "\nfn big() {\n    \
+         let a=1; let b=2; let c=3; let d=4; let e=5; let f=6; let g=7;\n    \
+         let h=8; let i=9; let j=10; let k=11; let l=12; let m=13; let n=14;\n    \
+         let o=15; let p=16; let q=17; let r=18; let s=19; let t=20;\n}\n",
+    )
+    .unwrap();
+
+    // deep-nesting: DEEP_NODE -> bucket_label(0), needs a node at CST depth >= 4.
+    fs::write(
+        root.join("src/deep.rs"),
+        "\nfn a() {\n    if true {\n        for _ in 0..1 {\n            \
+         if true {\n                do_work();\n            }\n        }\n    }\n}\n",
+    )
+    .unwrap();
+
+    // empty-function: EMPTY_BODY -> function_item, zero counted children in body.
+    fs::write(root.join("src/empty_fn.rs"), "\nfn todo_later() {\n}\n").unwrap();
+
+    // excessive-params: MANY_PARAMS -> bucket_label(0), needs >= 5 params
+    // (PARAM_EDGES[0] = 5).
+    fs::write(
+        root.join("src/many_params.rs"),
+        "\nfn many(a: i32, b: i32, c: i32, d: i32, e: i32) -> i32 {\n    \
+         a + b + c + d + e\n}\n",
+    )
+    .unwrap();
+
+    // empty-catch: EMPTY_BODY -> catch_clause, zero counted children in catch body.
+    fs::write(
+        root.join("src/empty_catch.ts"),
+        "\ntry {\n    f();\n} catch (e) {\n}\n",
+    )
+    .unwrap();
+
+    // ── Negative twins (AC3) — each crosses some but not all thresholds, or
+    // has none of the relevant marker; empirically dogfood-verified to NOT
+    // match its corresponding pattern. ──────────────────────────────────────
+
+    // 19 body statements: crosses BODY_STMT_EDGES[0]=10 but NOT [1]=20.
+    fs::write(
+        root.join("src/not_god_fn.rs"),
+        "fn nineteen() {\n    \
+         let a=1; let b=2; let c=3; let d=4; let e=5; let f=6; let g=7;\n    \
+         let h=8; let i=9; let j=10; let k=11; let l=12; let m=13; let n=14;\n    \
+         let o=15; let p=16; let q=17; let r=18; let s=19;\n}\n",
+    )
+    .unwrap();
+
+    // 4 params: below PARAM_EDGES[0]=5.
+    fs::write(
+        root.join("src/not_many_params.rs"),
+        "fn four(a: i32, b: i32, c: i32, d: i32) -> i32 {\n    a + b + c + d\n}\n",
+    )
+    .unwrap();
+
+    // Non-empty catch body.
+    fs::write(
+        root.join("src/not_empty_catch.ts"),
+        "try {\n    f();\n} catch (e) {\n    log(e);\n}\n",
+    )
+    .unwrap();
+
+    // Non-empty function body.
+    fs::write(
+        root.join("src/not_empty_fn.rs"),
+        "fn f() {\n    let x = 1;\n}\n",
+    )
+    .unwrap();
+
+    // Trivial top-level-only fixture — empirically dogfood-verified (via a
+    // real index build + `--ast deep-nesting` query) to have CST max_depth < 4.
+    // AC3 requires this be confirmed empirically, NOT by counting braces —
+    // depth is 0-indexed CST depth and even simple code can reach depth 4.
+    fs::write(root.join("src/not_deep.rs"), "struct S;\n").unwrap();
+
+    dir
+}
+
+/// AC1 (#394): standalone `--ast <pattern>` returns a NON-EMPTY result set
+/// whose text output CONTAINS the exhibiting file's exact path, for ALL FIVE
+/// synthetic-marker patterns. Before the fix, standalone `--ast` returned
+/// zero results for every one of these 5 patterns.
+///
+/// NEGATIVE (PF-007): if the fix regressed to always-empty, every iteration
+/// of this loop fails.
+#[test]
+fn run_ast_standalone_all_five_synthetic_patterns_positive_ac1_394() {
+    use super::super::manifest::FileManifest;
+
+    let project = make_project_with_394_synthetic_patterns();
+    let cache = tempfile::tempdir().unwrap();
+    build_project_index(project.path(), cache.path());
+
+    let manifest =
+        FileManifest::load(project.path().to_path_buf(), cache.path().to_path_buf()).unwrap();
+
+    let cases: [(&str, &str); 5] = [
+        ("god-function", "god_fn.rs"),
+        ("deep-nesting", "deep.rs"),
+        ("empty-function", "empty_fn.rs"),
+        ("empty-catch", "empty_catch.ts"),
+        ("excessive-params", "many_params.rs"),
+    ];
+
+    for (pattern, exhibiting_file) in cases {
+        let mut out: Vec<u8> = Vec::new();
+        let result = super::run_ast_standalone(
+            pattern,
+            20,
+            false,
+            cache.path(),
+            &manifest,
+            None,
+            None,
+            None,
+            project.path(),
+            &mut out,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            std::process::ExitCode::SUCCESS,
+            "AC1 (#394): --ast {pattern} must exit 0"
+        );
+
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.contains(exhibiting_file),
+            "AC1 (#394): --ast {pattern} must return a NON-EMPTY result set \
+             containing {exhibiting_file}; got:\n{text}"
+        );
+    }
+}
+
+/// AC2 (#394): the exhibiting file returned by standalone `--ast <p>` is ALSO
+/// returned by the compound path `<text> --ast <p>`, for ALL FIVE synthetic
+/// patterns (membership assertion — ranking/windowing may differ between the
+/// two paths, so list-identity is NOT asserted).
+#[test]
+fn run_ast_standalone_matches_compound_for_all_five_synthetic_patterns_ac2_394() {
+    use super::super::manifest::FileManifest;
+    use super::super::query::execute_query;
+
+    let project = make_project_with_394_synthetic_patterns();
+    let cache = tempfile::tempdir().unwrap();
+    build_project_index(project.path(), cache.path());
+
+    let manifest =
+        FileManifest::load(project.path().to_path_buf(), cache.path().to_path_buf()).unwrap();
+
+    // (pattern, exhibiting file, unique text term selecting that file)
+    let cases: [(&str, &str, &str); 5] = [
+        ("god-function", "god_fn.rs", "big"),
+        ("deep-nesting", "deep.rs", "do_work"),
+        ("empty-function", "empty_fn.rs", "todo_later"),
+        ("empty-catch", "empty_catch.ts", "catch"),
+        ("excessive-params", "many_params.rs", "many"),
+    ];
+
+    for (pattern, exhibiting_file, term) in cases {
+        // Standalone.
+        let mut standalone_out: Vec<u8> = Vec::new();
+        super::run_ast_standalone(
+            pattern,
+            20,
+            false,
+            cache.path(),
+            &manifest,
+            None,
+            None,
+            None,
+            project.path(),
+            &mut standalone_out,
+        )
+        .unwrap();
+        let standalone_text = String::from_utf8(standalone_out).unwrap();
+        assert!(
+            standalone_text.contains(exhibiting_file),
+            "AC2 (#394): standalone --ast {pattern} must contain {exhibiting_file}; \
+             got:\n{standalone_text}"
+        );
+
+        // Compound: text term + --ast.
+        let engine = super::open_ast_engine(cache.path()).unwrap();
+        let ast_scored = super::resolve_ast_scored(&engine, pattern).unwrap();
+        let config = make_query_config(
+            project.path(),
+            cache.path(),
+            term,
+            20,
+            Some(ast_scored),
+            None,
+        );
+        let compound_out = execute_query(&config, &TEST_ANALYTICS).unwrap();
+        let found = compound_out
+            .results
+            .iter()
+            .any(|r| r.path.contains(exhibiting_file));
+        assert!(
+            found,
+            "AC2 (#394): compound '{term} --ast {pattern}' must ALSO return \
+             {exhibiting_file}; got paths: {:?}",
+            compound_out
+                .results
+                .iter()
+                .map(|r| &r.path)
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+/// AC3 (#394): `pattern_occurs_in_file` returns FALSE for each synthetic
+/// pattern's negative twin — proves the gate discriminates rather than
+/// always-true. Uses direct file calls (no index build needed).
+///
+/// NEGATIVE (PF-007): an always-true stub (e.g. "any synthetic-containing
+/// pattern passes unconditionally") would fail every assertion below.
+#[test]
+fn pattern_occurs_in_file_false_for_all_five_synthetic_negative_twins_ac3_394() {
+    let project = make_project_with_394_synthetic_patterns();
+
+    let cases: [(&str, &str); 5] = [
+        ("god-function", "src/not_god_fn.rs"),
+        ("deep-nesting", "src/not_deep.rs"),
+        ("empty-function", "src/not_empty_fn.rs"),
+        ("empty-catch", "src/not_empty_catch.ts"),
+        ("excessive-params", "src/not_many_params.rs"),
+    ];
+
+    for (pattern, rel_path) in cases {
+        let query = rskim_search::parse_ast_query(pattern).unwrap();
+        let path = project.path().join(rel_path);
+        assert!(
+            !rskim_search::pattern_occurs_in_file(&path, &query, None),
+            "AC3 (#394): {pattern}'s negative twin ({rel_path}) must NOT match \
+             (gate must discriminate, not always-true)"
+        );
+    }
+
+    // POSITIVE control (PF-007 double-assertion): the SAME gate call returns
+    // true for the corresponding exhibiting file, proving it is not
+    // always-false either.
+    let positive_cases: [(&str, &str); 5] = [
+        ("god-function", "src/god_fn.rs"),
+        ("deep-nesting", "src/deep.rs"),
+        ("empty-function", "src/empty_fn.rs"),
+        ("empty-catch", "src/empty_catch.ts"),
+        ("excessive-params", "src/many_params.rs"),
+    ];
+    for (pattern, rel_path) in positive_cases {
+        let query = rskim_search::parse_ast_query(pattern).unwrap();
+        let path = project.path().join(rel_path);
+        assert!(
+            rskim_search::pattern_occurs_in_file(&path, &query, None),
+            "AC3 (#394) control: {pattern}'s exhibiting file ({rel_path}) must match"
+        );
+    }
+}
+
+/// AC7 (#394), parse-level half: a containment query written with
+/// synthetic-marker names is REJECTED at parse with `InvalidQuery` — synthetic
+/// names are not real vocabulary kinds, so `vocab_lookup` fails for them in
+/// `parse_bigram`. Only named `AstQuery::Pattern` queries can ever route
+/// synthetic (the `AncestorMatchTable::contains_synthetic_id`-false half of
+/// AC7 is covered in `reparse_tests.rs`, which has direct access to the
+/// private table).
+#[test]
+fn synthetic_marker_names_rejected_in_containment_query_ac7_394() {
+    let result = rskim_search::parse_ast_query("__deep_node__ > __deep_node_b4__");
+    assert!(
+        result.is_err(),
+        "AC7 (#394): a containment query using synthetic-marker names must be \
+         rejected at parse (InvalidQuery), not silently accepted; got: {result:?}"
+    );
+}
+
+/// AC8 (#394), CRITICAL invariant: no pattern in the catalog mixes a
+/// synthetic-containing n-gram (any resolved component >= BUCKET_LABEL_BASE)
+/// with a real n-gram (all components < BUCKET_LABEL_BASE). This is the
+/// safety assumption that makes AD-394-2's WHOLE-PATTERN routing sound; if it
+/// is ever violated, extraction-reuse would silently loosen a real pattern's
+/// gate too (see AD-394-2 / OD-394-2).
+///
+/// This test MUST fail fast if the invariant is ever violated (R4 mitigation).
+#[test]
+fn no_catalog_pattern_mixes_real_and_synthetic_ngrams_ac8_394() {
+    use rskim_search::is_synthetic_id;
+
+    for pattern in rskim_search::all_patterns() {
+        let query = rskim_search::parse_ast_query(pattern.name)
+            .unwrap_or_else(|e| panic!("pattern {:?} must parse: {e}", pattern.name));
+        let rskim_search::AstQuery::Pattern(p) = &query else {
+            panic!(
+                "catalog pattern {:?} must parse to AstQuery::Pattern",
+                pattern.name
+            );
+        };
+
+        let mut has_synthetic = false;
+        let mut has_real = false;
+        for bigram in p.resolved_bigrams() {
+            let (parent, child) = bigram.decode();
+            if is_synthetic_id(parent) || is_synthetic_id(child) {
+                has_synthetic = true;
+            } else {
+                has_real = true;
+            }
+        }
+        for trigram in p.resolved_trigrams() {
+            let (gp, parent, child) = trigram.decode();
+            if is_synthetic_id(gp) || is_synthetic_id(parent) || is_synthetic_id(child) {
+                has_synthetic = true;
+            } else {
+                has_real = true;
+            }
+        }
+
+        assert!(
+            !(has_synthetic && has_real),
+            "AC8 (#394) CRITICAL: pattern {:?} mixes synthetic AND real n-grams — \
+             this violates the whole-pattern routing invariant (AD-394-2/OD-394-2); \
+             a per-n-gram routing redesign or pattern split is required",
+            pattern.name
+        );
+    }
+}
+
+/// AC9 (#394): catalog-driven regression guard over ALL 29 patterns (moved
+/// here from `reparse_tests.rs` for LOCAL execution — `all_patterns`,
+/// `parse_ast_query`, and `pattern_occurs_in_file` are all pub-exported). For
+/// every pattern, writing its GOLD-verified `example` to a tempfile with the
+/// matching extension and calling `pattern_occurs_in_file` must return `true`
+/// — this is the guard that would have caught #394 at introduction (the 5
+/// synthetic patterns would have failed this assertion before the fix).
+#[test]
+fn catalog_driven_pattern_occurs_true_for_every_pattern_example_ac9_394() {
+    fn extension_for(lang: rskim_core::Language) -> &'static str {
+        match lang {
+            rskim_core::Language::Rust => "rs",
+            rskim_core::Language::TypeScript => "ts",
+            rskim_core::Language::Python => "py",
+            rskim_core::Language::Go => "go",
+            rskim_core::Language::Java => "java",
+            rskim_core::Language::Ruby => "rb",
+            other => panic!(
+                "AC9 (#394): pattern catalog example_lang {other:?} has no \
+                 extension mapping in this test — add one (load-bearing \
+                 symmetry with Language::from_path)"
+            ),
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+
+    for pattern in rskim_search::all_patterns() {
+        let ext = extension_for(pattern.example_lang);
+        let path = dir
+            .path()
+            .join(format!("{}.{ext}", pattern.name.replace('-', "_")));
+        fs::write(&path, pattern.example).unwrap();
+
+        let query = rskim_search::parse_ast_query(pattern.name)
+            .unwrap_or_else(|e| panic!("pattern {:?} must parse: {e}", pattern.name));
+
+        assert!(
+            rskim_search::pattern_occurs_in_file(&path, &query, None),
+            "AC9 (#394): catalog pattern {:?}'s GOLD-verified example must satisfy \
+             pattern_occurs_in_file (this is the guard that would have caught #394 \
+             — all 5 synthetic patterns failed this before the fix)",
+            pattern.name
+        );
+    }
+}
+
+/// AC10 (#394): synthetic-pattern rows carry a non-null `line` in `--json`
+/// output, equal to the ground-truth representative line (AD-394-5), for ALL
+/// FIVE patterns. PF-007 discriminating: asserts the VALUE, not just presence
+/// or exit 0 — a stub emitting `"line": null` or an arbitrary line fails this.
+#[test]
+fn run_ast_standalone_json_line_matches_ground_truth_for_all_five_ac10_394() {
+    use super::super::manifest::FileManifest;
+
+    let project = make_project_with_394_synthetic_patterns();
+    let cache = tempfile::tempdir().unwrap();
+    build_project_index(project.path(), cache.path());
+
+    let manifest =
+        FileManifest::load(project.path().to_path_buf(), cache.path().to_path_buf()).unwrap();
+
+    let cases: [(&str, &str, u32); 5] = [
+        ("god-function", "god_fn.rs", GOD_FUNCTION_LINE),
+        ("deep-nesting", "deep.rs", DEEP_NESTING_LINE),
+        ("empty-function", "empty_fn.rs", EMPTY_FUNCTION_LINE),
+        ("empty-catch", "empty_catch.ts", EMPTY_CATCH_LINE),
+        ("excessive-params", "many_params.rs", EXCESSIVE_PARAMS_LINE),
+    ];
+
+    for (pattern, exhibiting_file, expected_line) in cases {
+        let mut out: Vec<u8> = Vec::new();
+        super::run_ast_standalone(
+            pattern,
+            20,
+            true, // json
+            cache.path(),
+            &manifest,
+            None,
+            None,
+            None,
+            project.path(),
+            &mut out,
+        )
+        .unwrap();
+
+        let v: serde_json::Value = serde_json::from_str(&String::from_utf8(out).unwrap())
+            .unwrap_or_else(|e| panic!("AC10 (#394): --ast {pattern} --json must parse: {e}"));
+        let results = v["results"].as_array().unwrap();
+        // `path` is repo-relative (e.g. "src/god_fn.rs"), so match by substring
+        // against the bare filename — consistent with AC1/AC2's `.contains()`.
+        let entry = results
+            .iter()
+            .find(|r| {
+                r["path"]
+                    .as_str()
+                    .is_some_and(|p| p.contains(exhibiting_file))
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "AC10 (#394): --ast {pattern} --json must contain {exhibiting_file}; got: {v}"
+                )
+            });
+
+        let line = entry["line"].as_u64();
+        assert_eq!(
+            line,
+            Some(u64::from(expected_line)),
+            "AC10 (#394): --ast {pattern}'s {exhibiting_file} JSON `line` must equal \
+             the ground-truth representative line {expected_line} (NOT null, NOT \
+             an arbitrary value); got: {:?}",
+            entry["line"]
+        );
+        assert!(
+            entry["snippet"].as_str().is_some_and(|s| !s.is_empty()),
+            "AC10 (#394): --ast {pattern}'s {exhibiting_file} must carry a non-empty \
+             snippet; got: {:?}",
+            entry["snippet"]
+        );
+    }
+}
+
+/// AC13 (#394): per-pattern representative-line rule at the `recover_line`
+/// API level (direct calls, no index needed) — for each of the 5 synthetic
+/// patterns, `recover_line` returns `Some((line, range))` with `line` equal
+/// to the AD-394-5 ground-truth node line and a non-empty `range`.
+///
+/// Each of these 5 assertions FAILS before the fix (`recover_line` returns
+/// `None` for every synthetic pattern pre-#394), proving the new branch.
+///
+/// NEGATIVE control: a REAL pattern (`rust-nested-loop`) still recovers via
+/// the unchanged `MatchTable` walk on an unrelated fixture — proving the
+/// synthetic branch did not alter real-pattern line recovery.
+#[test]
+fn recover_line_matches_ground_truth_for_all_five_synthetic_patterns_ac13_394() {
+    let project = make_project_with_394_synthetic_patterns();
+
+    let cases: [(&str, &str, u32); 5] = [
+        ("god-function", "src/god_fn.rs", GOD_FUNCTION_LINE),
+        ("deep-nesting", "src/deep.rs", DEEP_NESTING_LINE),
+        ("empty-function", "src/empty_fn.rs", EMPTY_FUNCTION_LINE),
+        ("empty-catch", "src/empty_catch.ts", EMPTY_CATCH_LINE),
+        (
+            "excessive-params",
+            "src/many_params.rs",
+            EXCESSIVE_PARAMS_LINE,
+        ),
+    ];
+
+    for (pattern, rel_path, expected_line) in cases {
+        let query = rskim_search::parse_ast_query(pattern).unwrap();
+        let path = project.path().join(rel_path);
+        let result = rskim_search::recover_line(&path, &query, None);
+
+        let (line, range) = result.unwrap_or_else(|| {
+            panic!(
+                "AC13 (#394): recover_line({pattern}) on {rel_path} must return \
+                 Some((line, range)), not None (this is the pre-fix behavior for \
+                 every synthetic pattern)"
+            )
+        });
+        assert_eq!(
+            line, expected_line,
+            "AC13 (#394): recover_line({pattern}) on {rel_path} must report line \
+             {expected_line} (AD-394-5 ground truth); got {line}"
+        );
+        assert!(
+            !range.is_empty(),
+            "AC13 (#394): recover_line({pattern}) on {rel_path} must return a \
+             non-empty byte range so the snippet renders; got {range:?}"
+        );
+    }
+
+    // Determinism (AC-F3): repeated calls on the same file yield the same result.
+    let query = rskim_search::parse_ast_query("god-function").unwrap();
+    let path = project.path().join("src/god_fn.rs");
+    let r1 = rskim_search::recover_line(&path, &query, None);
+    let r2 = rskim_search::recover_line(&path, &query, None);
+    assert_eq!(
+        r1, r2,
+        "AC13 (#394) / AC-F3: recover_line must be deterministic for synthetic patterns"
+    );
+
+    // NEGATIVE control: a REAL pattern's line recovery is unchanged — uses the
+    // existing #374 nested-loop fixture convention (rust-nested-loop always
+    // has SOME resolvable trigram in Rust).
+    let real_dir = tempfile::tempdir().unwrap();
+    let real_path = real_dir.path().join("loops.rs");
+    fs::write(
+        &real_path,
+        "\nfn nested() {\n    for i in 0..10 {\n        for j in 0..10 {\n            \
+         println!(\"{i} {j}\");\n        }\n    }\n}\n",
+    )
+    .unwrap();
+    let real_query = rskim_search::parse_ast_query("rust-nested-loop").unwrap();
+    let real_result = rskim_search::recover_line(&real_path, &real_query, None);
+    assert!(
+        real_result.is_some(),
+        "AC13 (#394) control: a REAL pattern (rust-nested-loop) must still \
+         recover a line via the unchanged MatchTable walk; got None"
+    );
+}
+
+/// AC12 (#394): synthetic-pattern queries are query-time only — the AST
+/// on-disk FORMAT_VERSION does not change across consecutive queries, and no
+/// self-heal/rebuild fires on the second query.
+#[test]
+fn run_ast_standalone_synthetic_pattern_no_format_change_ac12_394() {
+    use super::super::manifest::FileManifest;
+
+    let project = make_project_with_394_synthetic_patterns();
+    let cache = tempfile::tempdir().unwrap();
+    build_project_index(project.path(), cache.path());
+
+    let version_before = rskim_search::AstIndexReader::index_version(cache.path())
+        .expect("index_version must succeed after build");
+
+    let manifest =
+        FileManifest::load(project.path().to_path_buf(), cache.path().to_path_buf()).unwrap();
+
+    // Query the SAME synthetic pattern twice.
+    for _ in 0..2 {
+        let mut out: Vec<u8> = Vec::new();
+        super::run_ast_standalone(
+            "god-function",
+            20,
+            false,
+            cache.path(),
+            &manifest,
+            None,
+            None,
+            None,
+            project.path(),
+            &mut out,
+        )
+        .unwrap();
+    }
+
+    let version_after = rskim_search::AstIndexReader::index_version(cache.path())
+        .expect("index_version must succeed after synthetic gate queries");
+
+    assert_eq!(
+        version_before, version_after,
+        "AC12 (#394): FORMAT_VERSION must not change across synthetic-pattern \
+         queries (read-side / query-time only fix, no persisted format touch)"
+    );
+    assert_eq!(
+        version_before,
+        rskim_search::AST_INDEX_FORMAT_VERSION,
+        "AC12 (#394): format version must equal AST_INDEX_FORMAT_VERSION ({})",
+        rskim_search::AST_INDEX_FORMAT_VERSION
+    );
+}


### PR DESCRIPTION
## Summary

Resolves the single failing acceptance criterion from the #394 Evaluator: **AC11 (performance)** was unmet because standalone `--ast <synthetic-pattern>` (deep-nesting, god-function, empty-function, empty-catch, excessive-params) was measured at ~6.9s on skim's own repo vs. the 500ms target (260x slower than `--ast try-catch`). Two root causes were fixed in tandem:

1. **Pool over-fetch** — `CANDIDATE_POOL_FLOOR=100` was applied uniformly, so even a `--limit 10` synthetic query fetched and gated 100 candidates instead of 10.
2. **Full traversal per candidate** — the verification path called `extract_ast_ngrams_with_metrics` (complete O(n) traversal) for each candidate; for `deep-nesting` (DEEP_NODE → bucket_label(0)) the match fires at the first node at depth ≥ 4, so the traversal was doing needless work.

## Changes

- **`crates/rskim-search/src/ast_index/extract.rs`**: New `synthetic_key_present(nodes, lang, target: AstBigram) -> bool` — same `ExtractState` state machine as `run_extraction` (ADR-006 single-source), exits immediately when `target` is found in `bigram_map`. Skips `emit_real_ngrams` and `update_branch_count` (synthetic IDs cannot appear in real n-gram slots; correct per the BUCKET_LABEL_BASE contract).
- **`crates/rskim-search/src/compound/reparse.rs`**: The synthetic branch (lines 366–393) now calls `linearize_source` + `synthetic_key_present` instead of the full extraction path, preserving the early-exit property inside the per-file verify gate.
- **`crates/rskim/src/cmd/search/ast.rs`**: New `ast_query_is_synthetic(query) -> bool` helper; `run_ast_standalone` sizes the candidate pool to `limit.max(1)` for synthetic queries instead of `max(K×limit, floor=100)`.
- **`crates/rskim/src/cmd/search/ast_tests.rs`**: AC11 test `ast_query_is_synthetic_classifies_correctly_ac11_394` asserts all 5 synthetic patterns → true, real-node patterns + containment → false.

## Breaking Changes

None. FORMAT_VERSION stays 2. The verify gate call site in `run_ast_standalone` is unchanged; routing is internal to `pattern_occurs_in_file`.

## Reviewer Focus Areas

- **ADR-006 compliance** in `synthetic_key_present`: same `ExtractState` helpers (`emit_depth_buckets`, `close_open_subtrees`, `fill_depth_gap`, `update_child_count`, `record_node`) as `run_extraction` — drift is structurally impossible because both paths share the same methods.
- **Early-exit placement**: check after `emit_depth_buckets` (fires for deep-nesting on first deep node) AND after `close_open_subtrees` (fires for god-function/empty-body/excessive-params when a subtree closes).
- **Pool gate**: `ast_query_is_synthetic` uses `is_synthetic_id` from the crate — same predicate as `AncestorMatchTable::contains_synthetic_id` in `reparse.rs`, no duplicate threshold.
- **AC8 invariant**: mixed (synthetic + real) patterns are rejected at the catalog level before this code runs; the pool gate and early-exit assume a pure-synthetic bigram set.

Closes #419 (the deferred AC11 follow-up filed in the original implementation commit).

Co-Authored-By: Claude <noreply@anthropic.com>