### PR TITLE
refactor(proxy): adopt shared is_passthrough_mode() helper

### DIFF
--- a/crates/rskim/src/cmd/proxy.rs
+++ b/crates/rskim/src/cmd/proxy.rs
@@ -275,7 +275,8 @@ enum PipelineSelection {
 /// This is a pure function so that tests can assert the selection logic
 /// without constructing stages, spawning threads, or reading env vars.
 ///
-/// `passthrough_env` is `true` when `SKIM_PASSTHROUGH == "1"`.
+/// `passthrough_env` is `true` when `SKIM_PASSTHROUGH` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive) — see [`crate::cmd::is_passthrough_mode`].
 /// `no_cache_align` is `true` when `--no-cache-align` was passed.
 ///
 /// `passthrough_env` takes priority: if it is `true`, the result is always
@@ -409,10 +410,12 @@ pub(crate) fn run(
     let align_handle: Option<std::thread::JoinHandle<()>>;
     let align_done_rx: Option<crossbeam_channel::Receiver<()>>;
 
-    let selection = select_pipeline(
-        std::env::var("SKIM_PASSTHROUGH").as_deref() == Ok("1"),
-        parsed.no_cache_align,
-    );
+    // Use the shared `is_passthrough_mode()` helper rather than a literal
+    // `SKIM_PASSTHROUGH == "1"` comparison: every other passthrough gate in the CLI
+    // (dispatch, file, execution, test runners, hook) routes through it, and a bare
+    // equality check silently ignores the `true` / `yes` spellings the helper accepts —
+    // so `SKIM_PASSTHROUGH=true` would bypass compression everywhere but the proxy.
+    let selection = select_pipeline(super::is_passthrough_mode(), parsed.no_cache_align);
     let pipeline = match selection {
         PipelineSelection::Identity | PipelineSelection::BlockRouterOnly => {
             // Identity: SKIM_PASSTHROUGH=1 → no compression.


### PR DESCRIPTION
## Summary

The Wave-3 rewrite of `proxy::run()` into the `PipelineSelection` / `select_pipeline(...)` design reintroduced a literal `SKIM_PASSTHROUGH == "1"` comparison at the pipeline-selection site. This swaps it for the shared `cmd::is_passthrough_mode()` helper, which already existed on `main` (and therefore on this wave).

## Changes

`crates/rskim/src/cmd/proxy.rs` — one runtime gate and one rustdoc line.

Before:

```rust
    let selection = select_pipeline(
        std::env::var("SKIM_PASSTHROUGH").as_deref() == Ok("1"),
        parsed.no_cache_align,
    );
```

After:

```rust
    // Use the shared `is_passthrough_mode()` helper rather than a literal
    // `SKIM_PASSTHROUGH == "1"` comparison: every other passthrough gate in the CLI
    // (dispatch, file, execution, test runners, hook) routes through it, and a bare
    // equality check silently ignores the `true` / `yes` spellings the helper accepts —
    // so `SKIM_PASSTHROUGH=true` would bypass compression everywhere but the proxy.
    let selection = select_pipeline(super::is_passthrough_mode(), parsed.no_cache_align);
```

The `select_pipeline` rustdoc previously read ``` `passthrough_env` is `true` when `SKIM_PASSTHROUGH == "1"` ``` — that claim is no longer accurate, so it now names the full truthy set and points at the helper. Other `SKIM_PASSTHROUGH=1` mentions (module docs, `--help` text, test assertion messages) were left alone: `1` is still valid, and none of them claim it is the *only* accepted value.

## Why

1. **Consistency.** `is_passthrough_mode()` is the gate used by `cmd/dispatch.rs`, `cmd/file/mod.rs`, `cmd/execution.rs`, `cmd/test/{go,pytest,shared}.rs`, and `cmd/rewrite/hook.rs`. The proxy was the only surface hand-rolling the check.
2. **Correctness.** The helper accepts `1`, `true`, `yes` (case-insensitive). The literal `== Ok("1")` silently rejected `true` and `yes`, so `SKIM_PASSTHROUGH=true` bypassed compression everywhere *except* the proxy — a surface-specific divergence in a documented escape hatch.
3. **Conflict pre-emption.** PR #508 makes the identical substitution on `main`, against the pre-Wave-3 form of this line — a line this wave deleted when it restructured `run()`. That is a guaranteed textual conflict when #508 meets the wave, and a naive "take the wave's side" resolution would silently discard #508's intent. Landing the same semantics on the wave now makes either resolution converge.

No behavior change for `SKIM_PASSTHROUGH=1`.

## Testing

No new tests. The existing `select_pipeline` tests take explicit booleans rather than reading the environment, so they cover the selection logic but are unaffected by this change; the truthy-parsing semantics are already covered by the `is_passthrough_mode` / `check_passthrough_str` tests in `cmd/mod.rs`.

Verbatim results (all run with `-p rskim --features proxy`):

```
$ cargo check -p rskim --features proxy
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 56s
EXIT=0

$ cargo nextest run -p rskim --bins --features proxy -j 4
    Starting 3353 tests across 1 binary
     Summary [  16.843s] 3353 tests run: 3353 passed, 0 skipped
EXIT=0

$ cargo clippy -p rskim --all-targets --features proxy -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 49s
EXIT=0

$ cargo fmt -- --check
EXIT=0
```

Passthrough-gate tests specifically:

```
PASS cmd::proxy::tests::test_select_pipeline_all_three_are_distinct
PASS cmd::proxy::tests::test_select_pipeline_no_cache_align_maps_to_block_router_only
PASS cmd::proxy::tests::test_select_pipeline_default_maps_to_full
PASS cmd::proxy::tests::test_select_pipeline_passthrough_wins
PASS cmd::proxy::tests::test_select_pipeline_stage_count
```

## Breaking Changes

None.
