### PR TITLE
fix(#305): eliminate per-event BPE rebuild in analytics consumer; make DB open concurrency-safe

### DIFF
--- a/crates/rskim-tokens/src/counter.rs
+++ b/crates/rskim-tokens/src/counter.rs
@@ -12,8 +12,10 @@
 //! slot table. Slots are read-only after first assignment and the cache is
 //! indexed by thread ID. Reads across threads from the same `CoreBPE` are
 //! safe. Above 128 concurrent threads, threads share a slot but only read
-//! it — no data race. `Counter` wraps `CoreBPE` in `OnceLock`, which is
-//! `Send + Sync`.
+//! it — no data race. `Counter` holds an `Arc<CoreBPE>` handed out by the
+//! process-wide BPE cache (see the private `cached_bpe`); `Arc<CoreBPE>` is `Send +
+//! Sync` because `CoreBPE` is, so many `Counter`s on many threads share one
+//! immutable table.
 //!
 //! # Usage
 //!
@@ -31,7 +33,7 @@
 //! # Ok::<(), rskim_tokens::TokenError>(())
 //! ```
 
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use tiktoken_rs::CoreBPE;
 
@@ -61,53 +63,112 @@ enum CounterInner {
     /// BPE-backed counter (cl100k_base or o200k_base). The `Encoding` tag
     /// distinguishes which vocabulary is loaded so `Counter::encoding()` can
     /// report the correct variant without storing a separate field.
-    Bpe(Encoding, OnceLock<CoreBPE>),
+    Bpe(Encoding, Arc<CoreBPE>),
     /// Anthropic offline approximation — uses a cl100k BPE internally.
-    AnthropicOffline(OnceLock<CoreBPE>),
+    AnthropicOffline(Arc<CoreBPE>),
     /// Byte-length heuristic (no BPE needed).
     Heuristic,
 }
 
-/// Create a pre-filled `OnceLock<CoreBPE>`.
+/// Memoised BPE-construction outcome: either the shared table or the stringified
+/// build error.
 ///
-/// The lock is set immediately so [`OnceLock::get`] always returns `Some`
-/// for any `CounterInner` variant that carries one.
-fn prefilled_lock(bpe: CoreBPE) -> OnceLock<CoreBPE> {
-    let lock = OnceLock::new();
-    let _ = lock.set(bpe);
-    lock
-}
+/// The error is a `String` rather than an `anyhow::Error` because `anyhow::Error`
+/// is not `Clone` and the memoised failure must be re-wrapped into a *fresh*
+/// [`TokenError::TiktokenInit`] on every subsequent call (see [`cached_bpe`]).
+type CachedBpe = std::result::Result<Arc<CoreBPE>, String>;
 
-/// Map a raw `tiktoken-rs` BPE-construction result into our error domain.
+/// Process-wide `cl100k_base` table (shared by `Cl100k` and `AnthropicOffline`).
+static CL100K: OnceLock<CachedBpe> = OnceLock::new();
+
+/// Process-wide `o200k_base` table.
+static O200K: OnceLock<CachedBpe> = OnceLock::new();
+
+/// Build (once) or hand out (thereafter) a process-wide shared BPE table.
 ///
-/// Centralises the `std::result::Result<CoreBPE, anyhow::Error> -> Result<CoreBPE>`
-/// translation used by every tiktoken-backed encoding (avoids triplicating the
-/// `map_err`). It is also the **fault-injection seam for AC10**: feeding it an
-/// `Err` exercises the `TokenError::TiktokenInit` arm that the embedded vocab
-/// never triggers in practice (see `counter_tests::build_bpe_err_path_*`).
-fn build_bpe(
+/// # Why this cache exists
+///
+/// `tiktoken_rs::cl100k_base()` / `o200k_base()` are **constructors, not
+/// accessors**: each call base64-decodes ~100,257 vocabulary lines, inserts
+/// every one into a hash map, and compiles a `fancy_regex` pattern. Measured
+/// cost: **~230 ms per call**. Before this cache, `Counter::new` called the
+/// constructor on every construction, and the proxy analytics consumer
+/// (`rskim::cmd::proxy_analytics::spawn_consumer`) constructs one `Counter`
+/// **per event** — it must, because each event carries its own provider+model
+/// and the encoding is resolved per event via `encoding_for_provider_model`.
+/// Hoisting a single `Counter` out of that drain loop is *not* a valid fix: a
+/// proxy multiplexes providers, so one hoisted `Counter` would count OpenAI
+/// bodies with the Anthropic tokeniser. The rebuild cost therefore has to be
+/// removed here, at the table.
+///
+/// Measured consumer-shutdown latency for a 20-event drain before the cache:
+/// 4573 ms at idle (p50) and 18972 ms at 30× CPU oversubscription. Token
+/// counting was 99.9 % of it; the SQLite writes were ≤ 12 ms.
+///
+/// # Keyed by TABLE, not by `Encoding`
+///
+/// There are four [`Encoding`] variants but only **two** BPE tables:
+/// `Cl100k` and `AnthropicOffline` both use `cl100k_base` (the latter
+/// post-multiplies the count by 1.25), `O200k` uses `o200k_base`, and
+/// `Heuristic` uses none. Keying the cache by `Encoding` would build a second,
+/// byte-identical copy of `cl100k_base` for `AnthropicOffline`.
+///
+/// # Why `Arc<CoreBPE>` and not `tiktoken_rs::cl100k_base_singleton()`
+///
+/// The upstream singleton returns `&'static CoreBPE` (no `Mutex`, so no
+/// serialisation concern) but it `.unwrap()`s inside `lazy_static!`. A vocab
+/// decode failure would therefore become a permanent panic, converting
+/// `Counter::new`'s documented `Result` contract into an abort (AC10 no-panic
+/// construction) and destroying the fault-injection seam the AC10 tests need.
+/// `OnceLock<Result<Arc<CoreBPE>, String>>` memoises the *outcome* — success or
+/// failure — and re-wraps a memoised failure into a fresh `TokenError` on every
+/// call, preserving both properties.
+///
+/// # Why sharing one table across threads is sound
+///
+/// `CoreBPE` is `Send + Sync`. tiktoken proves this itself: its own
+/// `lazy_static! { static ref CL100K_BASE: CoreBPE }` only compiles if
+/// `CoreBPE: Sync`. Its `_get_tl_regex` merely **reads** `regex_tls[hash % 128]`
+/// — the slot table is populated at construction and never mutated afterwards,
+/// so concurrent readers cannot race. The analytics file-op recorder already
+/// relies on this (`rows.into_par_iter()` under rayon).
+fn cached_bpe(
+    slot: &'static OnceLock<CachedBpe>,
     encoding: &'static str,
-    result: std::result::Result<CoreBPE, anyhow::Error>,
-) -> Result<CoreBPE> {
-    result.map_err(|source| TokenError::TiktokenInit { encoding, source })
+    build: fn() -> std::result::Result<CoreBPE, anyhow::Error>,
+) -> Result<Arc<CoreBPE>> {
+    match slot.get_or_init(|| build().map(Arc::new).map_err(|e| e.to_string())) {
+        Ok(bpe) => Ok(Arc::clone(bpe)),
+        Err(msg) => Err(TokenError::TiktokenInit {
+            encoding,
+            source: anyhow::anyhow!(msg.clone()),
+        }),
+    }
 }
 
-/// Count BPE tokens for a pre-filled lock, falling back to byte length if the
-/// lock is somehow unset (structurally impossible — preserved for the
-/// infallible contract).
+/// Shared `cl100k_base` table (`Cl100k` and `AnthropicOffline`).
+fn cl100k() -> Result<Arc<CoreBPE>> {
+    cached_bpe(&CL100K, "cl100k_base", tiktoken_rs::cl100k_base)
+}
+
+/// Shared `o200k_base` table (`O200k`).
+fn o200k() -> Result<Arc<CoreBPE>> {
+    cached_bpe(&O200K, "o200k_base", tiktoken_rs::o200k_base)
+}
+
+/// Count BPE tokens for a shared table.
 #[inline]
-fn count_bpe(lock: &OnceLock<CoreBPE>, text: &str) -> usize {
-    lock.get()
-        .map(|bpe| bpe.encode_with_special_tokens(text).len())
-        .unwrap_or_else(|| count_heuristic(text))
+fn count_bpe(bpe: &CoreBPE, text: &str) -> usize {
+    bpe.encode_with_special_tokens(text).len()
 }
 
 impl Counter {
     /// Construct a counter for the given [`Encoding`].
     ///
-    /// The BPE encoder is validated eagerly at construction time so callers
+    /// The BPE table is resolved eagerly at construction time so callers
     /// receive `Err` before any counting attempt (satisfies AC10 no-panic
-    /// invariant).
+    /// invariant). The table itself is built at most **once per process** and
+    /// shared via `Arc` — see the private `cached_bpe` for why.
     ///
     /// # Errors
     ///
@@ -115,21 +176,11 @@ impl Counter {
     /// fails to decode. This is practically unreachable at runtime.
     pub fn new(encoding: Encoding) -> Result<Self> {
         let inner = match encoding {
-            Encoding::Cl100k => CounterInner::Bpe(
-                Encoding::Cl100k,
-                prefilled_lock(build_bpe("cl100k_base", tiktoken_rs::cl100k_base())?),
-            ),
-            Encoding::O200k => CounterInner::Bpe(
-                Encoding::O200k,
-                prefilled_lock(build_bpe("o200k_base", tiktoken_rs::o200k_base())?),
-            ),
-            // AnthropicOffline delegates to cl100k counts internally.
-            Encoding::AnthropicOffline => {
-                CounterInner::AnthropicOffline(prefilled_lock(build_bpe(
-                    "cl100k_base (for AnthropicOffline)",
-                    tiktoken_rs::cl100k_base(),
-                )?))
-            }
+            Encoding::Cl100k => CounterInner::Bpe(Encoding::Cl100k, cl100k()?),
+            Encoding::O200k => CounterInner::Bpe(Encoding::O200k, o200k()?),
+            // AnthropicOffline delegates to cl100k counts internally — it shares
+            // the very same cached table (no second copy).
+            Encoding::AnthropicOffline => CounterInner::AnthropicOffline(cl100k()?),
             Encoding::Heuristic => CounterInner::Heuristic,
         };
         Ok(Self { inner })
@@ -145,14 +196,26 @@ impl Counter {
     /// For normal use, prefer [`Counter::new`].
     #[cfg(test)]
     pub(crate) fn from_raw_bpe(encoding: Encoding, bpe: CoreBPE) -> Self {
-        let lock = prefilled_lock(bpe);
+        let bpe = Arc::new(bpe);
         let inner = match encoding {
-            Encoding::Cl100k | Encoding::O200k => CounterInner::Bpe(encoding, lock),
-            Encoding::AnthropicOffline => CounterInner::AnthropicOffline(lock),
-            // Heuristic carries no BPE — the lock (and the bpe inside it) is dropped here.
+            Encoding::Cl100k | Encoding::O200k => CounterInner::Bpe(encoding, bpe),
+            Encoding::AnthropicOffline => CounterInner::AnthropicOffline(bpe),
+            // Heuristic carries no BPE — the Arc (and the bpe inside it) is dropped here.
             Encoding::Heuristic => CounterInner::Heuristic,
         };
         Self { inner }
+    }
+
+    /// Borrow the shared BPE table backing this counter, if it has one.
+    ///
+    /// Test-only accessor supporting the `Arc::ptr_eq` table-sharing guards in
+    /// `counter_tests`. Production code never needs the raw table.
+    #[cfg(test)]
+    pub(crate) fn bpe_for_test(&self) -> Option<&Arc<CoreBPE>> {
+        match &self.inner {
+            CounterInner::Bpe(_, bpe) | CounterInner::AnthropicOffline(bpe) => Some(bpe),
+            CounterInner::Heuristic => None,
+        }
     }
 
     /// Count the tokens in `text` using this counter's encoding.
@@ -169,8 +232,8 @@ impl Counter {
     #[must_use]
     pub fn count(&self, text: &str) -> usize {
         match &self.inner {
-            CounterInner::Bpe(_, lock) => count_bpe(lock, text),
-            CounterInner::AnthropicOffline(lock) => count_anthropic_offline(count_bpe(lock, text)),
+            CounterInner::Bpe(_, bpe) => count_bpe(bpe, text),
+            CounterInner::AnthropicOffline(bpe) => count_anthropic_offline(count_bpe(bpe, text)),
             CounterInner::Heuristic => count_heuristic(text),
         }
     }
@@ -232,7 +295,7 @@ impl Counter {
 }
 
 // Counter is Send + Sync *automatically* (auto-derived by the compiler):
-// - OnceLock<CoreBPE> is Send + Sync because CoreBPE is Send + Sync.
+// - Arc<CoreBPE> is Send + Sync because CoreBPE is Send + Sync.
 // - CounterInner::Heuristic carries no data.
 //
 // We deliberately do NOT hand-write `unsafe impl Send/Sync` here: doing so would
@@ -242,7 +305,7 @@ impl Counter {
 // auto-derived bounds hold at compile time (AC11).
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod counter_tests {
     use super::*;
 
@@ -279,16 +342,22 @@ mod counter_tests {
     }
 
     /// AC10: the `TokenError::TiktokenInit` Err arm is **exercised**, not merely
-    /// asserted to exist. The embedded vocab never fails in practice, so we inject
-    /// a failure through `build_bpe` (the same translation `Counter::new` uses) and
-    /// confirm it produces a `TiktokenInit` error carrying the encoding name.
+    /// asserted to exist. The embedded vocab never fails in practice, so we
+    /// pre-seed a test-local cache slot with a memoised `Err` and call the real
+    /// production helper [`cached_bpe`] against it. That covers the whole error
+    /// translation *including* the memoised-`Err` re-wrap, which is the arm that
+    /// makes a cached failure keep returning `Result` instead of panicking.
     #[test]
     #[allow(unreachable_patterns)] // see the feature-gating note on the match's catch-all arm
-    fn build_bpe_err_path_is_exercised() {
-        let injected = build_bpe(
-            "cl100k_base",
-            Err(anyhow::anyhow!("simulated embedded-vocab decode failure")),
-        );
+    fn cached_bpe_err_path_is_exercised() {
+        static POISONED: OnceLock<CachedBpe> = OnceLock::new();
+        POISONED
+            .set(Err("simulated embedded-vocab decode failure".to_string()))
+            .unwrap_or_else(|_| panic!("test-local slot must be settable exactly once"));
+
+        // The `build` fn is a real, working constructor: if the memoised Err were
+        // ignored and the builder re-run, this would return Ok and fail the match.
+        let injected = cached_bpe(&POISONED, "cl100k_base", tiktoken_rs::cl100k_base);
         match injected {
             Err(TokenError::TiktokenInit { encoding, source }) => {
                 assert_eq!(encoding, "cl100k_base");
@@ -303,19 +372,94 @@ mod counter_tests {
             // `--all-features`, where `TokenError`'s net-anthropic-gated variants
             // (`MissingApiKey`/`NetworkRequest`/`ApiResponse`) appear.
             Err(other) => panic!("expected TiktokenInit Err, got a different error: {other}"),
-            Ok(_) => panic!("expected Err, got Ok(CoreBPE)"),
+            Ok(_) => panic!("expected Err, got Ok(Arc<CoreBPE>)"),
         }
+
+        // The memoised failure must be re-wrappable an unbounded number of times —
+        // `anyhow::Error` is not Clone, which is why the cache stores a String.
+        assert!(
+            cached_bpe(&POISONED, "cl100k_base", tiktoken_rs::cl100k_base).is_err(),
+            "a memoised Err must keep producing Err on every subsequent call"
+        );
     }
 
-    /// AC10: the Ok arm of `build_bpe` passes a valid BPE straight through, so the
-    /// helper used by `Counter::new` is verified on both arms.
+    /// **Strict guard against reintroducing the per-event BPE rebuild.**
+    ///
+    /// Every `Counter::new(Cl100k)` must hand back the *same* `Arc<CoreBPE>`, and
+    /// `AnthropicOffline` must share that identical table rather than building a
+    /// second byte-identical copy (the cache is keyed by TABLE, not by
+    /// `Encoding`).
+    ///
+    /// This is a **pointer-identity** assertion, not a wall-clock one, so it can
+    /// never flake under CPU oversubscription — unlike a "construction must take
+    /// < N ms" test. Reverting `Counter::new` to call
+    /// `tiktoken_rs::cl100k_base()` per construction makes the pointers differ
+    /// and fails here immediately.
     #[test]
-    fn build_bpe_ok_path_passes_bpe_through() {
-        let bpe = tiktoken_rs::cl100k_base().unwrap();
-        let wrapped = build_bpe("cl100k_base", Ok(bpe));
+    fn counter_new_shares_one_cl100k_table_across_constructions() {
+        let a = Counter::new(Encoding::Cl100k).unwrap();
+        let b = Counter::new(Encoding::Cl100k).unwrap();
+        let anthropic = Counter::new(Encoding::AnthropicOffline).unwrap();
+
+        let a_bpe = a.bpe_for_test().expect("Cl100k counter must carry a table");
+        let b_bpe = b.bpe_for_test().expect("Cl100k counter must carry a table");
+        let anthropic_bpe = anthropic
+            .bpe_for_test()
+            .expect("AnthropicOffline counter must carry a table");
+
         assert!(
-            wrapped.is_ok(),
-            "build_bpe must pass a valid BPE through as Ok"
+            Arc::ptr_eq(a_bpe, b_bpe),
+            "two Cl100k Counters must share ONE cached cl100k_base table; \
+             distinct pointers mean Counter::new rebuilds the ~100k-entry BPE \
+             per construction (~230ms each)"
+        );
+        assert!(
+            Arc::ptr_eq(a_bpe, anthropic_bpe),
+            "AnthropicOffline must reuse the SAME cl100k_base table as Cl100k; \
+             a distinct pointer means the cache is keyed by Encoding instead of \
+             by table, doubling the resident BPE memory"
+        );
+    }
+
+    /// Companion guard for the second cached table — see
+    /// [`counter_new_shares_one_cl100k_table_across_constructions`].
+    #[test]
+    fn counter_new_shares_one_o200k_table_across_constructions() {
+        let a = Counter::new(Encoding::O200k).unwrap();
+        let b = Counter::new(Encoding::O200k).unwrap();
+
+        let a_bpe = a.bpe_for_test().expect("O200k counter must carry a table");
+        let b_bpe = b.bpe_for_test().expect("O200k counter must carry a table");
+
+        assert!(
+            Arc::ptr_eq(a_bpe, b_bpe),
+            "two O200k Counters must share ONE cached o200k_base table; \
+             distinct pointers mean Counter::new rebuilds the BPE per construction"
+        );
+    }
+
+    /// The two cached tables must be distinct — sharing one slot between
+    /// `cl100k_base` and `o200k_base` would silently count OpenAI bodies with the
+    /// wrong vocabulary.
+    #[test]
+    fn cl100k_and_o200k_are_separate_tables() {
+        let cl = Counter::new(Encoding::Cl100k).unwrap();
+        let o2 = Counter::new(Encoding::O200k).unwrap();
+        assert!(
+            !Arc::ptr_eq(
+                cl.bpe_for_test().expect("cl100k table"),
+                o2.bpe_for_test().expect("o200k table")
+            ),
+            "cl100k_base and o200k_base must be separate cached tables"
+        );
+    }
+
+    /// The heuristic counter carries no table at all.
+    #[test]
+    fn heuristic_counter_carries_no_bpe_table() {
+        assert!(
+            Counter::heuristic().bpe_for_test().is_none(),
+            "Heuristic counters must not hold a BPE table"
         );
     }
 }

--- a/crates/rskim/src/analytics/mod.rs
+++ b/crates/rskim/src/analytics/mod.rs
@@ -654,6 +654,68 @@ pub(crate) struct AnalyticsDb {
     conn: Connection,
 }
 
+/// Switch the connection to WAL journal mode, retrying a bounded number of times
+/// on `SQLITE_BUSY`.
+///
+/// # Why this needs its own retry loop
+///
+/// `PRAGMA journal_mode=WAL` is the one statement in [`AnalyticsDb::open`] that
+/// does **not** honour `busy_timeout`. Converting a database into WAL requires an
+/// EXCLUSIVE file lock, and SQLite's pager takes that lock directly
+/// (`pagerExclusiveLock`) without going through the busy handler — so a
+/// contending opener gets a bare `SQLITE_BUSY` immediately rather than waiting.
+/// Setting `busy_timeout` earlier (which `open()` now does) fixes the
+/// `PRAGMA user_version` read and `run_migrations`' `BEGIN IMMEDIATE`, but it
+/// cannot fix this statement.
+///
+/// The contended window is narrow and self-closing: it exists only while a
+/// brand-new database is still in rollback-journal mode. As soon as *any* opener
+/// completes the flip, the file header says WAL and the statement becomes a
+/// read-only no-op for everyone else. So a short bounded backoff is sufficient —
+/// we are waiting for a peer to finish one flip, not for a long transaction.
+///
+/// The bound is explicit (project reliability rule: every retry has a fixed upper
+/// bound). Exhausting it returns the underlying `SQLITE_BUSY` with context rather
+/// than silently continuing in rollback-journal mode, which would leave this
+/// connection's pager disagreeing with the on-disk header.
+fn enable_wal(conn: &Connection) -> anyhow::Result<()> {
+    /// ~500 ms ceiling (50 × 10 ms) — orders of magnitude more than one flip needs.
+    const MAX_ATTEMPTS: u32 = 50;
+    const BACKOFF: Duration = Duration::from_millis(10);
+
+    let mut attempt = 0;
+    loop {
+        match conn.execute_batch("PRAGMA journal_mode=WAL;") {
+            Ok(()) => return Ok(()),
+            Err(e) if is_busy(&e) && attempt + 1 < MAX_ATTEMPTS => {
+                attempt += 1;
+                std::thread::sleep(BACKOFF);
+            }
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context(format!(
+                    "PRAGMA journal_mode=WAL failed after {} attempt(s); another process may be \
+                     converting the analytics database concurrently",
+                    attempt + 1
+                )));
+            }
+        }
+    }
+}
+
+/// True when a rusqlite error is a lock-contention error worth retrying.
+fn is_busy(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked,
+                ..
+            },
+            _
+        )
+    )
+}
+
 impl AnalyticsDb {
     /// Open database at the given path, run migrations, enable WAL mode.
     ///
@@ -663,8 +725,22 @@ impl AnalyticsDb {
     pub(crate) fn open(path: &Path) -> anyhow::Result<Self> {
         let conn = Connection::open(path)?;
 
-        // AD-AN-5: future-version rejection — the FIRST step after Connection::open,
-        // before chmod, busy_timeout, WAL, and run_migrations (AC3).
+        // busy_timeout MUST be set before the PRAGMA user_version read below.
+        //
+        // A freshly created DB is still in rollback-journal mode until the
+        // `PRAGMA journal_mode=WAL` flip further down, and that flip needs the
+        // EXCLUSIVE lock. While a concurrent opener holds it, a zero-timeout
+        // `PRAGMA user_version` read returns SQLITE_BUSY and fails this open
+        // outright. `run_migrations` likewise needs the timeout to bound its
+        // `BEGIN IMMEDIATE` wait.
+        //
+        // This does NOT weaken AD-AN-5 (AC3): `busy_timeout` is a connection-level
+        // setting that writes nothing to the database file — no schema write, no
+        // WAL journal_mode flip, and no chmod happens before the version check.
+        conn.busy_timeout(Duration::from_millis(5000))?;
+
+        // AD-AN-5: future-version rejection — the first step that inspects the DB,
+        // before chmod, WAL, and run_migrations (AC3).
         //
         // Opening the connection is unavoidable (needed to read PRAGMA user_version),
         // but `Connection::open` does not mutate the DB file on its own.  Checking
@@ -694,8 +770,9 @@ impl AnalyticsDb {
             }
         }
 
-        conn.busy_timeout(Duration::from_millis(5000))?;
-        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+        // journal_mode MUST be flipped BEFORE run_migrations: SQLite cannot change
+        // journal_mode from inside a transaction, and run_migrations opens one.
+        enable_wal(&conn)?;
         schema::run_migrations(&conn)?;
         Ok(Self { conn })
     }
@@ -1524,6 +1601,22 @@ impl AnalyticsDb {
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Count rows in `token_savings` written by the proxy recording path.
+    ///
+    /// Test helper for the proxy-consumer drain tests: it answers "did the
+    /// consumer actually persist what it dequeued?" without depending on the
+    /// CLI-scope aggregates, which deliberately exclude `command_type = 'proxy'`
+    /// rows (AD-AN-6).
+    #[cfg(all(test, feature = "proxy"))]
+    pub(crate) fn query_proxy_row_count(&self) -> anyhow::Result<u64> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM token_savings WHERE command_type = 'proxy'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(count.max(0) as u64)
     }
 }
 
@@ -2468,6 +2561,55 @@ pub(crate) mod tests {
             .query_row("SELECT COUNT(*) FROM token_savings", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    /// Eight threads racing to create and migrate the SAME fresh database must
+    /// all succeed.
+    ///
+    /// A `Barrier` releases every thread into `open()` at the same instant. That
+    /// matters: the contended window is only open while the file is brand new and
+    /// still in rollback-journal mode, so staggered spawns can miss it entirely.
+    ///
+    /// DISCRIMINATING — this test reproduces all three failure modes the fix
+    /// addresses:
+    ///
+    /// 1. Reverting `schema::run_migrations` to an untransacted version read:
+    ///    two threads both read `user_version = 0`, both run the migration blocks,
+    ///    and the loser aborts with `duplicate column name: session_id` (v3
+    ///    `ALTER TABLE`) or `table proxy_block_decisions already exists` (v4
+    ///    `CREATE TABLE`).
+    /// 2. Removing the `busy_timeout` call that now precedes the `PRAGMA
+    ///    user_version` read in `open()`: SQLITE_BUSY on the version read while a
+    ///    peer holds the write lock.
+    /// 3. Replacing [`enable_wal`] with a bare `PRAGMA journal_mode=WAL`:
+    ///    `database is locked` (SQLITE_BUSY, code 5) — that statement does not
+    ///    honour `busy_timeout`, so it needs its own bounded retry.
+    #[test]
+    fn open_is_safe_under_concurrent_first_open() {
+        const THREADS: usize = 8;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("race.db");
+        let gate = std::sync::Barrier::new(THREADS);
+
+        let errs: Vec<String> = std::thread::scope(|s| {
+            (0..THREADS)
+                .map(|_| {
+                    s.spawn(|| {
+                        gate.wait();
+                        AnalyticsDb::open(&path).err().map(|e| format!("{e:#}"))
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .filter_map(|h| h.join().unwrap())
+                .collect()
+        });
+
+        assert!(
+            errs.is_empty(),
+            "concurrent first-open must not fail; got: {errs:?}"
+        );
     }
 
     #[test]

--- a/crates/rskim/src/analytics/schema.rs
+++ b/crates/rskim/src/analytics/schema.rs
@@ -1,6 +1,6 @@
 //! Database schema and migrations for analytics.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 /// Current schema version of this skim release.
 ///
@@ -8,9 +8,56 @@ use rusqlite::Connection;
 /// this constant before any schema mutation, WAL flip, or chmod (AC3).
 pub(super) const CURRENT_SCHEMA_VERSION: i64 = 5;
 
-/// Run all database migrations.
+/// Run all database migrations inside ONE `BEGIN IMMEDIATE` transaction.
+///
+/// # Why `BEGIN IMMEDIATE` wraps the version read
+///
+/// Reading `PRAGMA user_version` and then migrating used to be two separate,
+/// unsynchronised steps. Two processes (or two threads) opening the same fresh
+/// database concurrently both read version 0 and both ran the migration blocks;
+/// the loser then failed with `duplicate column name: session_id` (the v3
+/// `ALTER TABLE`) or `table proxy_block_decisions already exists` (the v4
+/// `CREATE TABLE`), aborting `AnalyticsDb::open()` outright. Measured: 24 of 55
+/// concurrent-open runs failed this way.
+///
+/// `BEGIN IMMEDIATE` takes the database write lock **before** the version is
+/// read, so the two openers serialise: the winner reads 0, migrates, and
+/// commits; the loser blocks on the write lock, and once it acquires it reads
+/// the already-migrated version and skips every block. Neither sees a partially
+/// migrated schema.
+///
+/// # Why no deadlock is possible
+///
+/// There is exactly one lock (the SQLite write lock) and it is acquired once, up
+/// front. No read lock is taken first and later promoted to a write lock — the
+/// classic SQLite `SQLITE_BUSY_SNAPSHOT` upgrade deadlock cannot occur here. A
+/// waiter is bounded by the connection's `busy_timeout`, which the caller must
+/// have already set (see the caller contract below), so the worst case is a
+/// bounded wait ending in `SQLITE_BUSY`, never an indefinite block.
+///
+/// # Rollback semantics
+///
+/// The [`Transaction`] guard defaults to `DropBehavior::Rollback`, so an early
+/// `?` return rolls the whole batch back and leaves no transaction open on the
+/// connection. `PRAGMA user_version` is itself transactional in SQLite and rolls
+/// back with the batch — which is why each version block still keeps
+/// `PRAGMA user_version = N` as its FINAL statement: a mid-block abort leaves
+/// the prior version intact and the migration safely retryable (ADR-006).
+///
+/// # Caller contract
+///
+/// - The connection MUST already have a `busy_timeout` set; otherwise a
+///   concurrent opener's `BEGIN IMMEDIATE` returns `SQLITE_BUSY` immediately.
+/// - The connection MUST NOT already be inside a transaction —
+///   [`Transaction::new_unchecked`] does not check, and SQLite has no nested
+///   transactions. For the same reason the individual version blocks below must
+///   NOT contain their own `BEGIN;` / `COMMIT;`.
+/// - `PRAGMA journal_mode` cannot be changed inside a transaction, so the WAL
+///   flip must happen BEFORE this call.
 pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
-    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+
+    let version: i64 = tx.query_row("PRAGMA user_version", [], |row| row.get(0))?;
 
     // AD-AN-5 / ADR-006: reject databases written by a newer skim build.
     // This is the same guard as `AnalyticsDb::open()` in mod.rs, replicated here
@@ -29,7 +76,7 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
     }
 
     if version < 1 {
-        conn.execute_batch(
+        tx.execute_batch(
             "CREATE TABLE IF NOT EXISTS token_savings (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp INTEGER NOT NULL,
@@ -51,7 +98,7 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
     }
 
     if version < 2 {
-        conn.execute_batch(
+        tx.execute_batch(
             "CREATE TABLE IF NOT EXISTS analytics_meta (
                 key TEXT PRIMARY KEY,
                 value INTEGER
@@ -64,7 +111,7 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
         // AD-AN-4: session_id is nullable for backward compatibility — rows
         // recorded before this migration have NULL session_id and are excluded
         // from per-session average calculations.
-        conn.execute_batch(
+        tx.execute_batch(
             "ALTER TABLE token_savings ADD COLUMN session_id TEXT;
             CREATE INDEX IF NOT EXISTS idx_ts_session_id ON token_savings(session_id);
             PRAGMA user_version = 3;",
@@ -72,7 +119,11 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
     }
 
     if version < 4 {
-        // AD-AN-5: v4 migration — single contiguous BEGIN..COMMIT block.
+        // AD-AN-5: v4 migration — runs inside the outer BEGIN IMMEDIATE opened by
+        // `run_migrations`. It must NOT open its own BEGIN/COMMIT: SQLite has no
+        // nested transactions, so an inner `BEGIN;` here would fail with
+        // "cannot start a transaction within a transaction". Its atomicity is
+        // subsumed by the outer transaction.
         //
         // Nullable token columns (raw_tokens, compressed_tokens, savings_pct)
         // require a table rebuild because SQLite cannot ALTER COLUMN to drop a
@@ -82,7 +133,7 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
         // interrupted rebuild — at any step including the proxy_block_decisions
         // detail-table DDL — rolls back the entire transaction leaving intact v3
         // (ADR-006: abort before persisting, old state survives). SQLite
-        // PRAGMA user_version is transactional and rolls back with the BEGIN block.
+        // PRAGMA user_version is transactional and rolls back with the transaction.
         //
         // AD-AN-13: proxy_block_decisions detail table (savings_id FK →
         // token_savings(id)) and its index are created inside the same transaction
@@ -91,9 +142,8 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
         // AC5/AC6: provider, model, turn_id, upstream_error_status are nullable
         // to support both CLI rows (always non-NULL tokens, NULL provider/model)
         // and proxy rows (NULL or non-NULL tokens, present provider/model/turn_id).
-        conn.execute_batch(
-            "BEGIN;
-            CREATE TABLE token_savings_new (
+        tx.execute_batch(
+            "CREATE TABLE token_savings_new (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp INTEGER NOT NULL,
                 command_type TEXT NOT NULL,
@@ -138,8 +188,7 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
                 bytes_out INTEGER NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_pbd_savings_id ON proxy_block_decisions(savings_id);
-            PRAGMA user_version = 4;
-            COMMIT;",
+            PRAGMA user_version = 4;",
         )?;
     }
 
@@ -149,16 +198,16 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
         // SHA-256 pair for losslessness audit). Migration is UNCONDITIONAL (not
         // proxy-gated) so DB versions never fork across build variants (finding 19).
         //
-        // ADR-006: wrapped in a single BEGIN..COMMIT transaction so any mid-batch
-        // failure (e.g. a pre-existing alignment_decisions with an incompatible
-        // schema causing the CREATE INDEX to fail) rolls back the entire batch and
-        // leaves user_version at 4, allowing a safe retry — identical structure to
-        // the v4 batch above.  PRAGMA user_version = 5 is the FINAL statement so a
-        // partial abort at any earlier statement rolls back before the version is
-        // advanced.
-        conn.execute_batch(
-            "BEGIN;
-            CREATE TABLE IF NOT EXISTS alignment_decisions (
+        // ADR-006: this batch runs inside the outer BEGIN IMMEDIATE opened by
+        // `run_migrations` (no inner BEGIN/COMMIT — SQLite has no nested
+        // transactions). Any mid-batch failure (e.g. a pre-existing
+        // alignment_decisions with an incompatible schema causing the CREATE INDEX
+        // to fail) rolls back the entire transaction and leaves user_version at 4,
+        // allowing a safe retry — identical structure to the v4 batch above.
+        // PRAGMA user_version = 5 is the FINAL statement so a partial abort at any
+        // earlier statement rolls back before the version is advanced.
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS alignment_decisions (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp INTEGER NOT NULL,
                 request_id TEXT NOT NULL,
@@ -175,11 +224,11 @@ pub(super) fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
                 output_sha256 BLOB NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_ad_timestamp ON alignment_decisions(timestamp);
-            PRAGMA user_version = 5;
-            COMMIT;",
+            PRAGMA user_version = 5;",
         )?;
     }
 
+    tx.commit()?;
     Ok(())
 }
 
@@ -333,17 +382,17 @@ mod tests {
     // schema (no `timestamp` column).  Call run_migrations: the v5 batch's
     // `CREATE TABLE IF NOT EXISTS` is a no-op (table exists), but `CREATE INDEX
     // ... ON alignment_decisions(timestamp)` fails (no such column).  With
-    // BEGIN..COMMIT wrapping the v5 batch (ADR-006), the whole batch rolls back
-    // and user_version stays at 4.  Drop the conflicting table, re-run migrations
-    // and confirm v5 completes.
+    // the outer BEGIN IMMEDIATE that `run_migrations` opens (ADR-006), the whole
+    // batch rolls back and user_version stays at 4.  Drop the conflicting table,
+    // re-run migrations and confirm v5 completes.
     //
     // DISCRIMINATING (PF-007): if PRAGMA user_version = 5 were placed BEFORE the
     // CREATE INDEX in the v5 batch, it would autocommit before the index fails,
     // leaving user_version = 5 after the error — this test catches that violation.
     // Unlike the previous version of this test (which hand-wrote its own BEGIN and
     // never called run_migrations), Phase 2 here drives the production migration
-    // code path — the statement ORDER of schema.rs:130-149 is what determines the
-    // outcome.
+    // code path — the statement ORDER inside the `version < 5` block of
+    // `run_migrations` is what determines the outcome.
     #[test]
     fn schema_mid_migration_failure_leaves_prior_version_intact() {
         // Phase 1: advance to v4.
@@ -362,7 +411,7 @@ mod tests {
 
         // Phase 2: inject a conflicting alignment_decisions table (wrong schema —
         // no `timestamp` column).  The v5 CREATE INDEX will fail at the column
-        // reference; with the BEGIN..COMMIT wrapper the whole batch rolls back and
+        // reference; with the outer BEGIN IMMEDIATE the whole batch rolls back and
         // user_version stays at 4.
         conn.execute_batch(
             "CREATE TABLE alignment_decisions (id INTEGER PRIMARY KEY, wrong_col TEXT);",
@@ -392,12 +441,14 @@ mod tests {
             "setup check: conflicting alignment_decisions must still be present"
         );
 
-        // SQLite does not auto-rollback when execute_batch fails mid-batch: the
-        // BEGIN; opened a transaction and the index-creation failure left it open.
-        // Explicitly roll it back so the connection is in a clean state before
-        // Phase 3 tries to start a new transaction.
-        conn.execute_batch("ROLLBACK;")
-            .expect("rollback the failed v5 transaction before retry");
+        // `run_migrations` owns its transaction via a `Transaction` guard whose
+        // DropBehavior is Rollback, so the early `?` return already rolled the
+        // failed v5 batch back and left NO transaction open on the connection.
+        // Starting (and immediately committing) a fresh one proves that.
+        assert!(
+            conn.execute_batch("BEGIN IMMEDIATE; COMMIT;").is_ok(),
+            "run_migrations must leave no transaction open after a mid-migration failure"
+        );
 
         // Phase 3: remove the conflicting table, then re-run — v5 must complete.
         conn.execute_batch("DROP TABLE alignment_decisions;")

--- a/crates/rskim/src/cmd/proxy.rs
+++ b/crates/rskim/src/cmd/proxy.rs
@@ -39,6 +39,7 @@
 use std::net::IpAddr;
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use rskim_align::Provider as LlmProvider;
 use rskim_compress::{BlockRouter, Policy};
@@ -457,6 +458,10 @@ pub(crate) fn run(
     let analytics_arc: Arc<dyn rskim_proxy::analytics::AnalyticsHook>;
     let consumer_handle: Option<std::thread::JoinHandle<()>>;
     let done_rx: Option<crossbeam_channel::Receiver<()>>;
+    // Second handle on the in-flight byte counter, retained by run() so the
+    // FLUSH_BOUND timeout arm below can report how much is still outstanding.
+    // It must be taken BEFORE `hook` is moved into `analytics_arc`.
+    let outstanding_bytes: Option<Arc<AtomicU64>>;
 
     if analytics_cfg.enabled {
         let (hook, rx) = super::proxy_analytics::BridgeAnalyticsHook::new(
@@ -464,6 +469,8 @@ pub(crate) fn run(
         );
         let drop_count = hook.drop_count_handle();
         let queued_bytes = hook.queued_bytes_handle();
+        // Taken here, while `hook` is still owned locally.
+        let outstanding = hook.queued_bytes_handle();
         let (done_tx, drx) = crossbeam_channel::bounded(1);
         let handle = super::proxy_analytics::spawn_consumer(
             rx,
@@ -478,10 +485,12 @@ pub(crate) fn run(
         analytics_arc = Arc::new(hook);
         consumer_handle = Some(handle);
         done_rx = Some(drx);
+        outstanding_bytes = Some(outstanding);
     } else {
         analytics_arc = Arc::new(rskim_proxy::analytics::NoopAnalyticsHook);
         consumer_handle = None;
         done_rx = None;
+        outstanding_bytes = None;
     }
 
     // Call serve_with_stage() — blocks until SIGINT/SIGTERM and drain completes (AC23).
@@ -515,7 +524,28 @@ pub(crate) fn run(
                 let _ = handle.join();
             }
             Err(_) => {
-                // FLUSH_BOUND elapsed → consumer did not finish in time.
+                // ADR-011 classification: LOSS-BEARING MARKER → unconditional
+                // stderr. It is NOT a no-loss raw-fallback banner, so it must
+                // NOT be moved behind SKIM_DEBUG / debug_log!.
+                //
+                // Records still sitting in the channel when the bound elapses are
+                // abandoned. They never reach `drop_count` (that counter only
+                // increments on enqueue overflow and fail-open DB errors), and
+                // the accumulated total is persisted only AFTER the drain loop,
+                // so abandonment also destroys the disclosure counter itself.
+                // `skim stats` therefore under-reports this run in a way nothing
+                // else discloses — the reader sees less than reality, which is
+                // exactly the condition that makes a notice a marker.
+                let outstanding = outstanding_bytes
+                    .as_ref()
+                    .map_or(0, |b| b.load(Ordering::Relaxed));
+                eprintln!(
+                    "skim proxy: analytics flush bound ({}s) elapsed with ~{outstanding} bytes \
+                     of proxy events still queued; those records were discarded WITHOUT being \
+                     added to the dropped-record counter, so `skim stats` will under-report \
+                     this run.",
+                    super::proxy_analytics::FLUSH_BOUND.as_secs()
+                );
                 // Drop the JoinHandle; OS reclaims the thread.
             }
         }
@@ -528,7 +558,15 @@ pub(crate) fn run(
                 let _ = handle.join();
             }
             Err(_) => {
-                // FLUSH_BOUND elapsed → consumer did not finish in time.
+                // ADR-011 classification: LOSS-BEARING MARKER → unconditional
+                // stderr, same reasoning as the analytics arm above. Do not
+                // convert this into a SKIM_DEBUG-gated banner.
+                eprintln!(
+                    "skim proxy: alignment flush bound ({}s) elapsed; cache-alignment records \
+                     still queued were discarded without being counted, so `skim stats` \
+                     alignment figures will under-report this run.",
+                    super::proxy_analytics::FLUSH_BOUND.as_secs()
+                );
                 // Drop the JoinHandle; OS reclaims the thread.
             }
         }

--- a/crates/rskim/src/cmd/proxy_analytics.rs
+++ b/crates/rskim/src/cmd/proxy_analytics.rs
@@ -87,10 +87,30 @@ pub(crate) const PROXY_QUEUE_BYTE_BUDGET: u64 = 128 * 1024 * 1024;
 /// ## AD-AN-12 — bounded shutdown termination (ADR-003 / PF-005)
 ///
 /// Defaults to `DEFAULT_GRACEFUL_DRAIN_SECS` (5 s) — reusing the existing
-/// proxy shutdown-drain constant rather than inventing a new number. This
-/// satisfies "joins within a fixed bound; records past the bound dropped and
-/// counted" (AC18). The consumer is not waited on past this bound; the OS
-/// reclaims the thread; its last action is to persist the drop total.
+/// proxy shutdown-drain constant rather than inventing a new number.
+///
+/// ## What the bound actually does (and what it does NOT do)
+///
+/// When the bound elapses, `run()` stops **waiting**. That is all it does:
+///
+/// - It does **not** stop the consumer thread. The consumer keeps draining until
+///   the channel closes; the OS reclaims it when the process exits.
+/// - It does **not** count what is left. Records still in the channel never touch
+///   `drop_count` — that counter only increments on enqueue overflow
+///   (`BridgeAnalyticsHook::on_request`) and on fail-open DB errors inside
+///   [`spawn_consumer`]'s drain loop. And because the accumulated total is
+///   persisted only AFTER the drain loop finishes, abandoning the wait also
+///   abandons the `proxy_dropped_records` disclosure counter this module's
+///   header designates.
+///
+/// An earlier version of this doc claimed records past the bound are "dropped
+/// and counted". They are not, on either count. Making that literally true would
+/// require an extra DB write on the hot drain path for a condition that the
+/// process-wide BPE cache in `rskim-tokens` has made roughly 19× less reachable,
+/// so the honest disclosure lives on stderr instead: `cmd/proxy.rs` emits an
+/// unconditional loss-bearing marker (ADR-011) on the `recv_timeout` timeout arm
+/// naming the bound, the approximate outstanding bytes, and the fact that
+/// `skim stats` will under-report that run.
 pub(crate) const FLUSH_BOUND: Duration = Duration::from_secs(DEFAULT_GRACEFUL_DRAIN_SECS);
 
 // ============================================================================
@@ -220,8 +240,8 @@ pub(crate) fn event_payload_bytes(event: &ProxyEvent) -> u64 {
 /// path (AC14 / AD-AN-8).
 ///
 /// Cross-Plan Amendment #4 (fulfilled): #305 swaps:
-/// - `NullSink` → `ChannelDecisionSink` (collector) in `server.rs:422`
-/// - `NoopAnalyticsHook` → real `BridgeAnalyticsHook` here in `proxy.rs:238`
+/// - `NullSink` → `ChannelDecisionSink` (collector) in `rskim_proxy::server`
+/// - `NoopAnalyticsHook` → real `BridgeAnalyticsHook` in `cmd::proxy::run`
 ///
 /// #306's `AlignmentRecorder` consumer adopts the same bounded lifecycle:
 /// `ChannelAlignmentRecorder::new_boxed` returns the thread handle and done
@@ -758,8 +778,9 @@ mod tests {
         );
     }
 
-    /// PF-007 discriminating: `spawn_consumer` calls `db.set_busy_timeout(100ms)`
-    /// (proxy_analytics.rs line 262) to cap each blocked write to at most 100ms.
+    /// PF-007 discriminating: `spawn_consumer` calls
+    /// `AnalyticsDb::set_busy_timeout(100ms)` immediately after opening the DB, to
+    /// cap each blocked write to at most 100ms.
     /// Without that call, `AnalyticsDb::open` leaves the timeout at 5000ms, and
     /// draining N events under an exclusive lock takes N × 5000ms ≈ 15s for N=3.
     /// With the cap, it takes N × 100ms ≈ 300ms. The wall-clock assertion below
@@ -836,7 +857,8 @@ mod tests {
         // fallback from AnalyticsDb::open is 5000ms/event → ~15s total.
         // 5s bound: observed 2.115s on CI (run 32871027659) with ~2.4× headroom.
         // The discriminating property is the ~3× gap to the ~15s uncapped path,
-        // not the absolute value.  Deleting proxy_analytics.rs line 262 must fail.
+        // not the absolute value.  Deleting the `set_busy_timeout(100ms)` call in
+        // `spawn_consumer` must fail this assertion.
         assert!(
             elapsed < std::time::Duration::from_millis(5_000),
             "AC15 busy_timeout cap: drained {N_EVENTS} events under exclusive lock in \
@@ -1623,15 +1645,51 @@ mod tests {
         }
     }
 
-    /// AC15 arm e: concurrent `stats --clear` (clearing `token_savings`) while
-    /// the consumer writes must not crash the consumer.
+    /// Liveness backstop, NOT a latency SLO (ADR-003 — ground-truthed, not baseless).
     ///
-    /// `AnalyticsDb::clear()` deletes from `token_savings`; the consumer writes
-    /// to `token_savings` in a separate WAL connection. SQLite WAL allows
-    /// concurrent readers + writers; the worst observable outcome is a rusqlite
-    /// error which the consumer counts as a fail-open drop.
+    /// Measured consumer shutdown for the 20-event drain in
+    /// [`test_concurrent_clear_does_not_crash_consumer`]:
+    ///
+    /// | | idle p50 | 30× CPU oversubscription |
+    /// |---|---|---|
+    /// | before the `rskim-tokens` BPE cache | 4573 ms | 18972 ms (13/13 failures) |
+    /// | after  | ≈240 ms | ≈970 ms |
+    ///
+    /// A 10 s bound was 46 % consumed at idle before the fix and blew through it
+    /// at load. Afterwards a single one-time BPE build still lands on the consumer
+    /// thread, so the residual cost is ≈240 ms — leaving ≈41× headroom at idle,
+    /// ≈10× at the worst measured load, and 2× the production [`FLUSH_BOUND`] of
+    /// 5 s.
+    ///
+    /// This bound exists only so a wedged consumer fails the test instead of
+    /// hanging it. It is **not** the regression detector: the behavioural
+    /// assertions below (`queued_bytes == 0`, persisted row count) are. The
+    /// timing-free guard against reintroducing the per-event BPE rebuild lives in
+    /// `crates/rskim-tokens/src/counter.rs`
+    /// (`counter_new_shares_one_cl100k_table_across_constructions`).
+    const CONSUMER_LIVENESS_BOUND: Duration = Duration::from_secs(10);
+
+    /// AC15 arm e: concurrent `stats --clear` (clearing `token_savings`) while
+    /// the consumer writes must not crash the consumer — and everything the
+    /// consumer dequeues afterwards must still be accounted for.
+    ///
+    /// `AnalyticsDb::clear()` deletes from `token_savings`; the consumer writes to
+    /// `token_savings` on a separate connection. WAL allows readers to run
+    /// concurrently with **one** writer — it does not make two writers concurrent.
+    /// `clear()` and `record_proxy()` are both writers to `token_savings`, so they
+    /// serialise on the WAL write lock; the loser waits up to the consumer's
+    /// 100 ms `busy_timeout` and then fails open as a counted drop. The conclusion
+    /// is unchanged: the worst case is a counted drop, never a panic or a hang.
+    ///
+    /// The scenario is driven in two phases so the assertions cannot be vacuous:
+    /// 20 events are sent into the contended window, then `clear()` runs, then a
+    /// further `POST_CLEAR` events are sent with no contention at all — nothing
+    /// deletes those, so each one must be persisted or counted.
     #[test]
     fn test_concurrent_clear_does_not_crash_consumer() {
+        const PRE_CLEAR: usize = 20;
+        const POST_CLEAR: usize = 5;
+
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("concurrent.db");
 
@@ -1649,26 +1707,61 @@ mod tests {
             done_tx,
         );
 
-        // Send several events to give the consumer something to process.
-        for _ in 0..20 {
+        // Phase 1 — send events into the window the clear will contend with.
+        for _ in 0..PRE_CLEAR {
             hook.on_request(&make_small_event());
         }
 
-        // Concurrently clear the DB while the consumer writes.
-        // AC15 arm e: clear must not crash the consumer.
-        if let Ok(db) = AnalyticsDb::open(&db_path) {
-            let _ = AnalyticsStore::clear(&db);
+        // Phase 2 — concurrent `stats --clear` while the consumer writes.
+        // No `if let Ok(...)` escape hatch: a failed open here IS the concurrent-open
+        // bug fixed in `schema::run_migrations` / `AnalyticsDb::open`, and it must
+        // fail loudly rather than silently skipping the whole scenario.
+        let db = AnalyticsDb::open(&db_path).expect("concurrent open must succeed");
+        AnalyticsStore::clear(&db).expect("clear must succeed");
+        drop(db);
+
+        // Phase 3 — post-clear events. Nothing contends for the write lock now and
+        // nothing deletes these rows afterwards.
+        for _ in 0..POST_CLEAR {
+            hook.on_request(&make_small_event());
         }
 
-        // Close the sender and wait for consumer to finish.
+        // Close the sender and wait for the consumer to finish.
         drop(hook);
-        let consumer_finished = done_rx.recv_timeout(Duration::from_secs(10)).is_ok();
+        let consumer_finished = done_rx.recv_timeout(CONSUMER_LIVENESS_BOUND).is_ok();
         let _ = handle.join();
 
         // Consumer must finish — no panic, no hang (AC15).
         assert!(
             consumer_finished,
             "consumer must signal completion after channel closes"
+        );
+
+        // Byte accounting must balance exactly: every enqueued event was dequeued
+        // and its payload subtracted. A leak or a double-subtract shows up here.
+        assert_eq!(
+            queued_bytes.load(Ordering::Relaxed),
+            0,
+            "every enqueued event must be dequeued and byte-accounted"
+        );
+
+        // The post-clear events must have landed. Channel capacity is
+        // PROXY_QUEUE_RECORD_CAPACITY (2048) and only 25 events were sent, so an
+        // enqueue-overflow drop is impossible — any shortfall here is a DB failure.
+        //
+        // `drops == 0` is deliberately NOT asserted: under heavy CPU
+        // oversubscription a scheduling stall could exceed the consumer's 100 ms
+        // busy_timeout and produce a legitimate fail-open drop. The row-count
+        // assertion captures the same claim without that flake.
+        let db = AnalyticsDb::open(&db_path).expect("post-run open must succeed");
+        let rows = db
+            .query_proxy_row_count()
+            .expect("proxy row count must be queryable");
+        assert!(
+            rows >= POST_CLEAR as u64,
+            "at least the {POST_CLEAR} uncontended post-clear events must be persisted; \
+             got {rows} rows (drops={})",
+            drop_count.load(Ordering::Relaxed)
         );
     }
 


### PR DESCRIPTION
Fixes the CI failure of `cmd::proxy_analytics::tests::test_concurrent_clear_does_not_crash_consumer` by removing its root cause rather than widening the bound.

## Root cause

The analytics consumer rebuilt the entire tiktoken BPE vocabulary **once per event**. `compute_token_counts` called `Counter::new` inside the drain loop, and `Counter::new` called the non-cached `tiktoken_rs::cl100k_base()` — ~100,257 base64 decodes plus a fancy-regex compile, ~230 ms per call. `prefilled_lock` created a fresh `OnceLock` per `Counter`, so nothing was ever reused.

Measured shutdown latency for the 20-event test:

| condition | p50 | result |
|---|---|---|
| idle, 10-core | 4573 ms | passed, but consumed 46% of the 10 s bound |
| 12x CPU oversubscription | 7268 ms | passed, 1.35x headroom |
| 30x CPU oversubscription | 18972 ms | **13/13 failed** |

Time attribution under load: token counting 18951 ms of 18972 ms (99.9%); SQLite writes ≤12 ms. Across 55 runs at a 120 s bound the consumer signalled 55/55 — always delayed, never lost, so raising the timeout would have masked a real defect.

**This was a production bug.** `spawn_consumer` is production code: every proxied request burned ~230 ms of consumer CPU rebuilding an identical table. At the shipped queue capacity (2048) a full drain took ~20 minutes against a `FLUSH_BOUND` of 5 s, silently discarding ~99.6% of queued analytics on shutdown — and because the drop counter is persisted after the drain loop, the disclosure counter meant to report that loss was destroyed by the same failure.

## Second bug found by measurement

`AnalyticsDb::open` was not concurrency-safe: the `PRAGMA user_version` read and the migrations were not atomic, so two connections opening the same fresh DB raced (`duplicate column name: session_id`, `table proxy_block_decisions already exists`). In 24 of 55 runs (44%) the consumer's open failed, every event took the fail-open path, and the test finished in ~1 ms **asserting nothing**. The test was a coin flip between a vacuous pass and real work.

## Changes

**`rskim-tokens/src/counter.rs`** — process-wide `Arc<CoreBPE>` cache keyed by *table* (cl100k and o200k are the only two; `AnthropicOffline` shares cl100k). `Counter::new` is now an refcount bump after first use. Deliberately does **not** hoist a single `Counter` out of the drain loop: each event carries its own provider+model and a proxy multiplexes providers, so hoisting would silently count OpenAI bodies with the Anthropic tokenizer. `tiktoken_rs::cl100k_base_singleton()` was rejected because it `unwrap()`s inside `lazy_static!`, converting the `Result` contract into a permanent poisoning panic.

**`analytics/schema.rs`** — `run_migrations` wrapped in a single `BEGIN IMMEDIATE` transaction, so the write lock is taken before `user_version` is read. Inner `BEGIN;`/`COMMIT;` removed from the v4/v5 batches (SQLite has no nested transactions).

**`analytics/mod.rs`** — `busy_timeout` moved ahead of the first read. New bounded-retry `enable_wal()` (50 x 10 ms): `PRAGMA journal_mode=WAL` takes an EXCLUSIVE lock via `pagerExclusiveLock` which **never invokes the busy handler**, so no `busy_timeout` value can protect it. New `open_is_safe_under_concurrent_first_open` regression test forces the race with a `Barrier`.

**`cmd/proxy.rs`** — the silent `Err(_)` arm on flush abandonment now emits an unconditional stderr marker (ADR-011 loss-bearing: the reader sees less than reality, so it is never `SKIM_DEBUG`-gated).

**`cmd/proxy_analytics.rs`** — test de-vacuumed: hard `.expect()` on open/clear instead of an `if let Ok` escape hatch, a post-clear phase, and discriminating assertions on `queued_bytes == 0` and `rows >= POST_CLEAR`. The bound is now a documented `CONSUMER_LIVENESS_BOUND` constant carrying the measurements that justify it (ADR-003). Corrected the false `FLUSH_BOUND` rustdoc claim that abandoned records are "dropped and counted", the incorrect "WAL allows concurrent readers + writers" comment (WAL allows readers concurrent with *one* writer), and replaced stale `line NNN` citations with symbol names.

## Verification

| check | result |
|---|---|
| target test @ 30x CPU oversubscription, 20 iterations | **20/20 pass**, p50 1118 ms (was 13/13 fail @ 18972 ms) |
| target test, idle | ~270 ms (was 4573 ms) |
| `open_is_safe_under_concurrent_first_open` @ 30x load, 20 iterations | 20/20 pass |
| `cargo nextest run -p rskim --bins --features proxy` | `3353 tests run: 3353 passed, 0 skipped` |
| `cargo test -p rskim-tokens` (+ doctests) | all pass; golden-corpus parity tests unmodified and green |
| `cargo clippy -p rskim --all-targets --features proxy -- -D warnings` | clean |
| `cargo clippy -p rskim-tokens --all-targets -- -D warnings` | clean |
| `cargo fmt -- --check` | clean |

The regression guard against reintroducing the per-event rebuild is a deterministic `Arc::ptr_eq` assertion in `rskim-tokens`, not a wall-clock threshold, so it cannot flake.

`PRAGMA synchronous` was deliberately left alone — a genuine durability trade-off that buys nothing here (SQLite is 12 ms of 19 s) and belongs in its own change.