### PR TITLE
test(rskim-core): replace wall-clock scaling guards with a deterministic source contract

### DIFF
--- a/crates/rskim-core/src/transform/minimal.rs
+++ b/crates/rskim-core/src/transform/minimal.rs
@@ -816,6 +816,61 @@ mod tests {
         panic!("could not find comment #{n} in root named children");
     }
 
+    // Helper: parse Go source into a tree-sitter Tree.
+    fn parse_go(source: &str) -> Tree {
+        let mut parser = crate::Parser::new(Language::Go).unwrap();
+        parser.parse(source).unwrap()
+    }
+
+    /// Total AST node count, derived independently of the walkers under test.
+    ///
+    /// Explicit stack + `Node::children`, so the count never depends on the
+    /// traversal the walker performs. That independence is the whole point: it is
+    /// what lets `node_count == count_all_nodes(root)` detect a walker that visits
+    /// the same node twice, which is invisible in the output.
+    fn count_all_nodes(root: Node) -> usize {
+        let mut n = 0usize;
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            n += 1;
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                stack.push(ch);
+            }
+        }
+        n
+    }
+
+    /// Drive the production comment walker directly, composing `CommentWalkContext`
+    /// exactly the way `transform_minimal` does.
+    ///
+    /// Returns the raw (unadjusted) removal ranges and the number of nodes the
+    /// walker visited. The visit count is the instrument a re-walk regression trips:
+    /// descending twice leaves the ranges — and therefore the output — unchanged
+    /// while doubling the count.
+    fn collect_minimal_ranges(
+        source: &str,
+        tree: &Tree,
+        language: Language,
+    ) -> (Vec<(usize, usize)>, usize) {
+        let root = tree.root_node();
+        let header_end_byte = compute_header_end_byte(root, source, language);
+        let go_doc_comment_starts = compute_go_doc_comment_starts(root, source, language);
+        let mut ranges: Vec<(usize, usize)> = Vec::new();
+        let mut node_count: usize = 0;
+        let mut ctx = CommentWalkContext {
+            ranges: &mut ranges,
+            node_count: &mut node_count,
+            classification: CommentClassification {
+                header_end_byte,
+                go_doc_comment_starts: &go_doc_comment_starts,
+            },
+        };
+        collect_removable_comments(root, source, language, &mut ctx, 0, false)
+            .expect("comment walk must succeed on these fixtures");
+        (ranges, node_count)
+    }
+
     // ── compute_header_end_byte correctness ─────────────────────────────────
 
     #[test]
@@ -1014,48 +1069,38 @@ mod tests {
         );
     }
 
-    // ── Performance regression guard ─────────────────────────────────────────
+    // ── Large header block, end to end ───────────────────────────────────────
 
+    /// A large contiguous header block survives `transform_minimal` intact, and the
+    /// comment walker visits every AST node exactly once.
+    ///
+    /// WHAT THIS PINS: the artifact — which comments survive, that nothing is
+    /// collected for removal, and that the walk is single-visit.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity. It cannot discriminate O(N) from O(N²);
+    /// every historical defect here was *output-preserving* (the cost lived in
+    /// tree-sitter's C code, not in the Rust statement count), so no behavioural
+    /// assertion can see one. That job belongs to
+    /// `contract_transform_walkers_use_no_root_descending_node_apis` in
+    /// `transform/mod.rs`.
     #[test]
-    fn test_large_header_block_linear_time() {
-        // CUBIC SMOKE TEST for the O(N³) defect in the old backward-walk
-        // implementation of is_module_header_comment.
-        //
-        // WHAT THIS TEST PROVES: that N=500 comments complete within 200 ms.
-        // The old O(N³) code took ~3 s at N=500 in a DEBUG build — well beyond
-        // 200 ms. The fixed O(N) code completes in < 10 ms.
-        //
-        // WHAT THIS TEST DOES NOT PROVE: linear vs quadratic scaling. An O(N²)
-        // regression at N=500 would complete in ~31 ms and pass this test. For
-        // the doubling-ratio guard that discriminates O(N) from O(N²), see
-        // test_quadratic_scaling_guard.
-        //
-        // Empirical measurement (fix/init-pin-wrappers-header-comments, DEBUG build):
-        //   O(N³) unfixed: N=200 → 213ms, N=400 → 1736ms, N=1000 → 23920ms
-        //   O(N)  fixed:   N=500 → < 10ms
-        //
-        // Budget tightened from 2000ms to 200ms: the O(N³) code reliably exceeds
-        // 200ms (extrapolated ~3 s at N=500), while the fixed code runs in < 10ms,
-        // leaving ~20× CI headroom. 2000ms gave a 222× margin and asserted almost
-        // nothing about scaling.
-        let n = 500usize;
+    fn test_python_large_header_block_survives_transform() {
+        let n = 512usize;
         let mut source = String::with_capacity(n * 25);
         for i in 0..n {
             source.push_str(&format!("# Header comment {i}\n"));
         }
         source.push_str("x = 1\n");
 
-        let start = std::time::Instant::now();
         let mut parser = crate::Parser::new(Language::Python).unwrap();
         let tree = parser.parse(&source).unwrap();
         let config = TransformConfig::default();
         let result = transform_minimal(&source, &tree, Language::Python, &config);
-        let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "transform must succeed: {:?}", result.err());
         let output = result.unwrap();
 
-        // All 500 header comments must be preserved (they form a contiguous leading block).
+        // All header comments must be preserved (they form a contiguous leading block).
         assert!(
             output.contains("# Header comment 0"),
             "first header comment must be preserved; got:\n{output}"
@@ -1065,11 +1110,15 @@ mod tests {
             "last header comment must be preserved; got:\n{output}"
         );
 
+        let (ranges, node_count) = collect_minimal_ranges(&source, &tree, Language::Python);
         assert!(
-            elapsed < std::time::Duration::from_millis(200),
-            "{n} leading comments must process in < 200ms (got {elapsed:?}); \
-             old O(N³) code took ~3 s at N={n} in DEBUG — this indicates a cubic regression. \
-             For quadratic regressions, see test_quadratic_scaling_guard."
+            ranges.is_empty(),
+            "the whole block is a module header, so nothing is removable; got {ranges:?}"
+        );
+        assert_eq!(
+            node_count,
+            count_all_nodes(tree.root_node()),
+            "collect_removable_comments must visit each AST node exactly once"
         );
     }
 
@@ -1333,126 +1382,95 @@ mod tests {
     // hypothetical malicious grammars or future grammar changes.
 
     // ========================================================================
-    // Scaling regression guard — catches regression to O(N²)
+    // Module-header precompute — exact artifact, not elapsed time
     // ========================================================================
     //
-    // The single-point timing tests above catch catastrophic regressions but cannot
-    // reliably detect a reintroduced O(N²) path if the constant is small.
-    // This doubling-ratio test makes the complexity class directly observable:
+    // `compute_header_end_byte` and `collect_removable_comments` are pinned by the
+    // exact values they produce and the number of node visits they make.
     //
-    //   O(N):  doubling N doubles time → ratio ≈ 2.0
-    //   O(N²): doubling N quadruples time → ratio ≈ 4.0
-    //
-    // Design choice: wall-clock ratio over a deterministic step counter.
-    // A per-iteration step counter at the outer loop level would count the same
-    // N+1 iterations for BOTH O(N) and O(N²) implementations — the cost difference
-    // is internal to tree-sitter's C code (ts_node_parent re-walks from the root,
-    // ts_node_named_child re-scans the child list from position 0). These are
-    // invisible from Rust without modifying tree-sitter. The ratio test at
-    // large-enough N (where signal exceeds scheduling noise) is the practical
-    // discriminator.
-    //
-    // NOTE: transform_minimal is called directly here, not via the CLI binary, so
-    // the skim file-level disk cache (which would mask the defect by serving a cached
-    // result instead of running the transform) is not involved. The measurements
-    // reflect the transform cost directly.
-    //
-    // Empirical basis (debug build, fix/init-pin-wrappers-header-comments):
-    //   O(N²) unfixed: N=1000 → 125.5ms, N=2000 → 508.0ms, ratio = 4.05
-    //   O(N)  fixed:   N=2000 → ~12.7ms,  N=8000 → ~30.4ms
-    //                  N=4000 → ~18.6ms (linear interpolation from the two points above)
-    //   N=4000 vs N=8000 ratio on fixed code:         ~30.4 / ~18.6 ≈ 1.63×
-    //   N=4000 vs N=8000 ratio on O(N²) unfixed code: ~8032ms / ~2008ms ≈ 4.0×
-    //   Threshold 2.5× sits midway: ≥ 0.9 margin from linear upper (1.6×),
-    //                               ≥ 1.3 margin below quadratic lower (3.8×).
-    //
-    // N sizes chosen so that t1 (N=4000) reliably exceeds 2 ms even on fast debug
-    // hardware (~18 ms measured), keeping the noise floor assertion below the expected
-    // measurement by ~9×.
+    // Neither this nor any other behavioural assertion can discriminate O(N) from
+    // O(N²) here: the historical defect (a per-node backward `parent()` /
+    // `named_child(i)` walk) executed the SAME Rust statements and produced
+    // BYTE-IDENTICAL output — the extra cost was entirely inside tree-sitter's C
+    // code, where a `TSNode` has no parent pointer and every such call re-descends
+    // from the root. The construct itself is therefore forbidden at the source level
+    // by `contract_transform_walkers_use_no_root_descending_node_apis` in
+    // `transform/mod.rs`, and the measured series that motivated the fix lives in
+    // the production rustdoc on `compute_header_end_byte` and `is_go_doc_comment`.
 
-    #[test]
-    fn test_quadratic_scaling_guard() {
-        // WHAT THIS TEST PROVES: that the doubling ratio (N=4000 → N=8000) stays
-        // below 2.5×. An O(N) implementation produces ~1.3–1.6×; O(N²) produces
-        // ~4.0×. The 2.5 threshold sits midway between them.
-        //
-        // WHAT THIS TEST DOES NOT PROVE: absolute throughput or strict O(N) vs
-        // O(N log N). It discriminates linear from quadratic, no finer.
-        //
-        // Build N=4000 and N=8000 contiguous-leading-comment Python files.
-        // (The same "gap-then-body-function" fixture as the other timing tests.)
-        let make_source = |n: usize| {
-            let mut s = String::with_capacity(n * 25 + 16);
-            for i in 0..n {
-                s.push_str(&format!("# Header comment {i}\n"));
-            }
-            s.push_str("def f(x): return x\n");
-            s
-        };
-        let source_4k = make_source(4000);
-        let source_8k = make_source(8000);
+    /// Tail appended after the synthetic header block. A constant because the
+    /// expected `header_end_byte` is derived from its length.
+    const PY_HEADER_TAIL: &str = "def f(x): return x\n";
 
-        let mut parser = crate::Parser::new(Language::Python).unwrap();
-        let config = TransformConfig::default();
-
-        // Warm up (parse once before measuring; avoids one-time tree-sitter
-        // initialisation costs skewing the N=4000 sample).
-        {
-            let tree = parser.parse(&source_4k).unwrap();
-            let _ = transform_minimal(&source_4k, &tree, Language::Python, &config);
+    /// `n` contiguous leading comments followed by [`PY_HEADER_TAIL`].
+    fn python_header_source(n: usize) -> String {
+        let mut s = String::with_capacity(n * 25 + PY_HEADER_TAIL.len());
+        for i in 0..n {
+            s.push_str(&format!("# Header comment {i}\n"));
         }
+        s.push_str(PY_HEADER_TAIL);
+        s
+    }
 
-        // Measure N=4000
-        let t1 = {
-            let tree = parser.parse(&source_4k).unwrap();
-            let start = std::time::Instant::now();
-            let r = transform_minimal(&source_4k, &tree, Language::Python, &config);
-            let elapsed = start.elapsed();
-            assert!(r.is_ok(), "N=4000 transform must succeed: {:?}", r.err());
-            elapsed
-        };
+    /// The module-header precompute lands on an exact byte, classifies the whole
+    /// block as KEEP, and is reached in a single visit per AST node.
+    ///
+    /// WHAT THIS PINS:
+    /// 1. `compute_header_end_byte` returns the end byte of the last leading
+    ///    comment — computed from the fixture's shape, not from a recorded run.
+    /// 2. `collect_removable_comments` collects nothing (every comment is a header)
+    ///    and visits each node exactly once — the assertion a re-walk regression
+    ///    trips while leaving the output untouched.
+    /// 3. The production entry point still composes the two (source-corpus PF-014:
+    ///    driving the pieces directly proves the counters; driving
+    ///    `transform_minimal` proves production still wires them together).
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity. It does NOT discriminate O(N) from
+    /// O(N²) — the defect was output-preserving. See the section note above and
+    /// the contract test in `transform/mod.rs`.
+    #[test]
+    fn test_python_module_header_precompute_is_exact_and_single_visit() {
+        for n in [256usize, 512] {
+            let source = python_header_source(n);
+            let tree = parse_python(&source);
+            let root = tree.root_node();
 
-        // Measure N=8000
-        let t2 = {
-            let tree = parser.parse(&source_8k).unwrap();
-            let start = std::time::Instant::now();
-            let r = transform_minimal(&source_8k, &tree, Language::Python, &config);
-            let elapsed = start.elapsed();
-            assert!(r.is_ok(), "N=8000 transform must succeed: {:?}", r.err());
-            elapsed
-        };
+            // The last comment ends just before the newline that precedes the tail.
+            let expected_header_end = source.len() - PY_HEADER_TAIL.len() - 1;
+            assert_eq!(
+                compute_header_end_byte(root, &source, Language::Python),
+                expected_header_end,
+                "n={n}: header_end_byte must be the end byte of the last leading comment"
+            );
 
-        let t1_ms = t1.as_secs_f64() * 1000.0;
-        let t2_ms = t2.as_secs_f64() * 1000.0;
+            let (ranges, node_count) = collect_minimal_ranges(&source, &tree, Language::Python);
+            assert!(
+                ranges.is_empty(),
+                "n={n}: a fully contiguous header block yields no removable comments; \
+                 got {ranges:?}"
+            );
+            assert_eq!(
+                node_count,
+                count_all_nodes(root),
+                "n={n}: collect_removable_comments must visit each AST node exactly once"
+            );
 
-        // N=4000 must produce a measurable result above the OS noise floor.
-        // In debug builds this is ~18 ms; 2 ms is the floor — if it completes
-        // faster than that, either the transform is being cached/skipped or N
-        // needs to be raised further.
-        //
-        // We FAIL rather than skip: a silently-passing ratio guard is worse than
-        // no guard at all. This assertion is the tripwire against that failure mode.
-        assert!(
-            t1_ms >= 2.0,
-            "N=4000 transform completed in {t1_ms:.3}ms — too fast to measure reliably \
-             (expected ≥ 2ms; ~18ms measured on debug builds). Either the transform is \
-             being cached/skipped or N should be raised further. \
-             DO NOT convert this to a skip — a silently-passing guard provides no protection."
-        );
-
-        // The doubling ratio must stay below 2.5 (O(N²) produces ~4.0×, O(N) ~1.3–1.6×).
-        // Threshold 2.5 is midway: ≥ 0.9 margin from linear upper bound, ≥ 1.3 below quadratic.
-        let ratio = t2_ms / t1_ms;
-        assert!(
-            ratio < 2.5,
-            "Doubling N from 4000 to 8000 must produce a ratio below 2.5 (got {ratio:.2}×). \
-             O(N) → ~1.3–1.6×; O(N²) → ~4.0× (empirically measured). \
-             This indicates a regression to super-linear scaling. Check that \
-             compute_header_end_byte uses a TreeCursor (not next_named_sibling), \
-             is_module_header_comment uses depth (not parent() calls), and \
-             collect_removable_comments threads in_function_body (not is_inside_function_body). \
-             N=4000 took {t1_ms:.1}ms, N=8000 took {t2_ms:.1}ms."
-        );
+            let config = TransformConfig::default();
+            let out = transform_minimal(&source, &tree, Language::Python, &config).unwrap();
+            assert!(
+                out.contains("# Header comment 0"),
+                "n={n}: first header comment must survive; got:\n{out}"
+            );
+            assert!(
+                out.contains(&format!("# Header comment {}", n - 1)),
+                "n={n}: last header comment must survive; got:\n{out}"
+            );
+            assert_eq!(
+                out.lines().count(),
+                source.lines().count(),
+                "n={n}: nothing is removed, so the line count must be preserved"
+            );
+        }
     }
 
     // ── build_newline_table correctness ─────────────────────────────────────
@@ -1868,55 +1886,26 @@ mod tests {
     }
 
     // ========================================================================
-    // Go comment-classification scaling guards
+    // Go comment classification — exact artifacts, not elapsed time
     // ========================================================================
     //
-    // All three pre-existing perf guards in this file are PYTHON-only, so a Go
-    // regression had no coverage whatsoever: an O(N²) Go regression at N=500
-    // finishes in ~31 ms and passes silently.
+    // These pin what `compute_go_doc_comment_starts` and the two walkers PRODUCE,
+    // and how many node visits it takes them.
     //
-    // MEASURED SERIES (DEBUG build, this branch, best-of-1 pre-fix / best-of-3
-    // post-fix; `transform_minimal` / `transform_pseudo_*` called directly, so
-    // the skim file-level disk cache is NOT involved — a warm parser cache
-    // hides exactly this defect class, PF-020).
-    //
-    //   Go leading comment run before `package main`, minimal:
-    //     BEFORE (Θ(M³/3)):  N=250 → 665.43 ms | N=500 → 5231.39 ms | N=1000 → 41615.57 ms
-    //                        ratios 7.86×, 7.95×   →   α = 2.98
-    //     AFTER  (linear):   N=250 →   0.38 ms | N=500 →    0.77 ms | N=1000 →     1.48 ms
-    //                        ratios 2.00×, 1.94×   →   α = 0.98        (28118× at N=1000)
-    //
-    //   Go leading comment run before `package main`, pseudo:
-    //     BEFORE:            N=250 → 656.58 ms | N=500 → 5212.06 ms | N=1000 → 41571.69 ms
-    //                        ratios 7.94×, 7.98×   →   α = 2.99
-    //     AFTER:             N=250 →   0.44 ms | N=500 →    0.85 ms | N=1000 →     1.66 ms
-    //                        ratios 1.93×, 1.95×   →   α = 0.96        (25043× at N=1000)
-    //
-    //   Go 3-line doc blocks each followed by a declaration, minimal:
-    //     BEFORE:            n=500 →  21.42 ms | n=1000 →   45.29 ms | n=2000 →   96.01 ms
-    //                        ratios 2.11×, 2.12×   →   α = 1.08
-    //     AFTER:             n=500 →  12.92 ms | n=1000 →   25.28 ms | n=2000 →   50.32 ms
-    //                        ratios 1.96×, 1.99×   →   α = 0.98
-    //
-    // NOTE, recorded deliberately: the doc-block shape was ALREADY LINEAR
-    // before the fix (α = 1.08, not the α ≈ 2 that was predicted). Short runs
-    // bound the forward walk to ~3 sibling steps, so the cubic term never
-    // develops. Its guard below is therefore a REGRESSION guard, not evidence
-    // of the fix. The leading-run shape is the one that demonstrates the defect.
-    //
-    // AFTER, at the guard sizes used below (best-of-3):
-    //   leading-run/minimal: N=2000 → 4.62 ms | N=4000 → 6.48 ms | N=8000 → 11.91 ms
-    //   leading-run/pseudo : N=2000 → 3.26 ms | N=4000 → 6.58 ms | N=8000 → 13.27 ms
-    //
-    // THRESHOLD RATIONALE — the ratio guards use 2.8, not the 2.5 used by the
-    // Python `test_quadratic_scaling_guard`. A doubling ratio of 2.8 ≈ 2^1.5 is
-    // the exponent-space midpoint between linear (2.0×) and quadratic (4.0×).
-    // The Python guard can afford 2.5 because its measured ratio is ~1.63 —
-    // fixed overhead pulls it well below 2.0. The Go guards measure ~1.84–2.02,
-    // so 2.5 would leave only ~25 % headroom and flake on a loaded machine.
+    // They do NOT discriminate O(N) from O(N²)/Θ(M³), and no behavioural assertion
+    // can: the Θ(M³/3) per-node `next_named_sibling()` walk executed the SAME Rust
+    // statements as the precompute and produced BYTE-IDENTICAL output. The whole
+    // cost difference lived in tree-sitter's C code, where a `TSNode` has no parent
+    // pointer and every sibling step rescans the parent's child list from 0. The
+    // construct is therefore forbidden at the source level by
+    // `contract_transform_walkers_use_no_root_descending_node_apis` in
+    // `transform/mod.rs`; the measured before/after series that motivated the fix
+    // lives in the production rustdoc on `is_go_doc_comment`.
 
     /// N contiguous comments at the very top, then `package main`.
-    /// Worst case for the old walk: every comment walked the whole remaining run.
+    ///
+    /// `package_clause` is not an `is_go_declaration` kind, so the entire run is
+    /// STRIP — not one comment in it is a doc comment.
     fn go_leading_run_source(n: usize) -> String {
         let mut s = String::with_capacity(n * 26 + 64);
         for i in 0..n {
@@ -1927,6 +1916,9 @@ mod tests {
     }
 
     /// `n` doc blocks of 3 comment lines, each immediately followed by a func.
+    ///
+    /// Every comment is a doc comment (KEEP): each run terminates on a
+    /// `function_declaration`, which IS an `is_go_declaration` kind.
     fn go_doc_blocks_source(n: usize) -> String {
         let mut s = String::with_capacity(n * 120 + 64);
         s.push_str("package main\n\n");
@@ -1941,151 +1933,223 @@ mod tests {
         s
     }
 
-    fn time_go_minimal(source: &str) -> f64 {
-        let mut parser = crate::Parser::new(Language::Go).unwrap();
-        let tree = parser.parse(source).unwrap();
-        let config = TransformConfig::default();
-        let start = std::time::Instant::now();
-        let r = transform_minimal(source, &tree, Language::Go, &config);
-        let ms = start.elapsed().as_secs_f64() * 1000.0;
-        assert!(r.is_ok(), "minimal transform must succeed: {:?}", r.err());
-        ms
+    /// Byte offsets of every `//` in `source` — the comment start bytes derived
+    /// from the TEXT, independently of the AST walk under test.
+    ///
+    /// Both Go fixtures above put exactly one `//` at the start of each comment
+    /// line and none anywhere else, so this is an exact expectation, not a proxy.
+    fn go_comment_start_bytes(source: &str) -> Vec<usize> {
+        source.match_indices("//").map(|(i, _)| i).collect()
     }
 
-    fn time_go_pseudo(source: &str) -> f64 {
-        let mut parser = crate::Parser::new(Language::Go).unwrap();
-        let tree = parser.parse(source).unwrap();
-        let config = TransformConfig::default();
-        let start = std::time::Instant::now();
-        let r = crate::transform::pseudo::transform_pseudo_with_spans_and_line_map(
-            source,
-            &tree,
-            Language::Go,
-            &config,
-        );
-        let ms = start.elapsed().as_secs_f64() * 1000.0;
-        assert!(r.is_ok(), "pseudo transform must succeed: {:?}", r.err());
-        ms
+    /// The comment nodes' `(start, end)` byte ranges, derived from the text: each
+    /// synthetic comment runs from its `//` to the end of its line.
+    fn go_comment_ranges(source: &str) -> Vec<(usize, usize)> {
+        go_comment_start_bytes(source)
+            .into_iter()
+            .map(|start| {
+                let len = source[start..]
+                    .find('\n')
+                    .expect("every synthetic comment line ends in a newline");
+                (start, start + len)
+            })
+            .collect()
     }
 
-    /// Cheap cubic tripwire. Runs FIRST inside each ratio guard so that a
-    /// reintroduced Θ(M³) implementation fails in ~40 s at N=1000 instead of
-    /// letting the N=8000 measurement grind for hours.
-    fn assert_no_cubic_regression(timer: fn(&str) -> f64, mode: &str) {
-        let probe = timer(&go_leading_run_source(1000));
-        assert!(
-            probe < 200.0,
-            "[{mode}] N=1000 Go leading comment run took {probe:.1}ms (budget 200ms). \
-             The Θ(M³/3) per-node next_named_sibling() walk took 41616ms here; the \
-             linear precompute takes ~1.5ms. This is a CUBIC regression — check that \
-             is_go_doc_comment does a binary_search over compute_go_doc_comment_starts \
-             and does NOT walk siblings (PF-020)."
-        );
-    }
-
+    /// A leading comment run terminated by `package main` yields no doc comments
+    /// and is stripped in full by minimal mode.
+    ///
+    /// WHAT THIS PINS: the artifact — an empty doc-comment table, one removal range
+    /// per comment, a single visit per AST node, and the stripped output.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity. It does not discriminate O(N) from
+    /// Θ(M³) — the defect was output-preserving. See the section note above.
     #[test]
-    fn test_go_leading_comment_run_linear_time() {
-        // CUBIC SMOKE TEST. Pre-fix: 41616 ms at N=1000. Post-fix: 1.48 ms.
-        // Budget 200 ms leaves ~135× headroom over the fixed code while the
-        // cubic code exceeds it by ~208×.
-        let n = 1000usize;
+    fn test_go_leading_comment_run_is_stripped_entirely() {
+        let n = 256usize;
         let source = go_leading_run_source(n);
-        let elapsed = time_go_minimal(&source);
+        let tree = parse_go(&source);
 
-        // Behaviour assertion alongside the timing: the whole run precedes
-        // `package main`, which is NOT an is_go_declaration kind, so every one
-        // of the N comments must be stripped.
+        // The whole run precedes `package main`, which is NOT an is_go_declaration
+        // kind, so NO comment in it is a doc comment.
+        let starts = compute_go_doc_comment_starts(tree.root_node(), &source, Language::Go);
+        assert!(
+            starts.is_empty(),
+            "a run terminated by package_clause contains no doc comments; got {starts:?}"
+        );
+
         let out = transform_go(&source, true);
         assert!(
             !out.contains("// leading run line"),
             "a leading comment run terminated by package_clause must be stripped entirely"
         );
 
-        assert!(
-            elapsed < 200.0,
-            "{n} leading Go comments must process in < 200ms (got {elapsed:.1}ms); \
-             the old Θ(M³/3) walk took 41616ms at N={n}."
+        let (ranges, node_count) = collect_minimal_ranges(&source, &tree, Language::Go);
+        assert_eq!(
+            ranges.len(),
+            n,
+            "every comment in the run must be collected for removal"
+        );
+        assert_eq!(
+            node_count,
+            count_all_nodes(tree.root_node()),
+            "collect_removable_comments must visit each AST node exactly once"
         );
     }
 
+    /// The removal ranges for a leading comment run are byte-exact, and the walk is
+    /// single-visit, at two sizes.
+    ///
+    /// WHAT THIS PINS: `collect_removable_comments` emits exactly one range per
+    /// comment node, at the byte offsets derived from the source text, and descends
+    /// once per AST node.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity — the defect was output-preserving. See
+    /// the section note above and the contract test in `transform/mod.rs`.
     #[test]
-    fn test_go_leading_comment_run_scaling_guard() {
-        assert_no_cubic_regression(time_go_minimal, "minimal");
+    fn test_go_leading_comment_run_ranges_are_exact_and_single_visit() {
+        for n in [128usize, 256] {
+            let source = go_leading_run_source(n);
+            let tree = parse_go(&source);
+            let root = tree.root_node();
 
-        let t1 = time_go_minimal(&go_leading_run_source(4000));
-        let t2 = time_go_minimal(&go_leading_run_source(8000));
+            let starts = compute_go_doc_comment_starts(root, &source, Language::Go);
+            assert!(
+                starts.is_empty(),
+                "n={n}: a run terminated by package_clause contains no doc comments; \
+                 got {starts:?}"
+            );
 
-        // Noise floor. We FAIL rather than skip: an absolute-ms guard elsewhere
-        // in this work went vacuous when a fix made it too fast to measure, and
-        // a silently-passing scaling guard provides no protection at all.
-        assert!(
-            t1 >= 1.5,
-            "N=4000 completed in {t1:.3}ms — too fast to measure reliably \
-             (expected ≥ 1.5ms; ~6.5ms measured on debug builds). Either the \
-             transform is being cached/skipped or N must be raised. \
-             DO NOT convert this to a skip."
-        );
+            let (mut ranges, node_count) = collect_minimal_ranges(&source, &tree, Language::Go);
+            ranges.sort_unstable();
+            assert_eq!(
+                ranges,
+                go_comment_ranges(&source),
+                "n={n}: one removal range per comment, at the exact comment byte offsets"
+            );
+            assert_eq!(
+                node_count,
+                count_all_nodes(root),
+                "n={n}: collect_removable_comments must visit each AST node exactly once"
+            );
 
-        let ratio = t2 / t1;
-        assert!(
-            ratio < 2.8,
-            "Doubling N from 4000 to 8000 must produce a ratio below 2.8 \
-             (got {ratio:.2}×; measured 1.84× on the linear implementation). \
-             O(N) → ~2.0×; O(N²) → ~4.0×; 2.8 ≈ 2^1.5 is the exponent-space \
-             midpoint. N=4000 took {t1:.2}ms, N=8000 took {t2:.2}ms."
-        );
+            // The production entry point still composes the precompute and the walk.
+            let out = transform_go(&source, true);
+            assert!(
+                !out.contains("// leading run line"),
+                "n={n}: the whole run must be stripped; got:\n{out}"
+            );
+            assert!(
+                out.contains("package main"),
+                "n={n}: the terminator must survive; got:\n{out}"
+            );
+        }
     }
 
+    /// The Go doc-comment precompute is byte-exact, strictly ascending, and reached
+    /// in a single visit per AST node.
+    ///
+    /// WHAT THIS PINS:
+    /// 1. `compute_go_doc_comment_starts` equals the `//` offsets derived from the
+    ///    text, `3 * n` of them, strictly ascending (`binary_search` depends on it).
+    /// 2. `collect_removable_comments` collects nothing — every comment is a doc
+    ///    comment — and visits each node exactly once.
+    /// 3. `transform_minimal` still composes the two.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity — the defect was output-preserving.
     #[test]
-    fn test_go_doc_block_scaling_guard() {
-        // n is capped at 2000: each block is ~17 AST nodes, so n=4000 would
-        // approach MAX_AST_NODES (100_000) and silently turn this guard into an
-        // Err(ComplexityLimit) assertion instead of a timing assertion.
-        //
-        // This shape was already linear before the fix (α = 1.08) — it is a
-        // REGRESSION guard, not evidence of the fix. See the series above.
-        let t1 = time_go_minimal(&go_doc_blocks_source(1000));
-        let t2 = time_go_minimal(&go_doc_blocks_source(2000));
+    fn test_go_doc_comment_precompute_is_exact_and_single_visit() {
+        for n in [128usize, 256] {
+            let source = go_doc_blocks_source(n);
+            let tree = parse_go(&source);
+            let root = tree.root_node();
 
-        assert!(
-            t1 >= 3.0,
-            "n=1000 doc blocks completed in {t1:.3}ms — too fast to measure \
-             reliably (expected ≥ 3ms; ~25ms measured). DO NOT convert to a skip."
-        );
+            let starts = compute_go_doc_comment_starts(root, &source, Language::Go);
+            assert_eq!(
+                starts,
+                go_comment_start_bytes(&source),
+                "n={n}: every `//` in this fixture begins a doc comment"
+            );
+            assert_eq!(
+                starts.len(),
+                3 * n,
+                "n={n}: three doc-comment lines per block"
+            );
+            assert!(
+                starts.windows(2).all(|w| w[0] < w[1]),
+                "n={n}: binary_search requires strictly ascending start bytes; got {starts:?}"
+            );
 
-        let ratio = t2 / t1;
-        assert!(
-            ratio < 2.8,
-            "Doubling doc-block count from 1000 to 2000 must produce a ratio \
-             below 2.8 (got {ratio:.2}×; measured 1.99×). \
-             n=1000 took {t1:.2}ms, n=2000 took {t2:.2}ms."
-        );
+            let (ranges, node_count) = collect_minimal_ranges(&source, &tree, Language::Go);
+            assert!(
+                ranges.is_empty(),
+                "n={n}: every comment is a doc comment (KEEP); got {ranges:?}"
+            );
+            assert_eq!(
+                node_count,
+                count_all_nodes(root),
+                "n={n}: collect_removable_comments must visit each AST node exactly once"
+            );
+
+            let out = transform_go(&source, true);
+            assert!(
+                out.contains("// Fn0 does a thing."),
+                "n={n}: first doc comment must survive; got:\n{out}"
+            );
+            assert!(
+                out.contains(&format!("// Even more detail about Fn{}.", n - 1)),
+                "n={n}: last doc comment must survive; got:\n{out}"
+            );
+            assert_eq!(
+                out.lines().count(),
+                source.lines().count(),
+                "n={n}: nothing is removed, so the line count must be preserved"
+            );
+        }
     }
 
+    /// The same leading-run classification through the PSEUDO path.
+    ///
+    /// pseudo is the production path: the cat/head/tail rewrite selects
+    /// `--mode=pseudo` for regular code files (ADR-008), so this is the mode an
+    /// agent actually reads Go through. Go's pseudo rules strip no node kinds, no
+    /// keywords and no semicolons, so the comment classification is the only thing
+    /// that can change the output.
+    ///
+    /// WHAT THIS PINS: the shared precompute is empty for this shape, and the
+    /// pseudo entry point strips the whole run while leaving the code intact.
+    ///
+    /// The pseudo walker's own single-visit counter is asserted in `pseudo.rs`,
+    /// where `collect_noise_ranges` and `NoiseWalkContext` are in scope.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity — the defect was output-preserving.
     #[test]
-    fn test_go_pseudo_leading_comment_run_scaling_guard() {
-        // pseudo is the PRODUCTION path: the cat/head/tail rewrite selects
-        // --mode=pseudo for regular code files (ADR-008), so this is the mode an
-        // agent actually reads Go through. Go's pseudo rules strip no node kinds
-        // and no keywords, so this measures the comment walk almost in isolation.
-        assert_no_cubic_regression(time_go_pseudo, "pseudo");
+    fn test_go_pseudo_leading_comment_run_is_stripped_entirely() {
+        for n in [128usize, 256] {
+            let source = go_leading_run_source(n);
+            let tree = parse_go(&source);
 
-        let t1 = time_go_pseudo(&go_leading_run_source(4000));
-        let t2 = time_go_pseudo(&go_leading_run_source(8000));
+            let starts = compute_go_doc_comment_starts(tree.root_node(), &source, Language::Go);
+            assert!(
+                starts.is_empty(),
+                "n={n}: a run terminated by package_clause contains no doc comments; \
+                 got {starts:?}"
+            );
 
-        assert!(
-            t1 >= 1.5,
-            "N=4000 pseudo completed in {t1:.3}ms — too fast to measure reliably \
-             (expected ≥ 1.5ms; ~6.6ms measured). DO NOT convert this to a skip."
-        );
-
-        let ratio = t2 / t1;
-        assert!(
-            ratio < 2.8,
-            "Doubling N from 4000 to 8000 in pseudo mode must produce a ratio \
-             below 2.8 (got {ratio:.2}×; measured 2.02×). \
-             N=4000 took {t1:.2}ms, N=8000 took {t2:.2}ms."
-        );
+            let out = transform_go(&source, false);
+            assert!(
+                !out.contains("// leading run line"),
+                "n={n}: pseudo must strip the whole run; got:\n{out}"
+            );
+            assert!(
+                out.contains("package main"),
+                "n={n}: pseudo must preserve the package clause; got:\n{out}"
+            );
+            assert!(
+                out.contains("func f()"),
+                "n={n}: pseudo must preserve the function; got:\n{out}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rskim-core/src/transform/mod.rs
+++ b/crates/rskim-core/src/transform/mod.rs
@@ -412,7 +412,7 @@ pub(crate) fn reconcile_line_map_after_truncation(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)] // Unwrapping/expect is acceptable in tests
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)] // acceptable in tests
 mod tests {
     use super::*;
     use crate::transform::minimal::trim_and_normalize;
@@ -767,5 +767,424 @@ mod tests {
             "Joining two lines by removing only the newline must map output line to source line 1, got {:?}",
             map
         );
+    }
+
+    // ========================================================================
+    // Source-level complexity contract for the transform walkers
+    // ========================================================================
+
+    /// Root-descending / index-scanning `tree_sitter` node APIs, each paired with
+    /// the reason it is banned from the transform walkers.
+    ///
+    /// Each entry is matched as a plain substring against the *production* region
+    /// of the policed file with comments and string literals blanked out. The
+    /// leading `.` and the trailing `(` are load-bearing:
+    ///
+    /// - `.child(` does not match `.child_by_field_name(` or `.child_count(`
+    /// - `.named_child(` does not match `.named_children(`
+    /// - `.next_sibling(` does not match `TreeCursor::goto_next_sibling(`
+    /// - `.next_named_sibling(` does not match `goto_next_named_sibling(`
+    ///
+    /// The genuinely O(1) traversal set — `Node::walk`,
+    /// `TreeCursor::goto_first_child` / `goto_next_sibling`, `Node::children`,
+    /// `Node::named_children`, `Node::child_count`, `child_by_field_name` on a node
+    /// already in hand — is deliberately absent and must stay absent: those are the
+    /// APIs the walkers are *supposed* to use, and `blank_comments_and_strings_self_test`
+    /// pins that none of them trips an entry here.
+    const FORBIDDEN_NODE_APIS: &[(&str, &str)] = &[
+        (
+            ".parent()",
+            "re-descends from the tree root; thread WalkPosition / depth instead",
+        ),
+        (
+            ".prev_sibling(",
+            "O(index-in-parent): scans the parent's child list from 0; use WalkPosition",
+        ),
+        (
+            ".next_sibling(",
+            "O(index-in-parent): scans the parent's child list from 0; use a TreeCursor",
+        ),
+        (
+            ".prev_named_sibling(",
+            "O(index) plus a parent() root descent",
+        ),
+        (
+            ".next_named_sibling(",
+            "O(index) plus a parent() root descent; this is the Theta(M^3/3) Go defect",
+        ),
+        (
+            ".named_child(",
+            "O(i) rescan from position 0; use root.named_children(&mut cursor)",
+        ),
+        (".child(", "O(i) rescan from position 0; use a TreeCursor"),
+        (
+            ".rfind(",
+            "O(start) backward byte scan; use build_newline_table + binary_search",
+        ),
+    ];
+
+    /// Blank every `//` line comment, `/* */` block comment (nesting-aware) and
+    /// `"`-delimited string literal, replacing their bytes with ASCII spaces.
+    ///
+    /// Single forward pass, **byte-length preserving** and **newline preserving**,
+    /// so byte offsets and line numbers in the result still address the original
+    /// file. Backslash escapes inside string literals are honoured, which also
+    /// makes multi-line `"… \` continuations (used heavily in this crate's assert
+    /// messages) come out intact.
+    ///
+    /// Char literals (`'…'`) are deliberately NOT tracked. In Rust the single quote
+    /// is shared with lifetimes and loop labels (`&'a str`, `'outer:`), so a naive
+    /// char-literal state machine mis-parses ordinary code far more often than it
+    /// helps. The only inputs this omission would corrupt are a `'"'` literal and a
+    /// raw string; the contract test asserts neither policed file contains one, so
+    /// the simplification stays honest rather than becoming a silent blind spot.
+    ///
+    /// Blanking exists because both policed files *document* the forbidden APIs in
+    /// rustdoc (`WalkPosition`'s fields are specified as "equivalent to
+    /// `node.parent()`…"), and because `is_doc_comment` holds `"/**"`, `"/*!"` and
+    /// `"///"` as string literals — an unsanitised text scan would both false-positive
+    /// on the prose and let `"/**"` open a comment that swallows real code
+    /// (source-corpus PF-018: sanitize before scanning source text).
+    fn blank_comments_and_strings(src: &str) -> String {
+        let bytes = src.as_bytes();
+        let n = bytes.len();
+        let mut out = bytes.to_vec();
+        let mut i = 0usize;
+
+        // Bounded by construction: every branch advances `i` by at least 1.
+        while i < n {
+            if bytes[i] == b'/' && i + 1 < n && bytes[i + 1] == b'/' {
+                // Line comment — blank through to (but not including) the newline.
+                while i < n && bytes[i] != b'\n' {
+                    out[i] = b' ';
+                    i += 1;
+                }
+            } else if bytes[i] == b'/' && i + 1 < n && bytes[i + 1] == b'*' {
+                // Block comment — Rust nests them, so track depth.
+                let mut depth = 0usize;
+                while i < n {
+                    if bytes[i] == b'/' && i + 1 < n && bytes[i + 1] == b'*' {
+                        depth += 1;
+                        out[i] = b' ';
+                        out[i + 1] = b' ';
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b'*' && i + 1 < n && bytes[i + 1] == b'/' {
+                        depth = depth.saturating_sub(1);
+                        out[i] = b' ';
+                        out[i + 1] = b' ';
+                        i += 2;
+                        if depth == 0 {
+                            break;
+                        }
+                        continue;
+                    }
+                    if bytes[i] != b'\n' {
+                        out[i] = b' ';
+                    }
+                    i += 1;
+                }
+            } else if bytes[i] == b'"' {
+                out[i] = b' ';
+                i += 1;
+                while i < n {
+                    if bytes[i] == b'\\' {
+                        out[i] = b' ';
+                        i += 1;
+                        if i < n {
+                            if bytes[i] != b'\n' {
+                                out[i] = b' ';
+                            }
+                            i += 1;
+                        }
+                        continue;
+                    }
+                    if bytes[i] == b'"' {
+                        out[i] = b' ';
+                        i += 1;
+                        break;
+                    }
+                    if bytes[i] != b'\n' {
+                        out[i] = b' ';
+                    }
+                    i += 1;
+                }
+            } else {
+                i += 1;
+            }
+        }
+
+        String::from_utf8(out).expect("blanking only ever substitutes ASCII spaces")
+    }
+
+    /// A Rust char literal holding a double quote, spelled without embedding one
+    /// literally so this constant does not itself become the thing it detects.
+    const DOUBLE_QUOTE_CHAR_LITERAL: &str = "'\u{22}'";
+
+    /// Does `src` open a raw string (`r"…"` / `r#"…"#`)?
+    ///
+    /// A bare `contains("r\"")` is useless here: any ordinary message ending in the
+    /// letter `r` matches it (`"… must be a module header"`). An `r` is a raw-string
+    /// prefix only when it does not continue an identifier and is followed by zero or
+    /// more `#` and then a quote.
+    fn contains_raw_string_opener(src: &str) -> bool {
+        let bytes = src.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b != b'r' {
+                continue;
+            }
+            if i > 0 && (bytes[i - 1] == b'_' || bytes[i - 1].is_ascii_alphanumeric()) {
+                continue;
+            }
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j] == b'#' {
+                j += 1;
+            }
+            if bytes.get(j) == Some(&b'"') {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// The production region of `name`: everything before the `#[cfg(test)]` that
+    /// gates the file's `mod tests`, with comments and string literals blanked.
+    ///
+    /// The cut uses the **last** `\n#[cfg(test)]` in the file, not the first:
+    /// `pseudo.rs` carries an earlier `#[cfg(test)]` on `transform_pseudo`, a
+    /// test-only *production* helper that must stay inside the policed region.
+    /// `minimal.rs` has only one marker, so the two agree there.
+    fn production_region(name: &str, src: &str) -> String {
+        const MARKER: &str = "\n#[cfg(test)]";
+
+        let blanked = blank_comments_and_strings(src);
+        let Some(cut) = blanked.rfind(MARKER) else {
+            panic!(
+                "{name}: no `{}` marker found, so the production region cannot be \
+                 delimited and this contract would police either everything or nothing. \
+                 A guard with no region is a vacuous guard (source-corpus PF-007 / PF-014).",
+                MARKER.trim_start()
+            );
+        };
+        let (head, tail) = blanked.split_at(cut);
+
+        assert!(
+            tail.contains("\nmod tests {"),
+            "{name}: nothing after the last `#[cfg(test)]` declares `mod tests` — \
+             the contract would police the wrong region (source-corpus PF-007 / PF-014: \
+             a guard aimed at the wrong text asserts nothing)."
+        );
+        // Stronger form of the same check, and the one that actually pins `rfind`:
+        // the marker we cut at must be the one *immediately* gating `mod tests`
+        // (attribute lines may sit between). With `find` instead of `rfind`,
+        // `pseudo.rs` cuts at `transform_pseudo` — whose tail still *contains*
+        // `\nmod tests {` further down, so the containment check alone passes and
+        // ~440 lines of production code silently leave the policed region.
+        let gated = tail[MARKER.len()..]
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty() && !line.starts_with("#["));
+        assert_eq!(
+            gated,
+            Some("mod tests {"),
+            "{name}: the last `#[cfg(test)]` does not gate `mod tests` (next item is \
+             {gated:?}) — the contract would police the wrong region \
+             (source-corpus PF-007 / PF-014)."
+        );
+
+        head.to_string()
+    }
+
+    /// The transform walkers must never reach for a relational fact about a node by
+    /// asking tree-sitter for it again.
+    ///
+    /// # Why a source-text guard and not an instrumented counter
+    ///
+    /// An operation counter cannot discriminate here. The quadratic term lives in
+    /// tree-sitter's C code, not in ours: a `TSNode` carries no parent pointer, so
+    /// `parent()`, `prev_sibling()`, `next_sibling()`, `next_named_sibling()` and
+    /// `named_child(i)` each re-descend from the tree root and rescan the parent's
+    /// child list from position 0 (source-corpus PF-020 — a `TSNode` walk is never
+    /// O(1)). The defective and the fixed walker execute the **same number of Rust
+    /// statements** and produce **byte-identical output**; the only thing that
+    /// differs is the C-side cost per call. Any counter that could tell them apart
+    /// would have to live inside the very code a regression replaces. See the
+    /// measured series in `minimal.rs` (`is_go_doc_comment`,
+    /// `compute_header_end_byte`) for the empirical form of that fact.
+    ///
+    /// So the checkable invariant is not "how many operations ran" but "which API
+    /// the source calls" — a property of the text, available before anything runs.
+    ///
+    /// # Why comments and string literals are blanked first
+    ///
+    /// Both policed files document the forbidden APIs in rustdoc — `WalkPosition`'s
+    /// fields are specified as "equivalent to `node.parent()`" — and `is_doc_comment`
+    /// holds `"/**"`, `"/*!"` and `"///"` as string literals. Scanning raw text would
+    /// therefore fail on prose that is *explaining* the ban, and `"/**"` would open a
+    /// block comment that swallowed live code (source-corpus PF-018).
+    ///
+    /// # Why the O(1) traversal set is excluded
+    ///
+    /// `Node::walk`, `TreeCursor::goto_first_child` / `goto_next_sibling`,
+    /// `Node::children`, `Node::named_children`, `Node::child_count` and
+    /// `child_by_field_name` on a node already in hand are the APIs the walkers are
+    /// *supposed* to use — a `TreeCursor` keeps an explicit ancestor stack, so each
+    /// step is genuinely O(1). Banning them would leave no legal way to traverse.
+    ///
+    /// # What this is not
+    ///
+    /// This is a **lint, not a proof**. It pins the construct, not the complexity:
+    /// a novel super-linear pattern that avoids all eight tokens would pass. The
+    /// stronger follow-up is a type-level facade — a `WalkNode` wrapper that exposes
+    /// only the O(1) set, making the forbidden construct unrepresentable rather than
+    /// merely detectable. That is tracked separately.
+    ///
+    /// It also does not discriminate O(N) from O(N²) on its own, and neither do the
+    /// per-walker artifact tests in `minimal.rs` / `pseudo.rs`: the defect was
+    /// output-preserving, which is exactly why the discriminating job lands here, on
+    /// the source text.
+    ///
+    /// Housed in `transform/mod.rs`, beside the code it polices, rather than in a
+    /// standalone lint crate (source-corpus PF-017).
+    ///
+    /// # A note on the PF citations above
+    ///
+    /// Every `PF-NNN` in this module refers to the **source-corpus** pitfall
+    /// numbering, which is a different sequence from the decisions-ledger numbering
+    /// in `.devflow/learning/pitfalls.md` (PF-023). The two collide: the ledger's
+    /// PF-020 is an unrelated entry. Read these IDs as source-corpus only.
+    #[test]
+    fn contract_transform_walkers_use_no_root_descending_node_apis() {
+        const POLICED: &[(&str, &str)] = &[
+            ("minimal.rs", include_str!("minimal.rs")),
+            ("pseudo.rs", include_str!("pseudo.rs")),
+        ];
+
+        for (name, src) in POLICED {
+            // `blank_comments_and_strings` does not model char literals or raw
+            // strings. Assert the assumption instead of hoping for it — an
+            // unmodelled double-quote char literal would open a phantom string and
+            // blank out live code, turning this contract vacuous
+            // (source-corpus PF-007 / PF-014).
+            assert!(
+                !src.contains(DOUBLE_QUOTE_CHAR_LITERAL),
+                "{name}: contains a double-quote char literal, which \
+                 `blank_comments_and_strings` does not model. Teach the blanker about \
+                 char literals before adding one, or this contract silently stops seeing \
+                 the code after it."
+            );
+            assert!(
+                !contains_raw_string_opener(src),
+                "{name}: contains a raw string literal, which \
+                 `blank_comments_and_strings` does not model (no backslash escapes, \
+                 `#` delimiters). Teach the blanker about raw strings before adding one."
+            );
+
+            let region = production_region(name, src);
+
+            for (token, reason) in FORBIDDEN_NODE_APIS {
+                let Some(idx) = region.find(token) else {
+                    continue;
+                };
+                let line = region[..idx].matches('\n').count() + 1;
+                panic!(
+                    "COMPLEXITY CONTRACT VIOLATION\n\
+                     \x20 file:   crates/rskim-core/src/transform/{name}:{line}\n\
+                     \x20 token:  `{token}`\n\
+                     \x20 reason: {reason}\n\
+                     \n\
+                     The transform walkers must obtain every relational fact about a node \
+                     (parent kind, previous sibling, index in parent, line start) from the \
+                     walk itself — a threaded `WalkPosition` / `depth`, a `TreeCursor`, or a \
+                     precomputed per-file table — never by asking tree-sitter for it again. \
+                     A `TSNode` carries no parent pointer, so each of these calls re-descends \
+                     from the tree root or rescans the parent's child list from position 0 \
+                     (source-corpus PF-020: a TSNode walk is never O(1)).\n\
+                     \n\
+                     Every historical quadratic/cubic defect in these two files used one of \
+                     these calls, and NONE of them changed the output by a single byte — so \
+                     no behavioural test and no operation counter can see them. This contract \
+                     is the only gate that can.\n\
+                     \n\
+                     If the call is provably O(1) at this site, add an explicit exception \
+                     here together with the measurement that proves it."
+                );
+            }
+        }
+    }
+
+    /// `blank_comments_and_strings` must be offset-faithful, must blank what it
+    /// claims to blank, must not blank live code, and must not let the legitimate
+    /// O(1) traversal APIs trip a `FORBIDDEN_NODE_APIS` entry.
+    ///
+    /// Without this the contract test above could pass by blanking everything
+    /// (source-corpus PF-007 / PF-014: reading a guard is not evidence it guards).
+    #[test]
+    fn blank_comments_and_strings_self_test() {
+        const SRC: &str = concat!(
+            "let k = node.parent();\n",
+            "// a comment naming node.parent() must not count\n",
+            "/* block /* nested */ still-blanked */\n",
+            "let jsdoc = \"/**\";\n",
+            "let after_string = 1;\n",
+        );
+
+        let blanked = blank_comments_and_strings(SRC);
+
+        // Offset fidelity: byte offsets and line numbers still address the original.
+        assert_eq!(
+            blanked.len(),
+            SRC.len(),
+            "blanking must preserve byte length so reported line numbers stay valid"
+        );
+        assert_eq!(
+            blanked.lines().count(),
+            SRC.lines().count(),
+            "blanking must preserve newlines so reported line numbers stay valid"
+        );
+
+        // A real call survives; the one inside a line comment does not.
+        assert!(
+            blanked.contains("node.parent();"),
+            "a live `.parent()` call must survive blanking, got:\n{blanked}"
+        );
+        assert_eq!(
+            blanked.matches(".parent()").count(),
+            1,
+            "exactly one `.parent()` must survive (the live one); the commented one \
+             must be blanked. Got:\n{blanked}"
+        );
+
+        // Block-comment content is blanked, nesting included.
+        assert!(
+            !blanked.contains("nested") && !blanked.contains("still-blanked"),
+            "block comment content (including nested comments) must be blanked, got:\n{blanked}"
+        );
+
+        // The string literal `"/**"` must NOT open a block comment — if it did, the
+        // rest of the file would be swallowed and the contract would see nothing.
+        assert!(
+            blanked.contains("let after_string = 1;"),
+            "the string literal \"/**\" must not open a block comment; code after it \
+             must survive. Got:\n{blanked}"
+        );
+
+        // The legitimate O(1) traversal set must not trip any forbidden token.
+        const LOOKALIKES: &str = concat!(
+            "cursor.goto_next_sibling();\n",
+            "n.child_count();\n",
+            "n.children(&mut c);\n",
+            "p.child_by_field_name(\"x\");\n",
+            "root.named_children(&mut c);\n",
+        );
+        let lookalikes = blank_comments_and_strings(LOOKALIKES);
+        for (token, _) in FORBIDDEN_NODE_APIS {
+            assert!(
+                !lookalikes.contains(token),
+                "legitimate O(1) traversal must not match forbidden token `{token}`; \
+                 the `.`/`(` anchoring is what keeps them apart. Got:\n{lookalikes}"
+            );
+        }
     }
 }

--- a/crates/rskim-core/src/transform/pseudo.rs
+++ b/crates/rskim-core/src/transform/pseudo.rs
@@ -2254,82 +2254,76 @@ mod tests {
     }
 
     // ========================================================================
-    // pseudo-walker scaling guards  (B2 / #494)
+    // pseudo-walker artifact pins  (B2 / #494)
     // ========================================================================
     //
     // pseudo is the PRODUCTION path: the cat/head/tail rewrite selects
     // --mode=pseudo for regular code files (ADR-008), so this walker is the
-    // hottest agent-facing transform in the product. Every pre-existing perf
-    // guard in this workspace is PYTHON-minimal-only or GO-only, so a
-    // TypeScript / C++ / Java / C# pseudo regression had no coverage at all.
+    // hottest agent-facing transform in the product. Every other walker pin in
+    // this workspace is Python-minimal-only or Go-only, so a TypeScript / Python /
+    // C++ pseudo regression had no coverage at all.
     //
-    // MEASURED SERIES (DEBUG build, this branch, best-of-3; the transform is
-    // called directly so the skim file-level disk cache is NOT involved — a warm
-    // parser cache hides exactly this defect class, PF-020).
+    // What these tests pin is the exact set of byte ranges the walker collects and
+    // the number of AST nodes it visits — both computable from the fixture's text,
+    // neither dependent on a clock.
     //
-    //   TS, N top-level `const vI = I;` statements — one `;` site per statement:
-    //     BEFORE: N=1000 → 10.42 ms | N=2000 → 21.46 ms | N=4000 → 43.30 ms
-    //             ratios 2.06×, 2.02×   →   α = 1.03
-    //     AFTER:  N=1000 →  8.72 ms | N=2000 → 18.13 ms | N=4000 → 37.66 ms
-    //             ratios 2.08×, 2.08×   →   α = 1.06        (1.15× faster at 4N)
-    //     BEFORE (XL): N=3000 → 32.40 ms | N=6000 → 66.43 ms | N=12000 → 143.47 ms  α = 1.07
-    //     AFTER  (XL): N=3000 → 26.92 ms | N=6000 → 57.78 ms | N=12000 → 117.62 ms  α = 1.06  (1.22×)
-    //
-    //   Python, N `def fI(a: int, b: int) -> int` — two return-type-field tests each:
-    //     BEFORE: N=500 → 15.74 ms | N=1000 → 32.65 ms | N=2000 → 68.33 ms   α = 1.06
-    //     AFTER:  N=500 → 13.55 ms | N=1000 → 28.43 ms | N=2000 → 57.78 ms   α = 1.05  (1.18×)
-    //
-    //   TypeScript, same shape via `type_annotation`:
-    //     BEFORE: N=500 → 14.72 ms | N=1000 → 30.34 ms | N=2000 → 60.80 ms   α = 1.02
-    //     AFTER:  N=500 → 12.21 ms | N=1000 → 24.95 ms | N=2000 → 51.11 ms   α = 1.03  (1.19×)
-    //
-    //   C++, N `template<typename T> T fI(T a, T b)` — one `prev_sibling()` site each:
-    //     BEFORE: N=500 → 13.28 ms | N=1000 → 27.26 ms | N=2000 → 55.24 ms   α = 1.03
-    //     AFTER:  N=500 → 12.20 ms | N=1000 → 24.83 ms | N=2000 → 50.09 ms   α = 1.02  (1.10×)
-    //
-    // ⚠ CORRECTION TO THE PLAN — these sites were NEVER Θ(N²), and the guards
-    // below are REGRESSION guards, not evidence of the fix. α is ~1.02–1.07 both
-    // before and after; the win is a constant factor of 1.10×–1.22×.
-    //
-    // Why the Θ(N²) prediction failed, measured rather than reasoned. Isolating
-    // the primitive on the exact `;` population (debug build, per call):
-    //
-    //     n=2000  parent() 1.655 µs   prev_sibling() 1.910 µs
-    //     n=4000  parent() 1.752 µs   prev_sibling() 2.009 µs
-    //     n=8000  parent() 1.885 µs   prev_sibling() 2.152 µs
-    //
-    // Per-call cost grows ~14 % while n quadruples — that is O(log N), not
-    // O(index). `ts_parser__balance_subtree` (tree-sitter 0.25.10 parser.c)
-    // rotates `repeat` subtrees so their depth stays logarithmic, and
-    // `ts_node_parent` descends that balanced structure.
-    //
-    // So PF-020's cost model needs splitting, not discarding. The O(index) half
-    // is the SIBLING scan — `ts_node__prev_sibling` / `ts_node__next_sibling`
-    // iterate the parent's child list from the start looking for `self` — and
-    // B1 measured that half directly (α = 2.98 for a per-node forward sibling
-    // walk over one large sibling group, 41 616 ms at N=1000). The `parent()`
-    // half does NOT scale that way, which is why the same pitfall produced a
-    // 28118× win in `minimal.rs` and a ~1.2× win here.
-    //
-    // Consequence for these guards, stated plainly: a ratio guard CANNOT detect
-    // re-introduction of `parent()` here, because `parent()` is O(log N). What
-    // they do cover is the gap B1 identified — a future super-linear regression
-    // in this walker (e.g. someone adding a per-node sibling walk, the Go bug's
-    // shape) would otherwise pass silently on every language except Python.
-    //
-    // THRESHOLD RATIONALE — 2.8 ≈ 2^1.5 is the exponent-space midpoint between
-    // linear (2.0×) and quadratic (4.0×), matching the Go guards in minimal.rs.
-    // These shapes measure 2.01×–2.07× at the guard sizes, so 2.8 leaves ~35 % headroom.
+    // What they deliberately do NOT pin is complexity. A walker that re-derived
+    // `parent()` / `prev_sibling()` per node instead of threading `WalkPosition`
+    // would produce EXACTLY these ranges and EXACTLY this visit count: the extra
+    // cost is inside tree-sitter's C code, where a `TSNode` has no parent pointer.
+    // That construct is forbidden at the source level by
+    // `contract_transform_walkers_use_no_root_descending_node_apis` in
+    // `transform/mod.rs`, which is the only gate that can see it.
 
-    fn time_pseudo(source: &str, language: Language) -> f64 {
-        let mut parser = Parser::new(language).unwrap();
-        let tree = parser.parse(source).unwrap();
-        let config = TransformConfig::with_mode(Mode::Pseudo);
-        let start = std::time::Instant::now();
-        let r = transform_pseudo_with_spans_and_line_map(source, &tree, language, &config);
-        let ms = start.elapsed().as_secs_f64() * 1000.0;
-        assert!(r.is_ok(), "pseudo transform must succeed: {:?}", r.err());
-        ms
+    /// Total AST node count, derived independently of the walker under test.
+    ///
+    /// Explicit stack + `Node::children`, so the count never depends on the
+    /// traversal `collect_noise_ranges` performs — that independence is what lets
+    /// it catch a walker that descends into the same node twice, which leaves the
+    /// output byte-identical.
+    fn count_all_nodes(root: Node) -> usize {
+        let mut n = 0usize;
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            n += 1;
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                stack.push(ch);
+            }
+        }
+        n
+    }
+
+    /// Drive the production noise walker directly, composing `NoiseWalkContext` the
+    /// way `transform_pseudo_with_spans_and_line_map` does.
+    ///
+    /// Returns the raw (unadjusted, unsorted) removal ranges and the number of
+    /// nodes visited.
+    fn collect_pseudo_ranges(
+        source: &str,
+        tree: &Tree,
+        language: Language,
+    ) -> (Vec<(usize, usize)>, usize) {
+        let rules = get_pseudo_rules(language);
+        let root = tree.root_node();
+        let header_end_byte = compute_header_end_byte(root, source, language);
+        let go_doc_comment_starts = compute_go_doc_comment_starts(root, source, language);
+        let mut ranges: Vec<(usize, usize)> = Vec::new();
+        let mut node_count: usize = 0;
+        let mut ctx = NoiseWalkContext {
+            source,
+            source_bytes: source.as_bytes(),
+            language,
+            ranges: &mut ranges,
+            node_count: &mut node_count,
+            classification: CommentClassification {
+                header_end_byte,
+                go_doc_comment_starts: &go_doc_comment_starts,
+            },
+        };
+        collect_noise_ranges(root, &mut ctx, &rules, 0, false, WalkPosition::default())
+            .expect("noise walk must succeed on these fixtures");
+        (ranges, node_count)
     }
 
     /// N top-level statements, each terminated by a `;` — the site-1 population.
@@ -2341,8 +2335,9 @@ mod tests {
         s
     }
 
-    /// N annotated defs — two `is_return_field_child` calls each (both params and
-    /// the return annotation are `type` nodes reaching the site-2 guard).
+    /// N annotated defs. Two parameter annotations each (both stripped) plus one
+    /// return annotation each (preserved — ADR-007), all `type` nodes reaching the
+    /// site-2 guard.
     fn python_return_type_source(n: usize) -> String {
         let mut s = String::with_capacity(n * 48 + 32);
         for i in 0..n {
@@ -2353,7 +2348,7 @@ mod tests {
         s
     }
 
-    /// N template functions — the site-3 `prev_sibling()` population.
+    /// N template functions — the site-3 previous-sibling population.
     fn cpp_template_source(n: usize) -> String {
         let mut s = String::with_capacity(n * 64 + 32);
         for i in 0..n {
@@ -2364,47 +2359,83 @@ mod tests {
         s
     }
 
+    /// The parameter annotation stripped from every `python_return_type_source`
+    /// def. `adjust_type_start` extends the `type` node backward over the `: `
+    /// separator, so the collected range covers this whole string.
+    const PY_PARAM_ANNOTATION: &str = ": int";
+
+    /// The C++ template prefix consumed as one range: the `template` keyword, its
+    /// parameter list, and the single trailing space that
+    /// `consume_trailing_whitespace` eats before the return type.
+    const CPP_TEMPLATE_PREFIX: &str = "template<typename T> ";
+
+    /// The TypeScript semicolon ranges are byte-exact and the walk is single-visit.
+    ///
+    /// WHAT THIS PINS: `collect_noise_ranges` emits exactly one 1-byte range per
+    /// source `;` and nothing else (`const vI = I;` carries no type annotation,
+    /// decorator or stripped keyword), and never descends into a node twice.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity. A walker that called `node.parent()` per
+    /// `;` instead of reading `pos.parent_kind` would produce these exact ranges and
+    /// this exact visit count — the defect is output-preserving. See the section
+    /// note above and the contract test in `transform/mod.rs`.
     #[test]
-    fn test_typescript_pseudo_semicolon_walk_scaling_guard() {
-        // Behaviour alongside the timing: these `;` are statement terminators,
-        // not for-loop separators, so all of them must be stripped.
+    fn test_typescript_pseudo_semicolon_ranges_are_exact_and_single_visit() {
+        // Behaviour pin: these `;` are statement terminators, not for-loop
+        // separators, so all of them must be stripped.
         let out = transform(&ts_semicolon_source(4), Language::TypeScript);
         assert!(
             !out.contains(';'),
             "top-level statement semicolons must be stripped, got: {out}"
         );
 
-        // N=8000 is ~56 k AST nodes, comfortably under MAX_AST_NODES (100 k);
-        // above it this would silently become an Err(ComplexityLimit) assertion.
-        let t1 = time_pseudo(&ts_semicolon_source(4000), Language::TypeScript);
-        let t2 = time_pseudo(&ts_semicolon_source(8000), Language::TypeScript);
+        for n in [256usize, 512] {
+            let source = ts_semicolon_source(n);
+            let mut parser = Parser::new(Language::TypeScript).unwrap();
+            let tree = parser.parse(&source).unwrap();
+            let root = tree.root_node();
+            let total_nodes = count_all_nodes(root);
 
-        // Noise floor. We FAIL rather than skip: an absolute-ms guard elsewhere
-        // in this work went vacuous when a fix made it too fast to measure, and
-        // a silently-passing scaling guard provides no protection at all.
-        assert!(
-            t1 >= 8.0,
-            "N=4000 completed in {t1:.3}ms — too fast to measure reliably \
-             (expected ≥ 8ms; ~36.0ms measured on debug builds). Either the \
-             transform is being cached/skipped or N must be raised. \
-             DO NOT convert this to a skip."
-        );
+            let (mut ranges, node_count) =
+                collect_pseudo_ranges(&source, &tree, Language::TypeScript);
+            ranges.sort_unstable();
 
-        let ratio = t2 / t1;
-        assert!(
-            ratio < 2.8,
-            "Doubling N from 4000 to 8000 must produce a ratio below 2.8 \
-             (got {ratio:.2}×; measured 2.07×). O(N) → ~2.0×; O(N²) → ~4.0×; \
-             2.8 ≈ 2^1.5 is the exponent-space midpoint. N=4000 took {t1:.2}ms, \
-             N=8000 took {t2:.2}ms. Check that the walker threads WalkPosition \
-             and does not walk siblings per node (PF-020)."
-        );
+            let expected: Vec<(usize, usize)> =
+                source.match_indices(';').map(|(i, _)| (i, i + 1)).collect();
+            assert_eq!(
+                expected.len(),
+                n,
+                "n={n}: the fixture must contain exactly one `;` per statement"
+            );
+            assert_eq!(
+                ranges, expected,
+                "n={n}: exactly one 1-byte removal range per source `;`, and nothing else"
+            );
+
+            // `<=`, not `==`: collect_noise_ranges returns early on stripped kinds,
+            // so it legitimately visits fewer nodes than the tree holds. Visiting
+            // MORE is the regression this catches.
+            assert!(
+                node_count <= total_nodes,
+                "n={n}: collect_noise_ranges must not visit a node twice \
+                 (visited {node_count}, tree has {total_nodes})"
+            );
+        }
     }
 
+    /// The Python parameter-annotation ranges are byte-exact and the walk is
+    /// single-visit.
+    ///
+    /// WHAT THIS PINS: exactly the two `: int` parameter annotations per def are
+    /// collected — the `-> int` return annotation is preserved wholesale (ADR-007)
+    /// — at the exact byte offsets, including the `: ` separator that
+    /// `adjust_type_start` folds in. And the walk never descends twice.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity — the defect was output-preserving.
     #[test]
-    fn test_python_pseudo_return_type_walk_scaling_guard() {
-        // ADR-007: pseudo PRESERVES function return types. Pin it here so the
-        // guard cannot pass on a walker that stopped classifying return types.
+    fn test_python_pseudo_return_type_ranges_are_exact_and_single_visit() {
+        // ADR-007: pseudo PRESERVES function return types. Pin it here so the test
+        // cannot pass on a walker that stopped classifying return types.
         let out = transform(&python_return_type_source(2), Language::Python);
         assert!(
             out.contains("-> int"),
@@ -2415,49 +2446,95 @@ mod tests {
             "pseudo must still strip Python parameter annotations, got: {out}"
         );
 
-        let t1 = time_pseudo(&python_return_type_source(1000), Language::Python);
-        let t2 = time_pseudo(&python_return_type_source(2000), Language::Python);
+        for n in [256usize, 512] {
+            let source = python_return_type_source(n);
+            let mut parser = Parser::new(Language::Python).unwrap();
+            let tree = parser.parse(&source).unwrap();
+            let root = tree.root_node();
+            let total_nodes = count_all_nodes(root);
 
-        assert!(
-            t1 >= 6.0,
-            "N=1000 completed in {t1:.3}ms — too fast to measure reliably \
-             (expected ≥ 6ms; ~27.3ms measured). DO NOT convert this to a skip."
-        );
+            let (mut ranges, node_count) = collect_pseudo_ranges(&source, &tree, Language::Python);
+            ranges.sort_unstable();
 
-        let ratio = t2 / t1;
-        assert!(
-            ratio < 2.8,
-            "Doubling N from 1000 to 2000 must produce a ratio below 2.8 \
-             (got {ratio:.2}×; measured 2.04×). N=1000 took {t1:.2}ms, \
-             N=2000 took {t2:.2}ms."
-        );
+            let expected: Vec<(usize, usize)> = source
+                .match_indices(PY_PARAM_ANNOTATION)
+                .map(|(i, _)| (i, i + PY_PARAM_ANNOTATION.len()))
+                .collect();
+            assert_eq!(
+                expected.len(),
+                2 * n,
+                "n={n}: two parameter annotations per def; `-> int` must not match"
+            );
+            assert_eq!(
+                ranges, expected,
+                "n={n}: exactly the two parameter annotations per def are collected, \
+                 each covering its `: ` separator; the return annotation is preserved"
+            );
+
+            assert!(
+                node_count <= total_nodes,
+                "n={n}: collect_noise_ranges must not visit a node twice \
+                 (visited {node_count}, tree has {total_nodes})"
+            );
+        }
     }
 
+    /// The C++ template ranges are byte-exact and the walk is single-visit.
+    ///
+    /// WHAT THIS PINS: the `template_parameter_list` special case reaches BACK over
+    /// its previous sibling, so each collected range starts at the `template`
+    /// keyword — not at `<` — and ends after the single trailing space. `template`
+    /// is NOT in the C++ `strip_keywords` list, so a walker that loses the
+    /// previous-sibling reach leaves the keyword orphaned in the output and fails
+    /// both this and the `!out.contains("template")` pin.
+    ///
+    /// WHAT THIS DOES NOT PIN: complexity. Reading the previous sibling back via
+    /// `node.prev_sibling()` instead of `pos.prev_sibling_kind` yields the identical
+    /// ranges — see the section note above and the contract test in
+    /// `transform/mod.rs`.
     #[test]
-    fn test_cpp_pseudo_template_walk_scaling_guard() {
-        // Behaviour alongside the timing: the `template` keyword must be
-        // consumed along with its parameter list, leaving no orphan.
+    fn test_cpp_pseudo_template_ranges_are_exact_and_single_visit() {
+        // Behaviour pin: the `template` keyword must be consumed along with its
+        // parameter list, leaving no orphan.
         let out = transform(&cpp_template_source(2), Language::Cpp);
         assert!(
             !out.contains("template"),
             "the `template` keyword must be consumed with its parameter list, got: {out}"
         );
 
-        let t1 = time_pseudo(&cpp_template_source(1000), Language::Cpp);
-        let t2 = time_pseudo(&cpp_template_source(2000), Language::Cpp);
+        for n in [128usize, 256] {
+            let source = cpp_template_source(n);
+            let mut parser = Parser::new(Language::Cpp).unwrap();
+            let tree = parser.parse(&source).unwrap();
+            let root = tree.root_node();
+            let total_nodes = count_all_nodes(root);
 
-        assert!(
-            t1 >= 5.0,
-            "N=1000 completed in {t1:.3}ms — too fast to measure reliably \
-             (expected ≥ 5ms; ~24.2ms measured). DO NOT convert this to a skip."
-        );
+            let (mut ranges, node_count) = collect_pseudo_ranges(&source, &tree, Language::Cpp);
+            ranges.sort_unstable();
 
-        let ratio = t2 / t1;
-        assert!(
-            ratio < 2.8,
-            "Doubling N from 1000 to 2000 must produce a ratio below 2.8 \
-             (got {ratio:.2}×; measured 2.01×). N=1000 took {t1:.2}ms, \
-             N=2000 took {t2:.2}ms."
-        );
+            // The fixture also yields one `;` range per function body; isolate the
+            // template ranges by the text they start on.
+            let template_ranges: Vec<(usize, usize)> = ranges
+                .iter()
+                .copied()
+                .filter(|&(start, _)| source[start..].starts_with("template"))
+                .collect();
+            let expected: Vec<(usize, usize)> = source
+                .match_indices(CPP_TEMPLATE_PREFIX)
+                .map(|(i, _)| (i, i + CPP_TEMPLATE_PREFIX.len()))
+                .collect();
+            assert_eq!(expected.len(), n, "n={n}: one template prefix per function");
+            assert_eq!(
+                template_ranges, expected,
+                "n={n}: each template range must start at the `template` keyword and end \
+                 after its single trailing space"
+            );
+
+            assert!(
+                node_count <= total_nodes,
+                "n={n}: collect_noise_ranges must not visit a node twice \
+                 (visited {node_count}, tree has {total_nodes})"
+            );
+        }
     }
 }

--- a/crates/rskim-core/tests/integration.rs
+++ b/crates/rskim-core/tests/integration.rs
@@ -1641,14 +1641,16 @@ fn test_python_minimal_class_level_comments_stripped() {
 }
 
 // ============================================================================
-// Large Header Block — O(N) regression guard
+// Large Header Block — end-to-end classification
 // ============================================================================
 //
 // The fixture `large_header.py` contains 500 contiguous leading comments
 // followed by a blank-line-separated comment (to be stripped) and a function.
-// The old O(N³) backward-walk would take ~3 s on this fixture in DEBUG mode;
-// the O(N) forward-pass fix completes in < 5 ms.  The 3000 ms deadline is
-// intentionally generous to tolerate CI scheduling noise.
+// These tests pin WHICH comments survive the public transform entry point, not
+// how long it takes. Complexity is guarded at the source level by
+// contract_transform_walkers_use_no_root_descending_node_apis in
+// crates/rskim-core/src/transform/mod.rs — the historical quadratic/cubic defects
+// were output-preserving, so no assertion over the output can see them.
 
 const LARGE_HEADER_PY: &str = include_str!("../../../tests/fixtures/python/large_header.py");
 
@@ -1702,33 +1704,41 @@ fn test_python_pseudo_large_header_preserves_all_header_comments() {
     );
 }
 
+/// The full transform stack keeps every one of the fixture's 500 header comments
+/// and drops exactly the one after the blank-line gap.
+///
+/// WHAT THIS PINS: the exact count of surviving header comments through the public
+/// entry point — the count, not just the first and last, so a walker that dropped
+/// comments from the middle of the block is caught here.
+///
+/// WHAT THIS DOES NOT PIN: complexity. It cannot discriminate O(N) from O(N²), and
+/// no behavioural assertion can: the historical defect executed the same statements
+/// and produced byte-identical output, differing only in tree-sitter's C-side cost
+/// per call. That is the job of
+/// contract_transform_walkers_use_no_root_descending_node_apis in
+/// crates/rskim-core/src/transform/mod.rs.
 #[test]
-fn test_python_minimal_large_header_linear_time() {
-    // CUBIC SMOKE TEST: 500 leading comments must process within 500 ms.
-    //
-    // WHAT THIS TEST PROVES: that N=500 comments complete within 500 ms through
-    // the full transform stack. The old O(N³) code took ~3–10 s at N=500; the
-    // fixed O(N) code completes in < 10 ms. The 500 ms budget gives ~50× CI
-    // headroom while being 6× below the O(N³) lower bound.
-    //
-    // WHAT THIS TEST DOES NOT PROVE: linear vs quadratic scaling. An O(N²)
-    // regression at N=500 would complete in ~31 ms and pass this test. For the
-    // doubling-ratio guard that discriminates O(N) from O(N²), see
-    // test_quadratic_scaling_guard in crates/rskim-core/src/transform/minimal.rs.
-    //
-    // Budget tightened from 3000 ms to 500 ms: the O(N³) code reliably exceeds
-    // 500 ms, while the fixed code runs in < 10 ms. 3000 ms gave a 333× margin
-    // and asserted almost nothing about scaling.
-    let start = std::time::Instant::now();
+fn test_python_minimal_large_header_comment_count_is_exact() {
     let result = transform(LARGE_HEADER_PY, Language::Python, Mode::Minimal);
-    let elapsed = start.elapsed();
-
     assert!(result.is_ok(), "transform must succeed: {:?}", result.err());
+    let output = result.unwrap();
+
+    let expected = LARGE_HEADER_PY
+        .lines()
+        .filter(|line| line.starts_with("# Header comment "))
+        .count();
+    let surviving = output
+        .lines()
+        .filter(|line| line.starts_with("# Header comment "))
+        .count();
+    assert_eq!(
+        surviving, expected,
+        "every header comment in the contiguous leading block must survive minimal mode"
+    );
     assert!(
-        elapsed < std::time::Duration::from_millis(500),
-        "500-comment file must process in < 500ms (got {elapsed:?}); \
-         old O(N³) code reliably exceeded this — cubic regression detected. \
-         For quadratic regressions, see test_quadratic_scaling_guard."
+        !output.contains("is NOT a header"),
+        "the comment after the blank-line gap must be stripped; got:\n{}",
+        &output[..output.len().min(400)]
     );
 }
 


### PR DESCRIPTION
## Problem

`crates/rskim-core` carried **ten** wall-clock timing assertions in tests — not the four that were flaking. All ten shared one pattern: build a synthetic source of size N (and usually 2N), take a **single un-warmed** `Instant::now()` / `elapsed()` sample per size, and assert either an absolute millisecond budget or a `t2/t1 < 2.8` doubling ratio. All ten ran inside the same ~1 s window of the same `rskim-core --lib` binary, so they competed with each other for the same cores.

Four of the ratio guards failed CI on GitHub-hosted 4-vCPU runners within a week of landing, with observed ratios of **2.89x, 4.94x, 3.12x and 3.82x against a 2.8 gate**; one failed twice consecutively on an isolated re-run. The ceilings were calibrated on developer hardware roughly **2x faster than the CI runner**, so the headroom the thresholds were designed with never existed in CI.

The ten (all now converted):

| # | Test | File |
|---|------|------|
| 1 | `test_large_header_block_linear_time` | `transform/minimal.rs` |
| 2 | `test_quadratic_scaling_guard` | `transform/minimal.rs` |
| 3 | `test_go_leading_comment_run_linear_time` | `transform/minimal.rs` |
| 4 | `test_go_leading_comment_run_scaling_guard` | `transform/minimal.rs` |
| 5 | `test_go_doc_block_scaling_guard` | `transform/minimal.rs` |
| 6 | `test_go_pseudo_leading_comment_run_scaling_guard` | `transform/minimal.rs` |
| 7 | `test_typescript_pseudo_semicolon_walk_scaling_guard` | `transform/pseudo.rs` |
| 8 | `test_python_pseudo_return_type_walk_scaling_guard` | `transform/pseudo.rs` |
| 9 | `test_cpp_pseudo_template_walk_scaling_guard` | `transform/pseudo.rs` |
| 10 | `test_python_minimal_large_header_linear_time` | `tests/integration.rs` |

Widening the ratio, adding warm-up, or taking best-of-N would all keep the clock — and therefore keep the flake. This removes the clock.

## Why not an operation counter

An instrumented counter cannot discriminate here, and this is the load-bearing fact of the design.

The quadratic term lives inside tree-sitter's C code, not ours. A `TSNode` carries no parent pointer, so `parent()`, `prev_sibling()`, `next_sibling()`, `next_named_sibling()` and `named_child(i)` each re-descend from the tree root and rescan the parent's child list from position 0. The defective and the fixed walker execute the **same number of Rust statements** and produce **byte-identical output**. Any counter able to tell them apart would have to live inside the very code a regression replaces.

So the checkable invariant is not *how many operations ran* but *which API the source calls* — a property of the text, available before anything executes.

## The fix

Three parts, and **zero production-code changes**: every diff hunk is inside a `#[cfg(test)] mod tests` or `tests/integration.rs`.

**1. A source-level complexity contract** (`transform/mod.rs`). `contract_transform_walkers_use_no_root_descending_node_apis` `include_str!`s `minimal.rs` and `pseudo.rs`, blanks comments and string literals, cuts the production region at the **last** `#[cfg(test)]`, and asserts eight root-descending tokens are absent:

```
.parent()  .prev_sibling(  .next_sibling(  .prev_named_sibling(
.next_named_sibling(  .named_child(  .child(  .rfind(
```

Blanking is not optional: both files *document* the banned APIs in rustdoc (`WalkPosition`'s fields are specified as "equivalent to `node.parent()`"), and `is_doc_comment` holds `"/**"`, `"/*!"` and `"///"` as string literals — an unsanitised scan would false-positive on the prose explaining the ban, and `"/**"` would open a comment swallowing live code.

The genuinely O(1) traversal set (`Node::walk`, `TreeCursor::goto_first_child` / `goto_next_sibling`, `Node::children`, `Node::named_children`, `Node::child_count`, `child_by_field_name` on a node already in hand) is deliberately excluded, and `blank_comments_and_strings_self_test` pins that none of those forms trips a token — the `.` prefix and `(` suffix are what keep `.child(` from matching `.child_by_field_name(`, `.named_child(` from matching `.named_children(`, and `.next_sibling(` from matching `goto_next_sibling(`.

Each failure names the file, line, token and reason, and tells the next engineer that a provably-O(1) call at that site may be added as an explicit exception *together with the measurement that proves it*.

**2. The ten timing bodies became exact-artifact assertions.** Every pre-existing behavioural assertion is kept verbatim. What replaced the clock:

- precomputed byte tables (`compute_header_end_byte`, `compute_go_doc_comment_starts`) compared against offsets derived independently from the fixture **text**;
- exact `(start, end)` removal-range sets from the walkers, compared against text-derived expectations;
- a **single-visit** `node_count`, compared against an independently-derived AST node count (`count_all_nodes`, an explicit stack over `Node::children`). This is the assertion a re-walk regression trips while leaving the output byte-identical.

N drops to 256/512 (128/256 for Go and C++). The cubic tripwires existed only to stop a reintroduced walk grinding CI for hours; the contract now forbids the construct outright.

Every test is renamed to say what it now asserts, and each carries a rustdoc paragraph stating explicitly that it does **not** discriminate O(N) from O(N²) on its own — the defect was output-preserving, and that job belongs to the contract test.

**3. Four now-dead helpers removed:** `time_go_minimal`, `time_go_pseudo`, `assert_no_cubic_regression` (`minimal.rs`), `time_pseudo` (`pseudo.rs`). The two cross-reference comments in `integration.rs` that named `test_quadratic_scaling_guard` now point at the contract test.

The empirical before/after series that motivated the original fixes is untouched — it already lives in the production rustdoc on `is_go_doc_comment` and `compute_header_end_byte`. `TransformResult::duration_ms` in `lib.rs` is untouched: that is production reporting, not a gate.

## Verification

All commands scoped to `-p rskim-core`, `-j 4`, `SKIM_PASSTHROUGH=1`.

```
$ cargo nextest run -p rskim-core -j 4 --no-fail-fast
    Starting 557 tests across 8 binaries
     Summary [   1.810s] 557 tests run: 557 passed, 0 skipped
exit 0

$ cargo test -p rskim-core --doc
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
exit 0

$ cargo clippy -p rskim-core --all-targets -- -D warnings
exit 0

$ cargo fmt -- --check
exit 0

$ grep -rn "Instant\|elapsed()\|Duration::from" \
      crates/rskim-core/src/transform/ crates/rskim-core/tests/integration.rs
exit 1   (no matches — the only remaining clock in the crate is
          lib.rs:335 TransformResult::duration_ms, production reporting)
```

## Mutation results

Each mutation is a one-line edit to **production** code, applied, run, then reverted (`git checkout --`, tree verified clean by `git status --porcelain`).

| # | Mutation | Result | Caught by |
|---|----------|--------|-----------|
| M1 | `compute_header_end_byte`: `TreeCursor` loop → `named_child(i)` index loop | `557 tests run: 556 passed, 1 failed` | **contract only** — token `` `.named_child(` `` at `minimal.rs:540` |
| M1b | `is_module_header_comment`: threaded `depth` → `node.parent()` kind test | `290 tests run: 289 passed, 1 failed` | **contract only** — token `` `.parent()` `` |
| M2 | `is_go_doc_comment`: `binary_search` → per-node `next_named_sibling()` walk | `290 tests run: 281 passed, 9 failed` | contract (token `` `.next_named_sibling(` ``) **+ 8 behavioural** — see note |
| M3 | `collect_noise_ranges`: `pos.parent_kind` → `node.parent()` | `290 tests run: 289 passed, 1 failed` | **contract only** — token `` `.parent()` `` |
| M4 | C++ template start: `pos.prev_sibling_*` → `node.prev_sibling()` | `290 tests run: 289 passed, 1 failed` | **contract only** — token `` `.prev_sibling(` `` |
| M5 | `adjust_range_for_line_removal`: `partition_point` → `rfind('\n')` | `290 tests run: 289 passed, 1 failed` | **contract only** — token `` `.rfind(` `` |
| M6 | C++ template range starts at `node.start_byte()` unconditionally | `290 tests run: 286 passed, 4 failed` | `test_cpp_pseudo_template_ranges_are_exact_and_single_visit`, `test_cpp_pseudo_no_orphaned_template`, `test_cpp_pseudo_strips_template_function`, `test_cpp_template_parameter_list_skips_recursion` |
| M7 | `collect_noise_ranges`: descend into each child twice | `290 tests run: 286 passed, 4 failed` | `test_typescript_pseudo_semicolon_ranges_…`, `test_cpp_pseudo_template_ranges_…`, `test_python_pseudo_return_type_ranges_…`, `test_large_doc_blocks_sections_pseudo` |
| M8 | `collect_removable_comments`: descend into each child twice | `290 tests run: 284 passed, 6 failed` | `test_python_module_header_precompute_…`, `test_python_large_header_block_survives_transform`, `test_go_doc_comment_precompute_…`, `test_go_leading_comment_run_…` (×2), `test_large_doc_blocks_sections_minimal` |
| M9 | `go_gap_breaks_run` returns `true` unconditionally | `290 tests run: 284 passed, 6 failed` | `test_go_doc_comment_precompute_is_exact_and_single_visit` (`starts.len() == 3n`) + 5 pre-existing Go classification tests |
| M10 | `production_region`: `rfind` → `find` (cut at the FIRST `#[cfg(test)]`) | `290 tests run: 289 passed, 1 failed` | `production_region`'s own gate assertion: ``pseudo.rs: the last `#[cfg(test)]` does not gate `mod tests` (next item is Some("pub(crate) fn transform_pseudo("))`` |

**The headline result, stated plainly:** M1, M1b, M3, M4 and M5 are the historical defects reintroduced verbatim, and each is caught by **exactly one test — the source contract**. All ten exact-artifact tests stay green under those five mutations, because the output really is byte-identical. That is the empirical confirmation of the design's central claim, and it is why the contract exists rather than a counter or a wider ratio.

**One deviation from the predicted outcome, recorded rather than glossed:** M2 as specified was expected to be contract-only, but it also fails 8 behavioural tests. The replacement body walks forward siblings looking for `is_go_declaration` **without** the blank-line-gap rule that `go_gap_breaks_run` enforces, so it is not an output-preserving reproduction of the historical defect — it changes Go doc-comment classification. The contract still catches it on `.next_named_sibling(`; the extra failures are a property of that particular replacement body, not a counter-example to the design.

M6–M10 confirm the per-test assertions and the guard's own tripwires are not vacuous.

**A note on M10.** `production_region` asserts *both* that the tail after the cut contains `\nmod tests {` **and**, more tightly, that the marker it cut at is the one immediately gating `mod tests` (attribute lines allowed between). The containment check alone does not catch `find`: cutting at `pseudo.rs`'s earlier `#[cfg(test)]` (the one on `transform_pseudo`) leaves a tail that still contains `\nmod tests {` further down, so ~440 lines of production code would silently drop out of the policed region while the guard reported success. The tighter assertion is what M10 trips.

## Follow-up

The contract is a **lint, not a proof**: it pins the construct, not the complexity, and a novel super-linear pattern avoiding all eight tokens would pass. The stronger form is a type-level `WalkNode` facade exposing only the O(1) traversal set, which makes the forbidden construct *unrepresentable* rather than merely detectable. Tracked separately.

## Constants pinned

Every constant in the new assertions was derived by reading the grammar and the fixture shapes, then pinned by running. **None required adjustment** — all twelve tests passed on the first execution:

| Constant | Derived value | After running |
|----------|---------------|---------------|
| Python header end byte | `source.len() - PY_HEADER_TAIL.len() - 1`, `PY_HEADER_TAIL = "def f(x): return x\n"` | unchanged |
| Python header removable ranges | `[]` (whole block is the module header) | unchanged |
| Go doc-comment starts (doc-block fixture) | `source.match_indices("//")`, length `3n`, strictly ascending | unchanged |
| Go doc-block removable ranges | `[]` (every comment is a doc comment) | unchanged |
| Go leading-run doc starts | `[]` (`package_clause` is not an `is_go_declaration` kind) | unchanged |
| Go leading-run removal ranges | one `(start, start + line_len)` per `//`, `n` of them | unchanged |
| TypeScript semicolon ranges | one `(i, i+1)` per `;`, `n` of them, **and nothing else** | unchanged |
| Python parameter annotations | `": int"` → `(i, i + 5)`, `2n` of them; `-> int` preserved (ADR-007) | unchanged |
| C++ template prefix | `"template<typename T> "` (21 bytes, trailing space consumed, stops before `T`) | unchanged |
| Node-visit counts | `== count_all_nodes(root)` for the minimal walker; `<=` for the pseudo walker (it returns early on stripped kinds) | unchanged |
| Integration header count | 500 surviving `# Header comment ` lines, derived from the fixture rather than hardcoded | unchanged |
