### PR TITLE
fix(tests): guard against ETXTBSY race when exec-ing a freshly-copied binary

### DIFF
--- a/crates/rskim/tests/cli_doctor.rs
+++ b/crates/rskim/tests/cli_doctor.rs
@@ -188,17 +188,21 @@ fn test_doctor_exits_0_on_binary_pin_mismatch() {
     // Run `init` using the copy so the hook pins to copy_path (via
     // current_exe() inside the copy).  Routes through skim_sandboxed_with_bin
     // so the sandbox env-var block stays in one authoritative place (PF-017).
-    common::skim_sandboxed_with_bin(home, &copy_path)
-        .args([
+    //
+    // Use the retry wrapper: on Linux, parallel tests can trigger ETXTBSY
+    // (os error 26) when a concurrently-forked child inherits the writable fd
+    // from std::fs::copy before it has exec'd and closed its O_CLOEXEC fds.
+    common::skim_sandboxed_with_bin_retried(home, &copy_path, |cmd| {
+        cmd.args([
             "init",
             "--agent",
             "claude-code",
             "--no-guidance",
             "--no-wrappers",
         ])
-        .env("PATH", hermetic_path())
-        .assert()
-        .success();
+        .env("PATH", hermetic_path());
+    })
+    .success();
 
     // Run doctor from the original binary: same version/commit, different path
     // → Verified integrity, pin_is_current == false → exit 0 (advisory ⚠, not drift).
@@ -345,17 +349,21 @@ fn test_doctor_exits_1_on_wrapper_target_mismatch() {
     }
 
     // Install hook AND wrappers using the copy — symlinks will point to copy_path.
-    common::skim_sandboxed_with_bin(home, &copy_path)
-        .args([
+    //
+    // Use the retry wrapper: on Linux, parallel tests can trigger ETXTBSY
+    // (os error 26) when a concurrently-forked child inherits the writable fd
+    // from std::fs::copy before it has exec'd and closed its O_CLOEXEC fds.
+    common::skim_sandboxed_with_bin_retried(home, &copy_path, |cmd| {
+        cmd.args([
             "init",
             "--agent",
             "claude-code",
             "--no-guidance",
             "--wrappers",
         ])
-        .env("PATH", hermetic_path())
-        .assert()
-        .success();
+        .env("PATH", hermetic_path());
+    })
+    .success();
 
     // Verify at least one wrapper symlink was created.
     let wrappers_dir = home.join(".skim").join("bin");

--- a/crates/rskim/tests/common/mod.rs
+++ b/crates/rskim/tests/common/mod.rs
@@ -36,6 +36,70 @@ pub fn skim() -> assert_cmd::Command {
     c
 }
 
+/// Spawn a sandboxed skim binary with bounded retry on ETXTBSY (os error 26).
+///
+/// # Why this exists
+///
+/// On Linux, `execve(2)` fails with ETXTBSY ("Text file busy") when a
+/// concurrently-forked child process holds an open writable file descriptor to
+/// the binary being exec'd.  This race surfaces when parallel integration tests
+/// do `std::fs::copy(src, dest)` and immediately exec `dest`: another test's
+/// `fork()` can inherit the writable fd from `std::fs::copy` before the parent
+/// closes it (the fd is O_CLOEXEC-marked, so it is released when *that child*
+/// execs, but not before).  The kernel keeps the inode's write count nonzero
+/// for the duration of that window — typically a few milliseconds under normal
+/// load.
+///
+/// # Protocol
+///
+/// `configure` is called once per attempt so the command can be freshly
+/// rebuilt without consuming a shared mutable builder.  Returns an [`Assert`]
+/// ready for chaining `.success()`, `.failure()`, etc.
+///
+/// # Bound
+///
+/// Exactly `ETXTBSY_MAX_ATTEMPTS` (5) total tries.  Back-off is
+/// `25 ms × 2^attempt`, giving cumulative sleep of at most
+/// 25 + 50 + 100 + 200 = 375 ms across the four retries before giving up.
+///
+/// [`Assert`]: assert_cmd::assert::Assert
+pub fn skim_sandboxed_with_bin_retried<F>(
+    home: &std::path::Path,
+    bin: &std::path::Path,
+    configure: F,
+) -> assert_cmd::assert::Assert
+where
+    F: Fn(&mut assert_cmd::Command),
+{
+    /// POSIX ETXTBSY — "Text file busy".  Value 26 is correct on Linux and macOS.
+    const ETXTBSY: i32 = 26;
+    /// Maximum spawn attempts before giving up.  Five covers the race window
+    /// observed in CI (typically resolved in 1–2 retries) with headroom to spare.
+    const ETXTBSY_MAX_ATTEMPTS: u32 = 5;
+
+    for attempt in 0..ETXTBSY_MAX_ATTEMPTS {
+        let mut cmd = skim_sandboxed_with_bin(home, bin);
+        configure(&mut cmd);
+        match cmd.output() {
+            Ok(output) => return assert_cmd::assert::Assert::new(output),
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) => {
+                // Another process holds a writable fd to the binary.  Sleep
+                // briefly and let it exec (which closes the O_CLOEXEC fd).
+                if attempt + 1 < ETXTBSY_MAX_ATTEMPTS {
+                    std::thread::sleep(std::time::Duration::from_millis(25u64 << attempt));
+                } else {
+                    panic!(
+                        "spawn still ETXTBSY after {} attempts: {}",
+                        ETXTBSY_MAX_ATTEMPTS, e
+                    );
+                }
+            }
+            Err(e) => panic!("spawn failed (attempt {}): {}", attempt + 1, e),
+        }
+    }
+    unreachable!("loop exits only via return or panic")
+}
+
 /// Build a sandboxed command for the given skim binary path.
 ///
 /// This is the **single authoritative source** for the sandbox env-var block


### PR DESCRIPTION
## Summary

- `test_doctor_exits_0_on_binary_pin_mismatch` and `test_doctor_exits_1_on_wrapper_target_mismatch` both copy the test binary with `std::fs::copy` and immediately exec the destination. On Linux, this triggers a fork+exec fd-inheritance race (ETXTBSY, os error 26) when a parallel test's forked child inherits the writable fd before it has exec'd and closed it.
- The fix adds `skim_sandboxed_with_bin_retried` to `common/mod.rs` — a bounded retry helper that wraps the single-source sandbox env block (PF-017 compliant) and retries `cmd.output()` on ETXTBSY up to 5 times with exponential back-off.
- Both affected exec sites are updated to use the helper. No test assertions are weakened.

## Root Cause

On Linux, `execve(2)` returns `ETXTBSY` when `i_writecount > 0` on the target inode. The race:

1. Thread A calls `std::fs::copy(src, dest)` — opens `dest` O_WRONLY (O_CLOEXEC), `i_writecount++` (= 1).
2. Thread B (parallel test) calls `Command::spawn()` → `fork()`. The child inherits the write fd. File-description sharing does **not** increment `i_writecount`, so count stays at 1.
3. Thread A closes `dest`. File-description refcount drops 1 → 1 (child still holds it), so `put_write_access()` is **not** called. `i_writecount` remains 1.
4. Thread A tries to `exec(dest)` — `i_writecount > 0` → **ETXTBSY**.

The window closes when Thread B's child `exec`s something (O_CLOEXEC fds closed → `put_write_access()` called → `i_writecount = 0`). This takes a few milliseconds on an unloaded machine, longer under CI load.

## Changes

- **`crates/rskim/tests/common/mod.rs`**: new `skim_sandboxed_with_bin_retried<F>()` helper. Calls `skim_sandboxed_with_bin` (preserving PF-017 single-source env block), then retries on `raw_os_error() == Some(26)` up to `ETXTBSY_MAX_ATTEMPTS = 5` times with 25ms × 2^attempt back-off (worst-case 375ms total sleep). Bound is an explicit named const; no unbounded loop.
- **`crates/rskim/tests/cli_doctor.rs`**: both `skim_sandboxed_with_bin(…).assert().success()` call sites for the copied binary are updated to use `skim_sandboxed_with_bin_retried`.

## Bound Chosen and Why

5 attempts: the race window is typically resolved within 1-2 retries (the forked child's exec takes milliseconds). 5 provides a 3× headroom over what CI load should require while still being a hard cap (no `loop {}` without a bound, per the repo's reliability rules). Worst-case additional latency is 375ms, only incurred if ETXTBSY fires repeatedly.

## Breaking Changes

None. Test assertions are unchanged; only the spawn dispatch gains retry logic.

## Reviewer Focus Areas

- `common/mod.rs` `skim_sandboxed_with_bin_retried`: check the retry bound, back-off arithmetic, and that `configure` is called on a freshly-built command each attempt (not a shared mutable one).
- Verify `raw_os_error() == Some(26)` is the correct ETXTBSY sentinel on both Linux and macOS (it is — POSIX defines ETXTBSY = 26 on both).
- Confirm both call sites are updated (both tests that `std::fs::copy` then exec).

## Flake Evidence

- **Before**: CI on `92b4f43` — `7 passed; 1 failed` for `test_doctor_exits_0_on_binary_pin_mismatch` with `Text file busy (os error 26)`.
- **After (local macOS, 10 runs)**: 10/10 pass. macOS does not reproduce ETXTBSY (it uses a different kernel exec path), so macOS runs cannot confirm the race is eliminated — they can only confirm no regressions are introduced. The fix is correct by the Linux kernel inode write-count invariant described above.
